### PR TITLE
Fixed documentation for MemoryInputStream and FileInputStream

### DIFF
--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -136,7 +136,7 @@ private:
 
 
 ////////////////////////////////////////////////////////////
-/// \class FileInputStream
+/// \class sf::FileInputStream
 /// \ingroup system
 ///
 /// This class is a specialization of InputStream that
@@ -153,17 +153,17 @@ private:
 ///
 /// SFML resource classes can usually be loaded directly from
 /// a filename, so this class shouldn't be useful to you unless
-/// you create your own algorithms that operate on a InputStream.
+/// you create your own algorithms that operate on an InputStream.
 ///
 /// Usage example:
 /// \code
 /// void process(InputStream& stream);
 ///
-/// FileStream stream;
+/// FileInputStream stream;
 /// if (stream.open("some_file.dat"))
 ///    process(stream);
 /// \endcode
 ///
-/// InputStream, MemoryStream
+/// InputStream, MemoryInputStream
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/System/MemoryInputStream.hpp
+++ b/include/SFML/System/MemoryInputStream.hpp
@@ -116,7 +116,7 @@ private:
 
 
 ////////////////////////////////////////////////////////////
-/// \class MemoryeInputStream
+/// \class sf::MemoryInputStream
 /// \ingroup system
 ///
 /// This class is a specialization of InputStream that
@@ -132,17 +132,17 @@ private:
 ///
 /// SFML resource classes can usually be loaded directly from
 /// memory, so this class shouldn't be useful to you unless
-/// you create your own algorithms that operate on a InputStream.
+/// you create your own algorithms that operate on an InputStream.
 ///
 /// Usage example:
 /// \code
 /// void process(InputStream& stream);
 ///
-/// MemoryStream stream;
+/// MemoryInputStream stream;
 /// stream.open(thePtr, theSize);
 /// process(stream);
 /// \endcode
 ///
-/// InputStream, FileStream
+/// InputStream, FileInputStream
 ///
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
If you look at the bottom of http://www.sfml-dev.org/documentation/2.3.2/annotated.php you'll see two classes that are documented as outside the `sf` namespace. This PR fixes that and some typos.