### PR TITLE
Fix function name in short example snippet in RenderStates.hpp

### DIFF
--- a/include/SFML/Graphics/RenderStates.hpp
+++ b/include/SFML/Graphics/RenderStates.hpp
@@ -150,7 +150,7 @@ public:
 /// directly without defining render states explicitly -- the
 /// default set of states is ok in most cases.
 /// \code
-/// window.Draw(sprite);
+/// window.draw(sprite);
 /// \endcode
 ///
 /// If you want to use a single specific render state,


### PR DESCRIPTION
Just a small typo.  I found it while browsing online docs.