### PR TITLE
FindSFML.cmake cache fix

### DIFF
--- a/cmake/Modules/FindSFML.cmake
+++ b/cmake/Modules/FindSFML.cmake
@@ -60,12 +60,6 @@ if(SFML_STATIC_LIBRARIES)
     add_definitions(-DSFML_STATIC)
 endif()
 
-# deduce the libraries suffix from the options
-set(FIND_SFML_LIB_SUFFIX "")
-if(SFML_STATIC_LIBRARIES)
-    set(FIND_SFML_LIB_SUFFIX "${FIND_SFML_LIB_SUFFIX}-s")
-endif()
-
 # define the list of search paths for headers and libraries
 set(FIND_SFML_PATHS
     ${SFML_ROOT}
@@ -124,24 +118,63 @@ set(SFML_FOUND TRUE) # will be set to false if one of the required modules is no
 foreach(FIND_SFML_COMPONENT ${SFML_FIND_COMPONENTS})
     string(TOLOWER ${FIND_SFML_COMPONENT} FIND_SFML_COMPONENT_LOWER)
     string(TOUPPER ${FIND_SFML_COMPONENT} FIND_SFML_COMPONENT_UPPER)
-    set(FIND_SFML_COMPONENT_NAME sfml-${FIND_SFML_COMPONENT_LOWER}${FIND_SFML_LIB_SUFFIX})
+    set(FIND_SFML_COMPONENT_NAME sfml-${FIND_SFML_COMPONENT_LOWER})
 
     # no suffix for sfml-main, it is always a static library
     if(FIND_SFML_COMPONENT_LOWER STREQUAL "main")
-        set(FIND_SFML_COMPONENT_NAME sfml-${FIND_SFML_COMPONENT_LOWER})
+        # release library
+        find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE
+                     NAMES ${FIND_SFML_COMPONENT_NAME}
+                     PATH_SUFFIXES lib64 lib
+                     PATHS ${FIND_SFML_PATHS})
+
+        # debug library
+        find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG
+                     NAMES ${FIND_SFML_COMPONENT_NAME}-d
+                     PATH_SUFFIXES lib64 lib
+                     PATHS ${FIND_SFML_PATHS})
+    else()
+        # static release library
+        find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_RELEASE
+                     NAMES ${FIND_SFML_COMPONENT_NAME}-s
+                     PATH_SUFFIXES lib64 lib
+                     PATHS ${FIND_SFML_PATHS})
+
+        # static debug library
+        find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_DEBUG
+                     NAMES ${FIND_SFML_COMPONENT_NAME}-s-d
+                     PATH_SUFFIXES lib64 lib
+                     PATHS ${FIND_SFML_PATHS})
+
+        # dynamic release library
+        find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_RELEASE
+                     NAMES ${FIND_SFML_COMPONENT_NAME}
+                     PATH_SUFFIXES lib64 lib
+                     PATHS ${FIND_SFML_PATHS})
+
+        # dynamic debug library
+        find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_DEBUG
+                     NAMES ${FIND_SFML_COMPONENT_NAME}-d
+                     PATH_SUFFIXES lib64 lib
+                     PATHS ${FIND_SFML_PATHS})
+
+        # choose the entries that fit the requested link type
+        if(SFML_STATIC_LIBRARIES)
+            if(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_RELEASE)
+                set(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE ${SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_RELEASE})
+            endif()
+            if(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_DEBUG)
+                set(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG ${SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_DEBUG})
+            endif()
+        else()
+            if(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_RELEASE)
+                set(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE ${SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_RELEASE})
+            endif()
+            if(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_DEBUG)
+                set(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG ${SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_DEBUG})
+            endif()
+        endif()
     endif()
-
-    # debug library
-    find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG
-                 NAMES ${FIND_SFML_COMPONENT_NAME}-d
-                 PATH_SUFFIXES lib64 lib
-                 PATHS ${FIND_SFML_PATHS})
-
-    # release library
-    find_library(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE
-                 NAMES ${FIND_SFML_COMPONENT_NAME}
-                 PATH_SUFFIXES lib64 lib
-                 PATHS ${FIND_SFML_PATHS})
 
     if (SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG OR SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE)
         # library found
@@ -175,7 +208,11 @@ foreach(FIND_SFML_COMPONENT ${SFML_FIND_COMPONENTS})
     # mark as advanced
     MARK_AS_ADVANCED(SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY
                      SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_RELEASE
-                     SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG)
+                     SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DEBUG
+                     SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_RELEASE
+                     SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_STATIC_DEBUG
+                     SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_RELEASE
+                     SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY_DYNAMIC_DEBUG)
 
     # add to the global list of libraries
     set(SFML_LIBRARIES ${SFML_LIBRARIES} "${SFML_${FIND_SFML_COMPONENT_UPPER}_LIBRARY}")


### PR DESCRIPTION
Fixes #637 by inserting an intermediate layer so that find_library doesn't save both static and dynamic libraries into variables with the same name, since it caches values based solely on their name.
