### PR TITLE
Relaxed requirements on iterator type of sf::Utf<8>::decode

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -57,7 +57,7 @@ In Utf<8>::decode(In begin, In end, Uint32& output, Uint32 replacement)
 
     // decode the character
     int trailingBytes = trailing[static_cast<Uint8>(*begin)];
-    if (begin + trailingBytes < end)
+    if (std::distance(begin, end) < trailingBytes)
     {
         output = 0;
         switch (trailingBytes)


### PR DESCRIPTION
This function, which is used by ```sf::String::fromUtf8```, can now work with input iterators instead of random-access iterators.

Forum thread for use case: http://en.sfml-dev.org/forums/index.php?topic=17345.0