### PR TITLE
Reduce joystick connection polling to once per second

### DIFF
--- a/src/SFML/Window/JoystickManager.cpp
+++ b/src/SFML/Window/JoystickManager.cpp
@@ -74,7 +74,7 @@ void JoystickManager::update()
                 item.state = JoystickState();
             }
         }
-        else
+        else if (item.connectionCheck.getElapsedTime().asSeconds() > 1.f)
         {
             // Check if the joystick was connected since last update
             if (JoystickImpl::isConnected(i))
@@ -85,6 +85,7 @@ void JoystickManager::update()
                     item.state = item.joystick.update();
                 }
             }
+            item.connectionCheck.restart();
         }
     }
 }

--- a/src/SFML/Window/JoystickManager.hpp
+++ b/src/SFML/Window/JoystickManager.hpp
@@ -31,6 +31,7 @@
 #include <SFML/Window/Joystick.hpp>
 #include <SFML/Window/JoystickImpl.hpp>
 #include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Clock.hpp>
 
 
 namespace sf
@@ -99,9 +100,10 @@ private:
     ////////////////////////////////////////////////////////////
     struct Item
     {
-        JoystickImpl  joystick;     ///< Joystick implementation
-        JoystickState state;        ///< The current joystick state
-        JoystickCaps  capabilities; ///< The joystick capabilities
+        JoystickImpl  joystick;        ///< Joystick implementation
+        JoystickState state;           ///< The current joystick state
+        JoystickCaps  capabilities;    ///< The joystick capabilities
+        sf::Clock     connectionCheck; ///< Connection check
     };
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Applied advice from http://en.sfml-dev.org/forums/index.php?topic=6079.0, reduces lag when no joystick is connected a LOT.

However, because it's using "Clock::getElapsedTime" now SetThreadAffinityMask (from getCurrentTime) uses 9% CPU (which is still a lot). Maybe remove the calls and put something in the comments about the behavior of these functions under certain multi cores/processors (from what I read it only concerns AMD processors).
