### PR TITLE
Added support for outlined text

### DIFF
--- a/examples/pong/Pong.cpp
+++ b/examples/pong/Pong.cpp
@@ -71,7 +71,7 @@ int main()
     pauseMessage.setFont(font);
     pauseMessage.setCharacterSize(40);
     pauseMessage.setPosition(170.f, 150.f);
-    pauseMessage.setColor(sf::Color::White);
+    pauseMessage.setFillColor(sf::Color::White);
     pauseMessage.setString("Welcome to SFML pong!\nPress space to start the game");
 
     // Define the paddles properties

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -300,12 +300,12 @@ int main()
     // Create the description text
     sf::Text description("Current effect: " + effects[current]->getName(), font, 20);
     description.setPosition(10, 530);
-    description.setColor(sf::Color(80, 80, 80));
+    description.setFillColor(sf::Color(80, 80, 80));
 
     // Create the instructions text
     sf::Text instructions("Press left and right arrows to change the current shader", font, 20);
     instructions.setPosition(280, 555);
-    instructions.setColor(sf::Color(80, 80, 80));
+    instructions.setFillColor(sf::Color(80, 80, 80));
 
     // Start the game loop
     sf::Clock clock;

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -166,14 +166,18 @@ public:
     /// might be available. If the glyph is not available at the
     /// requested size, an empty glyph is returned.
     ///
-    /// \param codePoint     Unicode code point of the character to get
-    /// \param characterSize Reference character size
-    /// \param bold          Retrieve the bold version or the regular one?
+    /// Be aware that using a negative value for the outline
+    /// thickness will cause distorted rendering.
+    ///
+    /// \param codePoint        Unicode code point of the character to get
+    /// \param characterSize    Reference character size
+    /// \param bold             Retrieve the bold version or the regular one?
+    /// \param outlineThickness Thickness of outline (when != 0 the glyph will not be filled)
     ///
     /// \return The glyph corresponding to \a codePoint and \a characterSize
     ///
     ////////////////////////////////////////////////////////////
-    const Glyph& getGlyph(Uint32 codePoint, unsigned int characterSize, bool bold) const;
+    const Glyph& getGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, float outlineThickness = 0) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the kerning offset of two glyphs
@@ -277,7 +281,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////
-    typedef std::map<Uint32, Glyph> GlyphTable; ///< Table mapping a codepoint to its glyph
+    typedef std::map<Uint64, Glyph> GlyphTable; ///< Table mapping a codepoint to its glyph
 
     ////////////////////////////////////////////////////////////
     /// \brief Structure defining a page of glyphs
@@ -302,14 +306,15 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Load a new glyph and store it in the cache
     ///
-    /// \param codePoint     Unicode code point of the character to load
-    /// \param characterSize Reference character size
-    /// \param bold          Retrieve the bold version or the regular one?
+    /// \param codePoint        Unicode code point of the character to load
+    /// \param characterSize    Reference character size
+    /// \param bold             Retrieve the bold version or the regular one?
+    /// \param outlineThickness Thickness of outline (when != 0 the glyph will not be filled)
     ///
     /// \return The glyph corresponding to \a codePoint and \a characterSize
     ///
     ////////////////////////////////////////////////////////////
-    Glyph loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold) const;
+    Glyph loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, float outlineThickness) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Find a suitable rectangle within the texture for a glyph
@@ -344,6 +349,7 @@ private:
     void*                      m_library;     ///< Pointer to the internal library interface (it is typeless to avoid exposing implementation details)
     void*                      m_face;        ///< Pointer to the internal font face (it is typeless to avoid exposing implementation details)
     void*                      m_streamRec;   ///< Pointer to the stream rec instance (it is typeless to avoid exposing implementation details)
+    void*                      m_stroker;     ///< Pointer to the stroker (it is typeless to avoid exposing implementation details)
     int*                       m_refCount;    ///< Reference counter used by implicit sharing
     Info                       m_info;        ///< Information about the font
     mutable PageTable          m_pages;       ///< Table containing the glyphs pages by character size

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -159,16 +159,63 @@ public:
     void setStyle(Uint32 style);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Set the global color of the text
+    /// \brief Set the fill color of the text
     ///
-    /// By default, the text's color is opaque white.
+    /// By default, the text's fill color is opaque white.
+    /// Setting the fill color to a transparent color with an outline
+    /// will cause the outline to be displayed in the fill area of the text.
     ///
-    /// \param color New color of the text
+    /// \param color New fill color of the text
     ///
-    /// \see getColor
+    /// \see getFillColor
+    ///
+    /// \deprecated There is now fill and outline colors instead
+    /// of a single global color.
+    /// Use setFillColor() or setOutlineColor() instead.
     ///
     ////////////////////////////////////////////////////////////
-    void setColor(const Color& color);
+    SFML_DEPRECATED void setColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the fill color of the text
+    ///
+    /// By default, the text's fill color is opaque white.
+    /// Setting the fill color to a transparent color with an outline
+    /// will cause the outline to be displayed in the fill area of the text.
+    ///
+    /// \param color New fill color of the text
+    ///
+    /// \see getFillColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setFillColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the outline color of the text
+    ///
+    /// By default, the text's outline color is opaque black.
+    ///
+    /// \param color New outline color of the text
+    ///
+    /// \see getOutlineColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOutlineColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the thickness of the text's outline
+    ///
+    /// By default, the outline thickness is 0.
+    ///
+    /// Be aware that using a negative value for the outline
+    /// thickness will cause distorted rendering.
+    ///
+    /// \param thickness New outline thickness, in pixels
+    ///
+    /// \see getOutlineThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOutlineThickness(float thickness);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the text's string
@@ -224,14 +271,48 @@ public:
     Uint32 getStyle() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get the global color of the text
+    /// \brief Get the fill color of the text
     ///
-    /// \return Global color of the text
+    /// \return Fill color of the text
     ///
-    /// \see setColor
+    /// \see setFillColor
+    ///
+    /// \deprecated There is now fill and outline colors instead
+    /// of a single global color.
+    /// Use getFillColor() or getOutlineColor() instead.
     ///
     ////////////////////////////////////////////////////////////
-    const Color& getColor() const;
+    SFML_DEPRECATED const Color& getColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the fill color of the text
+    ///
+    /// \return Fill color of the text
+    ///
+    /// \see setFillColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getFillColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the outline color of the text
+    ///
+    /// \return Outline color of the text
+    ///
+    /// \see setOutlineColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getOutlineColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the outline thickness of the text
+    ///
+    /// \return Outline thickness of the text, in pixels
+    ///
+    /// \see setOutlineThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    float getOutlineThickness() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the position of the \a index-th character
@@ -305,8 +386,11 @@ private:
     const Font*         m_font;               ///< Font used to display the string
     unsigned int        m_characterSize;      ///< Base size of characters, in pixels
     Uint32              m_style;              ///< Text style (see Style enum)
-    Color               m_color;              ///< Text color
-    mutable VertexArray m_vertices;           ///< Vertex array containing the text's geometry
+    Color               m_fillColor;          ///< Text fill color
+    Color               m_outlineColor;       ///< Text outline color
+    float               m_outlineThickness;   ///< Thickness of the text's outline
+    mutable VertexArray m_vertices;           ///< Vertex array containing the fill geometry
+    mutable VertexArray m_outlineVertices;    ///< Vertex array containing the outline geometry
     mutable FloatRect   m_bounds;             ///< Bounding rectangle of the text (in local coordinates)
     mutable bool        m_geometryNeedUpdate; ///< Does the geometry need to be recomputed?
 };


### PR DESCRIPTION
Considering all the requests [over the years](https://www.google.com/search?q=sfml+text+outline+site:sfml-dev.org) for outlined text ([and the totally hackish workarounds](http://en.sfml-dev.org/forums/index.php?topic=15071.msg106581#msg106581)) and also that my current project will definitely need this at some point, I went ahead and implemented it. I made the PR for code review.

Some key points are the following.

- Outlined glyphs are stored in the same page as normal glyphs (can be changed if this is deemed that it will fill up the page texture too fast).
- ```Text::[set|get]Color(...)``` is now marked as deprecated, instead everyone should use ```Text::[set|get]FillColor(...)```
- ```Font::getGlyph(...)``` has a new parameter, outline thickness which is defaulted to 0 (to avoid API breakage). The parameter determines how thick the outline will be in pixels.
- Since outlined glyphs are stored in the same page/texture the key type has been changed to Int64 to continue being unique now that the outline thickness is part of the key.
- I refactored ```Text::ensureGeometryUpdate()``` and split the duplicated code to append vertices to separate functions ```::addLine(...)``` and ```::addGlyphQuad(...)```. These can be renamed if someone could think of more appropriate names.
- ~~Outline thickness is unsigned, I don't see any easy ways with freetype to make the outline protrude inwards with a negative thickness.~~ It is a float, but a negative value causes distorted rendering.
- Nothing should change with the current rendering of text if the user decides not to use outlines.

As stated before, please review this and give some feedback.

```
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window({ 700, 400 }, "Outline test");
    window.setVerticalSyncEnabled(true);

    sf::Font font;
    font.loadFromFile("C:/Windows/Fonts/arial.ttf");

    sf::Text text(L"\u0476ZyG\noLPfkdf", font, 140);
    text.setPosition({ 20, 20 });

    text.setFillColor(sf::Color::Red);

    text.setOutlineThickness(5);
    text.setOutlineColor(sf::Color::White);

    text.setStyle(sf::Text::Underlined | sf::Text::Italic | sf::Text::StrikeThrough);

    while (window.isOpen())
    {
        sf::Event e;
        while (window.pollEvent(e))
        {
            if (e.type == sf::Event::Closed)
                window.close();
        }

        window.clear();

        window.draw(text);

        window.display();
    }
}
```

![Example Image](http://i.imgur.com/crqgL0x.png)