### PR TITLE
Support for debug contexts (Win32 and Linux only)

### DIFF
--- a/include/SFML/Window/ContextSettings.hpp
+++ b/include/SFML/Window/ContextSettings.hpp
@@ -43,14 +43,16 @@ struct ContextSettings
     /// \param antialiasing Antialiasing level
     /// \param major        Major number of the context version
     /// \param minor        Minor number of the context version
+    /// \param debug        Context debug flag
     ///
     ////////////////////////////////////////////////////////////
-    explicit ContextSettings(unsigned int depth = 0, unsigned int stencil = 0, unsigned int antialiasing = 0, unsigned int major = 2, unsigned int minor = 0) :
+    explicit ContextSettings(unsigned int depth = 0, unsigned int stencil = 0, unsigned int antialiasing = 0, unsigned int major = 2, unsigned int minor = 0, bool debug = false) :
     depthBits        (depth),
     stencilBits      (stencil),
     antialiasingLevel(antialiasing),
     majorVersion     (major),
-    minorVersion     (minor)
+    minorVersion     (minor),
+    debug            (debug)
     {
     }
 
@@ -62,6 +64,7 @@ struct ContextSettings
     unsigned int antialiasingLevel; ///< Level of antialiasing
     unsigned int majorVersion;      ///< Major number of the context version to create
     unsigned int minorVersion;      ///< Minor number of the context version to create
+    bool debug;                     ///< Debug context flag
 };
 
 } // namespace sf

--- a/src/SFML/Window/Linux/GlxContext.cpp
+++ b/src/SFML/Window/Linux/GlxContext.cpp
@@ -249,6 +249,7 @@ void GlxContext::createContext(GlxContext* shared, unsigned int bitsPerPixel, co
                     GLX_CONTEXT_MAJOR_VERSION_ARB, static_cast<int>(m_settings.majorVersion),
                     GLX_CONTEXT_MINOR_VERSION_ARB, static_cast<int>(m_settings.minorVersion),
                     GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+                    GLX_CONTEXT_FLAGS_ARB, (m_settings.debug ? GLX_CONTEXT_DEBUG_BIT_ARB : 0),
                     0, 0
                 };
                 m_context = glXCreateContextAttribsARB(m_display, configs[0], toShare, true, attributes);

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -270,6 +270,7 @@ void WglContext::createContext(WglContext* shared, unsigned int bitsPerPixel, co
                 WGL_CONTEXT_MAJOR_VERSION_ARB, m_settings.majorVersion,
                 WGL_CONTEXT_MINOR_VERSION_ARB, m_settings.minorVersion,
                 WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+                WGL_CONTEXT_FLAGS_ARB, (m_settings.debug ? WGL_CONTEXT_DEBUG_BIT_ARB : 0),
                 0, 0
             };
             m_context = wglCreateContextAttribsARB(m_deviceContext, sharedContext, attributes);


### PR DESCRIPTION
ContextSettings::debug will result in a debug context on Win32 and Linux.
MacOS seems to have no method of creating a debug context, so it does nothing there.

As per above, it's impossible to support this under MacOS, but the functionality is useful enough elsewhere (and I'd rather not maintain a fork).

Additionally, it might be an idea to add an err() for attempting to use this with a major version below 3, and on OS X.
