### PR TITLE
Added a wrapper class for angles

### DIFF
--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -31,6 +31,7 @@
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/System/Vector2.hpp>
+#include <SFML/System/Angle.hpp>
 
 
 namespace sf
@@ -194,17 +195,17 @@ public:
     /// can be chained.
     /// \code
     /// sf::Transform transform;
-    /// transform.rotate(90).translate(50, 20);
+    /// transform.rotate(sf::degree(90)).translate(50, 20);
     /// \endcode
     ///
-    /// \param angle Rotation angle, in degrees
+    /// \param angle Rotation angle
     ///
     /// \return Reference to *this
     ///
     /// \see translate, scale
     ///
     ////////////////////////////////////////////////////////////
-    Transform& rotate(float angle);
+    Transform& rotate(Angle angle);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a rotation
@@ -218,10 +219,10 @@ public:
     /// can be chained.
     /// \code
     /// sf::Transform transform;
-    /// transform.rotate(90, 8, 3).translate(50, 20);
+    /// transform.rotate(sf::degrees(90), 8, 3).translate(50, 20);
     /// \endcode
     ///
-    /// \param angle Rotation angle, in degrees
+    /// \param angle Rotation angle
     /// \param centerX X coordinate of the center of rotation
     /// \param centerY Y coordinate of the center of rotation
     ///
@@ -230,7 +231,7 @@ public:
     /// \see translate, scale
     ///
     ////////////////////////////////////////////////////////////
-    Transform& rotate(float angle, float centerX, float centerY);
+    Transform& rotate(Angle angle, float centerX, float centerY);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a rotation
@@ -244,10 +245,10 @@ public:
     /// can be chained.
     /// \code
     /// sf::Transform transform;
-    /// transform.rotate(90, sf::Vector2f(8, 3)).translate(sf::Vector2f(50, 20));
+    /// transform.rotate(sf::degrees(90), sf::Vector2f(8, 3)).translate(sf::Vector2f(50, 20));
     /// \endcode
     ///
-    /// \param angle Rotation angle, in degrees
+    /// \param angle Rotation angle
     /// \param center Center of rotation
     ///
     /// \return Reference to *this
@@ -255,7 +256,7 @@ public:
     /// \see translate, scale
     ///
     ////////////////////////////////////////////////////////////
-    Transform& rotate(float angle, const Vector2f& center);
+    Transform& rotate(Angle angle, const Vector2f& center);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a scaling

--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -90,12 +90,12 @@ public:
     /// See the rotate function to add an angle based on the previous rotation instead.
     /// The default rotation of a transformable object is 0.
     ///
-    /// \param angle New rotation, in degrees
+    /// \param angle New rotation
     ///
     /// \see rotate, getRotation
     ///
     ////////////////////////////////////////////////////////////
-    void setRotation(float angle);
+    void setRotation(Angle angle);
 
     ////////////////////////////////////////////////////////////
     /// \brief set the scale factors of the object
@@ -176,12 +176,12 @@ public:
     ///
     /// The rotation is always in the range [0, 360].
     ///
-    /// \return Current rotation, in degrees
+    /// \return Current rotation
     ///
     /// \see setRotation
     ///
     ////////////////////////////////////////////////////////////
-    float getRotation() const;
+    Angle getRotation() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief get the current scale of the object
@@ -249,10 +249,10 @@ public:
     /// object.setRotation(object.getRotation() + angle);
     /// \endcode
     ///
-    /// \param angle Angle of rotation, in degrees
+    /// \param angle Angle of rotation
     ///
     ////////////////////////////////////////////////////////////
-    void rotate(float angle);
+    void rotate(Angle angle);
 
     ////////////////////////////////////////////////////////////
     /// \brief Scale the object
@@ -318,7 +318,7 @@ private:
     ////////////////////////////////////////////////////////////
     Vector2f          m_origin;                     ///< Origin of translation/rotation/scaling of the object
     Vector2f          m_position;                   ///< Position of the object in the 2D world
-    float             m_rotation;                   ///< Orientation of the object, in degrees
+    Angle             m_rotation;                   ///< Orientation of the object
     Vector2f          m_scale;                      ///< Scale of the object
     mutable Transform m_transform;                  ///< Combined transformation of the object
     mutable bool      m_transformNeedUpdate;        ///< Does the transform need to be recomputed?

--- a/include/SFML/Graphics/View.hpp
+++ b/include/SFML/Graphics/View.hpp
@@ -116,12 +116,12 @@ public:
     ///
     /// The default rotation of a view is 0 degree.
     ///
-    /// \param angle New angle, in degrees
+    /// \param angle New angle
     ///
     /// \see getRotation
     ///
     ////////////////////////////////////////////////////////////
-    void setRotation(float angle);
+    void setRotation(Angle angle);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the target viewport
@@ -175,12 +175,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the current orientation of the view
     ///
-    /// \return Rotation angle of the view, in degrees
+    /// \return Rotation angle of the view
     ///
     /// \see setRotation
     ///
     ////////////////////////////////////////////////////////////
-    float getRotation() const;
+    Angle getRotation() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the target viewport rectangle of the view
@@ -216,12 +216,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Rotate the view relatively to its current orientation
     ///
-    /// \param angle Angle to rotate, in degrees
+    /// \param angle Angle to rotate
     ///
     /// \see setRotation, move, zoom
     ///
     ////////////////////////////////////////////////////////////
-    void rotate(float angle);
+    void rotate(Angle angle);
 
     ////////////////////////////////////////////////////////////
     /// \brief Resize the view rectangle relatively to its current size
@@ -271,7 +271,7 @@ private:
     ////////////////////////////////////////////////////////////
     Vector2f          m_center;              ///< Center of the view, in scene coordinates
     Vector2f          m_size;                ///< Size of the view, in scene coordinates
-    float             m_rotation;            ///< Angle of rotation of the view rectangle, in degrees
+    Angle             m_rotation;            ///< Angle of rotation of the view rectangle
     FloatRect         m_viewport;            ///< Viewport rectangle, expressed as a factor of the render-target's size
     mutable Transform m_transform;           ///< Precomputed projection transform corresponding to the view
     mutable Transform m_inverseTransform;    ///< Precomputed inverse projection transform corresponding to the view

--- a/include/SFML/System.hpp
+++ b/include/SFML/System.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 
 #include <SFML/Config.hpp>
+#include <SFML/System/Angle.hpp>
 #include <SFML/System/Clock.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/InputStream.hpp>

--- a/include/SFML/System/Angle.hpp
+++ b/include/SFML/System/Angle.hpp
@@ -60,6 +60,16 @@ public:
     Angle(float angle);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Implicit conversion to a float number representing
+    /// the angle in degrees to provide backward compatibility.
+    /// You should use toDegrees() instead.
+    ///
+    /// \return Angle in degrees
+    ///
+    ////////////////////////////////////////////////////////////
+    operator float () const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Return the angle's value in degrees
     ///
     /// \return Angle in degrees

--- a/include/SFML/System/Angle.hpp
+++ b/include/SFML/System/Angle.hpp
@@ -1,0 +1,449 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2014 Laurent Gomila (laurent.gom@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_ANGLE_HPP
+#define SFML_ANGLE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Represents an angle value
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API Angle
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Sets the angle value to zero.
+    ///
+    ////////////////////////////////////////////////////////////
+    Angle();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Implicit conversion from an angle in degrees to
+    /// provide backward compatibility. You should use degrees()
+    /// instead.
+    ///
+    /// \param angle Angle in degrees
+    ///
+    ////////////////////////////////////////////////////////////
+    Angle(float angle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the angle's value in degrees
+    ///
+    /// \return Angle in degrees
+    ///
+    /// \see asRadians
+    ///
+    ////////////////////////////////////////////////////////////
+    float asDegrees() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the angle's value in radians
+    ///
+    /// \return Angle in radians
+    ///
+    /// \see asDegree
+    ///
+    ////////////////////////////////////////////////////////////
+    float asRadians() const;
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const Angle Zero; ///< Predefined 0 degree angle value
+
+private:
+
+    friend SFML_SYSTEM_API Angle degrees(float);
+    friend SFML_SYSTEM_API Angle radians(float);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    float m_radians; ///< Angle value stored as radians
+};
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Construct an angle value from a number of degrees
+///
+/// \param amount Number of degrees
+///
+/// \return Angle value constructed from the amount of degrees
+///
+/// \see radians
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle degrees(float angle);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Construct an angle value from a number of radians
+///
+/// \param amount Number of radians
+///
+/// \return Angle value constructed from the amount of radians
+///
+/// \see degrees
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle radians(float angle);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of == operator to compare two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return True if both angle values are equal
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator ==(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of != operator to compare two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return True if both angle values are different
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator !=(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of < operator to compare two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return True if \a left is lesser than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator <(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of > operator to compare two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return True if \a left is greater than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator >(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of <= operator to compare two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return True if \a left is lesser or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator <=(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of >= operator to compare two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return True if \a left is greater or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator >=(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of unary - operator to negate an angle value
+///
+/// \param right Right operand (an angle)
+///
+/// \return Opposite of the angle value
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator -(Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary + operator to add two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return Sum of the two angle values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator +(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary += operator to add/assign two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return Sum of the two angle values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle& operator +=(Angle& left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary - operator to subtract two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return Difference of the two angle values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator -(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary -= operator to subtract/assign two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return Difference of the two angle values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle& operator -=(Angle& left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary * operator to scale an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator *(Angle left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary * operator to scale an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator *(Angle left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary * operator to scale an angle value
+///
+/// \param left  Left operand (a number)
+/// \param right Right operand (an angle)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator *(float left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary * operator to scale an angle value
+///
+/// \param left  Left operand (a number)
+/// \param right Right operand (an angle)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator *(Int64 left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary *= operator to scale/assign an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle& operator *=(Angle& left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary *= operator to scale/assign an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle& operator *=(Angle& left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary / operator to scale an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator /(Angle left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary / operator to scale an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator /(Angle left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary /= operator to scale/assign an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle& operator /=(Angle& left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary /= operator to scale/assign an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle& operator /=(Angle& left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary / operator to compute the ratio of two angle values
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API float operator /(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary % operator to compute remainder of an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return \a left modulo \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle operator %(Angle left, Angle right);
+
+////////////////////////////////////////////////////////////
+/// \relates Angle
+/// \brief Overload of binary %= operator to compute/assign remainder of an angle value
+///
+/// \param left  Left operand (an angle)
+/// \param right Right operand (an angle)
+///
+/// \return \a left modulo \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Angle& operator %=(Angle& left, Angle right);
+
+} // namespace sf
+
+
+#endif // SFML_ANGLE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Angle
+/// \ingroup system
+///
+/// sf::Angle encapsulates an angle value in a flexible way.
+/// It allows to define an angle value either as a number of
+/// degrees or radians. It also works the other way round:
+/// you can read an angle value as either a number of
+/// degrees or radians.
+///
+/// All angles are always normalized to the interval
+/// <em>[0 - 360[</em> (in degree).
+///
+/// By using such a flexible interface, the API doesn't
+/// impose any fixed type or resolution for angle values,
+/// and let the user choose its own favorite representation.
+///
+/// Angle values support the usual mathematical operations:
+/// you can add or subtract two angles, multiply or divide
+/// an angle by a number, compare two angles, etc.
+///
+/// Usage example:
+/// \code
+/// sf::Angle a1  = sf::degree(90.f);
+/// float radians = a1.asRadians(); // 1.5708
+///
+/// sf::Angle a2 = sf::radians(PI);
+/// float degrees = a2.asDegree(); // 180
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -177,11 +177,10 @@ Transform& Transform::translate(const Vector2f& offset)
 
 
 ////////////////////////////////////////////////////////////
-Transform& Transform::rotate(float angle)
+Transform& Transform::rotate(Angle angle)
 {
-    float rad = angle * 3.141592654f / 180.f;
-    float cos = std::cos(rad);
-    float sin = std::sin(rad);
+    float cos = std::cos(angle.asRadians());
+    float sin = std::sin(angle.asRadians());
 
     Transform rotation(cos, -sin, 0,
                        sin,  cos, 0,
@@ -192,11 +191,10 @@ Transform& Transform::rotate(float angle)
 
 
 ////////////////////////////////////////////////////////////
-Transform& Transform::rotate(float angle, float centerX, float centerY)
+Transform& Transform::rotate(Angle angle, float centerX, float centerY)
 {
-    float rad = angle * 3.141592654f / 180.f;
-    float cos = std::cos(rad);
-    float sin = std::sin(rad);
+    float cos = std::cos(angle.asRadians());
+    float sin = std::sin(angle.asRadians());
 
     Transform rotation(cos, -sin, centerX * (1 - cos) + centerY * sin,
                        sin,  cos, centerY * (1 - cos) - centerX * sin,
@@ -207,7 +205,7 @@ Transform& Transform::rotate(float angle, float centerX, float centerY)
 
 
 ////////////////////////////////////////////////////////////
-Transform& Transform::rotate(float angle, const Vector2f& center)
+Transform& Transform::rotate(Angle angle, const Vector2f& center)
 {
     return rotate(angle, center.x, center.y);
 }

--- a/src/SFML/Graphics/Transformable.cpp
+++ b/src/SFML/Graphics/Transformable.cpp
@@ -69,11 +69,9 @@ void Transformable::setPosition(const Vector2f& position)
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::setRotation(float angle)
+void Transformable::setRotation(Angle angle)
 {
-    m_rotation = static_cast<float>(fmod(angle, 360));
-    if (m_rotation < 0)
-        m_rotation += 360.f;
+    m_rotation = angle;
 
     m_transformNeedUpdate = true;
     m_inverseTransformNeedUpdate = true;
@@ -122,7 +120,7 @@ const Vector2f& Transformable::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-float Transformable::getRotation() const
+Angle Transformable::getRotation() const
 {
     return m_rotation;
 }
@@ -157,7 +155,7 @@ void Transformable::move(const Vector2f& offset)
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::rotate(float angle)
+void Transformable::rotate(Angle angle)
 {
     setRotation(m_rotation + angle);
 }
@@ -183,9 +181,8 @@ const Transform& Transformable::getTransform() const
     // Recompute the combined transform if needed
     if (m_transformNeedUpdate)
     {
-        float angle  = -m_rotation * 3.141592654f / 180.f;
-        float cosine = static_cast<float>(std::cos(angle));
-        float sine   = static_cast<float>(std::sin(angle));
+        float cosine = static_cast<float>(std::cos(-m_rotation.asRadians()));
+        float sine   = static_cast<float>(std::sin(-m_rotation.asRadians()));
         float sxc    = m_scale.x * cosine;
         float syc    = m_scale.y * cosine;
         float sxs    = m_scale.x * sine;

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -106,11 +106,9 @@ void View::setSize(const Vector2f& size)
 
 
 ////////////////////////////////////////////////////////////
-void View::setRotation(float angle)
+void View::setRotation(Angle angle)
 {
-    m_rotation = static_cast<float>(fmod(angle, 360));
-    if (m_rotation < 0)
-        m_rotation += 360.f;
+    m_rotation = angle;
 
     m_transformUpdated    = false;
     m_invTransformUpdated = false;
@@ -153,7 +151,7 @@ const Vector2f& View::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-float View::getRotation() const
+Angle View::getRotation() const
 {
     return m_rotation;
 }
@@ -181,7 +179,7 @@ void View::move(const Vector2f& offset)
 
 
 ////////////////////////////////////////////////////////////
-void View::rotate(float angle)
+void View::rotate(Angle angle)
 {
     setRotation(m_rotation + angle);
 }
@@ -201,9 +199,8 @@ const Transform& View::getTransform() const
     if (!m_transformUpdated)
     {
         // Rotation components
-        float angle  = m_rotation * 3.141592654f / 180.f;
-        float cosine = static_cast<float>(std::cos(angle));
-        float sine   = static_cast<float>(std::sin(angle));
+        float cosine = static_cast<float>(std::cos(m_rotation.asRadians()));
+        float sine   = static_cast<float>(std::sin(m_rotation.asRadians()));
         float tx     = -m_center.x * cosine - m_center.y * sine + m_center.x;
         float ty     =  m_center.x * sine - m_center.y * cosine + m_center.y;
 

--- a/src/SFML/System/Angle.cpp
+++ b/src/SFML/System/Angle.cpp
@@ -48,6 +48,13 @@ m_radians(0)
 
 
 ////////////////////////////////////////////////////////////
+Angle::operator float() const
+{
+    return m_radians * 180 / ::pi;
+}
+
+
+////////////////////////////////////////////////////////////
 float Angle::asDegrees() const
 {
     return m_radians * 180 / ::pi;

--- a/src/SFML/System/Angle.cpp
+++ b/src/SFML/System/Angle.cpp
@@ -1,0 +1,257 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2014 Laurent Gomila (laurent.gom@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Angle.hpp>
+#include <cmath>
+
+namespace
+{
+    const float pi = 3.141592654f;
+}
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+const Angle Angle::Zero;
+
+
+////////////////////////////////////////////////////////////
+Angle::Angle() :
+m_radians(0)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+float Angle::asDegrees() const
+{
+    return m_radians * 180 / ::pi;
+}
+
+
+////////////////////////////////////////////////////////////
+float Angle::asRadians() const
+{
+    return m_radians;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle::Angle(float angle)
+{
+    // Normalize to [0, 360[
+    angle = static_cast<float>(std::fmod(angle, 360));
+    if (angle < 0)
+        angle += 360;
+    
+    m_radians = angle * ::pi / 180;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle degrees(float amount)
+{
+    return Angle(amount);
+}
+
+
+////////////////////////////////////////////////////////////
+Angle radians(float amount)
+{
+    return Angle(amount * 180 / ::pi);
+}
+
+
+////////////////////////////////////////////////////////////
+bool operator ==(Angle left, Angle right)
+{
+    return left.asRadians() == right.asRadians();
+}
+
+
+////////////////////////////////////////////////////////////
+bool operator !=(Angle left, Angle right)
+{
+    return left.asRadians() != right.asRadians();
+}
+
+
+////////////////////////////////////////////////////////////
+bool operator <(Angle left, Angle right)
+{
+    return left.asRadians() < right.asRadians();
+}
+
+
+////////////////////////////////////////////////////////////
+bool operator >(Angle left, Angle right)
+{
+    return left.asRadians() > right.asRadians();
+}
+
+
+////////////////////////////////////////////////////////////
+bool operator <=(Angle left, Angle right)
+{
+    return left.asRadians() <= right.asRadians();
+}
+
+
+////////////////////////////////////////////////////////////
+bool operator >=(Angle left, Angle right)
+{
+    return left.asRadians() >= right.asRadians();
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator -(Angle right)
+{
+    return radians(-right.asRadians());
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator +(Angle left, Angle right)
+{
+    return radians(left.asRadians() + right.asRadians());
+}
+
+
+////////////////////////////////////////////////////////////
+Angle& operator +=(Angle& left, Angle right)
+{
+    return left = left + right;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator -(Angle left, Angle right)
+{
+    return radians(left.asRadians() - right.asRadians());
+}
+
+
+////////////////////////////////////////////////////////////
+Angle& operator -=(Angle& left, Angle right)
+{
+    return left = left - right;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator *(Angle left, float right)
+{
+    return radians(left.asRadians() * right);
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator *(Angle left, Int64 right)
+{
+    return radians(left.asRadians() * right);
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator *(float left, Angle right)
+{
+    return right * left;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator *(Int64 left, Angle right)
+{
+    return right * left;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle& operator *=(Angle& left, float right)
+{
+    return left = left * right;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle& operator *=(Angle& left, Int64 right)
+{
+    return left = left * right;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator /(Angle left, float right)
+{
+    return radians(left.asRadians() / right);
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator /(Angle left, Int64 right)
+{
+    return radians(left.asRadians() / right);
+}
+
+
+////////////////////////////////////////////////////////////
+Angle& operator /=(Angle& left, float right)
+{
+    return left = left / right;
+}
+
+
+////////////////////////////////////////////////////////////
+Angle& operator /=(Angle& left, Int64 right)
+{
+    return left = left / right;
+}
+
+
+////////////////////////////////////////////////////////////
+float operator /(Angle left, Angle right)
+{
+    return left.asRadians() / right.asRadians();
+}
+
+
+////////////////////////////////////////////////////////////
+Angle operator %(Angle left, Angle right)
+{
+    return radians(static_cast<float>(std::fmod(left.asRadians(), right.asRadians())));
+}
+
+
+////////////////////////////////////////////////////////////
+Angle& operator %=(Angle& left, Angle right)
+{
+    return left = left % right;
+}
+
+} // namespace sf

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -4,6 +4,8 @@ set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/System)
 
 # all source files
 set(SRC
+    ${SRCROOT}/Angle.cpp
+    ${INCROOT}/Angle.hpp
     ${SRCROOT}/Clock.cpp
     ${INCROOT}/Clock.hpp
     ${SRCROOT}/Err.cpp


### PR DESCRIPTION
`sf::Angle` works in a similar way to `sf::Time` providing conversion between radians and degrees in addition to basic mathematical operands.

Angles are always normalized to provide values within _[0, 360[ deg_ resp. _[0, 2 PI[ rad_.

In addition, there's a constructor taking a floating point value to provide backward compatibility with existing source code.

Right now conversion offers radians as well as degrees, although I could imagine adding [some more units](http://en.wikipedia.org/wiki/Angle#Units), such as _grads_ or _seconds of arc_.
