### PR TITLE
Changed tabs to spaces in various files

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -68,7 +68,7 @@ m_library  (NULL),
 m_face     (NULL),
 m_streamRec(NULL),
 m_refCount (NULL),
-m_info	   ()
+m_info     ()
 {
 
 }

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -150,7 +150,7 @@ Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short
         if (::connect(getHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) >= 0)
         {
             // We got instantly connected! (it may no happen a lot...)
-			setBlocking(blocking);
+            setBlocking(blocking);
             return Done;
         }
 

--- a/src/SFML/System/Win32/ClockImpl.cpp
+++ b/src/SFML/System/Win32/ClockImpl.cpp
@@ -34,7 +34,7 @@ namespace
     LARGE_INTEGER getFrequency()
     {
         LARGE_INTEGER frequency;
-	    QueryPerformanceFrequency(&frequency);
+        QueryPerformanceFrequency(&frequency);
         return frequency;
     }
 }

--- a/src/SFML/Window/FreeBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.hpp
@@ -104,15 +104,15 @@ private :
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int			m_file;                 ///< File descriptor of the joystick
+    int         m_file;                 ///< File descriptor of the joystick
 
-    report_desc_t	m_desc;			///< USB report descriptor
-    int			m_id;			///< USB id
+    report_desc_t   m_desc;         ///< USB report descriptor
+    int         m_id;           ///< USB id
 
-    void		*m_buffer;		///< USB HID buffer
-    int			m_length;		///< Buffer length
+    void        *m_buffer;      ///< USB HID buffer
+    int         m_length;       ///< Buffer length
 
-    JoystickState	m_state;                ///< Current state of the joystick
+    JoystickState   m_state;                ///< Current state of the joystick
 };
 
 } // namespace priv

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -138,7 +138,7 @@ bool JoystickImpl::isConnected(unsigned int index)
             char buffer[128];
             (void)read(notifyFd, buffer, sizeof(buffer));
         }
-	}
+    }
 
     // Then check if the joystick is connected
     return plugged[index];

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -162,19 +162,19 @@ void WglContext::createContext(WglContext* shared, unsigned int bitsPerPixel, co
             int intAttributes[] =
             {
                 WGL_DRAW_TO_WINDOW_ARB, GL_TRUE,
-		        WGL_SUPPORT_OPENGL_ARB, GL_TRUE,
-		        WGL_ACCELERATION_ARB,   WGL_FULL_ACCELERATION_ARB,
-		        WGL_DOUBLE_BUFFER_ARB,  GL_TRUE,
+                WGL_SUPPORT_OPENGL_ARB, GL_TRUE,
+                WGL_ACCELERATION_ARB,   WGL_FULL_ACCELERATION_ARB,
+                WGL_DOUBLE_BUFFER_ARB,  GL_TRUE,
                 WGL_SAMPLE_BUFFERS_ARB, (m_settings.antialiasingLevel ? GL_TRUE : GL_FALSE),
-		        WGL_SAMPLES_ARB,        static_cast<int>(m_settings.antialiasingLevel),
-		        0,                      0
+                WGL_SAMPLES_ARB,        static_cast<int>(m_settings.antialiasingLevel),
+                0,                      0
             };
 
             // Let's check how many formats are supporting our requirements
             int   formats[128];
-	        UINT  nbFormats;
-	        float floatAttributes[] = {0, 0};
-	        bool  isValid = wglChoosePixelFormatARB(m_deviceContext, intAttributes, floatAttributes, sizeof(formats) / sizeof(*formats), formats, &nbFormats) != 0;
+            UINT  nbFormats;
+            float floatAttributes[] = {0, 0};
+            bool  isValid = wglChoosePixelFormatARB(m_deviceContext, intAttributes, floatAttributes, sizeof(formats) / sizeof(*formats), formats, &nbFormats) != 0;
             while ((!isValid || (nbFormats == 0)) && m_settings.antialiasingLevel > 0)
             {
                 // Decrease the antialiasing level until we find a valid one


### PR DESCRIPTION
There were several files that broke the convention of using spaces instead of tabs. They were identified using the following command:

```
grep -Prn '\t' src/ include/
```
