### PR TITLE
Fix a bug in the font system.

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -624,7 +624,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
     if (!row)
     {
         int rowHeight = height + height / 10;
-        while (page.nextRow + rowHeight >= page.texture.getSize().y)
+        while ((page.nextRow + rowHeight >= page.texture.getSize().y) || (width >= page.texture.getSize().x))
         {
             // Not enough space: resize the texture if possible
             unsigned int textureWidth  = page.texture.getSize().x;


### PR DESCRIPTION
When the finding a rectangle for a glyph at a particular character size,
if the glyph happens to be wider than the current texture size, but less
high than the unused height in the texture, the texture will not be
correctly doubled in size (since only the height is checked).

In practice, this only occurs when finding the rectangle for the _very
first_ glyph (so the texture is at its default 128x128 size): otherwise,
the glyph would need to be unusually wide compared to its height to
trigger the bug.

This will trigger a debug assertion in Texture::update(). With assertions
disabled, there are knock-on effects and most text at that character size
will fail to render.
