### PR TITLE
More fixes for text rendering

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -181,7 +181,7 @@ public :
     /// \return Kerning value for \a first and \a second, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    int getKerning(Uint32 first, Uint32 second, unsigned int characterSize) const;
+    float getKerning(Uint32 first, Uint32 second, unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the line spacing
@@ -194,7 +194,7 @@ public :
     /// \return Line spacing, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    int getLineSpacing(unsigned int characterSize) const;
+    float getLineSpacing(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the underline
@@ -209,7 +209,7 @@ public :
     /// \see getUnderlineThickness
     ///
     ////////////////////////////////////////////////////////////
-    int getUnderlinePosition(unsigned int characterSize) const;
+    float getUnderlinePosition(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the thickness of the underline
@@ -223,7 +223,7 @@ public :
     /// \see getUnderlinePosition
     ///
     ////////////////////////////////////////////////////////////
-    int getUnderlineThickness(unsigned int characterSize) const;
+    float getUnderlineThickness(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Retrieve the texture containing the loaded glyphs of a certain size

--- a/include/SFML/Graphics/Glyph.hpp
+++ b/include/SFML/Graphics/Glyph.hpp
@@ -51,9 +51,9 @@ public :
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int     advance;     ///< Offset to move horizontically to the next character
-    IntRect bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
-    IntRect textureRect; ///< Texture coordinates of the glyph inside the font's texture
+    float     advance;     ///< Offset to move horizontically to the next character
+    FloatRect bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
+    IntRect   textureRect; ///< Texture coordinates of the glyph inside the font's texture
 };
 
 } // namespace sf

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Graphics/Text.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/RenderTarget.hpp>
+#include <cmath>
 
 
 namespace sf
@@ -262,14 +263,14 @@ void Text::ensureGeometryUpdate() const
     bool  underlined         = (m_style & Underlined) != 0;
     bool  strikeThrough      = (m_style & StrikeThrough) != 0;
     float italic             = (m_style & Italic) ? 0.208f : 0.f; // 12 degrees
-    float underlineOffset    = static_cast<float>(m_font->getUnderlinePosition(m_characterSize));
-    float underlineThickness = static_cast<float>(m_font->getUnderlineThickness(m_characterSize));
+    float underlineOffset    = m_font->getUnderlinePosition(m_characterSize);
+    float underlineThickness = m_font->getUnderlineThickness(m_characterSize);
 
     // Compute the location of the strike through dynamically
     // We use the center point of the lowercase 'x' glyph as the reference
     // We reuse the underline thickness as the thickness of the strike through as well
-    IntRect xBounds = m_font->getGlyph(L'x', m_characterSize, bold).bounds;
-    float strikeThroughOffset = static_cast<float>(xBounds.top) + static_cast<float>(xBounds.height) / 2.f;
+    FloatRect xBounds = m_font->getGlyph(L'x', m_characterSize, bold).bounds;
+    float strikeThroughOffset = xBounds.top + xBounds.height / 2.f;
 
     // Precompute the variables needed by the algorithm
     float hspace = static_cast<float>(m_font->getGlyph(L' ', m_characterSize, bold).advance);
@@ -294,8 +295,8 @@ void Text::ensureGeometryUpdate() const
         // If we're using the underlined style and there's a new line, draw a line
         if (underlined && (curChar == L'\n'))
         {
-            float top = y + underlineOffset;
-            float bottom = top + underlineThickness;
+            float top = std::floor(y + underlineOffset - (underlineThickness / 2) + 0.5f);
+            float bottom = top + std::floor(underlineThickness + 0.5f);
 
             m_vertices.append(Vertex(Vector2f(0, top),    m_color, Vector2f(1, 1)));
             m_vertices.append(Vertex(Vector2f(x, top),    m_color, Vector2f(1, 1)));
@@ -308,8 +309,8 @@ void Text::ensureGeometryUpdate() const
         // If we're using the strike through style and there's a new line, draw a line across all characters
         if (strikeThrough && (curChar == L'\n'))
         {
-            float top = y + strikeThroughOffset;
-            float bottom = top + underlineThickness;
+            float top = std::floor(y + strikeThroughOffset - (underlineThickness / 2) + 0.5f);
+            float bottom = top + std::floor(underlineThickness + 0.5f);
 
             m_vertices.append(Vertex(Vector2f(0, top),    m_color, Vector2f(1, 1)));
             m_vertices.append(Vertex(Vector2f(x, top),    m_color, Vector2f(1, 1)));
@@ -344,10 +345,10 @@ void Text::ensureGeometryUpdate() const
         // Extract the current glyph's description
         const Glyph& glyph = m_font->getGlyph(curChar, m_characterSize, bold);
 
-        int left   = glyph.bounds.left;
-        int top    = glyph.bounds.top;
-        int right  = glyph.bounds.left + glyph.bounds.width;
-        int bottom = glyph.bounds.top  + glyph.bounds.height;
+        float left   = glyph.bounds.left;
+        float top    = glyph.bounds.top;
+        float right  = glyph.bounds.left + glyph.bounds.width;
+        float bottom = glyph.bounds.top  + glyph.bounds.height;
 
         float u1 = static_cast<float>(glyph.textureRect.left);
         float v1 = static_cast<float>(glyph.textureRect.top);
@@ -375,8 +376,8 @@ void Text::ensureGeometryUpdate() const
     // If we're using the underlined style, add the last line
     if (underlined)
     {
-        float top = y + underlineOffset;
-        float bottom = top + underlineThickness;
+        float top = std::floor(y + underlineOffset - (underlineThickness / 2) + 0.5f);
+        float bottom = top + std::floor(underlineThickness + 0.5f);
 
         m_vertices.append(Vertex(Vector2f(0, top),    m_color, Vector2f(1, 1)));
         m_vertices.append(Vertex(Vector2f(x, top),    m_color, Vector2f(1, 1)));
@@ -389,8 +390,8 @@ void Text::ensureGeometryUpdate() const
     // If we're using the strike through style, add the last line across all characters
     if (strikeThrough)
     {
-        float top = y + strikeThroughOffset;
-        float bottom = top + underlineThickness;
+        float top = std::floor(y + strikeThroughOffset - (underlineThickness / 2) + 0.5f);
+        float bottom = top + std::floor(underlineThickness + 0.5f);
 
         m_vertices.append(Vertex(Vector2f(0, top),    m_color, Vector2f(1, 1)));
         m_vertices.append(Vertex(Vector2f(x, top),    m_color, Vector2f(1, 1)));


### PR DESCRIPTION
- Fixed missplaced underline with some fonts (including Windows' Arial)
- Fixed glyphs being 2 pixels too large in each dimension because of padding being applied to glyph bounding boxes as well
- Moved underline and strike through a bit so their centre is where it is supposed to be
