### PR TITLE
Clarified semantics of Shape::getGlobalBounds(), improved related documentation

### DIFF
--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -193,7 +193,7 @@ public:
     /// \param destX      X coordinate of the destination position
     /// \param destY      Y coordinate of the destination position
     /// \param sourceRect Sub-rectangle of the source image to copy
-    /// \param applyAlpha Should the copy take in account the source transparency?
+    /// \param applyAlpha Should the copy take into account the source transparency?
     ///
     ////////////////////////////////////////////////////////////
     void copy(const Image& source, unsigned int destX, unsigned int destY, const IntRect& sourceRect = IntRect(0, 0, 0, 0), bool applyAlpha = false);

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -227,13 +227,20 @@ public:
     FloatRect getLocalBounds() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get the global bounding rectangle of the entity
+    /// \brief Get the global (non-minimal) bounding rectangle of the entity
     ///
     /// The returned rectangle is in global coordinates, which means
-    /// that it takes in account the transformations (translation,
+    /// that it takes into account the transformations (translation,
     /// rotation, scale, ...) that are applied to the entity.
     /// In other words, this function returns the bounds of the
-    /// sprite in the global 2D world's coordinate system.
+    /// shape in the global 2D world's coordinate system.
+    ///
+    /// This function does not necessarily return the \a minimal
+    /// bounding rectangle. It merely ensures that the returned
+    /// rectangle covers all the vertices (but possibly more).
+    /// This allows for a fast approximation of the bounds as a
+    /// first check; you may want to use more precise checks
+    /// on top of that.
     ///
     /// \return Global bounding rectangle of the entity
     ///

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -179,7 +179,7 @@ public:
     /// \brief Get the global bounding rectangle of the entity
     ///
     /// The returned rectangle is in global coordinates, which means
-    /// that it takes in account the transformations (translation,
+    /// that it takes into account the transformations (translation,
     /// rotation, scale, ...) that are applied to the entity.
     /// In other words, this function returns the bounds of the
     /// sprite in the global 2D world's coordinate system.

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -268,10 +268,10 @@ public:
     /// \brief Get the global bounding rectangle of the entity
     ///
     /// The returned rectangle is in global coordinates, which means
-    /// that it takes in account the transformations (translation,
+    /// that it takes into account the transformations (translation,
     /// rotation, scale, ...) that are applied to the entity.
     /// In other words, this function returns the bounds of the
-    /// sprite in the global 2D world's coordinate system.
+    /// text in the global 2D world's coordinate system.
     ///
     /// \return Global bounding rectangle of the entity
     ///

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -163,8 +163,8 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Compute the bounding rectangle of the vertex array
     ///
-    /// This function returns the axis-aligned rectangle that
-    /// contains all the vertices of the array.
+    /// This function returns the minimal axis-aligned rectangle
+    /// that contains all the vertices of the array.
     ///
     /// \return Bounding rectangle of the vertex array
     ///

--- a/include/SFML/Window/Sensor.hpp
+++ b/include/SFML/Window/Sensor.hpp
@@ -122,7 +122,7 @@ public:
 ///
 /// You may wonder why some sensor types look so similar, for example
 /// Accelerometer and Gravity / UserAcceleration. The first one
-/// is the raw measurement of the acceleration, and takes in account
+/// is the raw measurement of the acceleration, and takes into account
 /// both the earth gravity and the user movement. The others are
 /// more precise: they provide these components separately, which is
 /// usually more useful. In fact they are not direct sensors, they


### PR DESCRIPTION
http://en.sfml-dev.org/forums/index.php?topic=18063

Makes clear that the returned rectangle is not the *minimal* bounding rect. Also fixes minor mistakes in related documentations.