### PR TITLE
Removed unnecessary sf:: prefixes

### DIFF
--- a/include/SFML/Audio/SoundRecorder.hpp
+++ b/include/SFML/Audio/SoundRecorder.hpp
@@ -183,7 +183,7 @@ protected:
     /// \param interval Processing interval
     ///
     ////////////////////////////////////////////////////////////
-    void setProcessingInterval(sf::Time interval);
+    void setProcessingInterval(Time interval);
 
     ////////////////////////////////////////////////////////////
     /// \brief Start capturing audio data
@@ -260,7 +260,7 @@ private:
     Thread             m_thread;             ///< Thread running the background recording task
     std::vector<Int16> m_samples;            ///< Buffer to store captured samples
     unsigned int       m_sampleRate;         ///< Sample rate
-    sf::Time           m_processingInterval; ///< Time period between calls to onProcessSamples
+    Time               m_processingInterval; ///< Time period between calls to onProcessSamples
     bool               m_isCapturing;        ///< Capturing state
     std::string        m_deviceName;         ///< Name of the audio capture device
 };

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -278,7 +278,7 @@ private:
         Page();
 
         GlyphTable       glyphs;  ///< Table mapping code points to their corresponding glyph
-        sf::Texture      texture; ///< Texture containing the pixels of the glyphs
+        Texture          texture; ///< Texture containing the pixels of the glyphs
         unsigned int     nextRow; ///< Y position of the next new row in the texture
         std::vector<Row> rows;    ///< List containing the position of all the existing rows
     };

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -399,7 +399,7 @@ public:
     /// \param transform Transform to assign
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, const sf::Transform& transform);
+    void setParameter(const std::string& name, const Transform& transform);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a texture parameter of the shader

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -187,7 +187,7 @@ public:
     /// \see loadFromFile, loadFromMemory, loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    bool loadFromStream(sf::InputStream& stream, const IntRect& area = IntRect());
+    bool loadFromStream(InputStream& stream, const IntRect& area = IntRect());
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from an image

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -123,7 +123,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
 #ifdef ANDROID
-    sf::priv::ResourceStream *m_file;
+    priv::ResourceStream* m_file;
 #else
     std::FILE* m_file; ///< stdio file stream
 #endif

--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -77,7 +77,7 @@ public:
     {
         Identification();
 
-        sf::String   name;      ///< Name of the joystick
+        String       name;      ///< Name of the joystick
         unsigned int vendorId;  ///< Manufacturer identifier
         unsigned int productId; ///< Product identifier
     };

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -135,7 +135,7 @@ std::vector<std::string> SoundRecorder::getAvailableDevices()
 {
     std::vector<std::string> deviceNameList;
 
-    const ALchar *deviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
+    const ALchar* deviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
     if (deviceList)
     {
         while (*deviceList)
@@ -210,7 +210,7 @@ bool SoundRecorder::isAvailable()
 
 
 ////////////////////////////////////////////////////////////
-void SoundRecorder::setProcessingInterval(sf::Time interval)
+void SoundRecorder::setProcessingInterval(Time interval)
 {
     m_processingInterval = interval;
 }

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -385,7 +385,7 @@ void Shader::setParameter(const std::string& name, const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const sf::Transform& transform)
+void Shader::setParameter(const std::string& name, const Transform& transform)
 {
     if (m_shaderProgram)
     {
@@ -768,7 +768,7 @@ void Shader::setParameter(const std::string& name, const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const sf::Transform& transform)
+void Shader::setParameter(const std::string& name, const Transform& transform)
 {
 }
 

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -66,7 +66,7 @@ void Shape::setTexture(const Texture* texture, bool resetRect)
     if (texture)
     {
         // Recompute the texture area if requested, or if there was no texture & rect before
-        if (resetRect || (!m_texture && (m_textureRect == sf::IntRect())))
+        if (resetRect || (!m_texture && (m_textureRect == IntRect())))
             setTextureRect(IntRect(0, 0, texture->getSize().x, texture->getSize().y));
     }
 

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -179,7 +179,7 @@ Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short
             {
                 // At this point the connection may have been either accepted or refused.
                 // To know whether it's a success or a failure, we must check the address of the connected peer
-                if (getRemoteAddress() != sf::IpAddress::None)
+                if (getRemoteAddress() != IpAddress::None)
                 {
                     // Connection accepted
                     status = Done;

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -60,7 +60,7 @@ bool FileInputStream::open(const std::string& filename)
 #ifdef ANDROID
     if (m_file)
         delete m_file;
-    m_file = new sf::priv::ResourceStream(filename);
+    m_file = new priv::ResourceStream(filename);
     return m_file->tell() != -1;
 #else
     if (m_file)
@@ -128,9 +128,9 @@ Int64 FileInputStream::getSize()
 #else
     if (m_file)
     {
-        sf::Int64 position = tell();
+        Int64 position = tell();
         std::fseek(m_file, 0, SEEK_END);
-        sf::Int64 size = tell();
+        Int64 size = tell();
         seek(position);
         return size;
     }


### PR DESCRIPTION
Just code style. There might be a few more `sf::` occurrences within the `sf`namespace, but I wasn't sure how to exclude all uses in comments with a regex. Does anybody have a good idea? :grimacing: 