### PR TITLE
Make sure the window still exists before we access the dimensions on it

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -386,13 +386,16 @@ static void onContentRectChanged(ANativeActivity* activity, const ARect* rect)
     sf::priv::ActivityStates* states = sf::priv::retrieveStates(activity);
     sf::Lock lock(states->mutex);
 
-    // Send an event to warn people about the window move/resize
-    sf::Event event;
-    event.type = sf::Event::Resized;
-    event.size.width = ANativeWindow_getWidth(states->window);
-    event.size.height = ANativeWindow_getHeight(states->window);
+    // Make sure the window still exists before we access the dimensions on it
+    if (states->window != NULL) {
+        // Send an event to warn people about the window move/resize
+        sf::Event event;
+        event.type = sf::Event::Resized;
+        event.size.width = ANativeWindow_getWidth(states->window);
+        event.size.height = ANativeWindow_getHeight(states->window);
 
-    states->forwardEvent(event);
+        states->forwardEvent(event);
+    }
 }
 
 


### PR DESCRIPTION
If you have the native window in landscape view and you open another view from it in portrait, on some devices we get a onDestroyNativeWindow (which sets states->window to NULL) and then afterwards we receive a onContentRectChanged that tries to access values on that window that was just destroyed.