### PR TITLE
Fix clear bug on RenderTextures

### DIFF
--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -509,6 +509,7 @@ private:
     bool         m_isSmooth;      ///< Status of the smooth filter
     bool         m_isRepeated;    ///< Is the texture in repeat mode?
     mutable bool m_pixelsFlipped; ///< To work around the inconsistency in Y orientation
+    bool         m_fboAttachment; ///< Is this texture owned by a framebuffer object?
     Uint64       m_cacheId;       ///< Unique number that identifies the texture to the render target's cache
 };
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -281,6 +281,11 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
         if (states.shader)
             applyShader(NULL);
 
+        // If the texture we used to draw belonged to a RenderTexture, then forcibly unbind that texture.
+        // This prevents a bug where some drivers do not clear RenderTextures properly.
+        if (states.texture && states.texture->m_fboAttachment)
+            applyTexture(NULL);
+
         // Update the cache
         m_cache.useVertexCache = useVertexCache;
     }

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -67,6 +67,9 @@ bool RenderTexture::create(unsigned int width, unsigned int height, bool depthBu
     {
         // Use frame-buffer object (FBO)
         m_impl = new priv::RenderTextureImplFBO;
+
+        // Mark the texture as being a framebuffer object attachment
+        m_texture.m_fboAttachment = true;
     }
     else
     {

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -78,6 +78,7 @@ m_texture      (0),
 m_isSmooth     (false),
 m_isRepeated   (false),
 m_pixelsFlipped(false),
+m_fboAttachment(false),
 m_cacheId      (getUniqueId())
 {
 }
@@ -91,6 +92,7 @@ m_texture      (0),
 m_isSmooth     (copy.m_isSmooth),
 m_isRepeated   (copy.m_isRepeated),
 m_pixelsFlipped(false),
+m_fboAttachment(false),
 m_cacheId      (getUniqueId())
 {
     if (copy.m_texture)
@@ -141,6 +143,7 @@ bool Texture::create(unsigned int width, unsigned int height)
     m_size.y        = height;
     m_actualSize    = actualSize;
     m_pixelsFlipped = false;
+    m_fboAttachment = false;
 
     ensureGlContext();
 
@@ -588,6 +591,7 @@ Texture& Texture::operator =(const Texture& right)
     std::swap(m_isSmooth,      temp.m_isSmooth);
     std::swap(m_isRepeated,    temp.m_isRepeated);
     std::swap(m_pixelsFlipped, temp.m_pixelsFlipped);
+    std::swap(m_fboAttachment, temp.m_fboAttachment);
     m_cacheId = getUniqueId();
 
     return *this;


### PR DESCRIPTION
Based on http://en.sfml-dev.org/forums/index.php?topic=18428.0.

Certain drivers seem to ignore requests to clear RenderTextures under certain circumstances.   Seems to be related to #591, which fixed part of the problem.  This fixes another part (hopefully the rest!).