### PR TITLE
Allow the creation of simple waveform sounds

### DIFF
--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -52,6 +52,17 @@ class InputStream;
 class SFML_AUDIO_API SoundBuffer
 {
 public :
+    ////////////////////////////////////////////////////////////
+    /// \brief Enumeration of the available waveforms
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Waveform
+    {
+        Sine = 0, ///< A sinusoidal wave sound
+        Sawtooth, ///< A sawtooth wave sound
+        Square,   ///< A square wave sound
+        Triangle  ///< A triangle wave sound
+    };
 
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
@@ -141,72 +152,26 @@ public :
     bool loadFromSamples(const Int16* samples, std::size_t sampleCount, unsigned int channelCount, unsigned int sampleRate);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Fills the sound buffer with a generated sawtooth wave
+    /// \brief Fills the sound buffer with a generated standard wave
     ///
+    /// The length of the generated sound will match the given
+    /// length. Keep in mind that this might make it impossible
+    /// to loop the generated samples without audible distortions.
+    ///
+    /// \param waveform     The waveform of the generated wave
     /// \param amplitude    The amplitude (volume) of the generated wave
     /// \param frequency    The frequency of the generated wave
-    /// \param sampleRate   Sample rate (number of samples to play per second)
     /// \param length       The length of the generated sound
     /// \param fadeIn       The length of the fade in
     /// \param fadeOut      The length of the fade out
-    ///
-    /// \return True if creation succeeded, false if it failed
-    ///
-    /// \see createSine, createSquare, createTriangle
-    ///
-    ////////////////////////////////////////////////////////////
-    bool createSawtooth(Int16 amplitude, float frequency, unsigned int sampleRate = 44100, sf::Time length = sf::seconds(1), sf::Time fadeIn = sf::Time::Zero, sf::Time fadeOut = sf::Time::Zero);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Fills the sound buffer with a generated sine wave
-    ///
-    /// \param amplitude    The amplitude (volume) of the generated wave
-    /// \param frequency    The frequency of the generated wave
     /// \param sampleRate   Sample rate (number of samples to play per second)
-    /// \param length       The length of the generated sound
-    /// \param fadeIn       The length of the fade in
-    /// \param fadeOut      The length of the fade out
     ///
     /// \return True if creation succeeded, false if it failed
     ///
-    /// \see createSawtooth, createSquare, createTriangle
+    /// \see Waveform, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    bool createSine(Int16 amplitude, float frequency, unsigned int sampleRate = 44100, sf::Time length = sf::seconds(1), sf::Time fadeIn = sf::Time::Zero, sf::Time fadeOut = sf::Time::Zero);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Fills the sound buffer with a generated square wave
-    ///
-    /// \param amplitude    The amplitude (volume) of the generated wave
-    /// \param frequency    The frequency of the generated wave
-    /// \param sampleRate   Sample rate (number of samples to play per second)
-    /// \param length       The length of the generated sound
-    /// \param fadeIn       The length of the fade in
-    /// \param fadeOut      The length of the fade out
-    ///
-    /// \return True if creation succeeded, false if it failed
-    ///
-    /// \see createSawtooth, createSine, createTriangle
-    ///
-    ////////////////////////////////////////////////////////////
-    bool createSquare(Int16 amplitude, float frequency, unsigned int sampleRate = 44100, sf::Time length = sf::seconds(1), sf::Time fadeIn = sf::Time::Zero, sf::Time fadeOut = sf::Time::Zero);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Fills the sound buffer with a generated triangle wave
-    ///
-    /// \param amplitude    The amplitude (volume) of the generated wave
-    /// \param frequency    The frequency of the generated wave
-    /// \param sampleRate   Sample rate (number of samples to play per second)
-    /// \param length       The length of the generated sound
-    /// \param fadeIn       The length of the fade in
-    /// \param fadeOut      The length of the fade out
-    ///
-    /// \return True if creation succeeded, false if it failed
-    ///
-    /// \see createSawtooth, createSine, createSquare
-    ///
-    ////////////////////////////////////////////////////////////
-    bool createTriangle(Int16 amplitude, float frequency, unsigned int sampleRate = 44100, sf::Time length = sf::seconds(1), sf::Time fadeIn = sf::Time::Zero, sf::Time fadeOut = sf::Time::Zero);
+    bool create(Waveform waveform, Int16 amplitude, float frequency, Time length = seconds(1), Time fadeIn = Time::Zero, Time fadeOut = Time::Zero, unsigned int sampleRate = 44100);
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the sound buffer to an audio file


### PR DESCRIPTION
`sf::SoundBuffer` can now be filled with standard waveforms.

This allows the creation of simple chiptune sounds on the fly using any of the following standard waveforms:
- Sawtooth
- Sine
- Square
- Triangle

It's possible to define the **length, frequency, sample rate, amplitude,** and optional **fade-in/fade-out** phases.

I felt like this functionality has been really lacking and it would also fit the general approach of SFML, considering it's also possible to create empty textures (without providing further means to manipulate them directly).

I've also created a [short Gist utilizing these changes](https://gist.github.com/MarioLiebisch/262e810c7944979abf22) to play children's songs encoded in a simplified ABC notation without the use of any additional files.

_Feel free to comment and nitpick as much as you can. I'll try to answer all questions and add corrections in case there are any issues. :)_
