### PR TITLE
Windows: Fixed mouse event coordinates for multi-screen setups

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -670,8 +670,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             // Mouse position is in screen coordinates, convert it to window coordinates
             POINT position;
-            position.x = static_cast<Int16>(LOWORD(lParam));
-            position.y = static_cast<Int16>(HIWORD(lParam));
+            position.x = static_cast<Int16>(GET_X_LPARAM(lParam));
+            position.y = static_cast<Int16>(GET_Y_LPARAM(lParam));
             ScreenToClient(m_handle, &position);
 
             Int16 delta = static_cast<Int16>(HIWORD(wParam));
@@ -698,8 +698,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             // Mouse position is in screen coordinates, convert it to window coordinates
             POINT position;
-            position.x = static_cast<Int16>(LOWORD(lParam));
-            position.y = static_cast<Int16>(HIWORD(lParam));
+            position.x = static_cast<Int16>(GET_X_LPARAM(lParam));
+            position.y = static_cast<Int16>(GET_Y_LPARAM(lParam));
             ScreenToClient(m_handle, &position);
 
             Int16 delta = static_cast<Int16>(HIWORD(wParam));
@@ -720,8 +720,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonPressed;
             event.mouseButton.button = Mouse::Left;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -732,8 +732,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonReleased;
             event.mouseButton.button = Mouse::Left;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -744,8 +744,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonPressed;
             event.mouseButton.button = Mouse::Right;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -756,8 +756,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonReleased;
             event.mouseButton.button = Mouse::Right;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -768,8 +768,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonPressed;
             event.mouseButton.button = Mouse::Middle;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -780,8 +780,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonReleased;
             event.mouseButton.button = Mouse::Middle;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -792,8 +792,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonPressed;
             event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::XButton1 : Mouse::XButton2;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -804,8 +804,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
             event.type               = Event::MouseButtonReleased;
             event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::XButton1 : Mouse::XButton2;
-            event.mouseButton.x      = static_cast<Int16>(LOWORD(lParam));
-            event.mouseButton.y      = static_cast<Int16>(HIWORD(lParam));
+            event.mouseButton.x      = static_cast<Int16>(GET_X_LPARAM(lParam));
+            event.mouseButton.y      = static_cast<Int16>(GET_Y_LPARAM(lParam));
             pushEvent(event);
             break;
         }
@@ -830,8 +830,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         case WM_MOUSEMOVE:
         {
             // Extract the mouse local coordinates
-            int x = static_cast<Int16>(LOWORD(lParam));
-            int y = static_cast<Int16>(HIWORD(lParam));
+            int x = static_cast<Int16>(GET_X_LPARAM(lParam));
+            int y = static_cast<Int16>(GET_Y_LPARAM(lParam));
 
             // Get the client area of the window
             RECT area;


### PR DESCRIPTION
In specific setups, the old code could report wrong coordinates [as noted on MSDN under Remarks](https://msdn.microsoft.com/en-us/library/windows/desktop/ms645607(v=vs.85).aspx).