### PR TITLE
Fix whitespace-measurement issues with Text

### DIFF
--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -290,6 +290,8 @@ private :
     Color         m_color;         ///< Text color
     VertexArray   m_vertices;      ///< Vertex array containing the text's geometry
     FloatRect     m_bounds;        ///< Bounding rectangle of the text (in local coordinates)
+
+	std::vector<unsigned int> m_emptyIndices; ///< Indices for characters that should be transparent
 };
 
 } // namespace sf


### PR DESCRIPTION
This fixes bugs related to measuring and rendering whitespaces such as those described by https://github.com/LaurentGomila/SFML/issues/216 by adding whitespaces as transparent quads.

May require some formatting, although Visual Studio 2010 showed the text properly formatted before I looked into the diffs...
