### PR TITLE
bug fix: compilation error in VS2013

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -101,7 +101,7 @@ namespace
         if (user32Dll)
         {
             typedef BOOL (WINAPI* SetProcessDPIAwareFuncType)(void);
-			SetProcessDPIAwareFuncType SetProcessDPIAwareFunc = (SetProcessDPIAwareFuncType)GetProcAddress(user32Dll, "SetProcessDPIAware");
+            SetProcessDPIAwareFuncType SetProcessDPIAwareFunc = reinterpret_cast<SetProcessDPIAwareFuncType>(GetProcAddress(user32Dll, "SetProcessDPIAware"));
 
             if (SetProcessDPIAwareFunc)
             {


### PR DESCRIPTION
Error   1   error C2440: 'initializing' : cannot convert from 'FARPROC' to 'SetProcessDPIAwareFuncType' 

SetProcessDPIAwareFunc needs to be explicitly cast in VS2013.
