### PR TITLE
Fixes a crash caused when creating a fullscreen window on linux

### DIFF
--- a/src/SFML/Window/Linux/WindowImplX11.cpp
+++ b/src/SFML/Window/Linux/WindowImplX11.cpp
@@ -477,7 +477,7 @@ void WindowImplX11::initialize()
                                    XNClientWindow, m_window,
                                    XNFocusWindow,  m_window,
                                    XNInputStyle,   XIMPreeditNothing  | XIMStatusNothing,
-                                   NULL);
+                                   (char*) NULL);
     }
     else
     {


### PR DESCRIPTION
The list of arguments XCreateIC function takes must be terminated by a NULL pointer, and, since these are variadic functions, this pointer must be cast (char *) NULL.
