### PR TITLE
Xcode 4.3 fix.

### DIFF
--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -141,7 +141,7 @@ struct SFMLmainWindow
     self.sfmlView           = nil;
     self.textField          = nil;
     
-    delete self.mainWindow;
+    delete (SFMLmainWindow*) self.mainWindow;
     self.mainWindow         = 0;
     self.renderTimer        = nil;
     


### PR DESCRIPTION
Change to examples/cocoa/CocoaAppDelegate.mm to fix compilation in Lion with XCode 4.3's Command Line Tools (LLVM 3.1).

Previous code generates error upon 'make':

<pre>
SFML/examples/cocoa/CocoaAppDelegate.mm:144:5: error: cannot delete expression of type '<pseudo-object type>'
    delete self.mainWindow;
    ^      ~~~~~~~~~~~~~~~
1 error generated.
</pre>


Code has not been tested with older versions of Xcode as I no longer have any other version installed.
