### PR TITLE
Added support for OS X 10.10

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -53,7 +53,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
         # detect OS X version. (use '/usr/bin/sw_vers -productVersion' to extract V from '10.V.x'.)
         EXEC_PROGRAM(/usr/bin/sw_vers ARGS -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
-        STRING(REGEX REPLACE "10\\.([0-9]).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
+        STRING(REGEX REPLACE "10\\.([0-9]+).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
         if(${MACOSX_VERSION} LESS 7)
             message(FATAL_ERROR "Unsupported version of OS X: ${MACOSX_VERSION_RAW}")
             return()

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -225,7 +225,7 @@ void WindowImplCocoa::setUpProcess(void)
 
         // Register an application delegate if there is none
         if (![[SFApplication sharedApplication] delegate])
-            [NSApp setDelegate:[[[SFApplicationDelegate alloc] init] autorelease]];
+            [[NSApplication sharedApplication] setDelegate:[[SFApplicationDelegate alloc] init]];
 
         // Create menus for the application (before finishing launching!)
         [SFApplication setUpMenuBar];


### PR DESCRIPTION
This is a patch for #691, ready to be tested.

Note: this only fix the compilation process. SFML was not thoroughly
tested on this OS yet.
