### PR TITLE
[Intel RenderTexture] Test version of single call to XOpenDisplay

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -60,6 +60,8 @@ elseif(LINUX)
         ${SRCROOT}/Linux/VideoModeImpl.cpp
         ${SRCROOT}/Linux/WindowImplX11.cpp
         ${SRCROOT}/Linux/WindowImplX11.hpp
+		${SRCROOT}/Linux/XDisplay.cpp
+		${SRCROOT}/Linux/XDisplay.hpp
     )
 else() # MACOSX
     set(SRC

--- a/src/SFML/Window/Linux/GlxContext.cpp
+++ b/src/SFML/Window/Linux/GlxContext.cpp
@@ -44,7 +44,7 @@ m_context   (NULL),
 m_ownsWindow(true)
 {
     // Open a connection with the X server
-    m_display = XOpenDisplay(NULL);
+    m_display = SXOpenDisplay();
 
     // Create a dummy window (disabled and hidden)
     int screen = DefaultScreen(m_display);
@@ -88,7 +88,7 @@ m_context   (NULL),
 m_ownsWindow(true)
 {
     // Open a connection with the X server
-    m_display = XOpenDisplay(NULL);
+    m_display = SXOpenDisplay();
 
     // Create the hidden window
     int screen = DefaultScreen(m_display);
@@ -127,7 +127,7 @@ GlxContext::~GlxContext()
     
     // Close the connection with the X server
     if (m_ownsWindow)
-        XCloseDisplay(m_display);
+        SXCloseDisplay();
 }
 
 

--- a/src/SFML/Window/Linux/GlxContext.hpp
+++ b/src/SFML/Window/Linux/GlxContext.hpp
@@ -31,7 +31,7 @@
 #include <SFML/Window/GlContext.hpp>
 #include <X11/Xlib.h>
 #include <GL/glx.h>
-
+#include "XDisplay.hpp"
 
 namespace sf
 {

--- a/src/SFML/Window/Linux/InputImpl.cpp
+++ b/src/SFML/Window/Linux/InputImpl.cpp
@@ -29,7 +29,7 @@
 #include <SFML/Window/Window.hpp>
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
-
+#include "XDisplay.hpp"
 
 namespace
 {
@@ -38,13 +38,13 @@ namespace
     {
         GlobalDisplay() 
         {
-            display = XOpenDisplay(NULL);
+            display = SXOpenDisplay();
             window = DefaultRootWindow(display);
         }
 
         ~GlobalDisplay()
         {
-            XCloseDisplay(display);
+            SXCloseDisplay();
         }
 
         ::Display* display;

--- a/src/SFML/Window/Linux/InputImpl.hpp
+++ b/src/SFML/Window/Linux/InputImpl.hpp
@@ -31,7 +31,6 @@
 #include <SFML/Window/Keyboard.hpp>
 #include <SFML/Window/Mouse.hpp>
 
-
 namespace sf
 {
 namespace priv

--- a/src/SFML/Window/Linux/JoystickImpl.hpp
+++ b/src/SFML/Window/Linux/JoystickImpl.hpp
@@ -31,6 +31,7 @@
 #if defined(SFML_SYSTEM_LINUX)
     #include <linux/joystick.h>
     #include <fcntl.h>
+    #include "XDisplay.hpp"
 #elif defined(SFML_SYSTEM_FREEBSD)
     // #include <sys/joystick.h> ?
     #define ABS_MAX 1

--- a/src/SFML/Window/Linux/VideoModeImpl.cpp
+++ b/src/SFML/Window/Linux/VideoModeImpl.cpp
@@ -30,7 +30,7 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 #include <algorithm>
-
+#include "XDisplay.hpp"
 
 namespace sf
 {
@@ -42,7 +42,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     std::vector<VideoMode> modes;
 
     // Open a connection with the X server
-    Display* disp = XOpenDisplay(NULL);
+    Display* disp = SXOpenDisplay();
     if (disp)
     {
         // Retrieve the default screen number
@@ -101,7 +101,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
         }
 
         // Close the connection with the X server
-        XCloseDisplay(disp);
+        SXCloseDisplay();
     }
     else
     {
@@ -119,7 +119,7 @@ VideoMode VideoModeImpl::getDesktopMode()
     VideoMode desktopMode;
 
     // Open a connection with the X server
-    Display* disp = XOpenDisplay(NULL);
+    Display* disp = SXOpenDisplay();
     if (disp)
     {
         // Retrieve the default screen number
@@ -159,7 +159,7 @@ VideoMode VideoModeImpl::getDesktopMode()
         }
 
         // Close the connection with the X server
-        XCloseDisplay(disp);
+        SXCloseDisplay();
     }
     else
     {

--- a/src/SFML/Window/Linux/WindowImplX11.cpp
+++ b/src/SFML/Window/Linux/WindowImplX11.cpp
@@ -72,7 +72,7 @@ m_hiddenCursor(0),
 m_keyRepeat   (true)
 {
     // Open a connection with the X server
-    m_display = XOpenDisplay(NULL);
+    m_display = SXOpenDisplay();
     m_screen  = DefaultScreen(m_display);
 
     // Save the window handle
@@ -101,7 +101,7 @@ m_hiddenCursor(0),
 m_keyRepeat   (true)
 {
     // Open a connection with the X server
-    m_display = XOpenDisplay(NULL);
+    m_display = SXOpenDisplay();
     m_screen  = DefaultScreen(m_display);
 
     // Compute position and size
@@ -255,7 +255,7 @@ WindowImplX11::~WindowImplX11()
         XCloseIM(m_inputMethod);
 
     // Close the connection with the X server
-    XCloseDisplay(m_display);
+    SXCloseDisplay();
 }
 
 

--- a/src/SFML/Window/Linux/WindowImplX11.hpp
+++ b/src/SFML/Window/Linux/WindowImplX11.hpp
@@ -33,7 +33,7 @@
 #include <X11/Xlib.h>
 #include <set>
 #include <string>
-
+#include "XDisplay.hpp"
 
 namespace sf
 {

--- a/src/SFML/Window/Linux/XDisplay.cpp
+++ b/src/SFML/Window/Linux/XDisplay.cpp
@@ -1,0 +1,18 @@
+#include "XDisplay.hpp"
+
+static Display *Dpy = NULL;
+static int ref_count = 0;
+
+Display *SXOpenDisplay() {
+  if (!Dpy) {
+    Dpy = XOpenDisplay(NULL);
+  }
+  ref_count++;
+  return Dpy;
+}
+
+void SXCloseDisplay() {
+  if (--ref_count == 0) {
+    XCloseDisplay(Dpy);
+  }
+}

--- a/src/SFML/Window/Linux/XDisplay.hpp
+++ b/src/SFML/Window/Linux/XDisplay.hpp
@@ -1,0 +1,9 @@
+#ifndef SFML_XDISPLAY_HPP
+#define SFML_XDISPLAY_HPP
+
+#include <X11/Xlib.h>
+
+Display *SXOpenDisplay();
+void SXCloseDisplay();
+
+#endif //SFML_XDISPLAY_HPP


### PR DESCRIPTION
I made this just to test if it works. 

With this version every test (the ones you posted in [RenderTexture on Intel GPU's. Let's fix this problem!](http://en.sfml-dev.org/forums/index.php?topic=9149.msg61856#msg61856) and the shader test) runs without error.

Unfortunately the shader test is not correct: the edge example uses the pixel shader on the objects.
