### PR TITLE
Fixed disabling key repeat on Linux

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -890,6 +890,13 @@ bool WindowImplX11::processEvent(XEvent windowEvent)
             }
             break;
         }
+
+        // Parent window changed
+        case ReparentNotify :
+        {
+            XSync(m_display, True); // Discard remaining events
+            break;
+        }
     }
 
     return true;


### PR DESCRIPTION
This is a fix for issue #564.
Key repeat was broken because the ReparentNotify xevent get stuck when the window is recreated (recreating the window does fire a reparenting xevent).
With this patch, remaining events are discarded upon window recreation. Holding a key down properly fires a KeyRelease xevent followed by a KeyPress xevent, which fixes the mechanism for disabling key repeat.
