### PR TITLE
Adding default arguments to the default constructors for CircleShape and RectangleShape.

### DIFF
--- a/include/SFML/Graphics/CircleShape.hpp
+++ b/include/SFML/Graphics/CircleShape.hpp
@@ -49,7 +49,7 @@ public :
     /// \param pointCount Number of points composing the circle
     ///
     ////////////////////////////////////////////////////////////
-    explicit CircleShape(float radius = 0, unsigned int pointCount = 30);
+    explicit CircleShape(float radius = 0, unsigned int pointCount = 30, const Vector2f& pos = Vector2f(0, 0), const Color& color = Color(), float outline = 0.0f, const Color& outlineColor = Color());
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the radius of the circle

--- a/include/SFML/Graphics/RectangleShape.hpp
+++ b/include/SFML/Graphics/RectangleShape.hpp
@@ -48,7 +48,7 @@ public :
     /// \param size Size of the rectangle
     ///
     ////////////////////////////////////////////////////////////
-    explicit RectangleShape(const Vector2f& size = Vector2f(0, 0));
+    explicit RectangleShape(const Vector2f& size = Vector2f(0, 0), const Vector2f& pos = Vector2f(0, 0), const Color& color = Color(), float outline = 0.0f, const Color& outlineColor = Color());
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the size of the rectangle

--- a/src/SFML/Graphics/CircleShape.cpp
+++ b/src/SFML/Graphics/CircleShape.cpp
@@ -32,10 +32,14 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-CircleShape::CircleShape(float radius, unsigned int pointCount) :
+CircleShape::CircleShape(float radius, unsigned int pointCount, const Vector2f& pos, const Color& color, float outline, const Color& outlineColor) :
 m_radius    (radius),
 m_pointCount(pointCount)
 {
+    setPosition(pos);
+    setFillColor(color);
+    setOutlineThickness(outline);
+    setOutlineColor(outlineColor);
     update();
 }
 

--- a/src/SFML/Graphics/RectangleShape.cpp
+++ b/src/SFML/Graphics/RectangleShape.cpp
@@ -32,9 +32,13 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-RectangleShape::RectangleShape(const Vector2f& size)
+RectangleShape::RectangleShape(const Vector2f& size, const Vector2f& pos, const Color& color, float outline, const Color& outlineColor)
 {
     setSize(size);
+    setPosition(pos);
+    setFillColor(color);
+    setOutlineThickness(outline);
+    setOutlineColor(outlineColor);
 }
 
 


### PR DESCRIPTION
These additions to the default constructors don't break anything, but make C++11 code much more readable since containers can now construct elements in-place now. For that reason, it makes sense to be able to provide a number of these values at insertion time.
