### PR TITLE
Fix for "that" sf::Font texture bug (now with your naming convention)

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -525,9 +525,9 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
                 page.texture.create(textureWidth * 2, textureHeight * 2);
                 
                 // Make sure to clear the new texture
-                sf::Image white_image;
-                white_image.create(textureWidth * 2, textureHeight * 2, Color(255, 255, 255, 0));
-                page.texture.loadFromImage(white_image);
+                sf::Image whiteImage;
+                whiteImage.create(textureWidth * 2, textureHeight * 2, Color(255, 255, 255, 0));
+                page.texture.loadFromImage(whiteImage);
                 
                 // Copy the pixels back in
                 page.texture.update(pixels);


### PR DESCRIPTION
The ominous fix we discussed earlier. Now follows your naming convention.
Only because you haven't committed it yet. But just ignore this if you'd like to.
