### PR TITLE
Fix 'instanciate' typo; correct is 'instantiate'

### DIFF
--- a/include/SFML/Audio/Listener.hpp
+++ b/include/SFML/Audio/Listener.hpp
@@ -167,7 +167,7 @@ public :
 /// and to adjust the global volume.
 ///
 /// Because the listener is unique in the scene, sf::Listener only
-/// contains static functions and doesn't have to be instanciated.
+/// contains static functions and doesn't have to be instantiated.
 ///
 /// Usage example:
 /// \code

--- a/include/SFML/System/Utf.hpp
+++ b/include/SFML/System/Utf.hpp
@@ -752,7 +752,7 @@ typedef Utf<32> Utf32;
 /// to handle ANSI, wide, latin-1, UTF-8, UTF-16 and UTF-32 encodings.
 ///
 /// sf::Utf<X> functions are all static, these classes are not meant to
-/// be instanciated. All the functions are template, so that you
+/// be instantiated. All the functions are template, so that you
 /// can use any character / string type for a given encoding.
 ///
 /// It has 3 specializations:

--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -153,7 +153,7 @@ public :
 ///
 /// sf::Joystick provides an interface to the state of the
 /// joysticks. It only contains static functions, so it's not
-/// meant to be instanciated. Instead, each joystick is identified
+/// meant to be instantiated. Instead, each joystick is identified
 /// by an index that is passed to the functions of this class.
 ///
 /// This class allows users to query the state of joysticks at any

--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -176,7 +176,7 @@ public :
 ///
 /// sf::Keyboard provides an interface to the state of the
 /// keyboard. It only contains static functions (a single
-/// keyboard is assumed), so it's not meant to be instanciated.
+/// keyboard is assumed), so it's not meant to be instantiated.
 ///
 /// This class allows users to query the keyboard state at any
 /// time and directly, without having to deal with a window and

--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -129,7 +129,7 @@ public :
 ///
 /// sf::Mouse provides an interface to the state of the
 /// mouse. It only contains static functions (a single
-/// mouse is assumed), so it's not meant to be instanciated.
+/// mouse is assumed), so it's not meant to be instantiated.
 ///
 /// This class allows users to query the mouse state at any
 /// time and directly, without having to deal with a window and

--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -97,7 +97,7 @@ void alCheckError(const std::string& file, unsigned int line)
 ////////////////////////////////////////////////////////////
 void ensureALInit()
 {
-    // The audio device is instanciated on demand rather than at global startup,
+    // The audio device is instantiated on demand rather than at global startup,
     // which solves a lot of weird crashes and errors.
     // It is destroyed at global exit which is fine.
 


### PR DESCRIPTION
This fixes all occurrences of "instanciate" which is a common misspelling of "instantiate". An object is an _instance_ of a class that we _instantiate_.
#### Sources

TFD entry: http://www.thefreedictionary.com/instantiate
Unsurprisingly, http://www.thefreedictionary.com/instanciate doesn't load.

Wiktionary article on "instanciate": http://en.wiktionary.org/wiki/instanciate
It states: "Common misspelling of instantiate."
