### PR TITLE
SFML_FIND_COMPONENTS fix/default behaviour

### DIFF
--- a/cmake/Modules/FindSFML.cmake
+++ b/cmake/Modules/FindSFML.cmake
@@ -18,6 +18,7 @@
 
 # deduce the libraries suffix from the options
 set(FIND_SFML_LIB_SUFFIX "")
+set(SFML_FIND_COMPONENTS GRAPHICS WINDOW SYSTEM NETWORK AUDIO MAIN)
 if(SFML_STATIC_LIBRARIES)
     set(FIND_SFML_LIB_SUFFIX "${FIND_SFML_LIB_SUFFIX}-s")
 endif()


### PR DESCRIPTION
Added SFML_FIND_COMPONENTS so that FindSFML.cmake actually does something. This can be set in the user's CMakeLists.txt, of course, but I think it's okay to look for all possible libraries by default. Otherwise it should be documented.
