### PR TITLE
New API to set shader uniforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,9 @@ if(NOT BUILD_SHARED_LIBS)
     add_definitions(-DSFML_STATIC)
 endif()
 
-# remove SL security warnings with Visual C++
+# Visual C++: remove warnings regarding SL security and algorithms on pointers
 if(SFML_COMPILER_MSVC)
-    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+    add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS)
 endif()
 
 # define SFML_OPENGL_ES if needed

--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -2000,7 +2000,9 @@ PREDEFINED             = SFML_SYSTEM_API \
                          SFML_NETWORK_API \
                          SFML_WINDOW_API \
                          SFML_AUDIO_API \
-                         SFML_GRAPHICS_API
+                         SFML_GRAPHICS_API \
+                         SFML_DEPRECATED \
+                         SFML_DOXYGEN
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -31,14 +31,14 @@ public:
         // Load the shader
         if (!m_shader.loadFromFile("resources/pixelate.frag", sf::Shader::Fragment))
             return false;
-        m_shader.setParameter("texture", sf::Shader::CurrentTexture);
+        m_shader.setUniform("texture", sf::Shader::CurrentTexture);
 
         return true;
     }
 
     void onUpdate(float, float x, float y)
     {
-        m_shader.setParameter("pixel_threshold", (x + y) / 30);
+        m_shader.setUniform("pixel_threshold", (x + y) / 30);
     }
 
     void onDraw(sf::RenderTarget& target, sf::RenderStates states) const
@@ -101,9 +101,9 @@ public:
 
     void onUpdate(float time, float x, float y)
     {
-        m_shader.setParameter("wave_phase", time);
-        m_shader.setParameter("wave_amplitude", x * 40, y * 40);
-        m_shader.setParameter("blur_radius", (x + y) * 0.008f);
+        m_shader.setUniform("wave_phase", time);
+        m_shader.setUniform("wave_amplitude", sf::Vector2f(x * 40, y * 40));
+        m_shader.setUniform("blur_radius", (x + y) * 0.008f);
     }
 
     void onDraw(sf::RenderTarget& target, sf::RenderStates states) const
@@ -155,10 +155,10 @@ public:
     void onUpdate(float time, float x, float y)
     {
         float radius = 200 + std::cos(time) * 150;
-        m_shader.setParameter("storm_position", x * 800, y * 600);
-        m_shader.setParameter("storm_inner_radius", radius / 3);
-        m_shader.setParameter("storm_total_radius", radius);
-        m_shader.setParameter("blink_alpha", 0.5f + std::cos(time * 3) * 0.25f);
+        m_shader.setUniform("storm_position", sf::Vector2f(x * 800, y * 600));
+        m_shader.setUniform("storm_inner_radius", radius / 3);
+        m_shader.setUniform("storm_total_radius", radius);
+        m_shader.setUniform("blink_alpha", 0.5f + std::cos(time * 3) * 0.25f);
     }
 
     void onDraw(sf::RenderTarget& target, sf::RenderStates states) const
@@ -215,14 +215,14 @@ public:
         // Load the shader
         if (!m_shader.loadFromFile("resources/edge.frag", sf::Shader::Fragment))
             return false;
-        m_shader.setParameter("texture", sf::Shader::CurrentTexture);
+        m_shader.setUniform("texture", sf::Shader::CurrentTexture);
 
         return true;
     }
 
     void onUpdate(float time, float x, float y)
     {
-        m_shader.setParameter("edge_threshold", 1 - (x + y) / 2);
+        m_shader.setUniform("edge_threshold", 1 - (x + y) / 2);
 
         // Update the position of the moving entities
         for (std::size_t i = 0; i < m_entities.size(); ++i)

--- a/include/SFML/Graphics/Glsl.hpp
+++ b/include/SFML/Graphics/Glsl.hpp
@@ -1,0 +1,227 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GLSL_HPP
+#define SFML_GLSL_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Transform.hpp>
+#include <SFML/Graphics/Color.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/System/Vector3.hpp>
+
+
+namespace sf
+{
+namespace priv
+{
+    // Forward declarations
+    template <std::size_t Columns, std::size_t Rows>
+    struct Matrix;
+
+    template <typename T>
+    struct Vector4;
+
+#include <SFML/Graphics/Glsl.inl>
+
+} // namespace priv
+
+
+////////////////////////////////////////////////////////////
+/// \brief Namespace with GLSL types
+///
+////////////////////////////////////////////////////////////
+namespace Glsl
+{
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 2D float vector (\p vec2 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector2<float> Vec2;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 2D int vector (\p ivec2 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector2<int> Ivec2;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 2D bool vector (\p bvec2 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector2<bool> Bvec2;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3D float vector (\p vec3 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector3<float> Vec3;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3D int vector (\p ivec3 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector3<int> Ivec3;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3D bool vector (\p bvec3 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector3<bool> Bvec3;
+
+#ifdef SFML_DOXYGEN
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4D float vector (\p vec4 in GLSL)
+    ///
+    /// 4D float vectors can be implicitly converted from sf::Color
+    /// instances. Each color channel is normalized from integers
+    /// in [0, 255] to floating point values in [0, 1].
+    /// \code
+    /// sf::Glsl::Vec4 zeroVector;
+    /// sf::Glsl::Vec4 vector(1.f, 2.f, 3.f, 4.f);
+    /// sf::Glsl::Vec4 color = sf::Color::Cyan;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Vec4;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4D int vector (\p ivec4 in GLSL)
+    ///
+    /// 4D int vectors can be implicitly converted from sf::Color
+    /// instances. Each color channel remains unchanged inside
+    /// the integer interval [0, 255].
+    /// \code
+    /// sf::Glsl::Ivec4 zeroVector;
+    /// sf::Glsl::Ivec4 vector(1, 2, 3, 4);
+    /// sf::Glsl::Ivec4 color = sf::Color::Cyan;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Ivec4;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4D bool vector (\p bvec4 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Bvec4;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3x3 float matrix (\p mat3 in GLSL)
+    ///
+    /// The matrix can be constructed from an array with 3x3
+    /// elements, aligned in column-major order. For example,
+    /// a translation by (x, y) looks as follows:
+    /// \code
+    /// float array[9] =
+    /// {
+    ///     1, 0, 0,
+    ///     0, 1, 0,
+    ///     x, y, 1
+    /// };
+    ///
+    /// sf::Glsl::Mat3 matrix(array);
+    /// \endcode
+    ///
+    /// Mat3 can also be implicitly converted from sf::Transform:
+    /// \code
+    /// sf::Transform transform;
+    /// sf::Glsl::Mat3 matrix = transform;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Mat3;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4x4 float matrix (\p mat4 in GLSL)
+    ///
+    /// The matrix can be constructed from an array with 4x4
+    /// elements, aligned in column-major order. For example,
+    /// a translation by (x, y, z) looks as follows:
+    /// \code
+    /// float array[16] =
+    /// {
+    ///     1, 0, 0, 0,
+    ///     0, 1, 0, 0,
+    ///     0, 0, 1, 0,
+    ///     x, y, z, 1
+    /// };
+    ///
+    /// sf::Glsl::Mat4 matrix(array);
+    /// \endcode
+    ///
+    /// Mat4 can also be implicitly converted from sf::Transform:
+    /// \code
+    /// sf::Transform transform;
+    /// sf::Glsl::Mat4 matrix = transform;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Mat4;
+
+#else // SFML_DOXYGEN
+
+    typedef priv::Vector4<float> Vec4;
+    typedef priv::Vector4<int> Ivec4;
+    typedef priv::Vector4<bool> Bvec4;
+    typedef priv::Matrix<3, 3> Mat3;
+    typedef priv::Matrix<4, 4> Mat4;
+
+#endif // SFML_DOXYGEN
+
+} // namespace Glsl
+} // namespace sf
+
+#endif // SFML_GLSL_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \namespace sf::Glsl
+/// \ingroup graphics
+///
+/// \details The sf::Glsl namespace contains types that match
+/// their equivalents in GLSL, the OpenGL shading language.
+/// These types are exclusively used by the sf::Shader class.
+///
+/// Types that already exist in SFML, such as \ref sf::Vector2<T>
+/// and \ref sf::Vector3<T>, are reused as typedefs, so you can use
+/// the types in this namespace as well as the original ones.
+/// Others are newly defined, such as Glsl::Vec4 or Glsl::Mat3. Their
+/// actual type is an implementation detail and should not be used.
+///
+/// All vector types support a default constructor that
+/// initializes every component to zero, in addition to a
+/// constructor with one parameter for each component.
+/// The components are stored in member variables called
+/// x, y, z, and w.
+///
+/// All matrix types support a constructor with a float*
+/// parameter that points to a float array of the appropriate
+/// size (that is, 9 in a 3x3 matrix, 16 in a 4x4 matrix).
+/// Furthermore, they can be converted from sf::Transform
+/// objects.
+///
+/// \see sf::Shader
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -1,0 +1,152 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+/// \brief Helper functions to copy sf::Transform to sf::Glsl::Mat3/4
+///
+////////////////////////////////////////////////////////////
+void copyMatrix(const Transform& source, Matrix<3, 3>& dest);
+void copyMatrix(const Transform& source, Matrix<4, 4>& dest);
+
+////////////////////////////////////////////////////////////
+/// \brief Copy array-based matrix with given number of elements
+///
+/// Indirection to std::copy() to avoid inclusion of
+/// <algorithm> and MSVC's annoying 4996 warning in header
+///
+////////////////////////////////////////////////////////////
+void copyMatrix(const float* source, std::size_t elements, float* dest);
+
+////////////////////////////////////////////////////////////
+/// \brief Helper functions to copy sf::Color to sf::Glsl::Vec4/Ivec4
+///
+////////////////////////////////////////////////////////////
+void copyVector(const Color& source, Vector4<float>& dest);
+void copyVector(const Color& source, Vector4<int>& dest);
+
+
+////////////////////////////////////////////////////////////
+/// \brief Matrix type, used to set uniforms in GLSL
+///
+////////////////////////////////////////////////////////////
+template <std::size_t Columns, std::size_t Rows>
+struct Matrix
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from raw data
+    ///
+    /// \param pointer Points to the beginning of an array that
+    ///                has the size of the matrix. The elements
+    ///                are copied to the instance.
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Matrix(const float* pointer)
+    {
+        copyMatrix(pointer, Columns * Rows, array);
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct implicitly from SFML transform
+    ///
+    /// This constructor is only supported for 3x3 and 4x4
+    /// matrices.
+    ///
+    /// \param transform Object containing a transform.
+    ///
+    ////////////////////////////////////////////////////////////
+    Matrix(const Transform& transform)
+    {
+        copyMatrix(transform, *this);
+    }
+
+    float array[Columns * Rows]; ///< Array holding matrix data
+};
+
+////////////////////////////////////////////////////////////
+/// \brief 4D vector type, used to set uniforms in GLSL
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+struct Vector4
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor, creates a zero vector
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector4() :
+    x(0),
+    y(0),
+    z(0),
+    w(0)
+    {
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from 4 vector components
+    ///
+    /// \param X,Y,Z,W Components of the 4D vector
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector4(T X, T Y, T Z, T W) :
+    x(X),
+    y(Y),
+    z(Z),
+    w(W)
+    {
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Conversion constructor
+    ///
+    /// \param other 4D vector of different type
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename U>
+    explicit Vector4(const Vector4<U>& other) :
+    x(static_cast<T>(other.x)),
+    y(static_cast<T>(other.y)),
+    z(static_cast<T>(other.z)),
+    w(static_cast<T>(other.w))
+    {
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct float vector implicitly from color
+    ///
+    /// \param color Color instance. Is normalized to [0, 1]
+    ///              for floats, and left as-is for ints.
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector4(const Color& color)
+    // uninitialized
+    {
+        copyVector(color, *this);
+    }
+
+    T x; ///< 1st component (X) of the 4D vector
+    T y; ///< 2nd component (Y) of the 4D vector
+    T z; ///< 3rd component (Z) of the 4D vector
+    T w; ///< 4th component (W) of the 4D vector
+};

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -29,8 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
-#include <SFML/Graphics/Transform.hpp>
-#include <SFML/Graphics/Color.hpp>
+#include <SFML/Graphics/Glsl.hpp>
 #include <SFML/Window/GlResource.hpp>
 #include <SFML/System/NonCopyable.hpp>
 #include <SFML/System/Vector2.hpp>
@@ -41,8 +40,10 @@
 
 namespace sf
 {
+class Color;
 class InputStream;
 class Texture;
+class Transform;
 
 ////////////////////////////////////////////////////////////
 /// \brief Shader class (vertex and fragment)
@@ -58,15 +59,15 @@ public:
     ////////////////////////////////////////////////////////////
     enum Type
     {
-        Vertex,  ///< Vertex shader
+        Vertex,  ///< %Vertex shader
         Fragment ///< Fragment (pixel) shader
     };
 
     ////////////////////////////////////////////////////////////
-    /// \brief Special type that can be passed to setParameter,
+    /// \brief Special type that can be passed to setUniform(),
     ///        and that represents the texture of the object being drawn
     ///
-    /// \see setParameter(const std::string&, CurrentTextureType)
+    /// \see setUniform(const std::string&, CurrentTextureType)
     ///
     ////////////////////////////////////////////////////////////
     struct CurrentTextureType {};
@@ -74,7 +75,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Represents the texture of the object being drawn
     ///
-    /// \see setParameter(const std::string&, CurrentTextureType)
+    /// \see setUniform(const std::string&, CurrentTextureType)
     ///
     ////////////////////////////////////////////////////////////
     static CurrentTextureType CurrentTexture;
@@ -220,193 +221,154 @@ public:
     bool loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change a float parameter of the shader
+    /// \brief Specify value for \p float uniform
     ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a float
-    /// (float GLSL type).
-    ///
-    /// Example:
-    /// \code
-    /// uniform float myparam; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// shader.setParameter("myparam", 5.2f);
-    /// \endcode
-    ///
-    /// \param name Name of the parameter in the shader
-    /// \param x    Value to assign
+    /// \param name Name of the uniform variable in GLSL
+    /// \param x    Value of the float scalar
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, float x);
+    void setUniform(const std::string& name, float x);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change a 2-components vector parameter of the shader
+    /// \brief Specify value for \p vec2 uniform
     ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 2x1 vector
-    /// (vec2 GLSL type).
-    ///
-    /// Example:
-    /// \code
-    /// uniform vec2 myparam; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// shader.setParameter("myparam", 5.2f, 6.0f);
-    /// \endcode
-    ///
-    /// \param name Name of the parameter in the shader
-    /// \param x    First component of the value to assign
-    /// \param y    Second component of the value to assign
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the vec2 vector
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, float x, float y);
+    void setUniform(const std::string& name, const Glsl::Vec2& vector);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change a 3-components vector parameter of the shader
+    /// \brief Specify value for \p vec3 uniform
     ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 3x1 vector
-    /// (vec3 GLSL type).
-    ///
-    /// Example:
-    /// \code
-    /// uniform vec3 myparam; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// shader.setParameter("myparam", 5.2f, 6.0f, -8.1f);
-    /// \endcode
-    ///
-    /// \param name Name of the parameter in the shader
-    /// \param x    First component of the value to assign
-    /// \param y    Second component of the value to assign
-    /// \param z    Third component of the value to assign
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the vec3 vector
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, float x, float y, float z);
+    void setUniform(const std::string& name, const Glsl::Vec3& vector);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change a 4-components vector parameter of the shader
+    /// \brief Specify value for \p vec4 uniform
     ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 4x1 vector
-    /// (vec4 GLSL type).
-    ///
-    /// Example:
-    /// \code
-    /// uniform vec4 myparam; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// shader.setParameter("myparam", 5.2f, 6.0f, -8.1f, 0.4f);
-    /// \endcode
-    ///
-    /// \param name Name of the parameter in the shader
-    /// \param x    First component of the value to assign
-    /// \param y    Second component of the value to assign
-    /// \param z    Third component of the value to assign
-    /// \param w    Fourth component of the value to assign
-    ///
-    ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, float x, float y, float z, float w);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Change a 2-components vector parameter of the shader
-    ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 2x1 vector
-    /// (vec2 GLSL type).
-    ///
-    /// Example:
-    /// \code
-    /// uniform vec2 myparam; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// shader.setParameter("myparam", sf::Vector2f(5.2f, 6.0f));
-    /// \endcode
-    ///
-    /// \param name   Name of the parameter in the shader
-    /// \param vector Vector to assign
-    ///
-    ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, const Vector2f& vector);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Change a 3-components vector parameter of the shader
-    ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 3x1 vector
-    /// (vec3 GLSL type).
-    ///
-    /// Example:
-    /// \code
-    /// uniform vec3 myparam; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// shader.setParameter("myparam", sf::Vector3f(5.2f, 6.0f, -8.1f));
-    /// \endcode
-    ///
-    /// \param name   Name of the parameter in the shader
-    /// \param vector Vector to assign
-    ///
-    ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, const Vector3f& vector);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Change a color parameter of the shader
-    ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 4x1 vector
-    /// (vec4 GLSL type).
+    /// This overload can also be called with sf::Color objects
+    /// that are converted to sf::Glsl::Vec4.
     ///
     /// It is important to note that the components of the color are
     /// normalized before being passed to the shader. Therefore,
     /// they are converted from range [0 .. 255] to range [0 .. 1].
-    /// For example, a sf::Color(255, 125, 0, 255) will be transformed
+    /// For example, a sf::Color(255, 127, 0, 255) will be transformed
     /// to a vec4(1.0, 0.5, 0.0, 1.0) in the shader.
     ///
-    /// Example:
-    /// \code
-    /// uniform vec4 color; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// shader.setParameter("color", sf::Color(255, 128, 0, 255));
-    /// \endcode
-    ///
-    /// \param name  Name of the parameter in the shader
-    /// \param color Color to assign
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the vec4 vector
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, const Color& color);
+    void setUniform(const std::string& name, const Glsl::Vec4& vector);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change a matrix parameter of the shader
+    /// \brief Specify value for \p int uniform
     ///
-    /// \a name is the name of the variable to change in the shader.
-    /// The corresponding parameter in the shader must be a 4x4 matrix
-    /// (mat4 GLSL type).
-    ///
-    /// Example:
-    /// \code
-    /// uniform mat4 matrix; // this is the variable in the shader
-    /// \endcode
-    /// \code
-    /// sf::Transform transform;
-    /// transform.translate(5, 10);
-    /// shader.setParameter("matrix", transform);
-    /// \endcode
-    ///
-    /// \param name      Name of the parameter in the shader
-    /// \param transform Transform to assign
+    /// \param name Name of the uniform variable in GLSL
+    /// \param x    Value of the int scalar
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, const Transform& transform);
+    void setUniform(const std::string& name, int x);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change a texture parameter of the shader
+    /// \brief Specify value for \p ivec2 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the ivec2 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Ivec2& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p ivec3 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the ivec3 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Ivec3& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p ivec4 uniform
+    ///
+    /// This overload can also be called with sf::Color objects
+    /// that are converted to sf::Glsl::Ivec4.
+    ///
+    /// If color conversions are used, the ivec4 uniform in GLSL
+    /// will hold the same values as the original sf::Color
+    /// instance. For example, sf::Color(255, 127, 0, 255) is
+    /// mapped to ivec4(255, 127, 0, 255).
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the ivec4 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Ivec4& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bool uniform
+    ///
+    /// \param name Name of the uniform variable in GLSL
+    /// \param x    Value of the bool scalar
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, bool x);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bvec2 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the bvec2 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Bvec2& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bvec3 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the bvec3 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Bvec3& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bvec4 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the bvec4 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Bvec4& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p mat3 matrix
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param matrix Value of the mat3 matrix
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Mat3& matrix);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p mat4 matrix
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param matrix Value of the mat4 matrix
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Mat4& matrix);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify a texture as \p sampler2D uniform
     ///
     /// \a name is the name of the variable to change in the shader.
     /// The corresponding parameter in the shader must be a 2D texture
-    /// (sampler2D GLSL type).
+    /// (\p sampler2D GLSL type).
     ///
     /// Example:
     /// \code
@@ -415,46 +377,186 @@ public:
     /// \code
     /// sf::Texture texture;
     /// ...
-    /// shader.setParameter("the_texture", texture);
+    /// shader.setUniform("the_texture", texture);
     /// \endcode
     /// It is important to note that \a texture must remain alive as long
     /// as the shader uses it, no copy is made internally.
     ///
-    /// To use the texture of the object being draw, which cannot be
+    /// To use the texture of the object being drawn, which cannot be
     /// known in advance, you can pass the special value
     /// sf::Shader::CurrentTexture:
     /// \code
-    /// shader.setParameter("the_texture", sf::Shader::CurrentTexture).
+    /// shader.setUniform("the_texture", sf::Shader::CurrentTexture).
     /// \endcode
     ///
     /// \param name    Name of the texture in the shader
     /// \param texture Texture to assign
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, const Texture& texture);
+    void setUniform(const std::string& name, const Texture& texture);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change a texture parameter of the shader
+    /// \brief Specify current texture as \p sampler2D uniform
     ///
     /// This overload maps a shader texture variable to the
     /// texture of the object being drawn, which cannot be
     /// known in advance. The second argument must be
     /// sf::Shader::CurrentTexture.
     /// The corresponding parameter in the shader must be a 2D texture
-    /// (sampler2D GLSL type).
+    /// (\p sampler2D GLSL type).
     ///
     /// Example:
     /// \code
     /// uniform sampler2D current; // this is the variable in the shader
     /// \endcode
     /// \code
-    /// shader.setParameter("current", sf::Shader::CurrentTexture);
+    /// shader.setUniform("current", sf::Shader::CurrentTexture);
     /// \endcode
     ///
     /// \param name Name of the texture in the shader
     ///
     ////////////////////////////////////////////////////////////
-    void setParameter(const std::string& name, CurrentTextureType);
+    void setUniform(const std::string& name, CurrentTextureType);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p float[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param scalarArray pointer to array of \p float values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const float* scalarArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p vec2[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param vectorArray pointer to array of \p vec2 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Vec2* vectorArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p vec3[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param vectorArray pointer to array of \p vec3 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Vec3* vectorArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p vec4[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param vectorArray pointer to array of \p vec4 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Vec4* vectorArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p mat3[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param matrixArray pointer to array of \p mat3 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Mat3* matrixArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p mat4[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param matrixArray pointer to array of \p mat4 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Mat4* matrixArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a float parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, float) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 2-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec2&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 3-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec3&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y, float z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 4-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec4&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y, float z, float w);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 2-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec2&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Vector2f& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 3-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec3&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Vector3f& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a color parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec4&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a matrix parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Mat4&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Transform& transform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a texture parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Texture&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Texture& texture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a texture parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, CurrentTextureType) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, CurrentTextureType);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the underlying OpenGL handle of the shader.
@@ -529,20 +631,29 @@ private:
     void bindTextures() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get the location ID of a shader parameter
+    /// \brief Get the location ID of a shader uniform
     ///
-    /// \param name Name of the parameter to search
+    /// \param name Name of the uniform variable to search
     ///
-    /// \return Location ID of the parameter, or -1 if not found
+    /// \return Location ID of the uniform, or -1 if not found
     ///
     ////////////////////////////////////////////////////////////
-    int getParamLocation(const std::string& name);
+    int getUniformLocation(const std::string& name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief RAII object to save and restore the program
+    ///        binding while uniforms are being set
+    ///
+    /// Implementation is private in the .cpp file.
+    ///
+    ////////////////////////////////////////////////////////////
+    struct UniformBinder;
 
     ////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////
     typedef std::map<int, const Texture*> TextureTable;
-    typedef std::map<std::string, int> ParamTable;
+    typedef std::map<std::string, int> UniformTable;
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -550,7 +661,7 @@ private:
     unsigned int m_shaderProgram;  ///< OpenGL identifier for the program
     int          m_currentTexture; ///< Location of the current texture in the shader
     TextureTable m_textures;       ///< Texture variables in the shader, mapped to their location
-    ParamTable   m_params;         ///< Parameters location cache
+    UniformTable m_uniforms;       ///< Parameters location cache
 };
 
 } // namespace sf
@@ -568,7 +679,7 @@ private:
 /// to apply real-time operations to the rendered entities.
 ///
 /// There are two kinds of shaders:
-/// \li Vertex shaders, that process vertices
+/// \li %Vertex shaders, that process vertices
 /// \li Fragment (pixel) shaders, that process pixels
 ///
 /// A sf::Shader can be composed of either a vertex shader
@@ -580,32 +691,49 @@ private:
 /// need to learn its basics before writing your own shaders
 /// for SFML.
 ///
-/// Like any C/C++ program, a shader has its own variables
-/// that you can set from your C++ application. sf::Shader
-/// handles 5 different types of variables:
-/// \li floats
+/// Like any C/C++ program, a GLSL shader has its own variables
+/// called \a uniforms that you can set from your C++ application.
+/// sf::Shader handles different types of uniforms:
+/// \li scalars: \p float, \p int, \p bool
 /// \li vectors (2, 3 or 4 components)
-/// \li colors
-/// \li textures
-/// \li transforms (matrices)
+/// \li matrices (3x3 or 4x4)
+/// \li samplers (textures)
 ///
-/// The value of the variables can be changed at any time
-/// with the various overloads of the setParameter function:
+/// Some SFML-specific types can be converted:
+/// \li sf::Color as a 4D vector (\p vec4)
+/// \li sf::Transform as matrices (\p mat3 or \p mat4)
+///
+/// Every uniform variable in a shader can be set through one of the
+/// setUniform() or setUniformArray() overloads. For example, if you
+/// have a shader with the following uniforms:
 /// \code
-/// shader.setParameter("offset", 2.f);
-/// shader.setParameter("point", 0.5f, 0.8f, 0.3f);
-/// shader.setParameter("color", sf::Color(128, 50, 255));
-/// shader.setParameter("matrix", transform); // transform is a sf::Transform
-/// shader.setParameter("overlay", texture); // texture is a sf::Texture
-/// shader.setParameter("texture", sf::Shader::CurrentTexture);
+/// uniform float offset;
+/// uniform vec3 point;
+/// uniform vec4 color;
+/// uniform mat4 matrix;
+/// uniform sampler2D overlay;
+/// uniform sampler2D current;
+/// \endcode
+/// You can set their values from C++ code as follows, using the types
+/// defined in the sf::Glsl namespace:
+/// \code
+/// shader.setUniform("offset", 2.f);
+/// shader.setUniform("point", sf::Vector3f(0.5f, 0.8f, 0.3f));
+/// shader.setUniform("color", sf::Glsl::Vec4(color));          // color is a sf::Color
+/// shader.setUniform("matrix", sf::Glsl::Mat4(transform));     // transform is a sf::Transform
+/// shader.setUniform("overlay", texture);                      // texture is a sf::Texture
+/// shader.setUniform("current", sf::Shader::CurrentTexture);
 /// \endcode
 ///
+/// The old setParameter() overloads are deprecated and will be removed in a
+/// future version. You should use their setUniform() equivalents instead.
+///
 /// The special Shader::CurrentTexture argument maps the
-/// given texture variable to the current texture of the
+/// given \p sampler2D uniform to the current texture of the
 /// object being drawn (which cannot be known in advance).
 ///
 /// To apply a shader to a drawable, you must pass it as an
-/// additional parameter to the Draw function:
+/// additional parameter to the \ref Window::draw() draw() function:
 /// \code
 /// window.draw(sprite, &shader);
 /// \endcode
@@ -652,5 +780,7 @@ private:
 /// ... render OpenGL geometry ...
 /// sf::Shader::bind(NULL);
 /// \endcode
+///
+/// \see sf::Glsl
 ///
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -11,6 +11,9 @@ set(SRC
     ${INCROOT}/Export.hpp
     ${SRCROOT}/Font.cpp
     ${INCROOT}/Font.hpp
+    ${SRCROOT}/Glsl.cpp
+    ${INCROOT}/Glsl.hpp
+    ${INCROOT}/Glsl.inl
     ${INCROOT}/Glyph.hpp
     ${SRCROOT}/GLCheck.cpp
     ${SRCROOT}/GLCheck.hpp

--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -172,6 +172,15 @@
     #define GLEXT_glUniform3f                         glUniform3fARB
     #define GLEXT_glUniform4f                         glUniform4fARB
     #define GLEXT_glUniform1i                         glUniform1iARB
+    #define GLEXT_glUniform2i                         glUniform2iARB
+    #define GLEXT_glUniform3i                         glUniform3iARB
+    #define GLEXT_glUniform4i                         glUniform4iARB
+    #define GLEXT_glUniform1fv                        glUniform1fvARB
+    #define GLEXT_glUniform2fv                        glUniform2fvARB
+    #define GLEXT_glUniform2iv                        glUniform2ivARB
+    #define GLEXT_glUniform3fv                        glUniform3fvARB
+    #define GLEXT_glUniform4fv                        glUniform4fvARB
+    #define GLEXT_glUniformMatrix3fv                  glUniformMatrix3fvARB
     #define GLEXT_glUniformMatrix4fv                  glUniformMatrix4fvARB
     #define GLEXT_glGetObjectParameteriv              glGetObjectParameterivARB
     #define GLEXT_glGetInfoLog                        glGetInfoLogARB

--- a/src/SFML/Graphics/Glsl.cpp
+++ b/src/SFML/Graphics/Glsl.cpp
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Glsl.hpp>
+#include <algorithm>
+
+
+namespace sf
+{
+namespace priv
+{
+
+    ////////////////////////////////////////////////////////////
+    void copyMatrix(const Transform& source, Matrix<3, 3>& dest)
+    {
+        const float* from = source.getMatrix(); // 4x4
+        float* to = dest.array;                 // 3x3
+
+        // Use only left-upper 3x3 block (for a 2D transform)
+        to[0] = from[ 0]; to[1] = from[ 1]; to[2] = from[ 3];
+        to[3] = from[ 4]; to[4] = from[ 5]; to[5] = from[ 7];
+        to[6] = from[12]; to[7] = from[13]; to[8] = from[15];
+    }
+
+
+    ////////////////////////////////////////////////////////////
+    void copyMatrix(const Transform& source, Matrix<4, 4>& dest)
+    {
+        // Adopt 4x4 matrix as-is
+        copyMatrix(source.getMatrix(), 4 * 4, dest.array);
+    }
+
+
+    ////////////////////////////////////////////////////////////
+    void copyMatrix(const float* source, std::size_t elements, float* dest)
+    {
+        std::copy(source, source + elements, dest);
+    }
+
+
+    ////////////////////////////////////////////////////////////
+    void copyVector(const Color& source, Vector4<float>& dest)
+    {
+        dest.x = source.r / 255.f;
+        dest.y = source.g / 255.f;
+        dest.z = source.b / 255.f;
+        dest.w = source.a / 255.f;
+    }
+
+
+    ////////////////////////////////////////////////////////////
+    void copyVector(const Color& source, Vector4<int>& dest)
+    {
+        dest.x = static_cast<int>(source.r);
+        dest.y = static_cast<int>(source.g);
+        dest.z = static_cast<int>(source.b);
+        dest.w = static_cast<int>(source.a);
+    }
+
+} // namespace priv
+} // namespace sf

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -28,6 +28,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Shader.hpp>
 #include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/Transform.hpp>
+#include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/GLCheck.hpp>
 #include <SFML/Window/Context.hpp>
 #include <SFML/System/InputStream.hpp>
@@ -146,6 +148,57 @@ namespace
 
         return available;
     }
+
+    // Transforms an array of 2D vectors into a contiguous array of scalars
+    template <typename T>
+    std::vector<T> flatten(const sf::Vector2<T>* vectorArray, std::size_t length)
+    {
+        const std::size_t vectorSize = 2;
+
+        std::vector<T> contiguous(vectorSize * length);
+        for (std::size_t i = 0; i < length; ++i)
+        {
+            contiguous[vectorSize * i]     = vectorArray[i].x;
+            contiguous[vectorSize * i + 1] = vectorArray[i].y;
+        }
+
+        return contiguous;
+    }
+
+    // Transforms an array of 3D vectors into a contiguous array of scalars
+    template <typename T>
+    std::vector<T> flatten(const sf::Vector3<T>* vectorArray, std::size_t length)
+    {
+        const std::size_t vectorSize = 3;
+
+        std::vector<T> contiguous(vectorSize * length);
+        for (std::size_t i = 0; i < length; ++i)
+        {
+            contiguous[vectorSize * i]     = vectorArray[i].x;
+            contiguous[vectorSize * i + 1] = vectorArray[i].y;
+            contiguous[vectorSize * i + 2] = vectorArray[i].z;
+        }
+
+        return contiguous;
+    }
+
+    // Transforms an array of 4D vectors into a contiguous array of scalars
+    template <typename T>
+    std::vector<T> flatten(const sf::priv::Vector4<T>* vectorArray, std::size_t length)
+    {
+        const std::size_t vectorSize = 4;
+
+        std::vector<T> contiguous(vectorSize * length);
+        for (std::size_t i = 0; i < length; ++i)
+        {
+            contiguous[vectorSize * i]     = vectorArray[i].x;
+            contiguous[vectorSize * i + 1] = vectorArray[i].y;
+            contiguous[vectorSize * i + 2] = vectorArray[i].z;
+            contiguous[vectorSize * i + 3] = vectorArray[i].w;
+        }
+
+        return contiguous;
+    }
 }
 
 
@@ -156,11 +209,54 @@ Shader::CurrentTextureType Shader::CurrentTexture;
 
 
 ////////////////////////////////////////////////////////////
+struct Shader::UniformBinder : private NonCopyable
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief Constructor: set up state before uniform is set
+    ///
+    ////////////////////////////////////////////////////////////
+    UniformBinder(Shader& shader, const std::string& name) :
+    savedProgram(0),
+    currentProgram(castToGlHandle(shader.m_shaderProgram)),
+    location(-1)
+    {
+        if (currentProgram)
+        {
+            ensureGlContext();
+
+            // Enable program object
+            glCheck(savedProgram = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
+            if (currentProgram != savedProgram)
+                glCheck(GLEXT_glUseProgramObject(currentProgram));
+
+            // Store uniform location for further use outside constructor
+            location = shader.getUniformLocation(name);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor: restore state after uniform is set
+    ///
+    ////////////////////////////////////////////////////////////
+    ~UniformBinder()
+    {
+        // Disable program object
+        if (currentProgram && (currentProgram != savedProgram))
+            glCheck(GLEXT_glUseProgramObject(savedProgram));
+    }
+
+    GLEXT_GLhandle savedProgram;   ///< Handle to the previously active program object
+    GLEXT_GLhandle currentProgram; ///< Handle to the program object of the modified sf::Shader instance
+    GLint          location;       ///< Uniform location, used by the surrounding sf::Shader code
+};
+
+
+////////////////////////////////////////////////////////////
 Shader::Shader() :
 m_shaderProgram (0),
 m_currentTexture(-1),
 m_textures      (),
-m_params        ()
+m_uniforms      ()
 {
 }
 
@@ -282,160 +378,132 @@ bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& fragme
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x)
+void Shader::setUniform(const std::string& name, float x)
 {
-    if (m_shaderProgram)
-    {
-        ensureGlContext();
-
-        // Enable program
-        GLEXT_GLhandle program;
-        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
-        glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
-
-        // Get parameter location and assign it new values
-        GLint location = getParamLocation(name);
-        if (location != -1)
-        {
-            glCheck(GLEXT_glUniform1f(location, x));
-        }
-
-        // Disable program
-        glCheck(GLEXT_glUseProgramObject(program));
-    }
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform1f(binder.location, x));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x, float y)
+void Shader::setUniform(const std::string& name, const Glsl::Vec2& v)
 {
-    if (m_shaderProgram)
-    {
-        ensureGlContext();
-
-        // Enable program
-        GLEXT_GLhandle program;
-        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
-        glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
-
-        // Get parameter location and assign it new values
-        GLint location = getParamLocation(name);
-        if (location != -1)
-        {
-            glCheck(GLEXT_glUniform2f(location, x, y));
-        }
-
-        // Disable program
-        glCheck(GLEXT_glUseProgramObject(program));
-    }
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform2f(binder.location, v.x, v.y));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x, float y, float z)
+void Shader::setUniform(const std::string& name, const Glsl::Vec3& v)
 {
-    if (m_shaderProgram)
-    {
-        ensureGlContext();
-
-        // Enable program
-        GLEXT_GLhandle program;
-        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
-        glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
-
-        // Get parameter location and assign it new values
-        GLint location = getParamLocation(name);
-        if (location != -1)
-        {
-            glCheck(GLEXT_glUniform3f(location, x, y, z));
-        }
-
-        // Disable program
-        glCheck(GLEXT_glUseProgramObject(program));
-    }
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform3f(binder.location, v.x, v.y, v.z));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x, float y, float z, float w)
+void Shader::setUniform(const std::string& name, const Glsl::Vec4& v)
 {
-    if (m_shaderProgram)
-    {
-        ensureGlContext();
-
-        // Enable program
-        GLEXT_GLhandle program;
-        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
-        glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
-
-        // Get parameter location and assign it new values
-        GLint location = getParamLocation(name);
-        if (location != -1)
-        {
-            glCheck(GLEXT_glUniform4f(location, x, y, z, w));
-        }
-
-        // Disable program
-        glCheck(GLEXT_glUseProgramObject(program));
-    }
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform4f(binder.location, v.x, v.y, v.z, v.w));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Vector2f& v)
+void Shader::setUniform(const std::string& name, int x)
 {
-    setParameter(name, v.x, v.y);
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform1i(binder.location, x));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Vector3f& v)
+void Shader::setUniform(const std::string& name, const Glsl::Ivec2& v)
 {
-    setParameter(name, v.x, v.y, v.z);
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform2i(binder.location, v.x, v.y));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Color& color)
+void Shader::setUniform(const std::string& name, const Glsl::Ivec3& v)
 {
-    setParameter(name, color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f);
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform3i(binder.location, v.x, v.y, v.z));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Transform& transform)
+void Shader::setUniform(const std::string& name, const Glsl::Ivec4& v)
 {
-    if (m_shaderProgram)
-    {
-        ensureGlContext();
-
-        // Enable program
-        GLEXT_GLhandle program;
-        glCheck(program = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
-        glCheck(GLEXT_glUseProgramObject(castToGlHandle(m_shaderProgram)));
-
-        // Get parameter location and assign it new values
-        GLint location = getParamLocation(name);
-        if (location != -1)
-        {
-            glCheck(GLEXT_glUniformMatrix4fv(location, 1, GL_FALSE, transform.getMatrix()));
-        }
-
-        // Disable program
-        glCheck(GLEXT_glUseProgramObject(program));
-    }
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform4i(binder.location, v.x, v.y, v.z, v.w));
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Texture& texture)
+void Shader::setUniform(const std::string& name, bool x)
+{
+    setUniform(name, static_cast<int>(x));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Bvec2& v)
+{
+    setUniform(name, Glsl::Ivec2(v));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Bvec3& v)
+{
+    setUniform(name, Glsl::Ivec3(v));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Bvec4& v)
+{
+    setUniform(name, Glsl::Ivec4(v));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Mat3& matrix)
+{
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniformMatrix3fv(binder.location, 1, GL_FALSE, matrix.array));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Mat4& matrix)
+{
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniformMatrix4fv(binder.location, 1, GL_FALSE, matrix.array));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Texture& texture)
 {
     if (m_shaderProgram)
     {
         ensureGlContext();
 
         // Find the location of the variable in the shader
-        int location = getParamLocation(name);
+        int location = getUniformLocation(name);
         if (location != -1)
         {
             // Store the location -> texture mapping
@@ -463,15 +531,157 @@ void Shader::setParameter(const std::string& name, const Texture& texture)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, CurrentTextureType)
+void Shader::setUniform(const std::string& name, CurrentTextureType)
 {
     if (m_shaderProgram)
     {
         ensureGlContext();
 
         // Find the location of the variable in the shader
-        m_currentTexture = getParamLocation(name);
+        m_currentTexture = getUniformLocation(name);
     }
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const float* scalarArray, std::size_t length)
+{
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform1fv(binder.location, length, scalarArray));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Vec2* vectorArray, std::size_t length)
+{
+    std::vector<float> contiguous = flatten(vectorArray, length);
+
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform2fv(binder.location, length, &contiguous[0]));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Vec3* vectorArray, std::size_t length)
+{
+    std::vector<float> contiguous = flatten(vectorArray, length);
+
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform3fv(binder.location, length, &contiguous[0]));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Vec4* vectorArray, std::size_t length)
+{
+    std::vector<float> contiguous = flatten(vectorArray, length);
+
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniform4fv(binder.location, length, &contiguous[0]));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Mat3* matrixArray, std::size_t length)
+{
+    const std::size_t matrixSize = 3 * 3;
+
+    std::vector<float> contiguous(matrixSize * length);
+    for (std::size_t i = 0; i < length; ++i)
+        priv::copyMatrix(matrixArray[i].array, matrixSize, &contiguous[matrixSize * i]);
+
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniformMatrix3fv(binder.location, length, GL_FALSE, &contiguous[0]));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Mat4* matrixArray, std::size_t length)
+{
+    const std::size_t matrixSize = 4 * 4;
+
+    std::vector<float> contiguous(matrixSize * length);
+    for (std::size_t i = 0; i < length; ++i)
+        priv::copyMatrix(matrixArray[i].array, matrixSize, &contiguous[matrixSize * i]);
+
+    UniformBinder binder(*this, name);
+    if (binder.location != -1)
+        glCheck(GLEXT_glUniformMatrix4fv(binder.location, length, GL_FALSE, &contiguous[0]));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, float x)
+{
+    setUniform(name, x);
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, float x, float y)
+{
+    setUniform(name, Glsl::Vec2(x, y));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, float x, float y, float z)
+{
+    setUniform(name, Glsl::Vec3(x, y, z));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, float x, float y, float z, float w)
+{
+    setUniform(name, Glsl::Vec4(x, y, z, w));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, const Vector2f& v)
+{
+    setUniform(name, v);
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, const Vector3f& v)
+{
+    setUniform(name, v);
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, const Color& color)
+{
+    setUniform(name, Glsl::Vec4(color));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, const Transform& transform)
+{
+    setUniform(name, Glsl::Mat4(transform));
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, const Texture& texture)
+{
+    setUniform(name, texture);
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setParameter(const std::string& name, CurrentTextureType)
+{
+    setUniform(name, CurrentTexture);
 }
 
 
@@ -550,7 +760,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* fragmentShaderCod
     // Reset the internal state
     m_currentTexture = -1;
     m_textures.clear();
-    m_params.clear();
+    m_uniforms.clear();
 
     // Create the program
     GLEXT_GLhandle shaderProgram;
@@ -657,11 +867,11 @@ void Shader::bindTextures() const
 
 
 ////////////////////////////////////////////////////////////
-int Shader::getParamLocation(const std::string& name)
+int Shader::getUniformLocation(const std::string& name)
 {
     // Check the cache
-    ParamTable::const_iterator it = m_params.find(name);
-    if (it != m_params.end())
+    UniformTable::const_iterator it = m_uniforms.find(name);
+    if (it != m_uniforms.end())
     {
         // Already in cache, return it
         return it->second;
@@ -670,7 +880,7 @@ int Shader::getParamLocation(const std::string& name)
     {
         // Not in cache, request the location from OpenGL
         int location = GLEXT_glGetUniformLocation(castToGlHandle(m_shaderProgram), name.c_str());
-        m_params.insert(std::make_pair(name, location));
+        m_uniforms.insert(std::make_pair(name, location));
 
         if (location == -1)
             err() << "Parameter \"" << name << "\" not found in shader" << std::endl;
@@ -744,6 +954,138 @@ bool Shader::loadFromStream(InputStream& stream, Type type)
 bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream)
 {
     return false;
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, float x)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Vec2& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Vec3& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Vec4& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, int x)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Ivec2& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Ivec3& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Ivec4& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, bool x)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Bvec2& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Bvec3& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Bvec4& v)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Mat3& matrix)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Glsl::Mat4& matrix)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, const Texture& texture)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniform(const std::string& name, CurrentTextureType)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const float* scalarArray, std::size_t length)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Vec2* vectorArray, std::size_t length)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Vec3* vectorArray, std::size_t length)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Vec4* vectorArray, std::size_t length)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Mat3* matrixArray, std::size_t length)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+void Shader::setUniformArray(const std::string& name, const Glsl::Mat4* matrixArray, std::size_t length)
+{
 }
 
 


### PR DESCRIPTION


*[Link to forum thread](http://en.sfml-dev.org/forums/index.php?topic=18146.0).*

This pull request implements https://github.com/SFML/SFML/issues/538 and introduces a new API to set uniform variables in `sf::Shader`. The old `setParameter()` overloads are deprecated in favor of new `setUniform()` ones.

The `sf::Glsl` namespace is added to SFML. It contains type definitions for types that can be passed to `Shader::setUniform()`. Most types are `typedef`s to existing SFML types (such as `sf::Vector2<T>`), there are however a couple of new ones:
```cpp
sf::Glsl::Mat3  // 3x3 matrix
sf::Glsl::Mat4  // 4x4 matrix
sf::Glsl::Vec4  // 4D float vector
sf::Glsl::Ivec4 // 4D int vector
sf::Glsl::Bvec4 // 4D bool vector
```
I provided implicit conversions from `sf::Transform` and `sf::Color` to these types where appropriate. Where necessary for ambiguity reasons, an explicit conversion must be used:
```cpp
sf::Color color;
shader.setUniform("color", sf::Glsl::Vec4(color)); // pass as 4D vector
shader.setUniform("color", color); // same call, implicit conversion

sf::Transform transform;
shader.setUniform("matrix", sf::Glsl::Mat3(transform)); // pass as 3x3
shader.setUniform("matrix", sf::Glsl::Mat4(transform)); // pass as 4x4
```

In addition to basic GLSL types, arrays are now supported as well. They can be specified with `Shader::setUniformArray()` that takes a pointer to the first element and the length:
```cpp
sf::Glsl::Vec2 positions[5] = ...;
shader.setUniformArray("positions", positions, 5);
```

-----
#### Design rationale

After extensive thinking about the design (see 2 forum threads), I came to the conclusion that `setUniform()` overloads are more appropriate than named functions `setUniformFloat()`, for the following reasons:
* The call is simpler and we don't force the user to type redundant information.
* We allow polymorphism (a user can write a template to pass uniforms of any type, without knowing the function names).
* The number of provided methods is smaller. We can work with conversions where possible. For example, we don't need to overload `setUniformMat3()` for `sf::Glsl::Mat3`, `float*` and `sf::Transform` separately, one method taking `sf::Glsl::Mat3` is enough.
* It is still possible to enforce type safety at compile time and at runtime. The former can be achieved with a wrapper function that explicitly requires the type to be specified.
* There is no way around dedicated types anyway, otherwise we can't support GLSL arrays (or only in a very low-level way).

-----
#### Try it out

A self-contained archive containing a C++ file, two GLSL shader files and an image can be downloaded temporarily from my homepage: www.bromeon.ch/sfml/feature-shader-uniforms.zip