### PR TITLE
64bit integers in sf::Packet (second attempt)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ if(COMPILER_MSVC)
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
 endif()
 
+# define SFML_BIGENDIAN if running on a big endian system
+if(BIGENDIAN)
+    add_definitions(-DSFML_BIGENDIAN)
+endif()
+
 # define an option for choosing between static and dynamic C runtime (Windows only)
 if(WINDOWS)
     sfml_set_option(SFML_USE_STATIC_STD_LIBS FALSE BOOL "TRUE to statically link to the standard libraries, FALSE to use them as DLLs")

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -33,6 +33,15 @@ else()
     return()
 endif()
 
+if(NOT WINDOWS)
+    # test endianness of the system
+    include(TestBigEndian)
+    test_big_endian(ENDIAN)
+    if(${ENDIAN})
+        set(BIGENDIAN 1)
+    endif()
+endif()
+
 # detect the compiler and its version
 # Note: on some platforms (OS X), CMAKE_COMPILER_IS_GNUCXX is true
 # even when CLANG is used, therefore the Clang test is done first

--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -181,6 +181,8 @@ public:
     Packet& operator >>(Uint16&       data);
     Packet& operator >>(Int32&        data);
     Packet& operator >>(Uint32&       data);
+    Packet& operator >>(Int64&        data);
+    Packet& operator >>(Uint64&       data);
     Packet& operator >>(float&        data);
     Packet& operator >>(double&       data);
     Packet& operator >>(char*         data);
@@ -200,6 +202,8 @@ public:
     Packet& operator <<(Uint16              data);
     Packet& operator <<(Int32               data);
     Packet& operator <<(Uint32              data);
+    Packet& operator <<(Int64               data);
+    Packet& operator <<(Uint64              data);
     Packet& operator <<(float               data);
     Packet& operator <<(double              data);
     Packet& operator <<(const char*         data);

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -30,6 +30,24 @@
 #include <SFML/System/String.hpp>
 #include <cstring>
 
+#if defined(WINVER) && WINVER >= 0x0602
+# include <Winsock2.h>
+#else
+# ifdef SFML_BIGENDIAN
+#  define ntohll(x) (x)
+#  define htonll(x) (x)
+# else
+#  if defined(__GNUC__) && defined(__GLIBC__)
+#   include <byteswap.h>
+#  elif defined(_MSC_VER)
+#   define bswap_64(n) _byteswap_uint64((sf::Uint64)(n))
+#  else
+#   define bswap_64(n) (((sf::Uint64)ntohl(n)) << 32) + ntohl((n) >> 32)
+#  endif
+#  define ntohll(x) (bswap_64(x))
+#  define htonll(x) (bswap_64(x))
+# endif
+#endif
 
 namespace sf
 {
@@ -180,6 +198,32 @@ Packet& Packet::operator >>(Uint32& data)
     if (checkSize(sizeof(data)))
     {
         data = ntohl(*reinterpret_cast<const Uint32*>(&m_data[m_readPos]));
+        m_readPos += sizeof(data);
+    }
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+Packet& Packet::operator >>(Int64& data)
+{
+    if (checkSize(sizeof(data)))
+    {
+        data = ntohll(*reinterpret_cast<const Int64*>(&m_data[m_readPos]));
+        m_readPos += sizeof(data);
+    }
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+Packet& Packet::operator >>(Uint64& data)
+{
+    if (checkSize(sizeof(data)))
+    {
+        data = ntohll(*reinterpret_cast<const Uint64*>(&m_data[m_readPos]));
         m_readPos += sizeof(data);
     }
 
@@ -379,6 +423,24 @@ Packet& Packet::operator <<(Int32 data)
 Packet& Packet::operator <<(Uint32 data)
 {
     Uint32 toWrite = htonl(data);
+    append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+Packet& Packet::operator <<(Int64 data)
+{
+    Int64 toWrite = htonll(data);
+    append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+Packet& Packet::operator <<(Uint64 data)
+{
+    Uint64 toWrite = htonll(data);
     append(&toWrite, sizeof(toWrite));
     return *this;
 }


### PR DESCRIPTION
This is a much more stable way of detecting endianness, should fix #208.
