### PR TITLE
Output error message when XOpenDisplay() fails

### DIFF
--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -25,8 +25,10 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/System/Err.hpp>
 #include <SFML/Window/Unix/Display.hpp>
 #include <cassert>
+#include <cstdlib>
 
 
 namespace
@@ -44,7 +46,18 @@ namespace priv
 Display* OpenDisplay()
 {
     if (referenceCount == 0)
+    {
         sharedDisplay = XOpenDisplay(NULL);
+
+        // Opening display failed: The best we can do at the moment is to output a meaningful error message
+        // and cause an abnormal program termination
+        if (!sharedDisplay)
+        {
+            err() << "Failed to open X11 display; make sure the DISPLAY environment variable is set correctly" << std::endl;
+            std::abort();
+        }
+    }
+
     referenceCount++;
     return sharedDisplay;
 }


### PR DESCRIPTION
Fixes issue #508.

When the X11 display could not be opened, the application crashed without notice. Now it still crashes (since we don't have any means of reporting the error until SFML 3, see discussion), but the user gets a meaningful error message.
