### PR TITLE
Speedup for debugging: don't create std::string on every call to glCheckError

### DIFF
--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -34,13 +34,14 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-void glCheckError(const std::string& file, unsigned int line)
+void glCheckError(const char* file, unsigned int line)
 {
     // Get the last error
     GLenum errorCode = glGetError();
 
     if (errorCode != GL_NO_ERROR)
     {
+        std::string fileString(file);
         std::string error = "unknown error";
         std::string description  = "no description";
 
@@ -99,7 +100,7 @@ void glCheckError(const std::string& file, unsigned int line)
 
         // Log the error
         err() << "An internal OpenGL call failed in "
-              << file.substr(file.find_last_of("\\/") + 1) << " (" << line << ") : "
+              << fileString.substr(fileString.find_last_of("\\/") + 1) << " (" << line << ") : "
               << error << ", " << description
               << std::endl;
     }

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -59,7 +59,7 @@ namespace priv
 /// \param line Line number of the source file where the call is located
 ///
 ////////////////////////////////////////////////////////////
-void glCheckError(const std::string& file, unsigned int line);
+void glCheckError(const char* file, unsigned int line);
 
 ////////////////////////////////////////////////////////////
 /// \brief Make sure that GLEW is initialized


### PR DESCRIPTION
Hi,

I was getting ~10 FPS when debugging in VS2012, and doing a performance analysis seems to indicate a lot of the time spent is simply creating std::strings on each call to `sf::priv::glCheckError(__FILE__, __LINE__);`.

This seems really unnecessary as the string is only needed once something actually goes wrong, so I changed it accordingly.

With the patch I get ~100 instead of ~10 FPS when debugging.

Cheers,
--
Christian
