### PR TITLE
Fix program crashing because of SIGPIPE.

### DIFF
--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -221,7 +221,7 @@ Socket::Status TcpSocket::send(const void* data, std::size_t size)
     for (int length = 0; length < sizeToSend; length += sent)
     {
         // Send a chunk of data
-        sent = ::send(getHandle(), static_cast<const char*>(data) + length, sizeToSend - length, 0);
+        sent = ::send(getHandle(), static_cast<const char*>(data) + length, sizeToSend - length, MSG_NOSIGNAL);
 
         // Check for errors
         if (sent < 0)


### PR DESCRIPTION
When one side of the socket crashes, the other side crashes with `SIGPIPE` when trying to call `sf::TcpSocket::send(...)`. This changes the behavior so that the call to `send` will fail with `sf::Socket::Error`.

```  
Program received signal SIGPIPE, Broken pipe.
```
