### PR TITLE
Reduced lock contention when playing and immediately querying the status of a SoundStream.

### DIFF
--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -274,17 +274,21 @@ void SoundStream::streamData()
             m_isStreaming = false;
             return;
         }
+    }
 
-        // Create the buffers
-        alCheck(alGenBuffers(BufferCount, m_buffers));
-        for (int i = 0; i < BufferCount; ++i)
-            m_endBuffers[i] = false;
+    // Create the buffers
+    alCheck(alGenBuffers(BufferCount, m_buffers));
+    for (int i = 0; i < BufferCount; ++i)
+        m_endBuffers[i] = false;
 
-        // Fill the queue
-        requestStop = fillQueue();
+    // Fill the queue
+    requestStop = fillQueue();
 
-        // Play the sound
-        alCheck(alSourcePlay(m_source));
+    // Play the sound
+    alCheck(alSourcePlay(m_source));
+
+    {
+        Lock lock(m_threadMutex);
 
         // Check if the thread was launched Paused
         if (m_threadStartState == Paused)


### PR DESCRIPTION
Fixes behaviour described [here](http://en.sfml-dev.org/forums/index.php?topic=16727.0).
