### PR TITLE
convert FLAC name to upper case

### DIFF
--- a/cmake/Modules/FindSFML.cmake
+++ b/cmake/Modules/FindSFML.cmake
@@ -329,7 +329,7 @@ if(SFML_STATIC_LIBRARIES)
         find_sfml_dependency(VORBIS_LIBRARY "Vorbis" vorbis)
         find_sfml_dependency(VORBISFILE_LIBRARY "VorbisFile" vorbisfile)
         find_sfml_dependency(VORBISENC_LIBRARY "VorbisEnc" vorbisenc)
-        find_sfml_dependency(FLAC_LIBRARY "FLAC" flac)
+        find_sfml_dependency(FLAC_LIBRARY "FLAC" FLAC)
 
         # update the list
         set(SFML_AUDIO_DEPENDENCIES ${OPENAL_LIBRARY} ${FLAC_LIBRARY} ${VORBISENC_LIBRARY} ${VORBISFILE_LIBRARY} ${VORBIS_LIBRARY} ${OGG_LIBRARY})


### PR DESCRIPTION
This change is needed to find FLAC library on Ubuntu 14.04. Change is consistent with latest changes in FindFLAC.cmake 3fbfde39a5aa167f9cd606b85ad0118411831a96.