### PR TITLE
Robust alCheck and glCheck macros

### DIFF
--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -26,8 +26,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/ALCheck.hpp>
-#include <SFML/Audio/AudioDevice.hpp>
 #include <SFML/System/Err.hpp>
+#include <string>
 
 
 namespace sf
@@ -35,14 +35,16 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-void alCheckError(const std::string& file, unsigned int line)
+void alCheckError(const char* file, unsigned int line, const char* expression)
 {
     // Get the last error
     ALenum errorCode = alGetError();
 
     if (errorCode != AL_NO_ERROR)
     {
-        std::string error, description;
+        std::string fileString = file;
+        std::string error = "Unknown error";
+        std::string description = "No description";
 
         // Decode the error code
         switch (errorCode)
@@ -50,43 +52,44 @@ void alCheckError(const std::string& file, unsigned int line)
             case AL_INVALID_NAME:
             {
                 error = "AL_INVALID_NAME";
-                description = "an unacceptable name has been specified";
+                description = "A bad name (ID) has been specified.";
                 break;
             }
 
             case AL_INVALID_ENUM:
             {
                 error = "AL_INVALID_ENUM";
-                description = "an unacceptable value has been specified for an enumerated argument";
+                description = "An unacceptable value has been specified for an enumerated argument.";
                 break;
             }
 
             case AL_INVALID_VALUE:
             {
                 error = "AL_INVALID_VALUE";
-                description = "a numeric argument is out of range";
+                description = "A numeric argument is out of range.";
                 break;
             }
 
             case AL_INVALID_OPERATION:
             {
                 error = "AL_INVALID_OPERATION";
-                description = "the specified operation is not allowed in the current state";
+                description = "The specified operation is not allowed in the current state.";
                 break;
             }
 
             case AL_OUT_OF_MEMORY:
             {
                 error = "AL_OUT_OF_MEMORY";
-                description = "there is not enough memory left to execute the command";
+                description = "There is not enough memory left to execute the command.";
                 break;
             }
         }
 
         // Log the error
         err() << "An internal OpenAL call failed in "
-              << file.substr(file.find_last_of("\\/") + 1) << " (" << line << ") : "
-              << error << ", " << description
+              << fileString.substr(fileString.find_last_of("\\/") + 1) << "(" << line << ")."
+              << "\nExpression:\n   " << expression
+              << "\nError description:\n   " << error << "\n   " << description << "\n"
               << std::endl;
     }
 }

--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -50,7 +50,8 @@ namespace priv
 #ifdef SFML_DEBUG
 
     // If in debug mode, perform a test on every call
-    #define alCheck(x) x; sf::priv::alCheckError(__FILE__, __LINE__);
+    // The do-while loop is needed so that alCheck can be used as a single statement in if/else branches
+    #define alCheck(expr) do { expr; sf::priv::alCheckError(__FILE__, __LINE__, #expr); } while (false)
 
 #else
 

--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -29,8 +29,6 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
-#include <iostream>
-#include <string>
 #ifdef SFML_SYSTEM_IOS
     #include <OpenAl/al.h>
     #include <OpenAl/alc.h>
@@ -45,7 +43,7 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-/// Let's define a macro to quickly check every OpenAL API calls
+/// Let's define a macro to quickly check every OpenAL API call
 ////////////////////////////////////////////////////////////
 #ifdef SFML_DEBUG
 
@@ -56,7 +54,7 @@ namespace priv
 #else
 
     // Else, we don't add any overhead
-    #define alCheck(Func) (Func)
+    #define alCheck(expr) (expr)
 
 #endif
 
@@ -66,9 +64,10 @@ namespace priv
 ///
 /// \param file Source file where the call is located
 /// \param line Line number of the source file where the call is located
+/// \param expression The evaluated expression as a string
 ///
 ////////////////////////////////////////////////////////////
-void alCheckError(const std::string& file, unsigned int line);
+void alCheckError(const char* file, unsigned int line, const char* expression);
 
 } // namespace priv
 

--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/GLCheck.hpp>
 #include <SFML/System/Err.hpp>
+#include <string>
 
 
 namespace sf
@@ -34,16 +35,16 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-void glCheckError(const char* file, unsigned int line)
+void glCheckError(const char* file, unsigned int line, const char* expression)
 {
     // Get the last error
     GLenum errorCode = glGetError();
 
     if (errorCode != GL_NO_ERROR)
     {
-        std::string fileString(file);
-        std::string error = "unknown error";
-        std::string description  = "no description";
+        std::string fileString = file;
+        std::string error = "Unknown error";
+        std::string description  = "No description";
 
         // Decode the error code
         switch (errorCode)
@@ -51,57 +52,58 @@ void glCheckError(const char* file, unsigned int line)
             case GL_INVALID_ENUM:
             {
                 error = "GL_INVALID_ENUM";
-                description = "an unacceptable value has been specified for an enumerated argument";
+                description = "An unacceptable value has been specified for an enumerated argument.";
                 break;
             }
 
             case GL_INVALID_VALUE:
             {
                 error = "GL_INVALID_VALUE";
-                description = "a numeric argument is out of range";
+                description = "A numeric argument is out of range.";
                 break;
             }
 
             case GL_INVALID_OPERATION:
             {
                 error = "GL_INVALID_OPERATION";
-                description = "the specified operation is not allowed in the current state";
+                description = "The specified operation is not allowed in the current state.";
                 break;
             }
 
             case GL_STACK_OVERFLOW:
             {
                 error = "GL_STACK_OVERFLOW";
-                description = "this command would cause a stack overflow";
+                description = "This command would cause a stack overflow.";
                 break;
             }
 
             case GL_STACK_UNDERFLOW:
             {
                 error = "GL_STACK_UNDERFLOW";
-                description = "this command would cause a stack underflow";
+                description = "This command would cause a stack underflow.";
                 break;
             }
 
             case GL_OUT_OF_MEMORY:
             {
                 error = "GL_OUT_OF_MEMORY";
-                description = "there is not enough memory left to execute the command";
+                description = "There is not enough memory left to execute the command.";
                 break;
             }
 
             case GLEXT_GL_INVALID_FRAMEBUFFER_OPERATION:
             {
                 error = "GL_INVALID_FRAMEBUFFER_OPERATION";
-                description = "the object bound to FRAMEBUFFER_BINDING is not \"framebuffer complete\"";
+                description = "The object bound to FRAMEBUFFER_BINDING is not \"framebuffer complete\".";
                 break;
             }
         }
 
         // Log the error
         err() << "An internal OpenGL call failed in "
-              << fileString.substr(fileString.find_last_of("\\/") + 1) << " (" << line << ") : "
-              << error << ", " << description
+              << fileString.substr(fileString.find_last_of("\\/") + 1) << "(" << line << ")."
+              << "\nExpression:\n   " << expression
+              << "\nError description:\n   " << error << "\n   " << description << "\n"
               << std::endl;
     }
 }

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -43,7 +43,8 @@ namespace priv
 #ifdef SFML_DEBUG
 
     // In debug mode, perform a test on every OpenGL call
-    #define glCheck(x) x; sf::priv::glCheckError(__FILE__, __LINE__);
+    // The do-while loop is needed so that glCheck can be used as a single statement in if/else branches
+    #define glCheck(expr) do { expr; sf::priv::glCheckError(__FILE__, __LINE__, #expr); } while (false)
 
 #else
 

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -30,7 +30,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 #include <SFML/Graphics/GLExtensions.hpp>
-#include <string>
 
 
 namespace sf
@@ -38,7 +37,7 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-/// Let's define a macro to quickly check every OpenGL API calls
+/// Let's define a macro to quickly check every OpenGL API call
 ////////////////////////////////////////////////////////////
 #ifdef SFML_DEBUG
 
@@ -49,7 +48,7 @@ namespace priv
 #else
 
     // Else, we don't add any overhead
-    #define glCheck(call) (call)
+    #define glCheck(expr) (expr)
 
 #endif
 
@@ -58,9 +57,10 @@ namespace priv
 ///
 /// \param file Source file where the call is located
 /// \param line Line number of the source file where the call is located
+/// \param expression The evaluated expression as a string
 ///
 ////////////////////////////////////////////////////////////
-void glCheckError(const char* file, unsigned int line);
+void glCheckError(const char* file, unsigned int line, const char* expression);
 
 } // namespace priv
 

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -117,7 +117,8 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
     glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureId, 0));
 
     // A final check, just to be sure...
-    GLenum status = glCheck(GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
+    GLenum status;
+    glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
     if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
     {
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -275,7 +275,8 @@ void Shader::setParameter(const std::string& name, float x)
         ensureGlContext();
 
         // Enable program
-        GLEXT_GLhandle program = glCheck(GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
+        GLEXT_GLhandle program;
+        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
         glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
 
         // Get parameter location and assign it new values
@@ -299,7 +300,8 @@ void Shader::setParameter(const std::string& name, float x, float y)
         ensureGlContext();
 
         // Enable program
-        GLEXT_GLhandle program = glCheck(GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
+        GLEXT_GLhandle program;
+        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
         glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
 
         // Get parameter location and assign it new values
@@ -323,7 +325,8 @@ void Shader::setParameter(const std::string& name, float x, float y, float z)
         ensureGlContext();
 
         // Enable program
-        GLEXT_GLhandle program = glCheck(GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
+        GLEXT_GLhandle program;
+        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
         glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
 
         // Get parameter location and assign it new values
@@ -347,7 +350,8 @@ void Shader::setParameter(const std::string& name, float x, float y, float z, fl
         ensureGlContext();
 
         // Enable program
-        GLEXT_GLhandle program = glCheck(GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
+        GLEXT_GLhandle program;
+        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
         glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
 
         // Get parameter location and assign it new values
@@ -392,7 +396,8 @@ void Shader::setParameter(const std::string& name, const Transform& transform)
         ensureGlContext();
 
         // Enable program
-        GLEXT_GLhandle program = glCheck(GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
+        GLEXT_GLhandle program;
+        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
         glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
 
         // Get parameter location and assign it new values
@@ -534,13 +539,15 @@ bool Shader::compile(const char* vertexShaderCode, const char* fragmentShaderCod
     m_params.clear();
 
     // Create the program
-    GLEXT_GLhandle shaderProgram = glCheck(GLEXT_glCreateProgramObject());
+    GLEXT_GLhandle shaderProgram;
+    glCheck(shaderProgram = GLEXT_glCreateProgramObject());
 
     // Create the vertex shader if needed
     if (vertexShaderCode)
     {
         // Create and compile the shader
-        GLEXT_GLhandle vertexShader = glCheck(GLEXT_glCreateShaderObject(GLEXT_GL_VERTEX_SHADER));
+        GLEXT_GLhandle vertexShader;
+        glCheck(vertexShader = GLEXT_glCreateShaderObject(GLEXT_GL_VERTEX_SHADER));
         glCheck(GLEXT_glShaderSource(vertexShader, 1, &vertexShaderCode, NULL));
         glCheck(GLEXT_glCompileShader(vertexShader));
 
@@ -567,7 +574,8 @@ bool Shader::compile(const char* vertexShaderCode, const char* fragmentShaderCod
     if (fragmentShaderCode)
     {
         // Create and compile the shader
-        GLEXT_GLhandle fragmentShader = glCheck(GLEXT_glCreateShaderObject(GLEXT_GL_FRAGMENT_SHADER));
+        GLEXT_GLhandle fragmentShader;
+        glCheck(fragmentShader = GLEXT_glCreateShaderObject(GLEXT_GL_FRAGMENT_SHADER));
         glCheck(GLEXT_glShaderSource(fragmentShader, 1, &fragmentShaderCode, NULL));
         glCheck(GLEXT_glCompileShader(fragmentShader));
 


### PR DESCRIPTION
Forum topic: http://en.sfml-dev.org/forums/index.php?topic=18440
Since this PR fixes currently broken behavior in SFML, I recommend an inclusion in SFML 2.3.1 or 2.3.2.

### 1. Macro robustness
The internally used macros `alCheck` and `glCheck` are currently implemented as follows (in Debug mode):
```cpp
#define glCheck(x) x; sf::priv::glCheckError(__FILE__, __LINE__);
```
This is a ticking time bomb, because it looks like a function call, but behaves as two separate statements. In the forum thread, such code caused a very subtle bug:
```cpp
if (condition)
    alCheck(...);
```
The problem is extremely hard to spot, especially if one is not familiar with the implementation of the macros. This pull requests mitigates this problem by making the implementation more robust when used in branches, as shown below. For those who consider the code strange, the do-while idiom is pretty common for exactly this thing, check [StackOverflow](http://stackoverflow.com/q/154136) for example.
```cpp
#define alCheck(expr) do { expr; sf::priv::alCheckError(__FILE__, __LINE__); } while (false) 
```
An alternative implementation uses the comma operator. Advantage is that compilers will certainly not emit a warning because of constant loop conditions (I'm not sure if they do now), however it may lead to problems if the comma operator is overloaded (extremely unlikely to occur within SFML source code).
```cpp
#define alCheck(expr) ((expr), sf::priv::alCheckError(__FILE__, __LINE__))
```

-----
### 2. Improved diagnostic output
If a call verified by `alCheck` or `glCheck` fails, the error message is currently looking as follows:
```
An internal OpenGL call failed in userfile.cpp(50) : GL_INVALID_ENUM, an unacceptable value has been specified for an enumerated argument
```

This PR makes the output more readable, by splitting it across multiple lines, and more expressive, by incorporating the failed expression in the output:
```
An internal OpenGL call failed in userfile.cpp(50).
Expression:
   glBegin(GL_TRIANGLES)
Error description:
   GL_INVALID_ENUM
   An unacceptable value has been specified for an enumerated argument.
```

Still needs testing.