### PR TITLE
[Android] Fixed redundant touch moved events

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -368,6 +368,9 @@ void WindowImplAndroid::processMotionEvent(AInputEvent* _event, ActivityStates* 
         }
         else if (device == AINPUT_SOURCE_TOUCHSCREEN)
         {
+            if (states->touchEvents[id].x == x && states->touchEvents[id].y == y)
+                continue;
+
             event.touch.finger = id;
             event.touch.x = x;
             event.touch.y = y;


### PR DESCRIPTION
Previously moving any finger would create `sf::Event::TouchMoved` events for all fingers, even if their position didn't change at all.
