### PR TITLE
Fix for issue #119

### DIFF
--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -36,7 +36,8 @@ namespace sf
 ////////////////////////////////////////////////////////////
 Packet::Packet() :
 myReadPos(0),
-myIsValid(true)
+myIsValid(true),
+myData(sizeof(Uint32), 0)
 {
 
 }
@@ -64,8 +65,8 @@ void Packet::Append(const void* data, std::size_t sizeInBytes)
 ////////////////////////////////////////////////////////////
 void Packet::Clear()
 {
-    myData.clear();
-    myReadPos = 0;
+    myData.erase(myData.begin()+sizeof(Uint32),myData.end());
+	myReadPos = 0;
     myIsValid = true;
 }
 
@@ -73,21 +74,21 @@ void Packet::Clear()
 ////////////////////////////////////////////////////////////
 const char* Packet::GetData() const
 {
-    return !myData.empty() ? &myData[0] : NULL;
+    return !myData.empty() ? (&myData[0] + sizeof(Uint32)) : NULL;
 }
 
 
 ////////////////////////////////////////////////////////////
 std::size_t Packet::GetDataSize() const
 {
-    return myData.size();
+    return myData.size() - sizeof(Uint32);
 }
 
 
 ////////////////////////////////////////////////////////////
 bool Packet::EndOfPacket() const
 {
-    return myReadPos >= myData.size();
+    return myReadPos >= GetDataSize();
 }
 
 
@@ -489,7 +490,7 @@ Packet& Packet::operator <<(const String& data)
 ////////////////////////////////////////////////////////////
 bool Packet::CheckSize(std::size_t size)
 {
-    myIsValid = myIsValid && (myReadPos + size <= myData.size());
+    myIsValid = myIsValid && (myReadPos + size <= GetDataSize());
 
     return myIsValid;
 }


### PR DESCRIPTION
Fix for issue #119: Two packets are sent when using sf::TcpSocket::Send(sf::Packet);

<strong>Brainstorm:</strong>
- Of course with TCP you need a way to tell how long the data is.
- Sending two packets is a "working" solution, but the TCP/IP overhead is extremely huge. Most games needs short/quick real-time updates and that header is often bigger than the actual data sent... 
- The best way to fix this is to prepend the data with an Uint32 telling how long the following data is. (Just like the operator<<(std::string) function does, but for the entire packet data.
- We can't put too much complexity into Packet::onSend() because it's a virtual function.
- Creating a temporary buffer to push the size and also copy the packet's data is counter-intuitive and CPU intensive way.

<strong>Resolution:</strong>
- Every Packet object is now created with a data buffer containing an Uint32 (the size of the packet).
- A few pointers arithmetic have been introduced, but the class internals is fairly simple. Basically, when you call GetDataSize(), you get the internal buffer size minus the Uint32 placeholder... when you read/write data, you do so after the placeholder... basically we're just ignoring the new placeholder, but it's still there in the buffer.
- The placeholder for the size is written only when the packet needs to be sent.
- The current API isn't broken in any way. To achieve that, I needed to do a const_cast<> on Packet::GetData()

<strong>Result/Note:</strong>

I think everything should be fine. UDPSocket doesn't need a size due to datagrams and other functions doesn't use a Packet object.
