### PR TITLE
Make sure texture unit 0 is active when reseting RenderTarget states (#5...

### DIFF
--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -58,6 +58,10 @@
     #define GLEXT_GL_DEPTH_COMPONENT               GL_DEPTH_COMPONENT16_OES
     #define GLEXT_GL_INVALID_FRAMEBUFFER_OPERATION GL_INVALID_FRAMEBUFFER_OPERATION_OES
     #define GLEXT_texture_non_power_of_two         false
+    #define GLEXT_multitexture                     true
+    #define GLEXT_glClientActiveTexture            glClientActiveTexture
+    #define GLEXT_glActiveTexture                  glActiveTexture
+    #define GLEXT_GL_TEXTURE0                      GL_TEXTURE0
 
 #else
 
@@ -88,6 +92,10 @@
     #define GLEXT_GL_DEPTH_COMPONENT               GL_DEPTH_COMPONENT
     #define GLEXT_GL_INVALID_FRAMEBUFFER_OPERATION GL_INVALID_FRAMEBUFFER_OPERATION_EXT
     #define GLEXT_texture_non_power_of_two         GLEW_ARB_texture_non_power_of_two
+    #define GLEXT_multitexture                     GLEW_ARB_multitexture
+    #define GLEXT_glClientActiveTexture            glClientActiveTextureARB
+    #define GLEXT_glActiveTexture                  glActiveTextureARB
+    #define GLEXT_GL_TEXTURE0                      GL_TEXTURE0_ARB
 
 #endif
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -93,6 +93,9 @@ void RenderTarget::clear(const Color& color)
 {
     if (activate(true))
     {
+        // Unbind texture to fix RenderTexture preventing clear
+        applyTexture(NULL);
+
         glCheck(glClearColor(color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f));
         glCheck(glClear(GL_COLOR_BUFFER_BIT));
     }
@@ -364,6 +367,14 @@ void RenderTarget::resetGLStates()
         applyTexture(NULL);
         if (Shader::isAvailable())
             applyShader(NULL);
+
+        // Make sure that the texture unit which is active is the number 0
+        if (GLEXT_multitexture)
+        {
+            glCheck(GLEXT_glClientActiveTexture(GLEXT_GL_TEXTURE0));
+            glCheck(GLEXT_glActiveTexture(GLEXT_GL_TEXTURE0));
+        }
+
         m_cache.useVertexCache = false;
 
         // Set the default view


### PR DESCRIPTION
...23), fix RenderTarget not clearing when a texture used as a RenderTexture color attachment is left bound in a different context (http://en.sfml-dev.org/forums/index.php?topic=9350.0).
