### PR TITLE
Fix typos and missing Joystick::

### DIFF
--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -320,7 +320,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
 
 
 ////////////////////////////////////////////////////////////
-Identifcation JoystickImpl::getIdentification() const
+Joystick::Identification JoystickImpl::getIdentification() const
 {
     return m_identification;
 }

--- a/src/SFML/Window/FreeBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.hpp
@@ -97,7 +97,7 @@ public :
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Identification getIdentification() const;
+    Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
@@ -119,7 +119,7 @@ private :
 
     void           *m_buffer;       ///< USB HID buffer
     int            m_length;        ///< Buffer length
-    Identification m_identificaion; ///< Joystick identification
+    Joystick::Identification m_identification; ///< Joystick identification
 
     JoystickState  m_state;         ///< Current state of the joystick
 };


### PR DESCRIPTION
This fixes the errors when building on FreeBSD.
