### PR TITLE
Fix behavior of sf::Event::Resized

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -236,6 +236,8 @@ private :
     HICON    m_icon;             ///< Custom icon assigned to the window
     bool     m_keyRepeatEnabled; ///< Automatic key-repeat state for keydown events
     bool     m_isCursorIn;       ///< Is the mouse cursor in the window's area ?
+    Vector2u m_lastSize;         ///< The last handled size of the window
+    bool     m_resizing;         ///< Is the window being resized ?
 };
 
 } // namespace priv


### PR DESCRIPTION
Here is a clean fix (I hope) for issue #68.
I tested it on Windows 7 and it is working as intended.
