### PR TITLE
Make sf::Ftp::SendCommand public

### DIFF
--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -479,8 +479,6 @@ public :
     ////////////////////////////////////////////////////////////
     Response Upload(const std::string& localFile, const std::string& remotePath, TransferMode mode = Binary);
 
-private :
-
     ////////////////////////////////////////////////////////////
     /// \brief Send a command to the FTP server
     ///
@@ -491,6 +489,8 @@ private :
     ///
     ////////////////////////////////////////////////////////////
     Response SendCommand(const std::string& command, const std::string& parameter = "");
+
+private :
 
     ////////////////////////////////////////////////////////////
     /// \brief Receive a response from the server


### PR DESCRIPTION
This is very useful for non-standard FTP commands (`SITE CHMOD`).

(I hope this is the right way to do a pull request. :P)
