### PR TITLE
Added Vector3u, Vector2d and Vector3d types

### DIFF
--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -253,6 +253,7 @@ bool operator !=(const Vector2<T>& left, const Vector2<T>& right);
 typedef Vector2<int>          Vector2i;
 typedef Vector2<unsigned int> Vector2u;
 typedef Vector2<float>        Vector2f;
+typedef Vector2<double>       Vector2d;
 
 } // namespace sf
 

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -252,8 +252,10 @@ bool operator !=(const Vector3<T>& left, const Vector3<T>& right);
 #include <SFML/System/Vector3.inl>
 
 // Define the most common types
-typedef Vector3<int>   Vector3i;
-typedef Vector3<float> Vector3f;
+typedef Vector3<int>          Vector3i;
+typedef Vector3<unsigned int> Vector3u;
+typedef Vector3<float>        Vector3f;
+typedef Vector3<double>       Vector3d;
 
 } // namespace sf
 


### PR DESCRIPTION
- Vector2u does exist but Vector3u doesn't, so we added it for
  consistency purposes
- There are the types Vector2f and Vector3f (float), so the types
  Vector2d and Vector3d (double) are also expected to be defined