### PR TITLE
[Android] Don't try to display without a surface

### DIFF
--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -180,7 +180,8 @@ bool EglContext::makeCurrent()
 ////////////////////////////////////////////////////////////
 void EglContext::display()
 {
-    eglCheck(eglSwapBuffers(m_display, m_surface));
+    if (m_surface != EGL_NO_SURFACE)
+        eglCheck(eglSwapBuffers(m_display, m_surface));
 }
 
 


### PR DESCRIPTION
- Android apps would still try to call `eglSwapBuffers()` even though they don't have a valid surface right now (i.e. due to being inactive/in background).
