### PR TITLE
sf::String constructor for iterators

### DIFF
--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -156,6 +156,15 @@ public :
     String(const String& copy);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct from iterators.
+    ///
+    /// \param begin Begin iterator.
+    /// \param end End iterator.
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const ConstIterator& begin, const ConstIterator& end);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Implicit cast operator to std::string (ANSI string)
     ///
     /// The current global locale is used for conversion. If you

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -131,6 +131,10 @@ myString(copy.myString)
 {
 }
 
+String::String(const ConstIterator& begin, const ConstIterator& end) :
+myString( begin, end )
+{
+}
 
 ////////////////////////////////////////////////////////////
 String::operator std::string() const


### PR DESCRIPTION
I've added a constructor for constructing sf::Strings by sf::String iterators (see issue 21).
