### PR TITLE
Added repeating to sf::RenderTexture

### DIFF
--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -109,6 +109,29 @@ public :
     bool isSmooth() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable texture repeating
+    ///
+    /// This function is similar to Texture::setRepeated.
+    /// This parameter is disabled by default.
+    ///
+    /// \param repeated True to enable repeating, false to disable it
+    ///
+    /// \see isRepeated
+    ///
+    ////////////////////////////////////////////////////////////
+    void setRepeated(bool repeated);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the texture is repeated or not
+    ///
+    /// \return True if texture is repeated
+    ///
+    /// \see setRepeated
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isRepeated() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Activate of deactivate the render-texture for rendering
     ///
     /// This function makes the render-texture's context current for

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -100,6 +100,20 @@ bool RenderTexture::isSmooth() const
 
 
 ////////////////////////////////////////////////////////////
+void RenderTexture::setRepeated(bool repeated)
+{
+    m_texture.setRepeated(repeated);
+}
+
+
+////////////////////////////////////////////////////////////
+bool RenderTexture::isRepeated() const
+{
+    return m_texture.isRepeated();
+}
+
+
+////////////////////////////////////////////////////////////
 bool RenderTexture::setActive(bool active)
 {
     return m_impl && m_impl->activate(active);


### PR DESCRIPTION
Added the missing setRepeated() and isRepeated() methods to sf::RenderTexture. 
I worked on a little project that needed repeated renderTexture's so I added the two methods. It's tested and works. Since it has been requested a couple times on the forum I though I share my code. 
