### PR TITLE
Fixed VS 2005 CMake issue and added support for TDM and VS 2013 compilers.

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -36,15 +36,17 @@ endif()
 # Note: on some platforms (OS X), CMAKE_COMPILER_IS_GNUCXX is true
 # even when CLANG is used, therefore the Clang test is done first
 if(CMAKE_CXX_COMPILER MATCHES ".*clang[+][+]" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-   # CMAKE_CXX_COMPILER_ID is an internal CMake variable subject to change,
-   # but there is no other way to detect CLang at the moment
-   set(SFML_COMPILER_CLANG 1)
-   execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "--version" OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
-   string(REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" SFML_CLANG_VERSION "${CLANG_VERSION_OUTPUT}")
+    # CMAKE_CXX_COMPILER_ID is an internal CMake variable subject to change,
+    # but there is no other way to detect CLang at the moment
+    set(SFML_COMPILER_CLANG 1)
+    execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "--version" OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
+    string(REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" SFML_CLANG_VERSION "${CLANG_VERSION_OUTPUT}")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
     set(SFML_COMPILER_GCC 1)
     execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "-dumpversion" OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
     string(REGEX REPLACE "([0-9]+\\.[0-9]+).*" "\\1" SFML_GCC_VERSION "${GCC_VERSION_OUTPUT}")
+    execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "--version" OUTPUT_VARIABLE GCC_COMPILER_VERSION)
+    string(REGEX MATCHALL ".*(tdm[64]*-[1-9]).*" SFML_COMPILER_GCC_TDM "${GCC_COMPILER_VERSION}")
     execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "-dumpmachine" OUTPUT_VARIABLE GCC_MACHINE)
     string(STRIP "${GCC_MACHINE}" GCC_MACHINE)
     if(${GCC_MACHINE} MATCHES ".*w64.*")
@@ -60,6 +62,8 @@ elseif(MSVC)
         set(SFML_MSVC_VERSION 2010)
     elseif(MSVC_VERSION EQUAL 1700)
         set(SFML_MSVC_VERSION 2011)
+    elseif(MSVC_VERSION EQUAL 1800)
+        set(SFML_MSVC_VERSION 2012)
     endif()
 else()
     message(FATAL_ERROR "Unsupported compiler")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -99,9 +99,11 @@ macro(sfml_add_library target)
     set_target_properties(${target} PROPERTIES FOLDER "SFML")
 
     # for gcc >= 4.0 on Windows, apply the SFML_USE_STATIC_STD_LIBS option if it is enabled
-    if(SFML_OS_WINDOWS AND SFML_COMPILER_GCC AND SFML_USE_STATIC_STD_LIBS)
-        if(NOT SFML_GCC_VERSION VERSION_LESS "4")
+    if(SFML_OS_WINDOWS AND SFML_COMPILER_GCC AND NOT SFML_GCC_VERSION VERSION_LESS "4")
+        if(SFML_USE_STATIC_STD_LIBS AND NOT SFML_COMPILER_GCC_TDM)
             set_target_properties(${target} PROPERTIES LINK_FLAGS "-static-libgcc -static-libstdc++")
+        elseif(NOT SFML_USE_STATIC_STD_LIBS AND SFML_COMPILER_GCC_TDM)
+            set_target_properties(${target} PROPERTIES LINK_FLAGS "-shared-libgcc -shared-libstdc++")
         endif()
     endif()
 
@@ -182,9 +184,11 @@ macro(sfml_add_example target)
     set_target_properties(${target} PROPERTIES FOLDER "Examples")
 
     # for gcc >= 4.0 on Windows, apply the SFML_USE_STATIC_STD_LIBS option if it is enabled
-    if(SFML_OS_WINDOWS AND SFML_COMPILER_GCC AND SFML_USE_STATIC_STD_LIBS)
-        if(NOT SFML_GCC_VERSION VERSION_LESS "4")
+    if(SFML_OS_WINDOWS AND SFML_COMPILER_GCC AND NOT SFML_GCC_VERSION VERSION_LESS "4")
+        if(SFML_USE_STATIC_STD_LIBS AND NOT SFML_COMPILER_GCC_TDM)
             set_target_properties(${target} PROPERTIES LINK_FLAGS "-static-libgcc -static-libstdc++")
+        elseif(NOT SFML_USE_STATIC_STD_LIBS AND SFML_COMPILER_GCC_TDM)
+            set_target_properties(${target} PROPERTIES LINK_FLAGS "-shared-libgcc -shared-libstdc++")
         endif()
     endif()
 


### PR DESCRIPTION
There was a missing change from the latest CMake file changes for VS 2005.
TDM should now correctly build shared when shared is selected and static when static is selected.
VS 2013 should now get recognized by SFML.
