### PR TITLE
Replaced unsigned int with std::size_t for array indices/sizes

### DIFF
--- a/include/SFML/Graphics/CircleShape.hpp
+++ b/include/SFML/Graphics/CircleShape.hpp
@@ -49,7 +49,7 @@ public:
     /// \param pointCount Number of points composing the circle
     ///
     ////////////////////////////////////////////////////////////
-    explicit CircleShape(float radius = 0, unsigned int pointCount = 30);
+    explicit CircleShape(float radius = 0, std::size_t pointCount = 30);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the radius of the circle
@@ -79,7 +79,7 @@ public:
     /// \see getPointCount
     ///
     ////////////////////////////////////////////////////////////
-    void setPointCount(unsigned int count);
+    void setPointCount(std::size_t count);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of points of the circle
@@ -89,7 +89,7 @@ public:
     /// \see setPointCount
     ///
     ////////////////////////////////////////////////////////////
-    virtual unsigned int getPointCount() const;
+    virtual std::size_t getPointCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a point of the circle
@@ -104,15 +104,15 @@ public:
     /// \return index-th point of the shape
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2f getPoint(unsigned int index) const;
+    virtual Vector2f getPoint(std::size_t index) const;
 
 private:
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    float        m_radius;     ///< Radius of the circle
-    unsigned int m_pointCount; ///< Number of points composing the circle
+    float       m_radius;     ///< Radius of the circle
+    std::size_t m_pointCount; ///< Number of points composing the circle
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/ConvexShape.hpp
+++ b/include/SFML/Graphics/ConvexShape.hpp
@@ -49,7 +49,7 @@ public:
     /// \param pointCount Number of points of the polygon
     ///
     ////////////////////////////////////////////////////////////
-    explicit ConvexShape(unsigned int pointCount = 0);
+    explicit ConvexShape(std::size_t pointCount = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the number of points of the polygon
@@ -61,7 +61,7 @@ public:
     /// \see getPointCount
     ///
     ////////////////////////////////////////////////////////////
-    void setPointCount(unsigned int count);
+    void setPointCount(std::size_t count);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of points of the polygon
@@ -71,7 +71,7 @@ public:
     /// \see setPointCount
     ///
     ////////////////////////////////////////////////////////////
-    virtual unsigned int getPointCount() const;
+    virtual std::size_t getPointCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the position of a point
@@ -88,7 +88,7 @@ public:
     /// \see getPoint
     ///
     ////////////////////////////////////////////////////////////
-    void setPoint(unsigned int index, const Vector2f& point);
+    void setPoint(std::size_t index, const Vector2f& point);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of a point
@@ -105,7 +105,7 @@ public:
     /// \see setPoint
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2f getPoint(unsigned int index) const;
+    virtual Vector2f getPoint(std::size_t index) const;
 
 private:
 

--- a/include/SFML/Graphics/RectangleShape.hpp
+++ b/include/SFML/Graphics/RectangleShape.hpp
@@ -77,7 +77,7 @@ public:
     ///         shapes, this number is always 4.
     ///
     ////////////////////////////////////////////////////////////
-    virtual unsigned int getPointCount() const;
+    virtual std::size_t getPointCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a point of the rectangle
@@ -92,7 +92,7 @@ public:
     /// \return index-th point of the shape
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2f getPoint(unsigned int index) const;
+    virtual Vector2f getPoint(std::size_t index) const;
 
 private:
 

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -244,7 +244,7 @@ public:
     /// \param states      Render states to use for drawing
     ///
     ////////////////////////////////////////////////////////////
-    void draw(const Vertex* vertices, unsigned int vertexCount,
+    void draw(const Vertex* vertices, std::size_t vertexCount,
               PrimitiveType type, const RenderStates& states = RenderStates::Default);
 
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -193,7 +193,7 @@ public:
     /// \see getPoint
     ///
     ////////////////////////////////////////////////////////////
-    virtual unsigned int getPointCount() const = 0;
+    virtual std::size_t getPointCount() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a point of the shape
@@ -210,7 +210,7 @@ public:
     /// \see getPointCount
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2f getPoint(unsigned int index) const = 0;
+    virtual Vector2f getPoint(std::size_t index) const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the local bounding rectangle of the entity

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -61,7 +61,7 @@ public:
     /// \param vertexCount Initial number of vertices in the array
     ///
     ////////////////////////////////////////////////////////////
-    explicit VertexArray(PrimitiveType type, unsigned int vertexCount = 0);
+    explicit VertexArray(PrimitiveType type, std::size_t vertexCount = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the vertex count
@@ -69,7 +69,7 @@ public:
     /// \return Number of vertices in the array
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getVertexCount() const;
+    std::size_t getVertexCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-write access to a vertex by its index
@@ -85,7 +85,7 @@ public:
     /// \see getVertexCount
     ///
     ////////////////////////////////////////////////////////////
-    Vertex& operator [](unsigned int index);
+    Vertex& operator [](std::size_t index);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only access to a vertex by its index
@@ -101,7 +101,7 @@ public:
     /// \see getVertexCount
     ///
     ////////////////////////////////////////////////////////////
-    const Vertex& operator [](unsigned int index) const;
+    const Vertex& operator [](std::size_t index) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear the vertex array
@@ -126,7 +126,7 @@ public:
     /// \param vertexCount New size of the array (number of vertices)
     ///
     ////////////////////////////////////////////////////////////
-    void resize(unsigned int vertexCount);
+    void resize(std::size_t vertexCount);
 
     ////////////////////////////////////////////////////////////
     /// \brief Add a vertex to the array

--- a/src/SFML/Graphics/CircleShape.cpp
+++ b/src/SFML/Graphics/CircleShape.cpp
@@ -32,7 +32,7 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-CircleShape::CircleShape(float radius, unsigned int pointCount) :
+CircleShape::CircleShape(float radius, std::size_t pointCount) :
 m_radius    (radius),
 m_pointCount(pointCount)
 {
@@ -56,21 +56,21 @@ float CircleShape::getRadius() const
 
 
 ////////////////////////////////////////////////////////////
-void CircleShape::setPointCount(unsigned int count)
+void CircleShape::setPointCount(std::size_t count)
 {
     m_pointCount = count;
     update();
 }
 
 ////////////////////////////////////////////////////////////
-unsigned int CircleShape::getPointCount() const
+std::size_t CircleShape::getPointCount() const
 {
     return m_pointCount;
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2f CircleShape::getPoint(unsigned int index) const
+Vector2f CircleShape::getPoint(std::size_t index) const
 {
     static const float pi = 3.141592654f;
 

--- a/src/SFML/Graphics/ConvexShape.cpp
+++ b/src/SFML/Graphics/ConvexShape.cpp
@@ -31,14 +31,14 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-ConvexShape::ConvexShape(unsigned int pointCount)
+ConvexShape::ConvexShape(std::size_t pointCount)
 {
     setPointCount(pointCount);
 }
 
 
 ////////////////////////////////////////////////////////////
-void ConvexShape::setPointCount(unsigned int count)
+void ConvexShape::setPointCount(std::size_t count)
 {
     m_points.resize(count);
     update();
@@ -46,14 +46,14 @@ void ConvexShape::setPointCount(unsigned int count)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int ConvexShape::getPointCount() const
+std::size_t ConvexShape::getPointCount() const
 {
-    return static_cast<unsigned int>(m_points.size());
+    return m_points.size();
 }
 
 
 ////////////////////////////////////////////////////////////
-void ConvexShape::setPoint(unsigned int index, const Vector2f& point)
+void ConvexShape::setPoint(std::size_t index, const Vector2f& point)
 {
     m_points[index] = point;
     update();
@@ -61,7 +61,7 @@ void ConvexShape::setPoint(unsigned int index, const Vector2f& point)
 
 
 ////////////////////////////////////////////////////////////
-Vector2f ConvexShape::getPoint(unsigned int index) const
+Vector2f ConvexShape::getPoint(std::size_t index) const
 {
     return m_points[index];
 }

--- a/src/SFML/Graphics/RectangleShape.cpp
+++ b/src/SFML/Graphics/RectangleShape.cpp
@@ -54,14 +54,14 @@ const Vector2f& RectangleShape::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-unsigned int RectangleShape::getPointCount() const
+std::size_t RectangleShape::getPointCount() const
 {
     return 4;
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2f RectangleShape::getPoint(unsigned int index) const
+Vector2f RectangleShape::getPoint(std::size_t index) const
 {
     switch (index)
     {

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -190,7 +190,7 @@ void RenderTarget::draw(const Drawable& drawable, const RenderStates& states)
 
 
 ////////////////////////////////////////////////////////////
-void RenderTarget::draw(const Vertex* vertices, unsigned int vertexCount,
+void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
                         PrimitiveType type, const RenderStates& states)
 {
     // Nothing to draw?
@@ -218,7 +218,7 @@ void RenderTarget::draw(const Vertex* vertices, unsigned int vertexCount,
         if (useVertexCache)
         {
             // Pre-transform the vertices and store them into the vertex cache
-            for (unsigned int i = 0; i < vertexCount; ++i)
+            for (std::size_t i = 0; i < vertexCount; ++i)
             {
                 Vertex& vertex = m_cache.vertexCache[i];
                 vertex.position = states.transform * vertices[i].position;

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -175,7 +175,7 @@ m_bounds          ()
 void Shape::update()
 {
     // Get the total number of points of the shape
-    unsigned int count = getPointCount();
+    std::size_t count = getPointCount();
     if (count < 3)
     {
         m_vertices.resize(0);
@@ -186,7 +186,7 @@ void Shape::update()
     m_vertices.resize(count + 2); // + 2 for center and repeated first point
 
     // Position
-    for (unsigned int i = 0; i < count; ++i)
+    for (std::size_t i = 0; i < count; ++i)
         m_vertices[i + 1].position = getPoint(i);
     m_vertices[count + 1].position = m_vertices[1].position;
 
@@ -230,7 +230,7 @@ void Shape::draw(RenderTarget& target, RenderStates states) const
 ////////////////////////////////////////////////////////////
 void Shape::updateFillColors()
 {
-    for (unsigned int i = 0; i < m_vertices.getVertexCount(); ++i)
+    for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
         m_vertices[i].color = m_fillColor;
 }
 
@@ -238,7 +238,7 @@ void Shape::updateFillColors()
 ////////////////////////////////////////////////////////////
 void Shape::updateTexCoords()
 {
-    for (unsigned int i = 0; i < m_vertices.getVertexCount(); ++i)
+    for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
     {
         float xratio = m_insideBounds.width > 0 ? (m_vertices[i].position.x - m_insideBounds.left) / m_insideBounds.width : 0;
         float yratio = m_insideBounds.height > 0 ? (m_vertices[i].position.y - m_insideBounds.top) / m_insideBounds.height : 0;
@@ -251,12 +251,12 @@ void Shape::updateTexCoords()
 ////////////////////////////////////////////////////////////
 void Shape::updateOutline()
 {
-    unsigned int count = m_vertices.getVertexCount() - 2;
+    std::size_t count = m_vertices.getVertexCount() - 2;
     m_outlineVertices.resize((count + 1) * 2);
 
-    for (unsigned int i = 0; i < count; ++i)
+    for (std::size_t i = 0; i < count; ++i)
     {
-        unsigned int index = i + 1;
+        std::size_t index = i + 1;
 
         // Get the two segments shared by the current point
         Vector2f p0 = (i == 0) ? m_vertices[count].position : m_vertices[index - 1].position;
@@ -298,7 +298,7 @@ void Shape::updateOutline()
 ////////////////////////////////////////////////////////////
 void Shape::updateOutlineColors()
 {
-    for (unsigned int i = 0; i < m_outlineVertices.getVertexCount(); ++i)
+    for (std::size_t i = 0; i < m_outlineVertices.getVertexCount(); ++i)
         m_outlineVertices[i].color = m_outlineColor;
 }
 

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -118,7 +118,7 @@ void Text::setColor(const Color& color)
         // (if geometry is updated anyway, we can skip this step)
         if (!m_geometryNeedUpdate)
         {
-            for (unsigned int i = 0; i < m_vertices.getVertexCount(); ++i)
+            for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
                 m_vertices[i].color = m_color;
         }
     }

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -40,7 +40,7 @@ m_primitiveType(Points)
 
 
 ////////////////////////////////////////////////////////////
-VertexArray::VertexArray(PrimitiveType type, unsigned int vertexCount) :
+VertexArray::VertexArray(PrimitiveType type, std::size_t vertexCount) :
 m_vertices     (vertexCount),
 m_primitiveType(type)
 {
@@ -48,21 +48,21 @@ m_primitiveType(type)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int VertexArray::getVertexCount() const
+std::size_t VertexArray::getVertexCount() const
 {
-    return static_cast<unsigned int>(m_vertices.size());
+    return m_vertices.size();
 }
 
 
 ////////////////////////////////////////////////////////////
-Vertex& VertexArray::operator [](unsigned int index)
+Vertex& VertexArray::operator [](std::size_t index)
 {
     return m_vertices[index];
 }
 
 
 ////////////////////////////////////////////////////////////
-const Vertex& VertexArray::operator [](unsigned int index) const
+const Vertex& VertexArray::operator [](std::size_t index) const
 {
     return m_vertices[index];
 }
@@ -76,7 +76,7 @@ void VertexArray::clear()
 
 
 ////////////////////////////////////////////////////////////
-void VertexArray::resize(unsigned int vertexCount)
+void VertexArray::resize(std::size_t vertexCount)
 {
     m_vertices.resize(vertexCount);
 }
@@ -144,7 +144,7 @@ FloatRect VertexArray::getBounds() const
 void VertexArray::draw(RenderTarget& target, RenderStates states) const
 {
     if (!m_vertices.empty())
-        target.draw(&m_vertices[0], static_cast<unsigned int>(m_vertices.size()), m_primitiveType, states);
+        target.draw(&m_vertices[0], m_vertices.size(), m_primitiveType, states);
 }
 
 } // namespace sf


### PR DESCRIPTION
See http://en.sfml-dev.org/forums/index.php?topic=16747

The type `unsigned int` is replaced by `std::size_t` in places where values clearly represent array indices or sizes. This affects mainly the `sf::VertexArray` class and the `sf::Shape` class hierarchy. The change makes the API more consistent to existing parts like `sf::String`.

Points to consider regarding the decision on introducing this PR into SFML 2.2:
- It is an API change, although a backwards-compatible one. This means the documentation will be updated, in particular the one on the website will look different when this modification is merged. Thus, if this is merged shortly after 2.2, people will have an outdated online doc until the next release (although it will hardly make a real difference whether one reads `unsigned int` or `std::size_t`).
- It is not a critical bugfix. Currently, compiler warnings are generated on systems where `unsigned int` and `std::size_t` are different types. 
- The change is cosmetical and should not have noticeable implications on the behavior. In practice, an array of more than 4G vertices or points (where the size would not fit into `unsigned int`) would lead to completely different problems.

I would appreciate if the latest changes could be tested with fully enabled conversion warnings -- in my environment, `unsigned int` and `std::size_t` are the same types, so I don`t see potential warnings.
