### PR TITLE
You know you gotta love that C++11

### DIFF
--- a/src/SFML/System/Sleep.cpp
+++ b/src/SFML/System/Sleep.cpp
@@ -27,7 +27,9 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Sleep.hpp>
 
-#if defined(SFML_SYSTEM_WINDOWS)
+#if defined(SFML_CPP11)
+    #include <SFML/System/SleepImpl.hpp>
+#else if defined(SFML_SYSTEM_WINDOWS)
     #include <SFML/System/Win32/SleepImpl.hpp>
 #else
     #include <SFML/System/Unix/SleepImpl.hpp>

--- a/src/SFML/System/SleepImpl.cpp
+++ b/src/SFML/System/SleepImpl.cpp
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2009 Laurent Gomila (laurent.gom@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/SleepImpl.hpp>
+#include <chrono>
+#include <thread>
+
+
+namespace sf
+{
+namespace priv
+{
+////////////////////////////////////////////////////////////
+void SleepImpl(Uint32 time)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(time));
+}
+
+} // namespace priv
+
+} // namespace sf

--- a/src/SFML/System/SleepImpl.hpp
+++ b/src/SFML/System/SleepImpl.hpp
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2009 Laurent Gomila (laurent.gom@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SLEEPIMPLCPP11_HPP
+#define SFML_SLEEPIMPLCPP11_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+namespace sf
+{
+namespace priv
+{
+////////////////////////////////////////////////////////////
+/// \brief C++11 implementation of sf::Sleep
+///
+/// \param time Time to sleep, in milliseconds
+///
+////////////////////////////////////////////////////////////
+void SleepImpl(Uint32 time);
+
+} // namespace priv
+
+} // namespace sf
+
+
+#endif // SFML_SLEEPIMPLCPP11_HPP


### PR DESCRIPTION
A cross platform method of sleeping for all compilers which support C++11. So gcc 4.6, VC11, and maybe some others should all work fine with this.
You'll have to define SFML_CPP11 somewhere, like in the config, or through cmake maybe.
My goal is to replace all the Impl stuff in System with C++11 implementations.
Feel free to modify this commit as needed to make it conform to your standards.
