### PR TITLE
Fix Config.hpp so SFML compiles on Debian kFreeBSD

### DIFF
--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -80,7 +80,7 @@
          // Linux
         #define SFML_SYSTEM_LINUX
 
-    #elif defined(__FreeBSD__)
+    #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
 
         // FreeBSD
         #define SFML_SYSTEM_FREEBSD


### PR DESCRIPTION
Debian kFreeBSD only defines `__FreeBSD_kernel__` and not `__FreeBSD__` so you need to check for both to compile everywhere.
