### PR TITLE
Prevent showing garbage from uninitialized padding in sf::Texture

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -34,6 +34,7 @@
 #include <SFML/System/Mutex.hpp>
 #include <SFML/System/Lock.hpp>
 #include <SFML/System/Err.hpp>
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 
@@ -159,6 +160,12 @@ bool Texture::create(unsigned int width, unsigned int height)
     // Initialize the texture
     glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
     glCheck(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_actualSize.x, m_actualSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL));
+    if(m_actualSize != m_size)
+    {
+      std::vector<Uint8> pixels(std::max((m_actualSize.x-m_size.x) * m_size.y, m_actualSize.x * (m_actualSize.y-m_size.y)) * 4, 0);
+      glCheck(glTexSubImage2D(GL_TEXTURE_2D, 0, m_size.x, 0, m_actualSize.x-m_size.x, m_size.y, GL_RGBA, GL_UNSIGNED_BYTE, &pixels[0]));
+      glCheck(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, m_size.y, m_actualSize.x, m_actualSize.y-m_size.y, GL_RGBA, GL_UNSIGNED_BYTE, &pixels[0]));
+    }
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, m_isRepeated ? GL_REPEAT : GL_CLAMP_TO_EDGE));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, m_isRepeated ? GL_REPEAT : GL_CLAMP_TO_EDGE));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));


### PR DESCRIPTION
Fixes issue #719 
