### PR TITLE
Prevent crashes on android when trying to open a resource that does not exists.

### DIFF
--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -49,13 +49,16 @@ m_file (NULL)
 ////////////////////////////////////////////////////////////
 ResourceStream::~ResourceStream()
 {
-    AAsset_close(m_file);
+    if (m_file != nullptr)
+        AAsset_close(m_file);
 }
 
 
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::read(void *data, Int64 size)
 {
+    if (m_file == nullptr)
+        return -1;
     return AAsset_read(m_file, data, size);
 }
 
@@ -63,6 +66,8 @@ Int64 ResourceStream::read(void *data, Int64 size)
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::seek(Int64 position)
 {
+    if (m_file == nullptr)
+        return -1;
     return AAsset_seek(m_file, position, SEEK_SET);
 }
 
@@ -70,6 +75,8 @@ Int64 ResourceStream::seek(Int64 position)
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::tell()
 {
+    if (m_file == nullptr)
+        return -1;
     return getSize() - AAsset_getRemainingLength(m_file);
 }
 
@@ -77,6 +84,8 @@ Int64 ResourceStream::tell()
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::getSize()
 {
+    if (m_file == nullptr)
+        return 0;
     return AAsset_getLength(m_file);
 }
 

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -49,7 +49,7 @@ m_file (NULL)
 ////////////////////////////////////////////////////////////
 ResourceStream::~ResourceStream()
 {
-    if (m_file != nullptr)
+    if (m_file)
         AAsset_close(m_file);
 }
 
@@ -57,7 +57,7 @@ ResourceStream::~ResourceStream()
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::read(void *data, Int64 size)
 {
-    if (m_file == nullptr)
+    if (!m_file)
         return -1;
     return AAsset_read(m_file, data, size);
 }
@@ -66,7 +66,7 @@ Int64 ResourceStream::read(void *data, Int64 size)
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::seek(Int64 position)
 {
-    if (m_file == nullptr)
+    if (!m_file)
         return -1;
     return AAsset_seek(m_file, position, SEEK_SET);
 }
@@ -75,7 +75,7 @@ Int64 ResourceStream::seek(Int64 position)
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::tell()
 {
-    if (m_file == nullptr)
+    if (!m_file)
         return -1;
     return getSize() - AAsset_getRemainingLength(m_file);
 }
@@ -84,7 +84,7 @@ Int64 ResourceStream::tell()
 ////////////////////////////////////////////////////////////
 Int64 ResourceStream::getSize()
 {
-    if (m_file == nullptr)
+    if (!m_file)
         return 0;
     return AAsset_getLength(m_file);
 }

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -85,7 +85,7 @@ Int64 ResourceStream::tell()
 Int64 ResourceStream::getSize()
 {
     if (!m_file)
-        return 0;
+        return -1;
     return AAsset_getLength(m_file);
 }
 


### PR DESCRIPTION
http://en.sfml-dev.org/forums/index.php?topic=18581.0

When trying to open an none-existing asset on Android, the application crashed, because a nullptr is used in the AAsset_getRemainingLength function.

Not a perfect solution IMHO. But at least it prevents crashes.