### PR TITLE
Fixed crash when resizing a window to a zero-height/width size

### DIFF
--- a/src/SFML/Window/OSX/SFOpenGLView.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView.mm
@@ -171,6 +171,17 @@ BOOL isValidTextUnicode(NSEvent* event);
 
 
 ////////////////////////////////////////////////////////
+-(void)update
+{
+    // In order to prevent an infinite recursion when the window/view is
+    // resized to zero-height/width, we ignore update event when resizing.
+    if (![self inLiveResize]) {
+        [super update];
+    }
+}
+
+
+////////////////////////////////////////////////////////
 -(void)finishInit
 {
     // Register for window focus events


### PR DESCRIPTION
This patches #984.

@caupetit can you give it a try?