### PR TITLE
Fixed documentation warnings

### DIFF
--- a/src/SFML/Window/OSX/SFContext.hpp
+++ b/src/SFML/Window/OSX/SFContext.hpp
@@ -117,7 +117,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled: True to enable v-sync, false to deactivate
+    /// \param enabled True to enable v-sync, false to deactivate
     ///
     ////////////////////////////////////////////////////////////
     virtual void setVerticalSyncEnabled(bool enabled);

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -91,7 +91,7 @@ public:
     /// \brief Change the joystick threshold, ie. the value below which
     ///        no move event will be generated
     ///
-    /// \param threshold: New threshold, in range [0, 100]
+    /// \param threshold New threshold, in range [0, 100]
     ///
     ////////////////////////////////////////////////////////////
     void setJoystickThreshold(float threshold);
@@ -227,7 +227,7 @@ private:
     ///
     ////////////////////////////////////////////////////////////
     void processJoystickEvents();
-    
+
     ////////////////////////////////////////////////////////////
     /// \brief Read the sensors state and generate the appropriate events
     ///


### PR DESCRIPTION
Such as:
- WindowImpl.hpp:94:16: warning: parameter 'threshold:' not found in the function declaration
- SFContext.hpp:120:16: warning: parameter 'enabled:' not found in the function declaration

Should not be a big deal. :)
