### PR TITLE
Linux: added initial multi-touch support

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -31,6 +31,8 @@
 #include <SFML/Window/Event.hpp>
 #include <SFML/Window/WindowImpl.hpp>
 #include <SFML/System/String.hpp>
+#include <X11/extensions/XI2.h>
+#include <X11/extensions/XInput2.h>
 #include <X11/Xlib-xcb.h>
 #include <xcb/randr.h>
 #include <deque>
@@ -304,6 +306,26 @@ private:
     bool processEvent(XEvent windowEvent);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Process an incoming XInput2 event from the window
+    ///
+    /// \param cookie XGenericEventCookie which has been received
+    ///
+    /// \return True if the event was processed, false if it was discarded
+    ///
+    ////////////////////////////////////////////////////////////
+    bool processXI2Event(XGenericEventCookie *cookie);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a XIDeviceEvent into a Event
+    ///
+    /// \param xiDeviceEvent XIDeviceEvent which has been received
+    ///
+    /// \return True if the event was processed, false if it was discarded
+    ///
+    ////////////////////////////////////////////////////////////
+    Event deviceEventToTouchEvent(const XIDeviceEvent* deviceEvent, Event::EventType type) const;
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     xcb_window_t                      m_window;          ///< xcb identifier defining our window
@@ -319,6 +341,7 @@ private:
     Vector2i                          m_previousSize;    ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
     bool                              m_useSizeHints;    ///< Is the size of the window fixed with size hints?
     bool                              m_fullscreen;      ///< Is window in fullscreen?
+    int                               m_xiOpcode;        ///< Major opcode for the extension (0 if not available)
 };
 
 } // namespace priv


### PR DESCRIPTION
This pull request add multi-touch support with Linux using XInput2 (X11 extension), and is based on 
[Mario PR: feature/windows_touch](https://github.com/SFML/SFML/pull/912).

I'm using this extension because that's the way it is usually done with other libraries (such as GTK or SDL).

Just like Mario PR, I did not implement non-event touch functions like `sf::Touch::isDown(i)` for obvious reasons (see Mario comments). I'll wait for these features to be implemented into Mario PR.



