### PR TITLE
Fixes the incorrect conversion from degrees to radians.  

### DIFF
--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -139,7 +139,7 @@ JoystickState JoystickImpl::update()
         // Special case for POV, it is given as an angle
         if (pos.dwPOV != 0xFFFF)
         {
-            float angle = pos.dwPOV / 36000.f * 3.141592654f;
+            float angle = pos.dwPOV / 18000.f * 3.141592654f;
             state.axes[Joystick::PovX] = std::cos(angle) * 100;
             state.axes[Joystick::PovY] = std::sin(angle) * 100;
         }


### PR DESCRIPTION
After reimplementing much of my game's input code from SFML 1.6 to SFML 2.0, I noticed that I was getting unexpecting values from POV controls in Windows and not Linux.  I would never get negative values for PovY.  Investigating, I noticed that the code converting Windows POV values to split axes, that SFML 2.0 uses, was handled by an incorrect formula for converting degrees to radians.  
