### PR TITLE
Explicit use signed char for included font data to enable cross-compile

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -338,7 +338,7 @@ const Font& Font::GetDefaultFont()
     // Load the default font on first call
     if (!loaded)
     {
-        static const char data[] =
+        static const signed char data[] =
         {
             #include <SFML/Graphics/Arial.hpp>
         };


### PR DESCRIPTION
I'm trying to cross compile sfml for an arm based board, which failed due to a different
default behavior for char.

From ISO/IEC 9899:1999, 6.2.5.15 (p. 49):
The implementation shall define char to have the same range,
representation, and behavior as either signed char or unsigned char.
