### PR TITLE
Fixed mouse clicks not activating windows (Win32)

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -194,6 +194,14 @@ private :
     void processEvent(UINT message, WPARAM wParam, LPARAM lParam);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Enables or disables tracking for the mouse cursor leaving the window
+    ///
+    /// \param track True to enable, false to disable
+    ///
+    ////////////////////////////////////////////////////////////
+    void setTracking(bool track);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Convert a Win32 virtual key code to a SFML key code
     ///
     /// \param key   Virtual key code to convert
@@ -237,8 +245,9 @@ private :
     HICON    m_icon;             ///< Custom icon assigned to the window
     bool     m_keyRepeatEnabled; ///< Automatic key-repeat state for keydown events
     Vector2u m_lastSize;         ///< The last handled size of the window
-    bool     m_resizing;         ///< Is the window being resized ?
+    bool     m_resizing;         ///< Is the window being resized?
     Uint16   m_surrogate;        ///< First half of the surrogate pair, in case we're receiving a Unicode character in two events
+    bool     m_mouseInside;      ///< Mouse is inside the window?
 };
 
 } // namespace priv


### PR DESCRIPTION
- This fixes issue #437, except Alt+F4, which would be a different issue?
- This is essentially based around @All8Up's suggestion.
- The new member variable `m_focused` is meant to be exposed later on so the user is able to determine whether the window is active without doing separate event tracking.
- Activating mouse clicks aren't passed to the event queue. This is something not really consistent across games or applications in general, but I prefer this behavior (avoids triggering anything by accident).
