### PR TITLE
Multi-GPU preference

### DIFF
--- a/src/SFML/Main/MainWin32.cpp
+++ b/src/SFML/Main/MainWin32.cpp
@@ -41,6 +41,13 @@
 
 #include <windows.h>
 
+// Inform the Nvidia/AMD driver that this SFML application could
+// benefit from using the more powerful discrete GPU
+extern "C"
+{
+__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
 
 extern int main(int argc, char* argv[]);
 


### PR DESCRIPTION
Add additional information to executables linking to sfml-main on Windows to help the driver decide whether it should prefer using the discrete GPU if set to automatically select.

Supersedes #867.