### PR TITLE
Caching of GLSL uniform locations (via Parameter objects)

### DIFF
--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -70,6 +70,46 @@ public :
     struct CurrentTextureType {};
     static CurrentTextureType CurrentTexture;
 
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Parameter class, for avoiding overhead of name lookup in setParameter calls
+    ///
+    ////////////////////////////////////////////////////////////
+    class Parameter
+    {
+    public :
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        /// This constructor creates an invalid parameter.
+        ///
+        ////////////////////////////////////////////////////////////
+        Parameter();
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Find a named parameter's location in a shader
+        ///
+        /// This function looks up a parameter's location in a
+        /// shader using its textual name. It is only valid for
+        /// the given shader; other shaders with parameters of
+        /// the same name will need their own Parameter objects.
+        /// Note that this does not survive a subsequent
+        /// Shader::compile of the associated shader object.
+        ///
+        /// \param shader   Shader to look up parameter location from
+        /// \param name     Name of the parameter in the shader
+        ///
+        /// \return True if lookup succeeded, false if it failed
+        ///
+        ////////////////////////////////////////////////////////////
+        bool find(const Shader& shader, const std::string& name);
+
+    private :
+        friend class Shader;
+
+        int m_location;
+    };
+
 public :
 
     ////////////////////////////////////////////////////////////
@@ -209,6 +249,253 @@ public :
     ///
     ////////////////////////////////////////////////////////////
     bool loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a float parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// float (float GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform float myparam; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// Parameter myparam = shader.getParameter("myparam");
+    /// shader.setParameter(myparam, 5.2f);
+    /// \endcode
+    ///
+    /// \param name Name of the parameter in the shader
+    /// \param x    Value to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, float x);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 2-components vector parameter of the shader
+    ///
+    /// \a name is the name of the variable to change in the shader.
+    /// The corresponding parameter in the shader must be a 2x1 vector
+    /// (vec2 GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform vec2 myparam; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// shader.setParameter("myparam", 5.2f, 6.0f);
+    /// \endcode
+    ///
+    /// \param name Name of the parameter in the shader
+    /// \param x    First component of the value to assign
+    /// \param y    Second component of the value to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, float x, float y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 3-components vector parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// 3x1 vector (vec3 GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform vec3 myparam; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// Parameter myparam = shader.getParameter("myparam");
+    /// shader.setParameter(myparam, 5.2f, 6.0f, -8.1f);
+    /// \endcode
+    ///
+    /// \param name Name of the parameter in the shader
+    /// \param x    First component of the value to assign
+    /// \param y    Second component of the value to assign
+    /// \param z    Third component of the value to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, float x, float y, float z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 4-components vector parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// 4x1 vector (vec4 GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform vec4 myparam; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// Parameter myparam = shader.getParameter("myparam");
+    /// shader.setParameter(myparam, 5.2f, 6.0f, -8.1f, 0.4f);
+    /// \endcode
+    ///
+    /// \param name Name of the parameter in the shader
+    /// \param x    First component of the value to assign
+    /// \param y    Second component of the value to assign
+    /// \param z    Third component of the value to assign
+    /// \param w    Fourth component of the value to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, float x, float y, float z, float w);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 2-components vector parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// 2x1 vector (vec2 GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform vec2 myparam; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// Parameter myparam = shader.getParameter("myparam");
+    /// shader.setParameter(myparam, sf::Vector2f(5.2f, 6.0f));
+    /// \endcode
+    ///
+    /// \param name   Name of the parameter in the shader
+    /// \param vector Vector to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, const Vector2f& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 3-components vector parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// 3x1 vector (vec3 GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform vec3 myparam; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// Parameter myparam = shader.getParameter("myparam");
+    /// shader.setParameter(myparam, sf::Vector3f(5.2f, 6.0f, -8.1f));
+    /// \endcode
+    ///
+    /// \param name   Name of the parameter in the shader
+    /// \param vector Vector to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, const Vector3f& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a color parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// 4x1 vector (vec4 GLSL type).
+    ///
+    /// It is important to note that the components of the color are
+    /// normalized before being passed to the shader. Therefore,
+    /// they are converted from range [0 .. 255] to range [0 .. 1].
+    /// For example, a sf::Color(255, 125, 0, 255) will be transformed
+    /// to a vec4(1.0, 0.5, 0.0, 1.0) in the shader.
+    ///
+    /// Example:
+    /// \code
+    /// uniform vec4 color; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// Parameter color = shader.getParameter("color");
+    /// shader.setParameter(color, sf::Color(255, 128, 0, 255));
+    /// \endcode
+    ///
+    /// \param name  Name of the parameter in the shader
+    /// \param color Color to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a matrix parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// 4x4 matrix (mat4 GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform mat4 matrix; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// sf::Transform transform;
+    /// transform.Translate(5, 10);
+    /// Parameter matrix = shader.getParameter("matrix");
+    /// shader.setParameter(matrix, transform);
+    /// \endcode
+    ///
+    /// \param name      Name of the parameter in the shader
+    /// \param transform Transform to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, const sf::Transform& transform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a texture parameter of the shader
+    ///
+    /// \a param is a Parameter for the variable to change in the
+    /// shader. The corresponding parameter in the shader must be a
+    /// 2D texture (sampler2D GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform sampler2D the_texture; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// sf::Texture texture;
+    /// ...
+    /// Parameter the_texture = shader.getParameter("the_texture");
+    /// shader.setParameter(the_texture, texture);
+    /// \endcode
+    /// It is important to note that \a texture must remain alive as long
+    /// as the shader uses it, no copy is made internally.
+    ///
+    /// To use the texture of the object being draw, which cannot be
+    /// known in advance, you can pass the special value
+    /// sf::Shader::CurrentTexture:
+    /// \code
+    /// Parameter the_texture = shader.getParameter("the_texture");
+    /// shader.setParameter(the_texture, sf::Shader::CurrentTexture).
+    /// \endcode
+    ///
+    /// \param name    Name of the texture in the shader
+    /// \param texture Texture to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, const Texture& texture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a texture parameter of the shader
+    ///
+    /// This overload maps a shader texture variable to the
+    /// texture of the object being drawn, which cannot be
+    /// known in advance. The second argument must be
+    /// sf::Shader::CurrentTexture.
+    /// The corresponding parameter in the shader must be a 2D texture
+    /// (sampler2D GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform sampler2D current; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// Parameter current = shader.getParameter("current");
+    /// shader.setParameter(current, sf::Shader::CurrentTexture);
+    /// \endcode
+    ///
+    /// \param name Name of the texture in the shader
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(const Parameter &param, CurrentTextureType);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a float parameter of the shader
@@ -474,7 +761,10 @@ public :
     ////////////////////////////////////////////////////////////
     static bool isAvailable();
 
+
 private :
+
+    friend class Parameter;
 
     ////////////////////////////////////////////////////////////
     /// \brief Compile the shader(s) and create the program
@@ -612,5 +902,17 @@ private :
 /// ... render OpenGL geometry ...
 /// shader.unbind();
 /// \endcode
+///
+/// Performance Note:
+///
+/// If you're making enough setParameter calls that you're noticing
+/// it show up as a CPU bottleneck for your GL driver, then you may
+/// want to consider using the setParameter calls that take a Parameter
+/// object instead of a string. By saving and reusing the Parameter
+/// object, you can avoid a hash lookup in the GL driver for each call.
+/// \code
+/// sf::Shader::Parameter param;
+/// param.find("location");
+/// shader.setParameter(location, matrix);
 ///
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -216,6 +216,30 @@ bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& fragme
 
 
 ////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, float x)
+{
+    if (m_shaderProgram)
+    {
+        ensureGlContext();
+
+        // Enable program
+        GLhandleARB program = glGetHandleARB(GL_PROGRAM_OBJECT_ARB);
+        glCheck(glUseProgramObjectARB(m_shaderProgram));
+
+        // Get parameter location and assign it new values
+        GLint location = param.m_location;
+        if (location != -1)
+            glCheck(glUniform1fARB(location, x));
+        else
+            err() << "Invalid parameter" << std::endl;
+
+        // Disable program
+        glCheck(glUseProgramObjectARB(program));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 void Shader::setParameter(const std::string& name, float x)
 {
     if (m_shaderProgram)
@@ -232,6 +256,30 @@ void Shader::setParameter(const std::string& name, float x)
             glCheck(glUniform1fARB(location, x));
         else
             err() << "Parameter \"" << name << "\" not found in shader" << std::endl;
+
+        // Disable program
+        glCheck(glUseProgramObjectARB(program));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, float x, float y)
+{
+    if (m_shaderProgram)
+    {
+        ensureGlContext();
+
+        // Enable program
+        GLhandleARB program = glGetHandleARB(GL_PROGRAM_OBJECT_ARB);
+        glCheck(glUseProgramObjectARB(m_shaderProgram));
+
+        // Get parameter location and assign it new values
+        GLint location = param.m_location;
+        if (location != -1)
+            glCheck(glUniform2fARB(location, x, y));
+        else
+            err() << "Invalid parameter" << std::endl;
 
         // Disable program
         glCheck(glUseProgramObjectARB(program));
@@ -264,6 +312,30 @@ void Shader::setParameter(const std::string& name, float x, float y)
 
 
 ////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, float x, float y, float z)
+{
+    if (m_shaderProgram)
+    {
+        ensureGlContext();
+
+        // Enable program
+        GLhandleARB program = glGetHandleARB(GL_PROGRAM_OBJECT_ARB);
+        glCheck(glUseProgramObjectARB(m_shaderProgram));
+
+        // Get parameter location and assign it new values
+        GLint location = param.m_location;
+        if (location != -1)
+            glCheck(glUniform3fARB(location, x, y, z));
+        else
+            err() << "Invalid parameter" << std::endl;
+
+        // Disable program
+        glCheck(glUseProgramObjectARB(program));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 void Shader::setParameter(const std::string& name, float x, float y, float z)
 {
     if (m_shaderProgram)
@@ -280,6 +352,30 @@ void Shader::setParameter(const std::string& name, float x, float y, float z)
             glCheck(glUniform3fARB(location, x, y, z));
         else
             err() << "Parameter \"" << name << "\" not found in shader" << std::endl;
+
+        // Disable program
+        glCheck(glUseProgramObjectARB(program));
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, float x, float y, float z, float w)
+{
+    if (m_shaderProgram)
+    {
+        ensureGlContext();
+
+        // Enable program
+        GLhandleARB program = glGetHandleARB(GL_PROGRAM_OBJECT_ARB);
+        glCheck(glUseProgramObjectARB(m_shaderProgram));
+
+        // Get parameter location and assign it new values
+        GLint location = param.m_location;
+        if (location != -1)
+            glCheck(glUniform4fARB(location, x, y, z, w));
+        else
+            err() << "Invalid parameter" << std::endl;
 
         // Disable program
         glCheck(glUseProgramObjectARB(program));
@@ -312,9 +408,23 @@ void Shader::setParameter(const std::string& name, float x, float y, float z, fl
 
 
 ////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter &param, const Vector2f& v)
+{
+    setParameter(param, v.x, v.y);
+}
+
+
+////////////////////////////////////////////////////////////
 void Shader::setParameter(const std::string& name, const Vector2f& v)
 {
     setParameter(name, v.x, v.y);
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, const Vector3f& v)
+{
+    setParameter(param, v.x, v.y, v.z);
 }
 
 
@@ -326,9 +436,40 @@ void Shader::setParameter(const std::string& name, const Vector3f& v)
 
 
 ////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, const Color& color)
+{
+    setParameter(param, color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f);
+}
+
+
+////////////////////////////////////////////////////////////
 void Shader::setParameter(const std::string& name, const Color& color)
 {
     setParameter(name, color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f);
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter &param, const sf::Transform& transform)
+{
+    if (m_shaderProgram)
+    {
+        ensureGlContext();
+
+        // Enable program
+        GLhandleARB program = glGetHandleARB(GL_PROGRAM_OBJECT_ARB);
+        glCheck(glUseProgramObjectARB(m_shaderProgram));
+
+        // Get parameter location and assign it new values
+        GLint location = param.m_location;
+        if (location != -1)
+            glCheck(glUniformMatrix4fvARB(location, 1, GL_FALSE, transform.getMatrix()));
+        else
+            err() << "Invalid parameter" << std::endl;
+
+        // Disable program
+        glCheck(glUseProgramObjectARB(program));
+    }
 }
 
 
@@ -356,6 +497,42 @@ void Shader::setParameter(const std::string& name, const sf::Transform& transfor
 }
 
 
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, const Texture& texture)
+{
+    if (m_shaderProgram)
+    {
+        ensureGlContext();
+
+        // Find the location of the variable in the shader
+        int location = param.m_location;
+        if (location == -1)
+        {
+            err() << "Invalid texture parameter" << std::endl;
+            return;
+        }
+
+        // Store the location -> texture mapping
+        TextureTable::iterator it = m_textures.find(location);
+        if (it == m_textures.end())
+        {
+            // New entry, make sure there are enough texture units
+            static const GLint maxUnits = getMaxTextureImageUnits();
+            if (m_textures.size() + 1 >= static_cast<std::size_t>(maxUnits))
+            {
+                err() << "Impossible to use texture for shader: all available texture image units are used" << std::endl;
+                return;
+            }
+
+            m_textures[location] = &texture;
+        }
+        else
+        {
+            // Location already used, just replace the texture
+            it->second = &texture;
+        }
+    }
+}
 ////////////////////////////////////////////////////////////
 void Shader::setParameter(const std::string& name, const Texture& texture)
 {
@@ -390,6 +567,21 @@ void Shader::setParameter(const std::string& name, const Texture& texture)
             // Location already used, just replace the texture
             it->second = &texture;
         }
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const Parameter& param, CurrentTextureType)
+{
+    if (m_shaderProgram)
+    {
+        ensureGlContext();
+
+        // Find the location of the variable in the shader
+        m_currentTexture = param.m_location;
+        if (m_currentTexture == -1)
+            err() << "Invalid parameter" << std::endl;
     }
 }
 
@@ -557,5 +749,38 @@ void Shader::bindTextures() const
     // Make sure that the texture unit which is left active is the number 0
     glCheck(glActiveTextureARB(GL_TEXTURE0_ARB));
 }
+
+
+
+////////////////////////////////////////////////////////////
+Shader::Parameter::Parameter() :
+m_location(-1)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::Parameter::find(const Shader& shader, const std::string& name)
+{
+    if (shader.m_shaderProgram)
+    {
+        shader.ensureGlContext();
+
+        // Find the location of the variable in the shader
+        m_location = glGetUniformLocationARB(shader.m_shaderProgram, name.c_str());
+        if (m_location == -1)
+        {
+            err() << "Parameter \"" << name << "\" not found in shader" << std::endl;
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+
+
+
+
 
 } // namespace sf


### PR DESCRIPTION
I've added caching of GLSL uniform locations to save the overhead of the string hash check in the driver. Not sure if this is something that you're interested in, but I've at least done this much. Feel free to integrate it if it interests you. I won't be offended if you decide not to use it. :)

Oh, and I switched which GL constant is checked for max texture image units. That one is a straight-up fix, from what I can tell. I'd recommend grabbing that commit even if you don't want the parameter cache stuff, since it's typically the difference between using just 8 textures, or as many as the card can actually support.
