### PR TITLE
Added implementation of Window::hasFocus() on iOS

### DIFF
--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -103,7 +103,7 @@ namespace
     {
         sf::Event event;
         event.type = sf::Event::LostFocus;
-        sfWindow->pushEvent(event);
+        sfWindow->forwardEvent(event);
     }
 }
 
@@ -127,7 +127,7 @@ namespace
     {
         sf::Event event;
         event.type = sf::Event::GainedFocus;
-        sfWindow->pushEvent(event);
+        sfWindow->forwardEvent(event);
     }
 }
 
@@ -147,7 +147,7 @@ namespace
     {
         sf::Event event;
         event.type = sf::Event::Closed;
-        sfWindow->pushEvent(event);
+        sfWindow->forwardEvent(event);
     }
 }
 
@@ -176,7 +176,7 @@ namespace
             event.type = sf::Event::Resized;
             event.size.width = size.x;
             event.size.height = size.y;
-            sfWindow->pushEvent(event);
+            sfWindow->forwardEvent(event);
         }
     }
 }
@@ -215,7 +215,7 @@ namespace
         event.touch.finger = index;
         event.touch.x = position.x;
         event.touch.y = position.y;
-        sfWindow->pushEvent(event);
+        sfWindow->forwardEvent(event);
     }
 }
 
@@ -236,7 +236,7 @@ namespace
         event.touch.finger = index;
         event.touch.x = position.x;
         event.touch.y = position.y;
-        sfWindow->pushEvent(event);
+        sfWindow->forwardEvent(event);
     }
 }
 
@@ -256,7 +256,7 @@ namespace
         event.touch.finger = index;
         event.touch.x = position.x;
         event.touch.y = position.y;
-        sfWindow->pushEvent(event);
+        sfWindow->forwardEvent(event);
     }
 }
 
@@ -269,7 +269,7 @@ namespace
         sf::Event event;
         event.type = sf::Event::TextEntered;
         event.text.unicode = character;
-        sfWindow->pushEvent(event);
+        sfWindow->forwardEvent(event);
     }
 }
 

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -174,7 +174,13 @@ public:
 
 public:
 
-    using WindowImpl::pushEvent;
+    ////////////////////////////////////////////////////////////
+    /// \brief Notify an event
+    ///
+    /// \param event Evenet to forward
+    ///
+    ////////////////////////////////////////////////////////////
+    void forwardEvent(Event event);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the window's view
@@ -208,6 +214,7 @@ private:
     UIWindow*         m_window;         ///< Pointer to the internal UIKit window
     SFView*           m_view;           ///< OpenGL view of the window
     SFViewController* m_viewController; ///< Controller attached to the view
+    bool              m_hasFocus;       ///< Current focus state of the window
 };
     
 } // namespace priv

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -41,6 +41,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 WindowImplUIKit::WindowImplUIKit(WindowHandle handle)
 {
+    // Not implemented
 }
 
 
@@ -62,6 +63,7 @@ WindowImplUIKit::WindowImplUIKit(VideoMode mode,
     // Create the window
     CGRect frame = [UIScreen mainScreen].bounds; // Ignore user size, it wouldn't make sense to use something else
     m_window = [[UIWindow alloc] initWithFrame:frame];
+    m_hasFocus = true;
 
     // Assign it to the application delegate
     [SFAppDelegate getInstance].sfWindow = this;
@@ -173,18 +175,29 @@ void WindowImplUIKit::setKeyRepeatEnabled(bool enabled)
 ////////////////////////////////////////////////////////////
 void WindowImplUIKit::requestFocus()
 {
-    // Not applicable
+    // To implement
 }
 
 
 ////////////////////////////////////////////////////////////
 bool WindowImplUIKit::hasFocus() const
 {
-    // Not applicable
-    return false;
+    return m_hasFocus;
 }
 
-    
+
+////////////////////////////////////////////////////////////
+void WindowImplUIKit::forwardEvent(Event event)
+{
+    if (event.type == Event::GainedFocus)
+        m_hasFocus = true;
+    else if (event.type == Event::LostFocus)
+        m_hasFocus = false;
+
+    pushEvent(event);
+}
+
+
 ////////////////////////////////////////////////////////////
 SFView* WindowImplUIKit::getGlView() const
 {


### PR DESCRIPTION
This PR implements Window::hasFocus() on iOS. The code is simple, it's similar to what's done on Android.
