### PR TITLE
Check socket descriptor limit. #153

### DIFF
--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -76,11 +76,20 @@ void SocketSelector::add(Socket& socket)
     SocketHandle handle = socket.getHandle();
     if (handle != priv::SocketImpl::invalidSocket())
     {
-        FD_SET(handle, &m_impl->AllSockets);
+        if (handle < FD_SETSIZE)
+        {
+            FD_SET(handle, &m_impl->AllSockets);
 
-        int size = static_cast<int>(handle);
-        if (size > m_impl->MaxSocket)
-            m_impl->MaxSocket = size;
+            int size = static_cast<int>(handle);
+            if (size > m_impl->MaxSocket)
+                m_impl->MaxSocket = size;
+        }
+        else
+        {
+            err() << "The socket can't be added to the selector because its "
+                  << "ID is too high. This is a limitation of your operating "
+                  << "system's FD_SETSIZE setting.";
+        }
     }
 }
 


### PR DESCRIPTION
When calling select(), there's an upper limit for the socket descriptor
which is defined as FD_SETSIZE. When the socket descriptor is higher
than FD_SETSIZE, a call to select() will not work as expected, at least
for the proper sockets.

This patch adds an error message and an assert as well.
