### PR TITLE
Image::flipVertically(), Image::flipHorizontally() optimizations.

### DIFF
--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -271,20 +271,19 @@ void Image::flipHorizontally()
 {
     if (!m_pixels.empty())
     {
-        std::vector<Uint8> before = m_pixels;
-        for (unsigned int y = 0; y < m_size.y; ++y)
-        {
-            const Uint8* source = &before[y * m_size.x * 4];
-            Uint8* dest = &m_pixels[(y + 1) * m_size.x * 4 - 4];
-            for (unsigned int x = 0; x < m_size.x; ++x)
-            {
-                dest[0] = source[0];
-                dest[1] = source[1];
-                dest[2] = source[2];
-                dest[3] = source[3];
+        std::size_t rowSize = m_size.x * 4;
 
-                source += 4;
-                dest -= 4;
+        for (std::size_t y = 0; y < m_size.y; ++y)
+        {
+            std::vector<Uint8>::iterator left = m_pixels.begin() + y * rowSize;
+            std::vector<Uint8>::iterator right = m_pixels.begin() + (y + 1) * rowSize - 4;
+
+            for (std::size_t x = 0; x < m_size.x / 2; ++x)
+            {
+                std::swap_ranges(left, left + 4, right);
+
+                left += 4;
+                right -= 4;
             }
         }
     }
@@ -296,16 +295,17 @@ void Image::flipVertically()
 {
     if (!m_pixels.empty())
     {
-        std::vector<Uint8> before = m_pixels;
-        const Uint8* source = &before[m_size.x * (m_size.y - 1) * 4];
-        Uint8* dest = &m_pixels[0];
         std::size_t rowSize = m_size.x * 4;
 
-        for (unsigned int y = 0; y < m_size.y; ++y)
+        std::vector<Uint8>::iterator top = m_pixels.begin();
+        std::vector<Uint8>::iterator bottom = m_pixels.end() - rowSize;
+
+        for (std::size_t y = 0; y < m_size.y / 2; ++y)
         {
-            std::memcpy(dest, source, rowSize);
-            source -= rowSize;
-            dest += rowSize;
+            std::swap_ranges(top, top + rowSize, bottom);
+
+            top += rowSize;
+            bottom -= rowSize;
         }
     }
 }


### PR DESCRIPTION
Hi.
I have made a few optimizations regarding these methods. Now they definitely perform better, but I kind of agree these're the micro-optimizations thus it is up to you whether or not to accept that.

Anyway, I benchmarked these methods using big PNG image (2048x2048px):

```
#include <SFML/Graphics.hpp>
#include <ctime>
#include <iostream>

int main() {

    sf::Image img;
    int num = 1000, i;

    if (img.loadFromFile("test_big_img.png")) {
    sf::Clock clock;
    for (i = 0; i < num; ++i) {
        //img.flipHorizontally();
        img.flipVertically();
    }
    sf::Time elapsed = clock.getElapsedTime();
    std::cout << "flipVertically: iterations: " << i << " total time: " << elapsed.asSeconds() << " average: " << elapsed.asSeconds() / num << std::endl;
    }

    return 0;
}
```

and here're the results:
//g++ -O2 -o bench ./bench.cpp -L/home/varnie/thrash/SFML-2.1/lib -lsfml-graphics -lsfml-window -lsfml-system

//current version: flipHorizontally: iterations: 1000 total time: 32.5636 average: 0.0325636
//new version     : flipHorizontally: iterations: 1000 total time: 13.855 average: 0.013855

//current version: flipVertically: iterations: 1000 total time: 31.548 average: 0.031548
//new version     : flipVertically: iterations: 1000 total time: 8.9526 average: 0.0089526

I have GCC version 4.7.2 

The image I used is located here: https://www.dropbox.com/s/f6co1urplxtgatm/test_big_img.png

Feel free to code-review my changes. Thank you.
