### PR TITLE
Fixing #935: Secure function against random data return.

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -32,8 +32,8 @@
 #include <SFML/Graphics/VertexArray.hpp>
 #include <SFML/Graphics/GLCheck.hpp>
 #include <SFML/System/Err.hpp>
+#include <cassert>
 #include <iostream>
-
 
 namespace
 {
@@ -53,6 +53,10 @@ namespace
             case sf::BlendMode::DstAlpha:         return GL_DST_ALPHA;
             case sf::BlendMode::OneMinusDstAlpha: return GL_ONE_MINUS_DST_ALPHA;
         }
+
+        sf::err() << "Invalid value for sf::BlendMode::Factor! Fallback to sf::BlendMode::Zero." << std::endl;
+        assert(false);
+        return GL_ZERO;
     }
 
 
@@ -64,6 +68,10 @@ namespace
             case sf::BlendMode::Add:             return GLEXT_GL_FUNC_ADD;
             case sf::BlendMode::Subtract:        return GLEXT_GL_FUNC_SUBTRACT;
         }
+
+        sf::err() << "Invalid value for sf::BlendMode::Equation! Fallback to sf::BlendMode::Add." << std::endl;
+        assert(false);
+        return GLEXT_GL_FUNC_ADD;
     }
 }
 


### PR DESCRIPTION
As described in bug #935, this will secure
sf::Uint32 factorToGlConstant(sf::BlendMode::Factor blendFactor)
and
sf::Uint32 equationToGlConstant(sf::BlendMode::Equation blendEquation)
from RenderTarget.cpp against returning random data.
The common consent was to apply the patch and add an assert on top.

See also discussion in bug report #935.