### PR TITLE
Fixed missing JoystickImpl member on Android

### DIFF
--- a/src/SFML/Window/Android/JoystickImpl.cpp
+++ b/src/SFML/Window/Android/JoystickImpl.cpp
@@ -79,6 +79,13 @@ JoystickCaps JoystickImpl::getCapabilities() const
 
 
 ////////////////////////////////////////////////////////////
+Joystick::Identification JoystickImpl::getIdentification() const
+{
+    return m_identification;
+}
+
+
+////////////////////////////////////////////////////////////
 JoystickState JoystickImpl::update()
 {
     // To implement

--- a/src/SFML/Window/Android/JoystickImpl.hpp
+++ b/src/SFML/Window/Android/JoystickImpl.hpp
@@ -85,6 +85,14 @@ public :
     JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the joystick identification
+    ///
+    /// \return Joystick identification
+    ///
+    ////////////////////////////////////////////////////////////
+    Joystick::Identification getIdentification() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
     ///
     /// \return Joystick state
@@ -97,7 +105,8 @@ private :
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int m_index; ///< Index of the joystick
+    int m_index;                               ///< Index of the joystick
+    Joystick::Identification m_identification; ///< Joystick identification
 };
 
 } // namespace priv


### PR DESCRIPTION
This fixes building after the rebase. The returned value is still not set though (since implementation is missing anyway).
