### PR TITLE
Make classes which use Transformable and Drawable virtually inherited

### DIFF
--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -41,7 +41,7 @@ namespace sf
 /// \brief Base class for textured shapes with outline
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Shape : public Drawable, public Transformable
+class SFML_GRAPHICS_API Shape : virtual public Drawable, virtual public Transformable
 {
 public :
 

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -44,7 +44,7 @@ class Texture;
 ///        own transformations, color, etc.
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Sprite : public Drawable, public Transformable
+class SFML_GRAPHICS_API Sprite : virtual public Drawable, virtual public Transformable
 {
 public :
 

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -45,7 +45,7 @@ namespace sf
 /// \brief Graphical text that can be drawn to a render target
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Text : public Drawable, public Transformable
+class SFML_GRAPHICS_API Text : virtual public Drawable, virtual public Transformable
 {
 public :
 

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -42,7 +42,7 @@ namespace sf
 /// \brief Define a set of one or more 2D primitives
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API VertexArray : public Drawable
+class SFML_GRAPHICS_API VertexArray : virtual public Drawable
 {
 public :
 


### PR DESCRIPTION
These classes should be virtually inherited to prevent Diamond inheritance in source code outside of SFML.
I would have liked to use a single queue in our application but found that because these classes were not virtually inherited that I would need to use my own separate queue for both Text and Sprites (as well as possibly other things) rather than just one global sf::Drawable queue.

I am not sure if there are other classes which should have these virtually inherted, I changed the ones which seemed to be problematic for me.

A few classes have virtual draw functions inside private sections of these classes, I am curious as to why you have them virtual if they're private?

Let me know if there are any other changes you would like me to do.
