### PR TITLE
Fixed small typo in RenderTexture::setActive() \brief

### DIFF
--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -132,7 +132,7 @@ public:
     bool isRepeated() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Activate of deactivate the render-texture for rendering
+    /// \brief Activate or deactivate the render-texture for rendering
     ///
     /// This function makes the render-texture's context current for
     /// future OpenGL rendering operations (so you shouldn't care


### PR DESCRIPTION
As per [the forums](http://en.sfml-dev.org/forums/index.php?topic=19054.msg137512;topicseen#msg137512).