### PR TITLE
Fixed building for OpenGL ES 1.1 platforms

### DIFF
--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -62,6 +62,9 @@
     #define GLEXT_glClientActiveTexture            glClientActiveTexture
     #define GLEXT_glActiveTexture                  glActiveTexture
     #define GLEXT_GL_TEXTURE0                      GL_TEXTURE0
+    #define GLEXT_glBlendEquation                  glBlendEquationOES
+    #define GLEXT_GL_FUNC_ADD                      GL_FUNC_ADD_OES
+    #define GLEXT_GL_FUNC_SUBTRACT                 GL_FUNC_SUBTRACT_OES
 
 #else
 
@@ -96,6 +99,9 @@
     #define GLEXT_glClientActiveTexture            glClientActiveTextureARB
     #define GLEXT_glActiveTexture                  glActiveTextureARB
     #define GLEXT_GL_TEXTURE0                      GL_TEXTURE0_ARB
+    #define GLEXT_glBlendEquation                  glBlendEquation
+    #define GLEXT_GL_FUNC_ADD                      GL_FUNC_ADD
+    #define GLEXT_GL_FUNC_SUBTRACT                 GL_FUNC_SUBTRACT
 
 #endif
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -63,8 +63,8 @@ namespace
         switch (blendEquation)
         {
             default:
-            case sf::BlendMode::Add:             return GL_FUNC_ADD;
-            case sf::BlendMode::Subtract:        return GL_FUNC_SUBTRACT;
+            case sf::BlendMode::Add:             return GLEXT_GL_FUNC_ADD;
+            case sf::BlendMode::Subtract:        return GLEXT_GL_FUNC_SUBTRACT;
         }
     }
 }
@@ -442,7 +442,7 @@ void RenderTarget::applyBlendMode(const BlendMode& mode)
     }
     else
     {
-        glCheck(glBlendEquation(equationToGlConstant(mode.colorEquation)));
+        glCheck(GLEXT_glBlendEquation(equationToGlConstant(mode.colorEquation)));
     }
 
     m_cache.lastBlendMode = mode;


### PR DESCRIPTION
- Added proper extension handling for `glBlendEquation` and related
  constants (required for OpenGL ES 1.1).
