### PR TITLE
Adds name, manufacturer ID and product ID for joysticks.

### DIFF
--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
+#include <SFML/System/String.hpp>
 
 
 namespace sf
@@ -66,6 +67,19 @@ public :
         V,    ///< The V axis
         PovX, ///< The X axis of the point-of-view hat
         PovY  ///< The Y axis of the point-of-view hat
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure holding a joystick's identification
+    ///
+    ////////////////////////////////////////////////////////////
+    struct Identification
+    {
+        Identification();
+
+        sf::String   name;      ///< Name of the joystick
+        unsigned int vendorId;  ///< Manufacturer identifier
+        unsigned int productId; ///< Product identifier
     };
 
     ////////////////////////////////////////////////////////////
@@ -128,6 +142,16 @@ public :
     ///
     ////////////////////////////////////////////////////////////
     static float getAxisPosition(unsigned int joystick, Axis axis);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the joystick information
+    ///
+    /// \param joystick Index of the joystick
+    ///
+    /// \return Structure containing joystick information.
+    ///
+    ////////////////////////////////////////////////////////////
+    static Identification getIdentification(unsigned int joystick);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the states of all joysticks

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -49,9 +49,9 @@ if(SFML_OS_WINDOWS)
         ${SRCROOT}/Win32/WindowImplWin32.hpp
     )
     source_group("windows" FILES ${PLATFORM_SRC})
-    
+
     # make sure that we use the Unicode version of the Win API functions
-    add_definitions(-DUNICODE)
+    add_definitions(-DUNICODE -D_UNICODE)
 elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD)
     set(PLATFORM_SRC
         ${SRCROOT}/Unix/Display.cpp
@@ -136,7 +136,7 @@ set(WINDOW_EXT_LIBS ${OPENGL_gl_LIBRARY})
 if(SFML_OS_WINDOWS)
     set(WINDOW_EXT_LIBS ${WINDOW_EXT_LIBS} winmm gdi32)
 elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD)
-    set(WINDOW_EXT_LIBS ${WINDOW_EXT_LIBS} ${X11_X11_LIB} ${X11_Xrandr_LIB})
+    set(WINDOW_EXT_LIBS ${WINDOW_EXT_LIBS} ${X11_X11_LIB} ${X11_Xrandr_LIB} udev)
     if(SFML_OS_FREEBSD)
         set(WINDOW_EXT_LIBS ${WINDOW_EXT_LIBS} usbhid)
     endif()

--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -320,6 +320,13 @@ JoystickCaps JoystickImpl::getCapabilities() const
 
 
 ////////////////////////////////////////////////////////////
+Identifcation JoystickImpl::getIdentification() const
+{
+    return m_identification;
+}
+
+
+////////////////////////////////////////////////////////////
 JoystickState JoystickImpl::JoystickImpl::update()
 {
     while (read(m_file, m_buffer, m_length) == m_length) {

--- a/src/SFML/Window/FreeBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.hpp
@@ -92,6 +92,14 @@ public :
     JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the joystick identification
+    ///
+    /// \return Joystick identification
+    ///
+    ////////////////////////////////////////////////////////////
+    Identification getIdentification() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
     ///
     /// \return Joystick state
@@ -104,15 +112,16 @@ private :
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int         m_file;                 ///< File descriptor of the joystick
+    int            m_file;          ///< File descriptor of the joystick
 
-    report_desc_t   m_desc;         ///< USB report descriptor
-    int         m_id;           ///< USB id
+    report_desc_t  m_desc;          ///< USB report descriptor
+    int            m_id;            ///< USB id
 
-    void        *m_buffer;      ///< USB HID buffer
-    int         m_length;       ///< Buffer length
+    void           *m_buffer;       ///< USB HID buffer
+    int            m_length;        ///< Buffer length
+    Identification m_identificaion; ///< Joystick identification
 
-    JoystickState   m_state;                ///< Current state of the joystick
+    JoystickState  m_state;         ///< Current state of the joystick
 };
 
 } // namespace priv

--- a/src/SFML/Window/Joystick.cpp
+++ b/src/SFML/Window/Joystick.cpp
@@ -67,9 +67,26 @@ float Joystick::getAxisPosition(unsigned int joystick, Axis axis)
 
 
 ////////////////////////////////////////////////////////////
+Joystick::Identification Joystick::getIdentification(unsigned int joystick)
+{
+    return priv::JoystickManager::getInstance().getIdentification(joystick);
+}
+
+
+////////////////////////////////////////////////////////////
 void Joystick::update()
 {
     return priv::JoystickManager::getInstance().update();
+}
+
+
+////////////////////////////////////////////////////////////
+Joystick::Identification::Identification() :
+name     ("No Joystick"),
+vendorId (0),
+productId(0)
+{
+
 }
 
 } // namespace sf

--- a/src/SFML/Window/JoystickImpl.hpp
+++ b/src/SFML/Window/JoystickImpl.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 #include <SFML/Window/Joystick.hpp>
+#include <SFML/System/String.hpp>
 #include <algorithm>
 
 
@@ -38,7 +39,7 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-/// \brief Structure holding a joystick's capabilities
+/// \brief Structure holding a joystick's information
 ///
 ////////////////////////////////////////////////////////////
 struct JoystickCaps

--- a/src/SFML/Window/JoystickManager.cpp
+++ b/src/SFML/Window/JoystickManager.cpp
@@ -55,6 +55,13 @@ const JoystickState& JoystickManager::getState(unsigned int joystick) const
 
 
 ////////////////////////////////////////////////////////////
+const Joystick::Identification& JoystickManager::getIdentification(unsigned int joystick) const
+{
+    return m_joysticks[joystick].identification;
+}
+
+
+////////////////////////////////////////////////////////////
 void JoystickManager::update()
 {
     for (int i = 0; i < Joystick::Count; ++i)
@@ -72,6 +79,7 @@ void JoystickManager::update()
                 item.joystick.close();
                 item.capabilities = JoystickCaps();
                 item.state = JoystickState();
+                item.identification = Joystick::Identification();
             }
         }
         else
@@ -83,6 +91,7 @@ void JoystickManager::update()
                 {
                     item.capabilities = item.joystick.getCapabilities();
                     item.state = item.joystick.update();
+                    item.identification = item.joystick.getIdentification();
                 }
             }
         }

--- a/src/SFML/Window/JoystickManager.hpp
+++ b/src/SFML/Window/JoystickManager.hpp
@@ -54,7 +54,7 @@ public :
     static JoystickManager& getInstance();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get the capabilities of an open joystick
+    /// \brief Get the capabilities for an open joystick
     ///
     /// \param joystick Index of the joystick
     ///
@@ -72,6 +72,16 @@ public :
     ///
     ////////////////////////////////////////////////////////////
     const JoystickState& getState(unsigned int joystick) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the identification for an open joystick
+    ///
+    /// \param joystick Index of the joystick
+    ///
+    /// \return Identification for the joystick
+    ///
+    ////////////////////////////////////////////////////////////
+    const Joystick::Identification& getIdentification(unsigned int joystick) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the state of all the joysticks
@@ -99,9 +109,10 @@ private:
     ////////////////////////////////////////////////////////////
     struct Item
     {
-        JoystickImpl  joystick;     ///< Joystick implementation
-        JoystickState state;        ///< The current joystick state
-        JoystickCaps  capabilities; ///< The joystick capabilities
+        JoystickImpl  joystick;                  ///< Joystick implementation
+        JoystickState state;                     ///< The current joystick state
+        JoystickCaps  capabilities;              ///< The joystick capabilities
+        Joystick::Identification identification; ///< The joystick identification
     };
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/JoystickImpl.hpp
+++ b/src/SFML/Window/OSX/JoystickImpl.hpp
@@ -30,7 +30,10 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/JoystickImpl.hpp>
+#include <SFML/System/String.hpp>
+#include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/hid/IOHIDDevice.h>
+#include <IOKit/hid/IOHIDKeys.h>
 #include <map>
 #include <vector>
 
@@ -93,6 +96,14 @@ public :
     JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the joystick identification
+    ///
+    /// \return Joystick identification
+    ///
+    ////////////////////////////////////////////////////////////
+    Joystick::Identification getIdentification() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
     ///
     /// \return Joystick state
@@ -103,15 +114,47 @@ public :
 private :
 
     ////////////////////////////////////////////////////////////
+    /// Get HID device property key as a string
+    ///
+    /// \param ref HID device
+    /// \param prop Property to retrieve from the device
+    ///
+    /// \return Value for the property as a string
+    ///
+    ////////////////////////////////////////////////////////////
+    std::string getDeviceString(IOHIDDeviceRef ref, CFStringRef prop);
+
+    ////////////////////////////////////////////////////////////
+    /// Get HID device property key as an unsigned int
+    ///
+    /// \param ref HID device
+    /// \param prop Property to retrieve from the device
+    ///
+    /// \return Value for the propery as an unsigned int
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getDeviceUint(IOHIDDeviceRef ref, CFStringRef prop);
+
+    ////////////////////////////////////////////////////////////
+    /// Convert a CFStringRef to std::string
+    ///
+    /// \param cfString CFStringRef to convert
+    ///
+    /// \return std::string
+    ////////////////////////////////////////////////////////////
+    std::string stringFromCFString(CFStringRef cfString);
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     typedef long                                          Location;
     typedef std::map<sf::Joystick::Axis, IOHIDElementRef> AxisMap;
     typedef std::vector<IOHIDElementRef>                  ButtonsVector;
 
-    AxisMap       m_axis;    ///< Axis (IOHIDElementRef) connected to the joystick
-    ButtonsVector m_buttons; ///< Buttons (IOHIDElementRef) connected to the joystick
-    unsigned int  m_index;   ///< SFML index
+    AxisMap       m_axis;                      ///< Axis (IOHIDElementRef) connected to the joystick
+    ButtonsVector m_buttons;                   ///< Buttons (IOHIDElementRef) connected to the joystick
+    unsigned int  m_index;                     ///< SFML index
+    Joystick::Identification m_identification; ///< Joystick identification
 
     static Location m_locationIDs[sf::Joystick::Count]; ///< Global Joystick register
     /// For a corresponding SFML index, m_locationIDs is either some usb

--- a/src/SFML/Window/Unix/JoystickImpl.hpp
+++ b/src/SFML/Window/Unix/JoystickImpl.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <linux/joystick.h>
 #include <fcntl.h>
+#include <string>
 
 
 namespace sf
@@ -91,6 +92,14 @@ public :
     JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the joystick identification
+    ///
+    /// \return Joystick identification
+    ///
+    ////////////////////////////////////////////////////////////
+    Joystick::Identification getIdentification() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
     ///
     /// \return Joystick state
@@ -101,11 +110,33 @@ public :
 private :
 
     ////////////////////////////////////////////////////////////
+    /// Get the joystick name
+    ///
+    /// \param index Index of the joystick
+    ///
+    /// \return Joystick name
+    ///
+    ////////////////////////////////////////////////////////////
+    std::string getJoystickName(unsigned int index);
+
+    ////////////////////////////////////////////////////////////
+    /// Get a system attribute from udev as an unsigned int
+    ///
+    /// \param index Index of the joystick
+    /// \param attributeName Name of the attribute to retrieve
+    ///
+    /// \return Attribute value as unsigned int
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getUdevAttributeUint(unsigned int index, std::string attributeName);
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int           m_file;                 ///< File descriptor of the joystick
-    char          m_mapping[ABS_MAX + 1]; ///< Axes mapping (index to axis id)
-    JoystickState m_state;                ///< Current state of the joystick
+    int           m_file;                          ///< File descriptor of the joystick
+    char          m_mapping[ABS_MAX + 1];          ///< Axes mapping (index to axis id)
+    JoystickState m_state;                         ///< Current state of the joystick
+    sf::Joystick::Identification m_identification; ///< Identification of the joystick
 };
 
 } // namespace priv

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -36,7 +36,9 @@
 #endif
 #define _WIN32_WINDOWS 0x0501
 #define _WIN32_WINNT   0x0501
+#include <SFML/Window/Joystick.hpp>
 #include <SFML/Window/JoystickImpl.hpp>
+#include <SFML/System/String.hpp>
 #include <windows.h>
 #include <mmsystem.h>
 #include <cmath>
@@ -101,6 +103,14 @@ public :
     JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the joystick identification
+    ///
+    /// \return Joystick identification
+    ///
+    ////////////////////////////////////////////////////////////
+    Joystick::Identification getIdentification() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
     ///
     /// \return Joystick state
@@ -111,10 +121,32 @@ public :
 private :
 
     ////////////////////////////////////////////////////////////
+    /// Get the joystick's name
+    ///
+    /// \param index Index of the joystick
+    /// \param caps JOYCAPS
+    ///
+    /// \return Joystick name
+    ///
+    ////////////////////////////////////////////////////////////
+    sf::String getDeviceName(unsigned int index, JOYCAPS caps);
+
+    ////////////////////////////////////////////////////////////
+    /// Get a system error string from an error code
+    ///
+    /// \param errorCode Error code
+    ///
+    /// \return Error message string
+    ///
+    ////////////////////////////////////////////////////////////
+    sf::String getErrorString(DWORD errorCode);
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int m_index; ///< Index of the joystick
-    JOYCAPS      m_caps;  ///< Joystick capabilities
+    unsigned int m_index;                      ///< Index of the joystick
+    JOYCAPS      m_caps;                       ///< Joystick capabilities
+    Joystick::Identification m_identification; ///< Joystick identification
 };
 
 } // namespace priv


### PR DESCRIPTION
Implemented on Windows, Mac OS and Linux as described in ticket #152.

**Changes**
1. `JoystickCaps` renamed to `JoystickInfo`.
2. Adds `name`, `manufacturerID` and `productID` properties to `JoystickInfo`.
3. Adds `getName(unsigned int index)`, `getManufacturerID(unsigned int index)` and `getProductID(unsigned int index)` methods to `sf::Joystick`.
4. _Linux_: Adds dependency on `udev` for getting joystick manufacturers and product IDs.
5. _Windows_: Defines `_UNICODE` for full Unicode support on Windows. See [this](http://stackoverflow.com/questions/4661304/define-unicode-not-working-with-mingw-codeblocks) and [this](http://blogs.msdn.com/b/oldnewthing/archive/2004/02/12/71851.aspx) for details.

**Testing**

Tested on Windows 8 x64 (compiled with Mingw) with the Xbox 360 pad (wired and wireless) and Dual Shock 3.

Tested on Mac OS 10.7 Lion (compiled with clang) with the Xbox 360 pad (wired), Dual Shock 3, and Wiimote (without attachements, with nunchuck, with classic controller).

Tested on Linux (Ubuntu 13.10, Mint 16, Manjaro, and Fedora 20 all 64-bits) with the Xbox 360 pad (wired). All Linux distros were running in VirtualBox.
