### PR TITLE
sf::Font texture corruption bug fixed

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -523,6 +523,13 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
                 // Make the texture 2 times bigger
                 sf::Image pixels = page.texture.copyToImage();
                 page.texture.create(textureWidth * 2, textureHeight * 2);
+                
+                // Make sure to clear the new texture
+                sf::Image white_image;
+                white_image.create(textureWidth * 2, textureHeight * 2, Color(255, 255, 255, 0));
+                page.texture.loadFromImage(white_image);
+                
+                // Copy the pixels back in
                 page.texture.update(pixels);
             }
             else


### PR DESCRIPTION
Dear Laurent!

I have found and fixed that bug in sf::Font that caused the rendering artifacts on sf::Texts with bigger character sizes. (At least it "worksforme" now.)
I would love to see this merged back into your repo.

Greetings,
Attila
