### PR TITLE
Forgot to update the internal attributes myWidth and myHeight

### DIFF
--- a/src/SFML/Window/Linux/WindowImplX11.cpp
+++ b/src/SFML/Window/Linux/WindowImplX11.cpp
@@ -315,6 +315,9 @@ void WindowImplX11::SetSize(unsigned int width, unsigned int height)
 {
     XResizeWindow(myDisplay, myWindow, width, height);
     XFlush(myDisplay);
+
+    myWidth = width;
+    myHeight = height;
 }
 
 


### PR DESCRIPTION
On Linux, GetWidth and GetHeight return the initial size of the window. In other words, it returns an incorrect value after resizing the window.

It's probably the same case for Windows, I didn't see any update of myWidth and myHeight and I didn't check for Mac.

Could anyone confirm this ?
