### PR TITLE
Added another place to search for libs in the FindSFML CMake module

### DIFF
--- a/cmake/Modules/FindSFML.cmake
+++ b/cmake/Modules/FindSFML.cmake
@@ -134,13 +134,13 @@ foreach(FIND_SFML_COMPONENT ${SFML_FIND_COMPONENTS})
     # debug library
     find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG
                  NAMES ${FIND_SFML_COMPONENT_NAME}-d
-                 PATH_SUFFIXES lib64 lib
+                 PATH_SUFFIXES lib64 lib lib/Debug
                  PATHS ${FIND_SFML_PATHS})
 
     # release library
     find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE
                  NAMES ${FIND_SFML_COMPONENT_NAME}
-                 PATH_SUFFIXES lib64 lib
+                 PATH_SUFFIXES lib64 lib lib/Release
                  PATHS ${FIND_SFML_PATHS})
 
     if (SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG OR SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE)


### PR DESCRIPTION
By default, when you build SFML in Visual Studio, it puts the .libs into SFML/lib/Debug (if you built it in Debug mode) or SFML/lib/Release (if you built it in Release mode).  The FindSFML CMake module does not check for these folders, so it will fail unless you move all of these files into SFML/lib.
