### PR TITLE
Brings sf::Window getPosition and setPosition closer to parity on OS X.

### DIFF
--- a/src/SFML/Window/OSX/SFViewController.mm
+++ b/src/SFML/Window/OSX/SFViewController.mm
@@ -138,7 +138,7 @@
 
 
 ////////////////////////////////////////////////////////.
--(void)setWindowPositionToX:(unsigned int)x Y:(unsigned int)y
+-(void)setWindowPositionToX:(int)x Y:(int)y
 {
     sf::err() << "Cannot move SFML area when SFML is integrated in a NSView. Use the view hanlder directly instead." << std::endl;
 }

--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -292,25 +292,34 @@
 ////////////////////////////////////////////////////////////
 -(NSPoint)position
 {
-    NSPoint pos = [m_oglView frame].origin;
+    NSRect frame = m_window.frame;
+    NSPoint pos = frame.origin;
+    NSRect screenFrame = m_window.screen.frame;
     
     // Flip for SFML window coordinate system.
-    pos.y = [self screenHeight] - pos.y;
+    pos.y += frame.size.height;
+    pos.y = screenFrame.size.height - pos.y;
     
     return pos;
 }
 
 
 ////////////////////////////////////////////////////////.
--(void)setWindowPositionToX:(unsigned int)x Y:(unsigned int)y
+-(void)setWindowPositionToX:(int)x Y:(int)y
 {
     NSPoint point = NSMakePoint(x, y);
+    NSScreen *screen = m_window.screen;
     
     // Flip for SFML window coordinate system.
-    point.y = [self screenHeight] - point.y;
+    point.y = m_window.screen.frame.size.height - point.y;
     
     // Place the window.
     [m_window setFrameTopLeftPoint:point];
+    
+    if (screen != [m_window screen]) {
+        // Oops.  Coordinates were for a different screen.  Do-over.
+        [self setWindowPositionToX:x Y:y];
+    }
 }
 
 

--- a/src/SFML/Window/OSX/WindowImplDelegateProtocol.h
+++ b/src/SFML/Window/OSX/WindowImplDelegateProtocol.h
@@ -104,7 +104,7 @@ namespace sf {
 /// Move the window (not the view if we handle not a window) (SFML Coordinates).
 ///
 ////////////////////////////////////////////////////////////
--(void)setWindowPositionToX:(unsigned int)x Y:(unsigned int)y;
+-(void)setWindowPositionToX:(int)x Y:(int)y;
 
 ////////////////////////////////////////////////////////////
 /// Get window's size.


### PR DESCRIPTION
The coordinate system transformation that occurs when dealing with window
positions on OS X requires (or at least warrants) some fuzzy logic in
dealing with getting and setting window positions.  In any windowing
system, requesting a position should effectively yield the components
for an identity transform of the window's current position.  In other
words, coordinates obtained by a call to getPosition should have no
impact in the window's position when immediately applied to setPosition.

This change brings getPosition and setPosition much closer to acheiving
that identity transform in the OS X implementation, correcting the error
in most cases, and producing far less unpredictable results in the cases
that remain affected.
