### PR TITLE
Android: Fixed audio files not loading (and possibly crashing)

### DIFF
--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -65,10 +65,7 @@ bool InputSoundFile::openFromFile(const std::string& filename)
     // Find a suitable reader for the file type
     m_reader = SoundFileFactory::createReaderFromFilename(filename);
     if (!m_reader)
-    {
-        err() << "Failed to open sound file \"" << filename << "\" (format not supported)" << std::endl;
         return false;
-    }
 
     // Wrap the file into a stream
     FileInputStream* file = new FileInputStream;
@@ -108,10 +105,7 @@ bool InputSoundFile::openFromMemory(const void* data, std::size_t sizeInBytes)
     // Find a suitable reader for the file type
     m_reader = SoundFileFactory::createReaderFromMemory(data, sizeInBytes);
     if (!m_reader)
-    {
-        err() << "Failed to open sound file from memory (format not supported)" << std::endl;
         return false;
-    }
 
     // Wrap the memory file into a stream
     MemoryInputStream* memory = new MemoryInputStream;
@@ -147,10 +141,7 @@ bool InputSoundFile::openFromStream(InputStream& stream)
     // Find a suitable reader for the file type
     m_reader = SoundFileFactory::createReaderFromStream(stream);
     if (!m_reader)
-    {
-        err() << "Failed to open sound file from stream (format not supported)" << std::endl;
         return false;
-    }
 
     // store the stream
     m_stream = &stream;

--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -28,7 +28,6 @@
 #include <SFML/Audio/OutputSoundFile.hpp>
 #include <SFML/Audio/SoundFileWriter.hpp>
 #include <SFML/Audio/SoundFileFactory.hpp>
-#include <SFML/System/Err.hpp>
 
 
 namespace sf
@@ -57,10 +56,7 @@ bool OutputSoundFile::openFromFile(const std::string& filename, unsigned int sam
     // Find a suitable writer for the file type
     m_writer = SoundFileFactory::createWriterFromFilename(filename);
     if (!m_writer)
-    {
-        err() << "Failed to open sound file \"" << filename << "\" (format not supported)" << std::endl;
         return false;
-    }
 
     // Pass the stream to the reader
     if (!m_writer->open(filename, sampleRate, channelCount))

--- a/src/SFML/Audio/SoundFileFactory.cpp
+++ b/src/SFML/Audio/SoundFileFactory.cpp
@@ -34,6 +34,7 @@
 #include <SFML/Audio/SoundFileWriterWav.hpp>
 #include <SFML/System/FileInputStream.hpp>
 #include <SFML/System/MemoryInputStream.hpp>
+#include <SFML/System/Err.hpp>
 
 
 namespace
@@ -69,8 +70,10 @@ SoundFileReader* SoundFileFactory::createReaderFromFilename(const std::string& f
 
     // Wrap the input file into a file stream
     FileInputStream stream;
-    if (!stream.open(filename))
+    if (!stream.open(filename)) {
+        err() << "Failed to open sound file \"" << filename << "\" (couldn't open stream)" << std::endl;
         return NULL;
+    }
 
     // Test the filename in all the registered factories
     for (ReaderFactoryArray::const_iterator it = s_readers.begin(); it != s_readers.end(); ++it)
@@ -81,6 +84,7 @@ SoundFileReader* SoundFileFactory::createReaderFromFilename(const std::string& f
     }
 
     // No suitable reader found
+    err() << "Failed to open sound file \"" << filename << "\" (format not supported)" << std::endl;
     return NULL;
 }
 
@@ -104,6 +108,7 @@ SoundFileReader* SoundFileFactory::createReaderFromMemory(const void* data, std:
     }
 
     // No suitable reader found
+    err() << "Failed to open sound file from memory (format not supported)" << std::endl;
     return NULL;
 }
 
@@ -123,6 +128,7 @@ SoundFileReader* SoundFileFactory::createReaderFromStream(InputStream& stream)
     }
 
     // No suitable reader found
+    err() << "Failed to open sound file from stream (format not supported)" << std::endl;
     return NULL;
 }
 
@@ -141,6 +147,7 @@ SoundFileWriter* SoundFileFactory::createWriterFromFilename(const std::string& f
     }
 
     // No suitable writer found
+    err() << "Failed to open sound file \"" << filename << "\" (format not supported)" << std::endl;
     return NULL;
 }
 

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -63,7 +63,7 @@ Int64 ResourceStream::read(void *data, Int64 size)
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::seek(Int64 position)
 {
-    AAsset_seek(m_file, position, SEEK_SET);
+    return AAsset_seek(m_file, position, SEEK_SET);
 }
 
 

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -61,6 +61,7 @@ bool FileInputStream::open(const std::string& filename)
     if (m_file)
         delete m_file;
     m_file = new sf::priv::ResourceStream(filename);
+    return m_file->tell() != -1;
 #else
     if (m_file)
         std::fclose(m_file);


### PR DESCRIPTION
* Added a missing return value for Android's `sf::FileInputStream::open()`.
* Added a missing return value for Android's `sf::priv::ResourceStream::seek()`.
* Moved error logging for `sf::InputSoundFile` and `sf::OutputSoundFile` to `sf::SoundFileFactory`, since this allows more details on *why* reading/writing failed. Before missing files would return "format not supported".