### PR TITLE
Added support for clipping masks (Implements #1)

### DIFF
--- a/include/SFML/Graphics.hpp
+++ b/include/SFML/Graphics.hpp
@@ -32,6 +32,7 @@
 #include <SFML/Window.hpp>
 #include <SFML/Graphics/BlendMode.hpp>
 #include <SFML/Graphics/CircleShape.hpp>
+#include <SFML/Graphics/ClippingMask.hpp>
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/ConvexShape.hpp>
 #include <SFML/Graphics/Drawable.hpp>

--- a/include/SFML/Graphics/ClippingMask.hpp
+++ b/include/SFML/Graphics/ClippingMask.hpp
@@ -1,0 +1,187 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CLIPPINGMASK_HPP
+#define SFML_CLIPPINGMASK_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/Transformable.hpp>
+#include <algorithm>
+#include <vector>
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Define a part of the world that rendered objects are clipped to
+///
+/// The clipping mask is implemented using the stencil buffer. If the
+/// stencil buffer was disabled during the context or target creation this class
+/// will not function.
+/// The mask can operate inclusively or exclusively - meaning you can either include
+/// or exclude the area that will be visible through the mask.
+/// The mask supports any type of drawable. Sprites that have textures will alpha
+/// channels can even be used to construct pixel based masks.
+/// It is also important to note that the mask only stores pointers to drawables
+/// and not copies. This means if the passed in drawable is destructed the
+/// behavior is undefined.
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API ClippingMask : public Transformable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clipping modes
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Mode
+    {
+        Inclusive, ///< Inclusive mode, only areas defined by the mask will be visible
+        Exclusive  ///< Exclusive mode, only areas defined by the mask will be hidden
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty clipping mask.
+    ///
+    ////////////////////////////////////////////////////////////
+    ClippingMask();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a clipping mask with the specified mode
+    ///
+    /// \param theMode Clipping mode to use
+    ///
+    ////////////////////////////////////////////////////////////
+    ClippingMask(Mode theMode);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a clipping mask with a custom transform
+    ///
+    /// \param theTransform Transform to use
+    ///
+    ////////////////////////////////////////////////////////////
+    ClippingMask(const Transform& theTransform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the drawable count
+    ///
+    /// \return Number of drawables in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t getDrawableCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a read-write access to a drawable by its index
+    ///
+    /// This function doesn't check \a index, it must be in range
+    /// [0, getDrawableCount() - 1]. The behavior is undefined
+    /// otherwise.
+    ///
+    /// \param index Index of the drawable to get
+    ///
+    /// \return Reference to the index-th vertex
+    ///
+    /// \see getDrawableCount
+    ///
+    ////////////////////////////////////////////////////////////
+    const Drawable*& operator [](std::size_t index);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a read-only access to a drawable by its index
+    ///
+    /// This function doesn't check \a index, it must be in range
+    /// [0, getDrawableCount() - 1]. The behavior is undefined
+    /// otherwise.
+    ///
+    /// \param index Index of the drawable to get
+    ///
+    /// \return Reference to the index-th vertex
+    ///
+    /// \see getDrawableCount
+    ///
+    ////////////////////////////////////////////////////////////
+    const Drawable* const& operator [](std::size_t index) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clear the drawable array
+    ///
+    /// This function removes all the drawables from the array.
+    /// It doesn't deallocate the corresponding memory, so that
+    /// adding new drawables after clearing doesn't involve
+    /// reallocating all the memory.
+    ///
+    ////////////////////////////////////////////////////////////
+    void clear();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Add a drawable to the array
+    ///
+    /// Only a pointer to the drawable will be stored, so the caller
+    /// must ensure that the drawable does not get destructed.
+    ///
+    /// \param drawable Drawable to add
+    ///
+    ////////////////////////////////////////////////////////////
+    void append(const Drawable& drawable);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Removes a drawable from the array
+    ///
+    /// \param drawable Drawable to remove
+    ///
+    ////////////////////////////////////////////////////////////
+    void remove(const Drawable& drawable);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current clipping mode
+    ///
+    ////////////////////////////////////////////////////////////
+    Mode getMode() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets the current clipping mode
+    ///
+    /// \param theMode Mode that the mask will use
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMode(Mode theMode);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::vector<const Drawable*> m_drawables; ///< Drawables that define the mask
+    Mode                         m_mode;      ///< Mode that the mask will use
+};
+
+} // namespace sf
+
+#endif // SFML_CLIPPINGMASK_HPP

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/ClippingMask.hpp>
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/View.hpp>
@@ -70,6 +71,60 @@ public:
     void clear(const Color& color = Color(0, 0, 0, 255));
 
     ////////////////////////////////////////////////////////////
+    /// \brief Clear the active clipping area
+    ///
+    /// This is equivalent to calling setClippingArea(IntRect())
+    ///
+    /// \see setClippingArea, getClippingArea
+    ///
+    ////////////////////////////////////////////////////////////
+    void clearClippingArea();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clear the active clipping mask
+    ///
+    /// This is equivalent to calling setClippingMask(ClippingMask())
+    ///
+    /// \see setClippingMask, getClippingMask
+    ///
+    ////////////////////////////////////////////////////////////
+    void clearClippingMask();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the active clipping area
+    ///
+    /// The clipping area is defined as an IntRect. It is very
+    /// important to remember the clipping is done in window
+    /// coordinates, not scene coordinates.
+    /// This means {0, 0} will be the top left of your window,
+    /// it is not affected by the view.
+    /// The clipping area will stay active until it is cleared
+    /// or another one is set.
+    ///
+    /// \param area New clipping area to use
+    ///
+    /// \see clearClippingArea, getClippingArea
+    ///
+    ////////////////////////////////////////////////////////////
+    void setClippingArea(IntRect area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the active clipping mask
+    ///
+    /// The clipping mask is a set of drawables which which can
+    /// be used to define custom shapes and pixel based masks.
+    /// The clipping mask will stay active until it is cleared
+    /// or another one is set.
+    ///
+    /// \param mask New clipping mask to use
+    ///
+    /// \see clearClippingMask, getClippingMask
+    ///
+    ////////////////////////////////////////////////////////////
+    void setClippingMask(const ClippingMask& mask);
+
+
+    ////////////////////////////////////////////////////////////
     /// \brief Change the current active view
     ///
     /// The view is like a 2D camera, it controls which part of
@@ -89,6 +144,26 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     void setView(const View& view);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the clipping area that is in use in the render target
+    ///
+    /// \return The clipping area that is currently used
+    ///
+    /// \see clearClippingArea, setClippingArea
+    ///
+    ////////////////////////////////////////////////////////////
+    IntRect getClippingArea() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the clipping mask that is in use in the render target
+    ///
+    /// \return The clipping mask object that is currently used
+    ///
+    /// \see clearClippingMask, setClippingMask
+    ///
+    ////////////////////////////////////////////////////////////
+    const ClippingMask& getClippingMask() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the view currently in use in the render target
@@ -343,6 +418,18 @@ protected:
 private:
 
     ////////////////////////////////////////////////////////////
+    /// \brief Apply the current clipping area
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyCurrentClippingArea();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Apply the current clipping mask
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyCurrentClippingMask();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Apply the current view
     ///
     ////////////////////////////////////////////////////////////
@@ -402,20 +489,25 @@ private:
     {
         enum {VertexCacheSize = 4};
 
-        bool      glStatesSet;    ///< Are our internal GL states set yet?
-        bool      viewChanged;    ///< Has the current view changed since last draw?
-        BlendMode lastBlendMode;  ///< Cached blending mode
-        Uint64    lastTextureId;  ///< Cached texture
-        bool      useVertexCache; ///< Did we previously use the vertex cache?
+        bool      glStatesSet;                  ///< Are our internal GL states set yet?
+        bool      viewChanged;                  ///< Has the current view changed since last draw?
+        bool      clippingAreaChanged;          ///< Has the current clipping area changed since last draw?
+        bool      clippingMaskChanged;          ///< Has the current clipping mask changed since last draw?
+        bool      scissorTestEnabled;           ///< Is the scissor test enabled?
+        BlendMode lastBlendMode;                ///< Cached blending mode
+        Uint64    lastTextureId;                ///< Cached texture
+        bool      useVertexCache;               ///< Did we previously use the vertex cache?
         Vertex    vertexCache[VertexCacheSize]; ///< Pre-transformed vertices cache
     };
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    View        m_defaultView; ///< Default view
-    View        m_view;        ///< Current view
-    StatesCache m_cache;       ///< Render states cache
+    View         m_defaultView;  ///< Default view
+    View         m_view;         ///< Current view
+    IntRect      m_clippingArea; ///< Current clipping area
+    ClippingMask m_clippingMask; ///< Current clipping mask
+    StatesCache  m_cache;        ///< Render states cache
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -76,14 +76,18 @@ public:
     /// a depth buffer. Otherwise it is unnecessary, and you should
     /// leave this parameter to false (which is its default value).
     ///
-    /// \param width       Width of the render-texture
-    /// \param height      Height of the render-texture
-    /// \param depthBuffer Do you want this render-texture to have a depth buffer?
+    /// Note: If a render texture is created without a stencil buffer then clipping masks
+    /// will fail to work.
+    ///
+    /// \param width         Width of the render-texture
+    /// \param height        Height of the render-texture
+    /// \param depthBuffer   Do you want this render-texture to have a depth buffer?
+    /// \param stencilBuffer Do you want this render-texture to have a depth buffer?
     ///
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    bool create(unsigned int width, unsigned int height, bool depthBuffer = false);
+    bool create(unsigned int width, unsigned int height, bool depthBuffer = false, bool stencilBuffer = true);
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable texture smoothing

--- a/include/SFML/Window/ContextSettings.hpp
+++ b/include/SFML/Window/ContextSettings.hpp
@@ -49,6 +49,9 @@ struct ContextSettings
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
+    /// Note: If a context is created without stencil bits then clipping masks
+    /// will fail to work.
+    ///
     /// \param depth        Depth buffer bits
     /// \param stencil      Stencil buffer bits
     /// \param antialiasing Antialiasing level
@@ -57,7 +60,7 @@ struct ContextSettings
     /// \param attributes   Attribute flags of the context
     ///
     ////////////////////////////////////////////////////////////
-    explicit ContextSettings(unsigned int depth = 0, unsigned int stencil = 0, unsigned int antialiasing = 0, unsigned int major = 1, unsigned int minor = 1, unsigned int attributes = Default) :
+    explicit ContextSettings(unsigned int depth = 0, unsigned int stencil = 8, unsigned int antialiasing = 0, unsigned int major = 2, unsigned int minor = 1, unsigned int attributes = Default) :
     depthBits        (depth),
     stencilBits      (stencil),
     antialiasingLevel(antialiasing),

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Graphics)
 set(SRC
     ${SRCROOT}/BlendMode.cpp
     ${INCROOT}/BlendMode.hpp
+    ${SRCROOT}/ClippingMask.cpp
+    ${INCROOT}/ClippingMask.hpp
     ${SRCROOT}/Color.cpp
     ${INCROOT}/Color.hpp
     ${INCROOT}/Export.hpp

--- a/src/SFML/Graphics/ClippingMask.cpp
+++ b/src/SFML/Graphics/ClippingMask.cpp
@@ -25,79 +25,81 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Graphics/RenderStates.hpp>
-#include <cstddef>
+#include <SFML/Graphics/ClippingMask.hpp>
 
 
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-// We cannot use the default constructor here, because it accesses BlendAlpha, which is also global (and dynamically
-// initialized). Initialization order of global objects in different translation units is not defined.
-////////////////////////////////////////////////////////////
-const RenderStates RenderStates::Default(BlendMode(
-    BlendMode::SrcAlpha, BlendMode::OneMinusSrcAlpha, BlendMode::Add,
-    BlendMode::One, BlendMode::OneMinusSrcAlpha, BlendMode::Add));
-
-
-////////////////////////////////////////////////////////////
-RenderStates::RenderStates() :
-blendMode(BlendAlpha),
-transform(),
-texture  (NULL),
-shader   (NULL)
+ClippingMask::ClippingMask() :
+m_drawables(),
+m_mode     (Mode::Inclusive)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-RenderStates::RenderStates(const Transform& theTransform) :
-blendMode(BlendAlpha),
-transform(theTransform),
-texture  (NULL),
-shader   (NULL)
+ClippingMask::ClippingMask(Mode theMode) :
+m_drawables(),
+m_mode     (theMode)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-RenderStates::RenderStates(const BlendMode& theBlendMode) :
-blendMode(theBlendMode),
-transform(),
-texture  (NULL),
-shader   (NULL)
+std::size_t ClippingMask::getDrawableCount() const
 {
+    return m_drawables.size();
 }
 
 
 ////////////////////////////////////////////////////////////
-RenderStates::RenderStates(const Texture* theTexture) :
-blendMode(BlendAlpha),
-transform(),
-texture  (theTexture),
-shader   (NULL)
+const Drawable*& ClippingMask::operator [](std::size_t index)
 {
+    return m_drawables[index];
 }
 
 
 ////////////////////////////////////////////////////////////
-RenderStates::RenderStates(const Shader* theShader) :
-blendMode(BlendAlpha),
-transform(),
-texture  (NULL),
-shader   (theShader)
+const Drawable* const& ClippingMask::operator [](std::size_t index) const
 {
+    return m_drawables[index];
 }
 
 
 ////////////////////////////////////////////////////////////
-RenderStates::RenderStates(const BlendMode& theBlendMode, const Transform& theTransform,
-                           const Texture* theTexture, const Shader* theShader) :
-blendMode(theBlendMode),
-transform(theTransform),
-texture  (theTexture),
-shader   (theShader)
+void ClippingMask::clear()
 {
+    m_drawables.clear();
 }
+
+
+////////////////////////////////////////////////////////////
+void ClippingMask::append(const Drawable& drawable)
+{
+    m_drawables.push_back(&drawable);
+}
+
+
+////////////////////////////////////////////////////////////
+void ClippingMask::remove(const Drawable& drawable)
+{
+    m_drawables.erase(std::remove(m_drawables.begin(), m_drawables.end(), &drawable), m_drawables.end());
+}
+
+
+////////////////////////////////////////////////////////////
+ClippingMask::Mode ClippingMask::getMode() const
+{
+    return m_mode;
+}
+
+
+////////////////////////////////////////////////////////////
+void ClippingMask::setMode(Mode theMode)
+{
+    m_mode = theMode;
+}
+
 
 } // namespace sf

--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -120,6 +120,7 @@
     // Core since 1.1
     #define GLEXT_GL_DEPTH_COMPONENT                  GL_DEPTH_COMPONENT
     #define GLEXT_GL_CLAMP                            GL_CLAMP
+    #define GLEXT_GL_STENCIL_INDEX                    GL_STENCIL_INDEX
 
     // The following extensions are listed chronologically
     // Extension macro first, followed by tokens then
@@ -213,6 +214,7 @@
     #define GLEXT_GL_RENDERBUFFER                     GL_RENDERBUFFER_EXT
     #define GLEXT_GL_COLOR_ATTACHMENT0                GL_COLOR_ATTACHMENT0_EXT
     #define GLEXT_GL_DEPTH_ATTACHMENT                 GL_DEPTH_ATTACHMENT_EXT
+    #define GLEXT_GL_STENCIL_ATTACHMENT               GL_STENCIL_ATTACHMENT_EXT
     #define GLEXT_GL_FRAMEBUFFER_COMPLETE             GL_FRAMEBUFFER_COMPLETE_EXT
     #define GLEXT_GL_FRAMEBUFFER_BINDING              GL_FRAMEBUFFER_BINDING_EXT
     #define GLEXT_GL_INVALID_FRAMEBUFFER_OPERATION    GL_INVALID_FRAMEBUFFER_OPERATION_EXT

--- a/src/SFML/Graphics/GLLoader.hpp
+++ b/src/SFML/Graphics/GLLoader.hpp
@@ -946,6 +946,7 @@ extern void (CODEGEN_FUNCPTR *sf_ptrc_glRenderbufferStorageEXT)(GLenum, GLenum, 
 #define glRenderbufferStorageEXT sf_ptrc_glRenderbufferStorageEXT
 #endif /*GL_EXT_framebuffer_object*/
 
+GLAPI void APIENTRY glAlphaFunc(GLenum, GLclampf);
 GLAPI void APIENTRY glBlendFunc(GLenum, GLenum);
 GLAPI void APIENTRY glClear(GLbitfield);
 GLAPI void APIENTRY glClearColor(GLfloat, GLfloat, GLfloat, GLfloat);

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/ClippingMask.hpp>
 #include <SFML/Graphics/Drawable.hpp>
 #include <SFML/Graphics/Shader.hpp>
 #include <SFML/Graphics/Texture.hpp>
@@ -61,8 +62,8 @@ namespace
     {
         switch (blendEquation)
         {
-            case sf::BlendMode::Add:             return GLEXT_GL_FUNC_ADD;
-            case sf::BlendMode::Subtract:        return GLEXT_GL_FUNC_SUBTRACT;
+            case sf::BlendMode::Add:      return GLEXT_GL_FUNC_ADD;
+            case sf::BlendMode::Subtract: return GLEXT_GL_FUNC_SUBTRACT;
         }
     }
 }
@@ -72,11 +73,16 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 RenderTarget::RenderTarget() :
-m_defaultView(),
-m_view       (),
-m_cache      ()
+m_defaultView (),
+m_view        (),
+m_clippingArea(),
+m_clippingMask(),
+m_cache       ()
 {
-    m_cache.glStatesSet = false;
+    m_cache.clippingAreaChanged = false;
+    m_cache.clippingMaskChanged = false;
+    m_cache.glStatesSet         = false;
+    m_cache.scissorTestEnabled  = false;
 }
 
 
@@ -94,9 +100,50 @@ void RenderTarget::clear(const Color& color)
         // Unbind texture to fix RenderTexture preventing clear
         applyTexture(NULL);
 
+        // Disable scissor test if enabled
+        if (m_cache.scissorTestEnabled)
+            glCheck(glDisable(GL_SCISSOR_TEST));
+
         glCheck(glClearColor(color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f));
         glCheck(glClear(GL_COLOR_BUFFER_BIT));
+
+        // Enable the scissor test again if we just disabled it
+        if (m_cache.scissorTestEnabled)
+            glCheck(glEnable(GL_SCISSOR_TEST));
+
+        // Ensure the clipping mask will be redrawn
+        m_cache.clippingMaskChanged = true;
     }
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderTarget::clearClippingArea()
+{
+    setClippingArea(IntRect());
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderTarget::clearClippingMask()
+{
+    setClippingMask(ClippingMask());
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderTarget::setClippingArea(IntRect area)
+{
+    m_clippingArea = area;
+    m_cache.clippingAreaChanged = true;
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderTarget::setClippingMask(const ClippingMask& mask)
+{
+    m_clippingMask = mask;
+    m_cache.clippingMaskChanged = true;
 }
 
 
@@ -105,6 +152,21 @@ void RenderTarget::setView(const View& view)
 {
     m_view = view;
     m_cache.viewChanged = true;
+    m_cache.clippingAreaChanged = true;
+}
+
+
+////////////////////////////////////////////////////////////
+IntRect RenderTarget::getClippingArea() const
+{
+    return m_clippingArea;
+}
+
+
+////////////////////////////////////////////////////////////
+const ClippingMask& RenderTarget::getClippingMask() const
+{
+    return m_clippingMask;
 }
 
 
@@ -211,6 +273,11 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
         if (!m_cache.glStatesSet)
             resetGLStates();
 
+        // Apply the clipping
+        // This may require other draw calls so it comes first
+        if (m_cache.clippingMaskChanged)
+            applyCurrentClippingMask();
+
         // Check if the vertex count is low enough so that we can pre-transform them
         bool useVertexCache = (vertexCount <= StatesCache::VertexCacheSize);
         if (useVertexCache)
@@ -249,6 +316,10 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
         // Apply the shader
         if (states.shader)
             applyShader(states.shader);
+
+        // Apply the clipping area
+        if (m_cache.clippingAreaChanged)
+            applyCurrentClippingArea();
 
         // If we pre-transform the vertices, we must use our internal vertex cache
         if (useVertexCache)
@@ -385,6 +456,10 @@ void RenderTarget::resetGLStates()
 
         // Set the default view
         setView(getView());
+
+        // Set the clipping area and mask
+        applyCurrentClippingArea();
+        applyCurrentClippingMask();
     }
 }
 
@@ -398,6 +473,98 @@ void RenderTarget::initialize()
 
     // Set GL states only on first draw, so that we don't pollute user's states
     m_cache.glStatesSet = false;
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderTarget::applyCurrentClippingArea()
+{
+    // Don't apply clipping area while a clipping mask is being applied
+    if (m_cache.clippingMaskChanged)
+        return;
+
+    if (m_clippingArea != IntRect())
+    {
+        // Enable the scissor test and set the boundries
+        glCheck(glEnable(GL_SCISSOR_TEST));
+        glCheck(glScissor(m_clippingArea.left,
+                         -m_clippingArea.top + getSize().y - m_clippingArea.height,
+                          m_clippingArea.width,
+                          m_clippingArea.height));
+
+        m_cache.scissorTestEnabled = true;
+    }
+    else
+    {
+        // Disable the scissor test
+        glCheck(glDisable(GL_SCISSOR_TEST));
+        m_cache.scissorTestEnabled = false;
+    }
+
+    m_cache.clippingAreaChanged = false;
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderTarget::applyCurrentClippingMask()
+{
+    static bool inProgress = false;
+
+    // Ensure that we only try to create the clipping mask once
+    if (inProgress)
+        return;
+    else
+        inProgress = true;
+
+    if (m_clippingMask.getDrawableCount())
+    {
+        // Clear the stencil buffer
+        glCheck(glStencilMask(0xFF));
+        glCheck(glClear(GL_STENCIL_BUFFER_BIT));
+
+        // Enable the alpha test
+        #ifndef SFML_OPENGL_ES
+            glCheck(glEnable(GL_ALPHA_TEST));
+            glCheck(glAlphaFunc(GL_EQUAL, 1));
+        #else
+            err() << "Alpha testing for clipping masks is not supported on OpenGL ES platforms" << std::endl;
+        #endif
+
+        // Enable the stencil test and set the required parameters for writing to the stencil buffer
+        glCheck(glEnable(GL_STENCIL_TEST));
+        glCheck(glStencilFunc(GL_NEVER, 1, 0xFF));
+        glCheck(glStencilOp(GL_REPLACE, GL_KEEP, GL_KEEP));
+
+        // Save scissor test state
+        if (m_cache.scissorTestEnabled)
+            glCheck(glDisable(GL_SCISSOR_TEST));
+
+        // Create transformed render states to draw the mask
+        RenderStates states(m_clippingMask.getTransform());
+
+        // Draw each drawable in the mask onto the stencil buffer
+        for (std::size_t i = 0; i < m_clippingMask.getDrawableCount(); ++i)
+            draw(*m_clippingMask[i], states);
+
+        // Set stencil test parameters to clip rendering
+        glCheck(glStencilMask(0x00));
+        glCheck(glStencilFunc(GL_EQUAL, m_clippingMask.getMode() == sf::ClippingMask::Inclusive ? 1 : 0, 0xFF));
+
+        // Restore scissor test state
+        if (m_cache.scissorTestEnabled)
+            glCheck(glEnable(GL_SCISSOR_TEST));
+    }
+    else
+    {
+        // Disable the stencil and alpha test
+        #ifndef SFML_OPENGL_ES
+            glCheck(glDisable(GL_ALPHA_TEST));
+        #endif
+        glCheck(glDisable(GL_STENCIL_TEST));
+    }
+
+    inProgress = false;
+    m_cache.clippingMaskChanged = false;
 }
 
 

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -49,7 +49,7 @@ RenderTexture::~RenderTexture()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTexture::create(unsigned int width, unsigned int height, bool depthBuffer)
+bool RenderTexture::create(unsigned int width, unsigned int height, bool depthBuffer, bool stencilBuffer)
 {
     // Create the texture
     if (!m_texture.create(width, height))
@@ -78,7 +78,7 @@ bool RenderTexture::create(unsigned int width, unsigned int height, bool depthBu
     }
 
     // Initialize the render texture
-    if (!m_impl->create(width, height, m_texture.m_texture, depthBuffer))
+    if (!m_impl->create(width, height, m_texture.m_texture, depthBuffer, stencilBuffer))
         return false;
 
     // We can now initialize the render target part

--- a/src/SFML/Graphics/RenderTextureImpl.hpp
+++ b/src/SFML/Graphics/RenderTextureImpl.hpp
@@ -60,7 +60,7 @@ public:
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer) = 0;
+    virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer, bool stencilBuffer) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering

--- a/src/SFML/Graphics/RenderTextureImplDefault.cpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.cpp
@@ -55,14 +55,14 @@ RenderTextureImplDefault::~RenderTextureImplDefault()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTextureImplDefault::create(unsigned int width, unsigned int height, unsigned int, bool depthBuffer)
+bool RenderTextureImplDefault::create(unsigned int width, unsigned int height, unsigned int, bool depthBuffer, bool stencilBuffer)
 {
     // Store the dimensions
     m_width = width;
     m_height = height;
 
     // Create the in-memory OpenGL context
-    m_context = new Context(ContextSettings(depthBuffer ? 32 : 0), width, height);
+    m_context = new Context(ContextSettings(depthBuffer ? 32 : 0, stencilBuffer ? 8 : 0), width, height);
 
     return true;
 }

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -71,7 +71,7 @@ private:
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer);
+    virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer, bool stencilBuffer);
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -81,7 +81,7 @@ bool RenderTextureImplFBO::isAvailable()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer)
+bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer, bool stencilBuffer)
 {
     // Create the context
     m_context = new Context;
@@ -111,6 +111,22 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
         glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthBuffer));
         glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH_COMPONENT, width, height));
         glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_DEPTH_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthBuffer));
+    }
+
+    // Create the stencil buffer if requested
+    if (stencilBuffer)
+    {
+        GLuint stencil = 0;
+        glCheck(GLEXT_glGenRenderbuffers(1, &stencil));
+        m_stencilBuffer = static_cast<unsigned int>(stencil);
+        if (!m_stencilBuffer)
+        {
+            err() << "Impossible to create render texture (failed to create the attached stencil buffer)" << std::endl;
+            return false;
+        }
+        glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_stencilBuffer));
+        glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_STENCIL_INDEX, width, height));
+        glCheck(glFramebufferRenderbufferEXT(GL_FRAMEBUFFER_EXT, GLEXT_GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER_EXT, m_stencilBuffer));
     }
 
     // Link the texture to the frame buffer

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -79,7 +79,7 @@ private:
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer);
+    virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, bool depthBuffer, bool stencilBuffer);
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering
@@ -102,9 +102,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Context*     m_context;     ///< Needs a separate OpenGL context for not messing up the other ones
-    unsigned int m_frameBuffer; ///< OpenGL frame buffer object
-    unsigned int m_depthBuffer; ///< Optional depth buffer attached to the frame buffer
+    Context*     m_context;       ///< Needs a separate OpenGL context for not messing up the other ones
+    unsigned int m_frameBuffer;   ///< OpenGL frame buffer object
+    unsigned int m_depthBuffer;   ///< Optional depth buffer attached to the frame buffer
+    unsigned int m_stencilBuffer; ///< Optional stencil buffer attached to the frame buffer
 };
 
 } // namespace priv


### PR DESCRIPTION
_Recreated from #842_

This is ready for a code review, hoping for a SFML 2.4 inclusion. This implements #1, yes the very first issue. :smile:

I based my branch on /feature/gl_dev_new due to the OpenGL changes. Clipping is done with the stencil buffer which gets enabled when a mask is applied to the render states.

Some points from #1 are answered below about this implementation.

> And do we clip in scene coordinates or in window coordinates?

Clipping is done in scene coordinates.

> However since it can be disabled (and is currently not enabled by default) in the context settings.

It is now enabled by default in the context and render texture constructors.

> it implies that the user can disable clipping masks, without even knowing it. So this must be at least well documented, and even enforced if possible.

It is now noted in the documentation that disabling stencil buffer will disable clipping masks. As for enforcing it? Its not really needed, if the user disables it - it is their fault because it is clearly stated.

> So the main problem is to decide what we use to define the clipping area. We could start with a `const sf::Drawable*` to have maximum flexibility.

Clipping area is defined by the `sf::ClippingMask` class which is a container for multiple `const sf::Drawable*` pointers.

> Another question is: do we allow only one active mask, or do we provide the ability to add multiple masks?

Only 1 mask is active at one time, but it can be defined by multiple drawables.

As with my other PR (#840), please review and test and then give feedback. **Even textures with alpha channels are supported.**

``` cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window({ 800, 600 }, "Clipping Mask Test");
    window.setVerticalSyncEnabled(true);

    // create a circle for part of the clipping mask
    sf::CircleShape keyholetop(50);
    keyholetop.setOrigin({ 50, 50 });

    // create a square for part of the clipping mask
    sf::RectangleShape keyholebody({ 36, 150 });
    keyholebody.setOrigin({ 18, 0 });

    // create the clipping mask
    sf::ClippingMask clipmask;

    // add the shapes to the clipping mask
    // sf::ClippingMask behaves like sf::VertexArray
    // so you can append any sf::Drawable to the mask
    // the mask will not copy the sf::Drawable, it only stores a pointer
    clipmask.append(keyholetop);
    clipmask.append(keyholebody);

    sf::Texture background;
    // use any background image
    // I used the image from opengl example
    background.loadFromFile("sfml/examples/opengl/resources/background.jpg");

    sf::Sprite backgroundsprite(background);

    // set a clipping area
    // for this example exlude the area 50px from the borders
    window.setClippingArea({ 50, 50, 700, 500 });

    while (window.isOpen())
    {
        sf::Event e;
        while (window.pollEvent(e))
        {
            if (e.type == sf::Event::Closed)
                window.close();
        }

        // get mouse position
        sf::Vector2f mousepos = window.mapPixelToCoords(sf::Mouse::getPosition(window));

        // update the mask position
        clipmask.setPosition(mousepos);

        //assign the clipping mask to the window
        window.setClippingMask(clipmask);

        window.clear(sf::Color::Blue);

        window.draw(backgroundsprite);

        window.display();
    }
}
```

![Example Screenshot](http://i.imgur.com/u2iKBwd.png)

---

I just updated the API. I removed the clipping mask from the render states and instead added function the render target class for setting the mask. Also all clipping is now cached instead of redrawn every time.

And I will say it again: **Please test and give feedback - even if you don't test this branch, at least comment on the API design, thanks** :smile: 

There was a total of 6 functions added to the render target class.

```
clearClipping[Area|Mask]();
setClipping[Area|Mask](...);
getClipping[Area|Mask]();
```

Clipping masks are the same as the previous commits, basically a list of drawables that allow users to define custom shapes / pixel based masks. The masks are implemented with the stencil buffer.

Clipping areas on the other hand are limited to a single IntRect that is defined in window coordinates. The clipping area is implemented using `glScissor(...)` which should provide faster, simpler clipping for those who just need it for basic GUIs.

The clipping mask on the other hand is heavier and uses the stencil buffer for clipping. It works in scene coordinates and is used for more complex masks.

Both clipping modes are applied like the view is. To set a clipping mode you first call `setClippingXXX(...)` with the appropriate parameters. The clipping mode will be cached until it is either cleared or updated (another set call).
