### PR TITLE
Enable Texture Unit 0 in resetGLStates

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -293,11 +293,9 @@ void RenderTarget::resetGLStates()
         // Make sure that GLEW is initialized
         priv::ensureGlewInit();
 
-        // Explicitly reset texture unit 0
-        glClientActiveTexture(GL_TEXTURE0);
-        glActiveTexture(GL_TEXTURE0);
-
         // Define the default OpenGL states
+        glCheck(glClientActiveTexture(GL_TEXTURE0));
+        glCheck(glActiveTexture(GL_TEXTURE0));
         glCheck(glDisable(GL_CULL_FACE));
         glCheck(glDisable(GL_LIGHTING));
         glCheck(glDisable(GL_DEPTH_TEST));


### PR DESCRIPTION
When we combine a 3D engine which uses multiple texture units (such as Horde3D) with SFML graphics API, SFML's textures won't show up. This is discussed in this [topic](http://en.sfml-dev.org/forums/index.php?topic=11151). 

The issue is that Horde3D does not reset texture unit 0 as the active texture unit when finishing rendering (see [here](https://github.com/horde3d/Horde3D/blob/master/Horde3D/Source/Horde3DEngine/egRendererBase.cpp#L1380))

The fix is simple: (re)activate texture unit 0 before rendering with SFML, i.e. when resetting GL states.

I made a [complete example](https://github.com/ColinDuquesnoy/sfml-horde3D-example) (based on the Horde3D chicago sample). Pre-compiled binaries for Windows are available in the [release section](https://github.com/ColinDuquesnoy/sfml-horde3D-example/releases) if you want to try it out by yourself.

Here is the output **without the fix**:

![notworking](https://f.cloud.github.com/assets/1681217/1850336/ba12fe6e-76ce-11e3-9a66-bb5f0fff878f.png)

And here is the output **with the fix**:

![working](https://f.cloud.github.com/assets/1681217/1850340/e1fb3d74-76ce-11e3-9635-45f74ebb5e72.png)

As you can see, SFML and Horde3D can play nicely together ;) I have tried the example on Windows 7, Windows Xp and Ubuntu 13.10 (using gcc 4.8)

I have hesitated a lot about whether to post the fix here or on the Horde3D bug-tracker but resetGLStates seems like the perfect place for this job.
