### PR TITLE
[Android] Fixed the app crashing on rotation

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -200,6 +200,9 @@ static void onDestroy(ANativeActivity* activity)
     // Delete our allocated states
     delete states;
 
+    // Reset the activity pointer for all modules
+    sf::priv::getActivity(NULL, true);
+
     // The application should now terminate
 }
 
@@ -386,7 +389,7 @@ void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_
     states->terminated = false;
 
     // Share it across the SFML modules
-    sf::priv::getActivity(states);
+    sf::priv::getActivity(states, true);
 
     // These functions will update the activity states and therefore, will allow
     // SFML to be kept in the know

--- a/src/SFML/System/Android/Activity.cpp
+++ b/src/SFML/System/Android/Activity.cpp
@@ -33,11 +33,11 @@ namespace sf
 {
 namespace priv
 {
-ActivityStates* getActivity(ActivityStates* initializedStates)
+ActivityStates* getActivity(ActivityStates* initializedStates, bool reset)
 {
     static ActivityStates* states = NULL;
 
-    if (!states)
+    if (!states || reset)
         states = initializedStates;
 
     return states;

--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -74,7 +74,7 @@ struct ActivityStates
     bool updated;
 };
 
-SFML_SYSTEM_API ActivityStates* getActivity(ActivityStates* initializedStates=NULL);
+SFML_SYSTEM_API ActivityStates* getActivity(ActivityStates* initializedStates=NULL, bool reset=false);
 
 } // namespace priv
 } // namespace sf


### PR DESCRIPTION
Rotating the screen will restart the app with the new window/orientation. This change properly updates the activity/states pointer for the other non-window modules. This fixes issue #531.
