### PR TITLE
Added operator for division of two sf::Time objects

### DIFF
--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -401,6 +401,18 @@ SFML_SYSTEM_API Time& operator /=(Time& left, Int64 right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Time
+/// \brief Overload of binary / operator to compute the ratio of two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API float operator /(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
 /// \brief Overload of binary % operator to compute remainder of a time value
 ///
 /// \param left  Left operand (a time)

--- a/src/SFML/System/Time.cpp
+++ b/src/SFML/System/Time.cpp
@@ -238,6 +238,13 @@ Time& operator /=(Time& left, Int64 right)
 
 
 ////////////////////////////////////////////////////////////
+float operator /(Time left, Time right)
+{
+    return left.asSeconds() / right.asSeconds();
+}
+
+
+////////////////////////////////////////////////////////////
 Time operator %(Time left, Time right)
 {
     return microseconds(left.asMicroseconds() % right.asMicroseconds());


### PR DESCRIPTION
Division operator that computes the ratio between two sf::Time objects.

Discussion: http://en.sfml-dev.org/forums/index.php?topic=12261
