### PR TITLE
C++11/14 compatibility

### DIFF
--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -234,10 +234,10 @@ void GlxContext::createContext(GlxContext* shared, unsigned int bitsPerPixel, co
             int nbConfigs = 0;
             int fbAttributes[] =
             {
-                GLX_DEPTH_SIZE, settings.depthBits,
-                GLX_STENCIL_SIZE, settings.stencilBits,
+                GLX_DEPTH_SIZE, static_cast<int>(settings.depthBits),
+                GLX_STENCIL_SIZE, static_cast<int>(settings.stencilBits),
                 GLX_SAMPLE_BUFFERS, settings.antialiasingLevel > 0,
-                GLX_SAMPLES, settings.antialiasingLevel,
+                GLX_SAMPLES, static_cast<int>(settings.antialiasingLevel),
                 GLX_RED_SIZE, 8,
                 GLX_GREEN_SIZE, 8,
                 GLX_BLUE_SIZE, 8,


### PR DESCRIPTION
cmake ../SFML_c11 -DCMAKE_INSTALL_PREFIX="/usr" -DCMAKE_C_COMPILER="/usr/bin/clang" -DCMAKE_CXX_COMPILER="/usr/bin/clang++" -DCMAKE_CXX_FLAGS="-std=c++1y -stdlib=libc++"

Small errors when using C++11/14 and clang:
src/SFML/Window/Unix/GlxContext.cpp:237:33: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
                GLX_DEPTH_SIZE, settings.depthBits,
                                ^~~~~~~~~~~~~~~~~~
src/SFML/Window/Unix/GlxContext.cpp:237:33: note: override this message by inserting an explicit cast
                GLX_DEPTH_SIZE, settings.depthBits,
                                ^~~~~~~~~~~~~~~~~~
                                static_cast<int>( )
src/SFML/Window/Unix/GlxContext.cpp:238:35: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
                GLX_STENCIL_SIZE, settings.stencilBits,
                                  ^~~~~~~~~~~~~~~~~~~~
src/SFML/Window/Unix/GlxContext.cpp:238:35: note: override this message by inserting an explicit cast
                GLX_STENCIL_SIZE, settings.stencilBits,
                                  ^~~~~~~~~~~~~~~~~~~~
                                  static_cast<int>(   )
src/SFML/Window/Unix/GlxContext.cpp:240:30: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
                GLX_SAMPLES, settings.antialiasingLevel,
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/SFML/Window/Unix/GlxContext.cpp:240:30: note: override this message by inserting an explicit cast
                GLX_SAMPLES, settings.antialiasingLevel,
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
                             static_cast<int>(         )
