### PR TITLE
Fixed PDB warnings by switching from /Zi to /Z7 for Visual Studio.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,14 +146,24 @@ if(SFML_OS_WINDOWS)
     endif()
 
     # for VC++, we can apply it globally by modifying the compiler flags
-    if(SFML_COMPILER_MSVC AND SFML_USE_STATIC_STD_LIBS)
+    if(SFML_COMPILER_MSVC)
         foreach(flag
                 CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
                 CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if(${flag} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+            if(${flag} MATCHES "/Zi")
+                string(REGEX REPLACE "/Zi" "/Z7" ${flag} "${${flag}}")
             endif()
         endforeach()
+    
+        if(SFML_USE_STATIC_STD_LIBS)
+            foreach(flag
+                    CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+                    CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+                if(${flag} MATCHES "/MD")
+                    string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+                endif()
+            endforeach()
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
In a [recent discussion](http://en.sfml-dev.org/forums/index.php?topic=18931.0) the whole PDB warning issue came up again, but this time a possible solution was provided, mainly by switching from `/Zi` to `/Z7`, which builds the debug information into the binaries.

I've tested this and it seems to work quite well, one can step into SFML and there's no warning anymore.

Let me know what your thoughts are.