### PR TITLE
fix getPosition() function in Linux Window implementation

### DIFF
--- a/src/SFML/Window/Linux/WindowImplX11.cpp
+++ b/src/SFML/Window/Linux/WindowImplX11.cpp
@@ -283,27 +283,20 @@ void WindowImplX11::processEvents()
 ////////////////////////////////////////////////////////////
 Vector2i WindowImplX11::getPosition() const
 {
+	
     ::Window activeWin = m_window;
     ::Window root = ::Window();
     int xCoordinate, yCoordinate;
     uint width, height, border_width, depth;
     ::Window *children;
-    uint childcount;
     
     int x = 0;
     int y = 0;
     
-    while (activeWin != root)
-    {
-        if (XGetGeometry(m_display, activeWin, &root, &xCoordinate, &yCoordinate, &width, &height, &border_width, &depth))
-        {
-            x += xCoordinate;
-            y += yCoordinate;
-        }
-   
-        XQueryTree(m_display, activeWin, &root, &activeWin, &children, &childcount);
-    }
-    
+
+    XGetGeometry(m_display, activeWin, &root, &xCoordinate, &yCoordinate, &width, &height, &border_width, &depth);
+    XTranslateCoordinates(m_display, m_window, root, 0, 0, &x, &y, &activeWin);
+
     return Vector2i(x, y);
 }
 


### PR DESCRIPTION
Bug described here:
https://github.com/LaurentGomila/SFML/issues/346

Fixed 2 things from my patch (which was attached to the issue):
- made tab into 4 spaces
- put open braces on new line
