### PR TITLE
Fixed `TouchBegan` reporting wrong coordinates

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -376,8 +376,6 @@ void WindowImplAndroid::processMotionEvent(AInputEvent* _event, ActivityStates* 
         }
         
         states->pendingEvents.push_back(event);
-
-        states->touchEvents[id] = Vector2i(event.touch.x, event.touch.y);
      }
 }
 
@@ -391,8 +389,8 @@ void WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* _event, Ac
     int index = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
     int id = AMotionEvent_getPointerId(_event, index);
 
-    float x = AMotionEvent_getX(_event, 0);
-    float y = AMotionEvent_getY(_event, 0);
+    float x = AMotionEvent_getX(_event, index);
+    float y = AMotionEvent_getY(_event, index);
     
     Event event;
 


### PR DESCRIPTION
- So far `sf::Event::TouchBegan` always reported the coordinates of the
  first pointer/finger.

I've provided an updated example app with commit 5e14bc03bad347c932e3adca62a38a359b0fe76a.
- Touch the screen to create expanding circles/ripples.
- To reproduce the bug, touch the screen at one position and keep your finger on the screen.
- Tap a second or third time.
- All additional circles will originate at the position of your first finger press rather than the new touch locations.
