### PR TITLE
Added loop point support to sf::Music

### DIFF
--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -180,6 +180,11 @@ public:
 
 protected:
 
+    enum
+    {
+        NoLoop = -1 ///< "Invalid" endSeeks value, telling us to continue uninterrupted
+    };
+
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
@@ -233,6 +238,18 @@ protected:
     ///
     ////////////////////////////////////////////////////////////
     virtual void onSeek(Time timeOffset) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current playing position in the stream source to the beginning of the loop
+    ///
+    /// This function can be overridden by derived classes to
+    /// allow implementation of custom loop points. Otherwise,
+    /// it just calls onSeek(Time::Zero) and returns 0.
+    ///
+    /// \return The seek position after looping (or -1 if there's no loop)
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 onLoop();
 
 private:
 
@@ -289,17 +306,17 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Thread        m_thread;                  ///< Thread running the background tasks
-    mutable Mutex m_threadMutex;             ///< Thread mutex
-    Status        m_threadStartState;        ///< State the thread starts in (Playing, Paused, Stopped)
-    bool          m_isStreaming;             ///< Streaming state (true = playing, false = stopped)
-    unsigned int  m_buffers[BufferCount];    ///< Sound buffers used to store temporary audio data
-    unsigned int  m_channelCount;            ///< Number of channels (1 = mono, 2 = stereo, ...)
-    unsigned int  m_sampleRate;              ///< Frequency (samples / second)
-    Uint32        m_format;                  ///< Format of the internal sound buffers
-    bool          m_loop;                    ///< Loop flag (true to loop, false to play once)
-    Uint64        m_samplesProcessed;        ///< Number of buffers processed since beginning of the stream
-    bool          m_endBuffers[BufferCount]; ///< Each buffer is marked as "end buffer" or not, for proper duration calculation
+    Thread        m_thread;                   ///< Thread running the background tasks
+    mutable Mutex m_threadMutex;              ///< Thread mutex
+    Status        m_threadStartState;         ///< State the thread starts in (Playing, Paused, Stopped)
+    bool          m_isStreaming;              ///< Streaming state (true = playing, false = stopped)
+    unsigned int  m_buffers[BufferCount];     ///< Sound buffers used to store temporary audio data
+    unsigned int  m_channelCount;             ///< Number of channels (1 = mono, 2 = stereo, ...)
+    unsigned int  m_sampleRate;               ///< Frequency (samples / second)
+    Uint32        m_format;                   ///< Format of the internal sound buffers
+    bool          m_loop;                     ///< Loop flag (true to loop, false to play once)
+    Uint64        m_samplesProcessed;         ///< Number of buffers processed since beginning of the stream
+    Int64         m_bufferSeeks[BufferCount]; ///< If buffer is an "end buffer", holds next seek position, else NoLoop. For play offset calculation.
 };
 
 } // namespace sf

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -36,7 +36,8 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 Music::Music() :
-m_file    ()
+m_file      (),
+m_loopSpan  (0, 0)
 {
 
 }
@@ -109,16 +110,93 @@ Time Music::getDuration() const
 
 
 ////////////////////////////////////////////////////////////
+Music::TimeSpan Music::getLoopPoints() const
+{
+    return TimeSpan(samplesToTime(m_loopSpan.offset), samplesToTime(m_loopSpan.length));
+}
+
+
+////////////////////////////////////////////////////////////
+void Music::setLoopPoints(TimeSpan timePoints)
+{
+    Span<Uint64> samplePoints(timeToSamples(timePoints.offset), timeToSamples(timePoints.length));
+
+    // Check our state. This averts a divide-by-zero. GetChannelCount() is cheap enough to use often
+    if (getChannelCount() == 0 || m_file.getSampleCount() == 0)
+    {
+        sf::err() << "Music is not in a valid state to assign Loop Points." << std::endl;
+        return;
+    }
+
+    // Round up to the next even sample if needed
+    samplePoints.offset += (getChannelCount() - 1);
+    samplePoints.offset -= (samplePoints.offset % getChannelCount());
+    samplePoints.length += (getChannelCount() - 1);
+    samplePoints.length -= (samplePoints.length % getChannelCount());
+
+    // Validate
+    if (samplePoints.offset >= m_file.getSampleCount())
+    {
+        sf::err() << "LoopPoints offset val must be in range [0, Duration)." << std::endl;
+        return;
+    }
+    if (samplePoints.length == 0)
+    {
+        sf::err() << "LoopPoints length val must be nonzero." << std::endl;
+        return;
+    }
+
+    // Clamp End Point
+    samplePoints.length = std::min(samplePoints.length, m_file.getSampleCount() - samplePoints.offset);
+
+    // If this change has no effect, we can return without touching anything
+    if (samplePoints.offset == m_loopSpan.offset && samplePoints.length == m_loopSpan.length)
+        return;
+
+    // When we apply this change, we need to "reset" this instance and its buffer
+
+    // Get old playing status and position
+    Status oldStatus = getStatus();
+    Time oldPos = getPlayingOffset();
+
+    // Unload
+    stop();
+
+    // Set
+    m_loopSpan = samplePoints;
+
+    // Restore
+    if (oldPos != Time::Zero)
+        setPlayingOffset(oldPos);
+
+    // Resume
+    if (oldStatus == Playing)
+        play();
+}
+
+
+////////////////////////////////////////////////////////////
 bool Music::onGetData(SoundStream::Chunk& data)
 {
     Lock lock(m_mutex);
 
-    // Fill the chunk parameters
-    data.samples     = &m_samples[0];
-    data.sampleCount = static_cast<std::size_t>(m_file.read(&m_samples[0], m_samples.size()));
+    std::size_t toFill = m_samples.size();
+    Uint64 currentOffset = m_file.getSampleOffset();
+    Uint64 loopEnd = m_loopSpan.offset + m_loopSpan.length;
 
-    // Check if we have stopped obtaining samples or reached the end of the audio file
-    return (data.sampleCount != 0) && (m_file.getSampleOffset() < m_file.getSampleCount());
+    // If the loop end is enabled and imminent, request less data.
+    // This will trip an "onLoop()" call from the underlying SoundStream,
+    // and we can then take action.
+    if (getLoop() && (m_loopSpan.length != 0) && (currentOffset <= loopEnd) && (currentOffset + toFill > loopEnd))
+        toFill = loopEnd - currentOffset;
+
+    // Fill the chunk parameters
+    data.samples = &m_samples[0];
+    data.sampleCount = static_cast<std::size_t>(m_file.read(&m_samples[0], toFill));
+    currentOffset += data.sampleCount;
+
+    // Check if we have stopped obtaining samples or reached either the EOF or the loop end point
+    return (data.sampleCount != 0) && (currentOffset < m_file.getSampleCount()) && !(currentOffset == loopEnd && m_loopSpan.length != 0);
 }
 
 
@@ -126,19 +204,68 @@ bool Music::onGetData(SoundStream::Chunk& data)
 void Music::onSeek(Time timeOffset)
 {
     Lock lock(m_mutex);
-
     m_file.seek(timeOffset);
+}
+
+
+////////////////////////////////////////////////////////////
+Int64 Music::onLoop()
+{
+    // Called by underlying SoundStream so we can determine where to loop.
+    Lock lock(m_mutex);
+    Uint64 currentOffset = m_file.getSampleOffset();
+    if (getLoop() && (m_loopSpan.length != 0) && (currentOffset == m_loopSpan.offset + m_loopSpan.length))
+    {
+        // Looping is enabled, and either we're at the loop end, or we're at the EOF
+        // when it's equivalent to the loop end (loop end takes priority). Send us to loop begin
+        m_file.seek(m_loopSpan.offset);
+        return m_file.getSampleOffset();
+    }
+    else if (getLoop() && (currentOffset >= m_file.getSampleCount()))
+    {
+        // If we're at the EOF, reset to 0
+        m_file.seek(0);
+        return 0;
+    }
+    return NoLoop;
 }
 
 
 ////////////////////////////////////////////////////////////
 void Music::initialize()
 {
+    // Compute the music positions
+    m_loopSpan.offset = 0;
+    m_loopSpan.length = m_file.getSampleCount();
+
     // Resize the internal buffer so that it can contain 1 second of audio samples
     m_samples.resize(m_file.getSampleRate() * m_file.getChannelCount());
 
     // Initialize the stream
     SoundStream::initialize(m_file.getChannelCount(), m_file.getSampleRate());
+}
+
+////////////////////////////////////////////////////////////
+Uint64 Music::timeToSamples(Time position) const
+{
+    // Always ROUND, no unchecked truncation, hence the addition in the numerator.
+    // This avoids most precision errors arising from "samples => Time => samples" conversions
+    // Original rounding calculation is ((Micros * Freq * Channels) / 1000000) + 0.5
+    // We refactor it to keep Int64 as the data type throughout the whole operation.
+    return ((position.asMicroseconds() * getSampleRate() * getChannelCount()) + 500000) / 1000000;
+}
+
+
+////////////////////////////////////////////////////////////
+Time Music::samplesToTime(Uint64 samples) const
+{
+    Time position = Time::Zero;
+
+    // Make sure we don't divide by 0
+    if (getSampleRate() != 0 && getChannelCount() != 0)
+        position = microseconds((samples * 1000000) / (getChannelCount() * getSampleRate()));
+
+    return position;
 }
 
 } // namespace sf


### PR DESCRIPTION
After working a bit with SFML, I noticed that I couldn't set any custom loop points for sounds, and I need them for a game I'm working on. I spotted issue #177 sitting around, so I figured I would try implementing myself.

For sf::Music / sf::SoundStream, I added a feature to detect a loop point and cut off the streaming of the buffer, and a pair of virtual functions that can allow sf::SoundStream to let its derived class decide where to seek upon looping. It's accomplished entirely within those two classes without doing anything too funny with OpenAL, and I'm happy with what I managed to accomplish with it.

~~For sf::SoundBuffer / sf::Sound, I ran into some more constraints. OpenAL-Soft has a way to set loop points, but it's not a well-documented feature, and it is also a buffer trait, rather than a source trait. It has a few more restrictions on the allowable values compared to the Music version because of this. It uses an "enum" value called AL_LOOP_POINTS_SOFT defined in "alext.h", which was present in SFML but not included, and I figured it was fair game to use. If not, then I can take the SoundBuffer implementation out.~~

The inline documentation will explain any interface differences, but they're roughly the same, with getLoopStart(), getLoopEnd(), setLoopPointsFromTime(), and setLoopPointsFromSamples(). Three of those work with sf::Time, to keep everything consistent, the fourth is if you have an exact sample position you want to use.

I hope this isn't frowned upon, but for testing, I augmented the SFML Sound Example to include some additional playings of the resource sounds, and demonstrating some of the extra features of the Music implementations. At least it should be easy to build and test. If any modification or more proof-of-functionality is needed, please let me know!
