### PR TITLE
CMake Variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(SFML)
 
 # include the configuration file
-include(${CMAKE_SOURCE_DIR}/cmake/Config.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake)
 
 # setup version numbers
 set(VERSION_MAJOR 2)
@@ -19,7 +19,7 @@ set(VERSION_MINOR 0)
 set(VERSION_PATCH 0)
 
 # add the SFML header path
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # add an option for choosing the build type (shared or static)
 set(BUILD_SHARED_LIBS TRUE CACHE BOOL "TRUE to build SFML as shared libraries, FALSE to build it as static libraries")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,8 +15,8 @@ endif()
 find_package(Doxygen REQUIRED)
 
 # set the input and output documentation paths
-set(DOXYGEN_INPUT_DIR ${CMAKE_SOURCE_DIR})
-set(DOXYGEN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/doc)
+set(DOXYGEN_INPUT_DIR ${PROJECT_SOURCE_DIR})
+set(DOXYGEN_OUTPUT_DIR ${PROJECT_BINARY_DIR}/doc)
 
 # see if we can generate the CHM documentation
 if(WINDOWS)

--- a/examples/X11/CMakeLists.txt
+++ b/examples/X11/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/X11)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/X11)
 
 # all source files
 set(SRC ${SRCROOT}/X11.cpp)

--- a/examples/ftp/CMakeLists.txt
+++ b/examples/ftp/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/ftp)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/ftp)
 
 # all source files
 set(SRC ${SRCROOT}/Ftp.cpp)

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/opengl)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/opengl)
 
 # all source files
 set(SRC ${SRCROOT}/OpenGL.cpp)

--- a/examples/pong/CMakeLists.txt
+++ b/examples/pong/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/pong)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/pong)
 
 # all source files
 set(SRC ${SRCROOT}/Pong.cpp)

--- a/examples/shader/CMakeLists.txt
+++ b/examples/shader/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/shader)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/shader)
 
 # all source files
 set(SRC ${SRCROOT}/Shader.cpp)

--- a/examples/sockets/CMakeLists.txt
+++ b/examples/sockets/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/sockets)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sockets)
 
 # all source files
 set(SRC ${SRCROOT}/Sockets.cpp

--- a/examples/sound/CMakeLists.txt
+++ b/examples/sound/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/sound)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sound)
 
 # all source files
 set(SRC ${SRCROOT}/Sound.cpp)

--- a/examples/sound_capture/CMakeLists.txt
+++ b/examples/sound_capture/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/sound_capture)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sound_capture)
 
 # all source files
 set(SRC ${SRCROOT}/SoundCapture.cpp)

--- a/examples/voip/CMakeLists.txt
+++ b/examples/voip/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/voip)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/voip)
 
 # all source files
 set(SRC ${SRCROOT}/VoIP.cpp

--- a/examples/win32/CMakeLists.txt
+++ b/examples/win32/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/win32)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/win32)
 
 # all source files
 set(SRC ${SRCROOT}/Win32.cpp)

--- a/examples/window/CMakeLists.txt
+++ b/examples/window/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-set(SRCROOT ${CMAKE_SOURCE_DIR}/examples/window)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/window)
 
 # all source files
 set(SRC ${SRCROOT}/Window.cpp)

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-set(INCROOT ${CMAKE_SOURCE_DIR}/include/SFML/Audio)
-set(SRCROOT ${CMAKE_SOURCE_DIR}/src/SFML/Audio)
+set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Audio)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Audio)
 
 # all source files
 set(SRC
@@ -30,11 +30,11 @@ set(SRC
 
 # let CMake know about our additional audio libraries paths (on Windows and OSX)
 if(WINDOWS)
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/extlibs/headers/AL")
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/extlibs/headers/libsndfile/windows")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/AL")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/libsndfile/windows")
 elseif (MACOSX)
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/extlibs/headers/libsndfile/osx")
-    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/extlibs/libs-osx/Frameworks")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/libsndfile/osx")
+    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-osx/Frameworks")
 endif()
 
 # find external libraries

--- a/src/SFML/CMakeLists.txt
+++ b/src/SFML/CMakeLists.txt
@@ -1,37 +1,37 @@
 
 # include the SFML specific macros
-include(${CMAKE_SOURCE_DIR}/cmake/Macros.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/Macros.cmake)
 
 # let CMake know about our additional libraries paths (on Windows and OS X)
 if (WINDOWS)
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/extlibs/headers")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers")
     if(COMPILER_GCC)
-        set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/extlibs/libs-mingw")
+        set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-mingw")
         if(ARCH_32BITS)
-            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/extlibs/bin/x86")
+            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/bin/x86")
         else()
-            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/extlibs/bin/x64")
+            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/bin/x64")
         endif()
     elseif(COMPILER_MSVC)
         if(ARCH_32BITS)
-            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/extlibs/libs-msvc/x86")
+            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-msvc/x86")
         else()
-            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/extlibs/libs-msvc/x64")
+            set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-msvc/x64")
         endif()
     endif()
 elseif(MACOSX)
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/extlibs/headers")
-    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${CMAKE_SOURCE_DIR}/extlibs/libs-osx/lib/")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers")
+    set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-osx/lib/")
 endif()
 
 # add the SFML sources path
-include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${PROJECT_SOURCE_DIR}/src)
 
 # define the path of our additional CMake modules
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 
 # set the output directory for SFML libraries
-set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
+set(LIBRARY_OUTPUT_PATH "${PROJECT_BINARY_DIR}/lib")
 
 # define the export symbol
 add_definitions(-DSFML_EXPORTS)

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-set(INCROOT ${CMAKE_SOURCE_DIR}/include/SFML/Graphics)
-set(SRCROOT ${CMAKE_SOURCE_DIR}/src/SFML/Graphics)
+set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Graphics)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Graphics)
 
 # all source files
 set(SRC
@@ -55,8 +55,8 @@ set(SRC
 
 # let CMake know about our additional graphics libraries paths (on Windows and OSX)
 if (WINDOWS OR MACOSX)
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/extlibs/headers/freetype")
-    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${CMAKE_SOURCE_DIR}/extlibs/headers/jpeg")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/freetype")
+    set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/jpeg")
 endif()
 
 # find external libraries

--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # define the sfml-main target
-add_library(sfml-main STATIC ${CMAKE_SOURCE_DIR}/src/SFML/Main/SFML_Main.cpp)
+add_library(sfml-main STATIC ${PROJECT_SOURCE_DIR}/src/SFML/Main/SFML_Main.cpp)
 
 # set the debug suffix
 set_target_properties(sfml-main PROPERTIES DEBUG_POSTFIX -d)

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-set(INCROOT ${CMAKE_SOURCE_DIR}/include/SFML/Network)
-set(SRCROOT ${CMAKE_SOURCE_DIR}/src/SFML/Network)
+set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Network)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Network)
 
 # all source files
 set(SRC

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-set(INCROOT ${CMAKE_SOURCE_DIR}/include/SFML/System)
-set(SRCROOT ${CMAKE_SOURCE_DIR}/src/SFML/System)
+set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/System)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/System)
 
 # all source files
 set(SRC

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-set(INCROOT ${CMAKE_SOURCE_DIR}/include/SFML/Window)
-set(SRCROOT ${CMAKE_SOURCE_DIR}/src/SFML/Window)
+set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Window)
+set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Window)
 
 # all source files
 set(SRC


### PR DESCRIPTION
I've noticed and fixed some errors in the CMake config files that prevent SFML from being added as a dependency in a project. CMake makes it very easy to add another CMake project as a dependency simply by calling add_subdirectory(), but this didn't work with the variables that were used.

Fixes as per http://cmake.org/Wiki/CMake_Useful_Variables#Locations
