### PR TITLE
Deprecation macro

### DIFF
--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -158,6 +158,44 @@
 
 
 ////////////////////////////////////////////////////////////
+// Cross-platform warning for deprecated functions and classes
+//
+// Usage:
+// class SFML_DEPRECATED MyClass
+// {
+//     SFML_DEPRECATED void memberFunc();
+// };
+//
+// SFML_DEPRECATED void globalFunc();
+////////////////////////////////////////////////////////////
+#if defined(SFML_NO_DEPRECATED_WARNINGS)
+
+    // User explicitly requests to disable deprecation warnings
+    #define SFML_DEPRECATED
+
+#elif defined(_MSC_VER)
+
+    // Microsoft C++ compiler
+    // Note: On newer MSVC versions, using deprecated functions causes a compiler error. In order to
+    // trigger a warning instead of an error, the compiler flag /sdl- (instead of /sdl) must be specified.
+    #define SFML_DEPRECATED __declspec(deprecated)
+
+#elif defined(__GNUC__)
+
+    // g++ and Clang
+    #define SFML_DEPRECATED __attribute__ ((deprecated))
+
+#else
+
+    // Other compilers are not supported, leave class or function as-is.
+    // With a bit of luck, the #pragma directive works, otherwise users get a warning (no error!) for unrecognized #pragma.
+    #pragma message("SFML_DEPRECATED is not supported for your compiler, please contact the SFML team")
+    #define SFML_DEPRECATED
+
+#endif
+
+
+////////////////////////////////////////////////////////////
 // Define portable fixed-size types
 ////////////////////////////////////////////////////////////
 namespace sf


### PR DESCRIPTION
*Forum thread: http://en.sfml-dev.org/forums/index.php?topic=17888*

I added a macro to deprecate functions and classes in a portable way. I used an object-style macro for simplicity and to avoid problems with commas in the evaluation. I don't consider a message necessary, as that's what the documentation is for.

Here is a minimal testing snippet that also shows the usage:
```cpp
struct SFML_DEPRECATED MyClass
{
    SFML_DEPRECATED void memberFunc() {}
};

SFML_DEPRECATED void globalFunc() {}

int main() 
{
   MyClass().memberFunc();
   globalFunc();
}
```

The code also checks for a definition of the macro `SFML_NO_DEPRECATED_WARNINGS`. I thought about this, but I think it's not our job to enforce the warnings. If people don't want to see the warnings, that's their problem. Anyway, they will just turn off warnings in their compiler globally -- providing the option to selectively disable SFML's warnings is much better.

I tested the macro on Visual Studio 2015 and g++ 5.2.0 (MinGW). I would be glad about feedback for further compilers, compiler versions and platforms.

One problem with Visual Studio 2013 and 2015 is that the usage of deprecated symbols triggers a compiler error, not a warning by default. This can be changed with the [`/sdl-` compiler flag](https://msdn.microsoft.com/en-us/library/jj161081.aspx), but it's something users explicitly have to do when working with SFML.

