### PR TITLE
Makes joystick button ordering predictable.

### DIFF
--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -30,6 +30,14 @@
 #include <SFML/Window/OSX/HIDInputManager.hpp>
 #include <SFML/Window/OSX/HIDJoystickManager.hpp>
 
+// Translation unit namespace
+namespace {
+    ////////////////////////////////////////////////////////////
+    bool JoystickButtonSortPredicate(IOHIDElementRef b1, IOHIDElementRef b2)
+    {
+        return IOHIDElementGetUsage(b1) < IOHIDElementGetUsage(b2);
+    }
+}
 
 namespace sf
 {
@@ -217,6 +225,10 @@ bool JoystickImpl::open(unsigned int index)
                 break;
         }
     }
+    
+    // Ensure that the buttons will be indexed in the same order as their
+    // HID Usage (assigned by manufacturer and/or a driver).
+    std::sort(m_buttons.begin(), m_buttons.end(), JoystickButtonSortPredicate);
     
     // Note : Joy::AxisPovX/Y are not supported (yet).
     // Maybe kIOHIDElementTypeInput_Axis is the corresponding type but I can't test.


### PR DESCRIPTION
Fixes unpredictable or unintentional joystick button ordering by sorting
buttons according to their HID Usage property.  This allows SFML to
adhere to a manufacturer's (or driver implentation's) intended button
ordering.

Resubmitting.  Hopefully I've not screwed up the branching this time...

This change is the same one I posted on the forums under the topic http://en.sfml-dev.org/forums/index.php?topic=9254.0

I'm not trying to rush anyone with this pull request. I just figured if my solution was accepted, it'd be convenient to have the code ready and waiting to be pulled. If I shouldn't be doing this, please let me know. I'm not sure if there's a more appropriate or official way I should be contributing.  

Hiura mentioned on the forum that he'd test this with his own devices when he has time, so this pull request should be left un-pulled until he gives a go-ahead on it.

This is related to LaurentGomila/SFML#288
