### PR TITLE
Fixed issue where the viewport's width and/or height could be off by 1 pixel

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -130,8 +130,8 @@ IntRect RenderTarget::getViewport(const View& view) const
 
     return IntRect(static_cast<int>(0.5f + width  * viewport.left),
                    static_cast<int>(0.5f + height * viewport.top),
-                   static_cast<int>(width  * viewport.width),
-                   static_cast<int>(height * viewport.height));
+                   static_cast<int>(0.5f + width  * viewport.width),
+                   static_cast<int>(0.5f + height * viewport.height));
 }
 
 


### PR DESCRIPTION
Due to float imprecision there was a bug causing a viewport to be 1 pixel smaller in width and/or height than it should be.
