### PR TITLE
Add mipmaps to sf::Texture

### DIFF
--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -109,7 +109,7 @@ public :
     /// of the whole image. If you want the entire image then leave
     /// the default value (which is an empty IntRect).
     /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size. 
+    /// is adjusted to fit the image size.
     ///
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
@@ -140,7 +140,7 @@ public :
     /// of the whole image. If you want the entire image then leave
     /// the default value (which is an empty IntRect).
     /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size. 
+    /// is adjusted to fit the image size.
     ///
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
@@ -172,7 +172,7 @@ public :
     /// of the whole image. If you want the entire image then leave
     /// the default value (which is an empty IntRect).
     /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size. 
+    /// is adjusted to fit the image size.
     ///
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
@@ -196,7 +196,7 @@ public :
     /// of the whole image. If you want the entire image then leave
     /// the default value (which is an empty IntRect).
     /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size. 
+    /// is adjusted to fit the image size.
     ///
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
@@ -377,6 +377,80 @@ public :
     bool isSmooth() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Enable creation and use of mipmaps or disable mipmap filtering
+    ///
+    /// When the mipmap filter is activated, the texture appears with
+    /// less artifacts like moire patterns or popping in pixels on a
+    /// minified texture that gets moved or rotated.
+    /// It does not affect a texture when it is magnified.
+    /// You would activate mipmaps before the last time you are calling
+    /// a create, update or load method, because on some old computers
+    /// they can not be generated without changing the pixel values. This
+    /// depends on available OpenGL version and extensions.
+    /// When setting this to 1 each time a texel would be read a single
+    /// mipmap would be chosen; when setting this to 2 the two nearest
+    /// mipmaps will be read and a linear interpolation happens.
+    /// The smooth filter determines how the filtering is done within a mipmap.
+    /// Even if you don't activate smoothing the mipmaping will improve
+    /// the quality of a largely minified texture, while at same time
+    /// keeping the original appearance on magnification.
+    /// If you never resize the texture and never have a shape in
+    /// a different size than the texture mipmaping is not needed
+    /// and would result in a higher amount of used memory.
+    /// When activating it once for a texture you would usually keep it
+    /// active as long as you dont change the pixels, as the mipmaps are
+    /// already generated and will not be deleted from the texture.
+    /// The mipmap filtering is disabled by default.
+    ///
+    /// \param mipmaps 0 to disable it, 1 or 2 to choose number of mipmap reads
+    ///
+    /// \see getUsedMipmaps, getRequestedMipmaps, hasMipmaps
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUsedMipmaps(unsigned int mipmaps);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell how many mipmaps are used currently
+    ///
+    /// This method lets you find out if mipmaps are activated.
+    /// It combines checking that both hasMipmaps is true and
+    /// getRequestedMipmaps is greater than 0.
+    ///
+    /// \return 0 if disabled, 1 or 2 if that many mipmaps should be used
+    ///
+    /// \see setUsedMipmaps, getRequestedMipmaps, hasMipmaps
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint8 getUsedMipmaps() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell how many mipmaps should be used
+    ///
+    /// This method does only tell if mipmaps were requested and OpenGL
+    /// functionality is available. To find out if they are activated
+    /// check getUsedMipmaps.
+    ///
+    /// \return 0 if disabled, 1 or 2 if that many mipmaps should be used
+    ///
+    /// \see setUsedMipmaps, getUsedMipmaps, hasMipmaps
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint8 getRequestedMipmaps() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether mipmaps are both generated and updated or not
+    ///
+    /// This method is not sufficient to tell if the mipmaps are
+    /// activated currently. For that please check getUsedMipmaps.
+    ///
+    /// \return True if up to date mipmaps are available, false if not
+    ///
+    /// \see setUsedMipmaps, getUsedMipmaps, getRequestedMipmaps
+    ///
+    ////////////////////////////////////////////////////////////
+    bool hasMipmaps() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Enable or disable repeating
     ///
     /// Repeating is involved when using texture coordinates
@@ -491,6 +565,8 @@ private :
     Vector2u     m_size;          ///< Public texture size
     Vector2u     m_actualSize;    ///< Actual texture size (can be greater than public size because of padding)
     unsigned int m_texture;       ///< Internal texture identifier
+    Int8         m_statusMipmaps; ///< Status of the mipmap generation
+    Uint8        m_needsMipmaps;  ///< User wants mipmap filtering using this many mipmap reads
     bool         m_isSmooth;      ///< Status of the smooth filter
     bool         m_isRepeated;    ///< Is the texture in repeat mode?
     mutable bool m_pixelsFlipped; ///< To work around the inconsistency in Y orientation
@@ -529,7 +605,7 @@ private :
 /// before creating the final texture, you can load your file to a
 /// sf::Image, do whatever you need with the pixels, and then call
 /// Texture::loadFromImage.
-/// 
+///
 /// Since they live in the graphics card memory, the pixels of a texture
 /// cannot be accessed without a slow copy first. And they cannot be
 /// accessed individually. Therefore, if you need to read the texture's

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -59,6 +59,8 @@ Texture::Texture() :
 m_size         (0, 0),
 m_actualSize   (0, 0),
 m_texture      (0),
+m_statusMipmaps(0),
+m_needsMipmaps (0),
 m_isSmooth     (false),
 m_isRepeated   (false),
 m_pixelsFlipped(false),
@@ -73,6 +75,8 @@ Texture::Texture(const Texture& copy) :
 m_size         (0, 0),
 m_actualSize   (0, 0),
 m_texture      (0),
+m_statusMipmaps(copy.m_statusMipmaps > 0 ? -copy.m_statusMipmaps : copy.m_statusMipmaps),
+m_needsMipmaps (copy.m_needsMipmaps),
 m_isSmooth     (copy.m_isSmooth),
 m_isRepeated   (copy.m_isRepeated),
 m_pixelsFlipped(false),
@@ -145,8 +149,22 @@ bool Texture::create(unsigned int width, unsigned int height)
     glCheck(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, m_actualSize.x, m_actualSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, m_isRepeated ? GL_REPEAT : GL_CLAMP_TO_EDGE));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, m_isRepeated ? GL_REPEAT : GL_CLAMP_TO_EDGE));
+    if (m_statusMipmaps > 0)
+        m_statusMipmaps = -m_statusMipmaps;
+    if (m_statusMipmaps == -2)
+    {
+        glCheck(glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, m_needsMipmaps ? GL_TRUE : GL_FALSE));
+        if (m_needsMipmaps != 0)
+            m_statusMipmaps = 2;
+    }
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
-    glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
+    glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                            m_isSmooth ? (m_needsMipmaps==0 ? GL_LINEAR
+                                                            : (m_needsMipmaps==1 ? GL_LINEAR_MIPMAP_NEAREST
+                                                                                 : GL_LINEAR_MIPMAP_LINEAR))
+                                       : (m_needsMipmaps==0 ? GL_NEAREST
+                                                            : (m_needsMipmaps==1 ? GL_NEAREST_MIPMAP_NEAREST
+                                                                                 : GL_NEAREST_MIPMAP_LINEAR))));
     m_cacheId = getUniqueId();
 
     return true;
@@ -334,6 +352,16 @@ void Texture::update(const Uint8* pixels, unsigned int width, unsigned int heigh
         // Copy pixels from the given array to the texture
         glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
         glCheck(glTexSubImage2D(GL_TEXTURE_2D, 0, x, y, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
+        // Use this chance to activate mipmaps if requested and still needed
+        if (m_needsMipmaps != 0 && m_statusMipmaps == -2)
+        {
+            m_statusMipmaps = -m_statusMipmaps;
+            glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                    m_isSmooth ? (m_needsMipmaps==1 ? GL_LINEAR_MIPMAP_NEAREST
+                                                                    : GL_LINEAR_MIPMAP_LINEAR)
+                                               : (m_needsMipmaps==1 ? GL_NEAREST_MIPMAP_NEAREST
+                                                                    : GL_NEAREST_MIPMAP_LINEAR)));
+        }
         m_pixelsFlipped = false;
         m_cacheId = getUniqueId();
     }
@@ -376,6 +404,16 @@ void Texture::update(const Window& window, unsigned int x, unsigned int y)
         // Copy pixels from the back-buffer to the texture
         glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
         glCheck(glCopyTexSubImage2D(GL_TEXTURE_2D, 0, x, y, 0, 0, window.getSize().x, window.getSize().y));
+        // Use this chance to activate mipmaps if requested and still needed
+        if (m_needsMipmaps != 0 && m_statusMipmaps == -2)
+        {
+            m_statusMipmaps = -m_statusMipmaps;
+            glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                    m_isSmooth ? (m_needsMipmaps==1 ? GL_LINEAR_MIPMAP_NEAREST
+                                                                    : GL_LINEAR_MIPMAP_LINEAR)
+                                               : (m_needsMipmaps==1 ? GL_NEAREST_MIPMAP_NEAREST
+                                                                    : GL_NEAREST_MIPMAP_LINEAR)));
+        }
         m_pixelsFlipped = true;
         m_cacheId = getUniqueId();
     }
@@ -397,8 +435,18 @@ void Texture::setSmooth(bool smooth)
             priv::TextureSaver save;
 
             glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
-            glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
-            glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
+            glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+                                    m_isSmooth ? GL_LINEAR : GL_NEAREST));
+            // Make sure to only change the smoothing part of the texture parameter
+            if (m_needsMipmaps != 0 && m_statusMipmaps > 0)
+                glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                        m_isSmooth ? (m_needsMipmaps==1 ? GL_LINEAR_MIPMAP_NEAREST
+                                                                        : GL_LINEAR_MIPMAP_LINEAR)
+                                                   : (m_needsMipmaps==1 ? GL_NEAREST_MIPMAP_NEAREST
+                                                                        : GL_NEAREST_MIPMAP_LINEAR)));
+            else
+                glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                        m_isSmooth ? GL_LINEAR : GL_NEAREST));
         }
     }
 }
@@ -408,6 +456,89 @@ void Texture::setSmooth(bool smooth)
 bool Texture::isSmooth() const
 {
     return m_isSmooth;
+}
+
+
+////////////////////////////////////////////////////////////
+void Texture::setUsedMipmaps(unsigned int mipmaps)
+{
+    // Stop if we know already its not supported
+    if (m_statusMipmaps == -1)
+      return;
+
+    // Check for mipmap availability if not done already
+    if (m_statusMipmaps == 0)
+    {
+        ensureGlContext();
+
+        // Make sure that GLEW is initialized
+        priv::ensureGlewInit();
+
+        if (GLEW_VERSION_1_4 || GLEW_SGIS_generate_mipmap)
+            m_statusMipmaps = -2;
+        else
+        {
+            m_statusMipmaps = -1;
+            m_needsMipmaps = 0;
+            return;
+        }
+    }
+
+    if (mipmaps != m_needsMipmaps)
+    {
+        if (mipmaps >= 2)
+            m_needsMipmaps = 2;
+        else
+            m_needsMipmaps = mipmaps;
+        if (m_texture)
+        {
+            ensureGlContext();
+
+            // Make sure that the current texture binding will be preserved
+            priv::TextureSaver save;
+
+            glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+            // Update mipmap generation as needed
+            glCheck(glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, m_needsMipmaps ? GL_TRUE : GL_FALSE));
+            if (m_needsMipmaps != 0 && m_statusMipmaps > 0)
+            {
+                // We need mipmaps and have them already, use them now
+                glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                        m_isSmooth ? (m_needsMipmaps==1 ? GL_LINEAR_MIPMAP_NEAREST
+                                                                        : GL_LINEAR_MIPMAP_LINEAR)
+                                                   : (m_needsMipmaps==1 ? GL_NEAREST_MIPMAP_NEAREST
+                                                                        : GL_NEAREST_MIPMAP_LINEAR)));
+            }
+            else
+            {
+                // Deactivate mipmaps to wait with using for a pixel update to prevent errors
+                // or just because it is requested
+                glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+                                        m_isSmooth ? GL_LINEAR : GL_NEAREST));
+            }
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+Uint8 Texture::getUsedMipmaps() const
+{
+    return m_statusMipmaps > 0 ? m_needsMipmaps : 0;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint8 Texture::getRequestedMipmaps() const
+{
+    return m_needsMipmaps;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Texture::hasMipmaps() const
+{
+    return m_statusMipmaps > 0;
 }
 
 
@@ -516,6 +647,8 @@ Texture& Texture::operator =(const Texture& right)
     std::swap(m_size,          temp.m_size);
     std::swap(m_actualSize,    temp.m_actualSize);
     std::swap(m_texture,       temp.m_texture);
+    std::swap(m_statusMipmaps, temp.m_statusMipmaps),
+    std::swap(m_needsMipmaps,  temp.m_needsMipmaps),
     std::swap(m_isSmooth,      temp.m_isSmooth);
     std::swap(m_isRepeated,    temp.m_isRepeated);
     std::swap(m_pixelsFlipped, temp.m_pixelsFlipped);


### PR DESCRIPTION
I think not having mipmaps in SFML is something that needs to be changed, because it helps when using setScale and when putting a larger texture onto a smaller sized shape.
As I liked to have it myself I added this to sf::Texture and it should also fix Issue #123 .
I made it such that its backwards compatible and keeps deactivated until used. When not used it just adds a check of a status variable on some method calls. Its possible to use all underlying modes in combination with the smooth setting.
This uses the texture parameter to generate the mipmaps.
It looks like its working for me, but you would probably want to test it before applying.

PS:
I also put some effort into adding code for using the newer glGenerateMipmapExt and glGenerateMipmap and making mipmaps available for the internal texture of sf::RenderTexture. You can view those other commits in my forked repository at https://github.com/wintertime/SFML/tree/mipmaps .
I did not include those here, because I get graphical glitches sometimes although other times it looks like it works. I think there is either something wrong with the order of calls to the OpenGL functions or I experienced the driver bug mentioned on http://www.opengl.org/wiki/Common_Mistakes#Automatic_mipmap_generation .

Here is a small test program for trying it out, you can change a few parameters in the code and then look at a larger area of the texture squeezed into the window by pressing Numpad6 so you can watch the effect of mipmaps:

```C++
#include "SFML/Graphics.hpp"
#include <vector>

int32_t windowx(512);
int32_t windowy(512);
bool fullscreen(false);

void CreateTexture(sf::Texture& tex,int sz,int w,int b) {
  std::vector<sf::Uint8> pix;
  pix.resize(sz*sz*4);
  for(int y(0);y<sz;y+=w+b) {
    int ty(0);
    for(;ty<w && y+ty<sz;++ty)
      for(int x(0);x<sz;x+=w+b) {
        int tx(0);
        for(;tx<w && x+tx<sz;++tx) {
          int index=((y+ty)*sz+(x+tx))*4;
          pix[index  ]=255;
          pix[index+1]=0;
          pix[index+2]=0;
          pix[index+3]=255;
        }
        for(;tx<w+b && x+tx<sz;++tx) {
          int index=((y+ty)*sz+(x+tx))*4;
          pix[index  ]=0;
          pix[index+1]=255;
          pix[index+2]=0;
          pix[index+3]=255;
        }
      }
    for(;ty<w+b && y+ty<sz;++ty)
      for(int x(0);x<sz;x+=w+b) {
        int tx(0);
        for(;tx<w && x+tx<sz;++tx) {
          int index=((y+ty)*sz+(x+tx))*4;
          pix[index  ]=0;
          pix[index+1]=0;
          pix[index+2]=0;
          pix[index+3]=255;
        }
        for(;tx<w+b && x+tx<sz;++tx) {
          int index=((y+ty)*sz+(x+tx))*4;
          pix[index  ]=0;
          pix[index+1]=0;
          pix[index+2]=255;
          pix[index+3]=255;
        }
      }
  }
  sf::Image img;
  img.create(sz,sz,&pix[0]);
  tex.loadFromImage(img);
}

int main(int argc,char* argv[]) {
  sf::RenderWindow window(sf::VideoMode(windowx,windowy),"Test",
                    fullscreen ? sf::Style::Fullscreen : sf::Style::Default,
                    sf::ContextSettings(0,0,0,2,1));
  window.setVerticalSyncEnabled(1);

  sf::Texture tex;
  float scale(1.0f);
  int sz(512);
  int w(128);
  int b(128);

  //tex.setSmooth(true);
  tex.setUsedMipmaps(2);
  tex.setRepeated(true);
  CreateTexture(tex,sz,w,b);

  sf::Event event;
  while(window.isOpen()) {
    window.clear();
    sf::RectangleShape shape(sf::Vector2f(512,512));
    shape.setTexture(&tex);
    shape.setTextureRect(sf::IntRect(0,0,sz*scale,sz*scale));
    window.draw(shape);
    window.display();

    while(window.pollEvent(event)) {
      if(event.type==sf::Event::Closed)
        window.close();
      else if(event.type==sf::Event::KeyPressed) {
        switch(event.key.code) {
        default:
          continue;
        case sf::Keyboard::Numpad6:
          scale*=1.1f;
          continue;
        case sf::Keyboard::Numpad5:
          scale=1.0f;
          continue;
        case sf::Keyboard::Numpad4:
          scale/=1.1f;
          continue;
        case sf::Keyboard::Numpad9:
          sz*=2;
          break;
        case sf::Keyboard::Numpad3:
          sz/=2;
          if(sz<1)
            sz=1;
          break;
        case sf::Keyboard::Numpad7:
          if(w<sz/2)
            w*=2;
          break;
        case sf::Keyboard::Numpad1:
          w/=2;
          if(w<1)
            w=1;
          break;
        case sf::Keyboard::Numpad8:
          if(b<sz/2)
            b*=2;
          break;
        case sf::Keyboard::Numpad2:
          b/=2;
          if(b<1)
            b=1;
          break;
        }
        CreateTexture(tex,sz,w,b);
      }
    }
  }

  return 0;
}
```