### PR TITLE
Add a lightweight logger frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ sfml_set_option(SFML_BUILD_DOC FALSE BOOL "TRUE to generate the API documentatio
 # add an option for choosing the OpenGL implementation
 sfml_set_option(SFML_OPENGL_ES ${OPENGL_ES} BOOL "TRUE to use an OpenGL ES implementation, FALSE to use a desktop OpenGL implementation")
 
+sfml_set_option(SFML_DISABLE_LOGGING TRUE BOOL "TRUE discard log entries at compile time, FALSE filter log entries at runtime")
+
 # Mac OS X specific options
 if(SFML_OS_MACOSX)
     # add an option to build frameworks instead of dylibs (release only)
@@ -123,6 +125,10 @@ endif()
 # define SFML_STATIC if the build type is not set to 'shared'
 if(NOT BUILD_SHARED_LIBS)
     add_definitions(-DSFML_STATIC)
+endif()
+
+if (SFML_DISABLE_LOGGING)
+	add_definitions(-DSFML_DISABLE_LOGGING)
 endif()
 
 # Visual C++: remove warnings regarding SL security and algorithms on pointers

--- a/include/SFML/System/Log.hpp
+++ b/include/SFML/System/Log.hpp
@@ -1,0 +1,372 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+/// \file
+/// \brief Defines the public logger interface
+///
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_LOG_HPP
+#define SFML_LOG_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/NonCopyable.hpp>
+#include <string>
+#include <sstream>
+
+namespace sf
+{
+namespace Log
+{
+////////////////////////////////////////////////////////////
+/// \brief Specifies the category of a log entry
+///
+////////////////////////////////////////////////////////////
+struct Level
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief The different supported log entry categories
+    /// 
+    ////////////////////////////////////////////////////////////
+    enum Native
+    {
+        Verbose,    ///< Very verbose information, which normally isn't necessary
+        Debug,      ///< Information assisting debugging
+        Info,       ///< Informational message like a system property, etc.
+        Warning,    ///< Recoverable failure
+        Error,      ///< Failure information
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Not useful, but required by stl containers.
+    ///
+    /// This constructor is equivalent to Level(Native::Verbose)
+    ////////////////////////////////////////////////////////////
+    inline Level();
+    ////////////////////////////////////////////////////////////
+    /// \brief Initializes a new instance representing the given
+    ///        category
+    ///
+    /// \param[in] value will be the significance represented by
+    ///            the new instance
+    ///
+    ////////////////////////////////////////////////////////////
+    inline Level(Native value);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Equality comparison
+    /// 
+    /// \param[in] right operand
+    ///
+    /// \returns true if the left operand is as significant as
+    ///          the right operand
+    ///
+    ////////////////////////////////////////////////////////////
+    inline bool operator==(const Level &right) const;
+    ////////////////////////////////////////////////////////////
+    /// \brief Lesser comparison
+    ///
+    /// \param[in] right operand  
+    ///  
+    /// \returns true if the left hand operand is less significant
+    ///
+    ////////////////////////////////////////////////////////////
+    inline bool operator<(const Level &right) const;
+    ////////////////////////////////////////////////////////////
+    /// \brief Greater comparison
+    ///
+    /// \param[in] right hand operand 
+    ///
+    /// \returns true if the left hand operand is more significant
+    ///
+    ////////////////////////////////////////////////////////////
+    inline bool operator>(const Level &right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns a string identifier for the represented
+    ///        significance
+    ///
+    /// \returns a pointer to the null terminated string
+    ///          associated with the Level represented.
+    ///
+    ////////////////////////////////////////////////////////////
+    inline const char * toString() const;
+
+private:
+    Native Value;
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Represents a log channel with which log entries
+///        can be grouped
+///
+////////////////////////////////////////////////////////////
+struct Channel
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief The standard SFML log channels
+    ///
+    /// \note You are not limited to the channels specified here,
+    ///       you can use any other integer to represent your own
+    ///       channels, just associate a name with them through
+    ///       sf::Log::Manager::registerCustomModuleName
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Native
+    {
+        Unspecified,
+        System,         ///< SFML System module channel \see sfLogSys
+        Window,         ///< SFML Window module channel \see sfLogWnd
+        Graphics,       ///< SFML Graphics module channel \see sfLogGra
+        Audio,          ///< SFML Audio module channel \see sfLogAud
+        Network,        ///< SFML Network module channel \see sfLogNet
+        Reserved1,
+        Reserved2,
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Initializes a new instance representing the given
+    ///        channel
+    ///
+    /// \param[in] id identifies the channel to be represented,
+    ///            this is either a Native value or a user
+    ///            defined one
+    ///
+    ////////////////////////////////////////////////////////////
+    inline Channel(unsigned int id);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Equality comparison
+    ///
+    /// \param[in] right operand
+    ///
+    /// \returns true if the left operand represents the same
+    ///          channel as the right operand
+    ///
+    ////////////////////////////////////////////////////////////
+    inline bool operator==(const Channel &right) const;
+    ////////////////////////////////////////////////////////////
+    /// \brief Lesser comparison, not meaningful, but required
+    ///        by some containers (e.g. std::map)
+    ///
+    /// \param[in] right hand operand
+    ///
+    /// \returns true if the left  operand is represented by a
+    ///          lesser value than the right operand
+    ///
+    ////////////////////////////////////////////////////////////
+    inline bool operator<(const Channel &right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns a string identifier for the represented
+    ///        significance
+    ///
+    /// \returns a pointer to the null terminated string
+    ///          associated with the Channel represented.
+    ///
+    ////////////////////////////////////////////////////////////
+    inline const char * toString() const;
+
+private:
+    unsigned int m_id;
+};
+
+////////////////////////////////////////////////////////////
+/// \brief SFML log adjustment functionality
+/// 
+/// \see Log.hpp
+///
+////////////////////////////////////////////////////////////
+namespace Manager
+{
+////////////////////////////////////////////////////////////
+/// \brief The signature of an user defined log entry sink
+///
+/// \param[in] userData will be the value with which
+///            setCustomLogEntryProcessor was called
+/// \param[in] channel specifies the Channel to which the
+///            message to be logged belongs
+/// \param[in] level specifies the importance of the log entry
+/// \param[in] message is obviously the text to be logged
+///
+////////////////////////////////////////////////////////////
+typedef void(*LogEntryProcessor)(void *userData, Channel channel, Level level, const std::string &message);
+
+////////////////////////////////////////////////////////////
+/// \brief Sets the global logger threshold
+///
+/// \param[in] threshold All log entries which are less
+///                      important won't be logged.
+///
+/// \note Defaults to Level::Debug for debug builds and to
+/// Level::Error for release builds.
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API void setGlobalThreshold(Level threshold);
+////////////////////////////////////////////////////////////
+/// \brief Sets the logger threshold for a Channel
+///
+/// \param[in] channel for which the threshold should be set
+/// \param[in] threshold All log entries which are less
+///                      important won't be logged.
+/// 
+/// \note All standard channels default to Level::Debug for
+/// debug builds and to Level::Error for release builds.
+/// Custom channels however default to the global threshold
+/// at the time when the first check with isBelowThreshold
+/// happens (which is called by sfLog()).
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API void setModuleThreshold(Channel channel, Level threshold);
+
+////////////////////////////////////////////////////////////
+/// \brief Associates a name with a channel
+///
+/// \param[in] channel for which the name should be set
+/// \param[in] name to be associated with the channel
+///
+/// \post The given name will be returned by Channel::toString()
+///       if the Channel instances equals the given one.
+///
+/// \note The standard SFML channel names can't be overridden.
+/// 
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API void registerCustomModuleName(Channel channel, const std::string &name);
+
+////////////////////////////////////////////////////////////
+/// \brief Installs a different log backend
+/// 
+/// By default all log entries are piped to std::cerr, with
+/// this function however you can format and redirect all
+/// log entries however and wherever you want.
+///
+/// \param[in] processor points to your custom log entry sink
+/// \param[in] userData will be passed to every subsequent
+///                     call to your custom processor
+///
+/// \note if processor == NULL the default log entry processor
+///       will be used.
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API void setCustomLogEntryProcessor(LogEntryProcessor processor, void *userData = NULL);
+}
+}
+
+namespace priv
+{
+SFML_SYSTEM_API bool isBelowThreshold(sf::Log::Channel channel, sf::Log::Level level);
+SFML_SYSTEM_API void processLogEntry(sf::Log::Channel channel, sf::Log::Level level, const std::string &message);
+SFML_SYSTEM_API const char * logModuleToString(sf::Log::Channel value);
+
+template< sf::Log::Channel::Native Mdl, sf::Log::Level::Native Lvl >
+class Log : sf::NonCopyable
+{
+public:
+    inline Log();
+    inline ~Log();
+
+    inline std::ostream & get();
+
+private:
+    std::ostringstream m_messageBuffer;
+};
+}
+}
+
+#include <SFML/System/Log.inl>
+
+////////////////////////////////////////////////////////////
+/// \brief Adds a log entry of the given category to the
+///        specified channel
+///
+/// \param[in] channel with which the new log entry will be
+///                    associated
+/// \param[in] level specifies the log category
+///
+/// \returns a std::ostream reference.
+///
+/// You may use this and all derived macros like so:
+/// \code
+/// sfLog(sf::Log::Channel::System, sf::Log::Level::Error)
+///     << "Something failed; additional formatted data: " << data;
+/// \endcode
+/// The default log entry processor would output the following to std::cerr:
+/// \code
+/// SFML SYSTEM ERROR: Something failed; additional formatted data: ostreamed data
+/// \endcode
+///
+/// \note It is recommended to use an appropriate shorthand macro
+/// instead of this one.
+///
+////////////////////////////////////////////////////////////
+#define sfLog(channel, level) if (::sf::priv::isBelowThreshold(::sf::Log::Channel(channel), ::sf::Log::Level(level))) { } \
+                             else ::sf::priv::Log<(channel), (level)>().get()
+
+#define sfLogErr(channel)   sfLog(channel, ::sf::Log::Level::Error)
+#define sfLogWarn(channel)  sfLog(channel, ::sf::Log::Level::Warning)
+#define sfLogInfo(channel)  sfLog(channel, ::sf::Log::Level::Info)
+#define sfLogDebug(channel) sfLog(channel, ::sf::Log::Level::Debug)
+
+/// \see sfLog()
+#define sfLogSys(level) sfLog(::sf::Log::Channel::System, level)
+#define sfLogSysErr()   sfLogSys(::sf::Log::Level::Error)
+#define sfLogSysWarn()  sfLogSys(::sf::Log::Level::Warning)
+#define sfLogSysInfo()  sfLogSys(::sf::Log::Level::Info)
+#define sfLogSysDebug() sfLogSys(::sf::Log::Level::Debug)
+
+/// \see sfLog()
+#define sfLogWnd(level) sfLog(::sf::Log::Channel::Window, level)
+#define sfLogWndErr()   sfLogWnd(::sf::Log::Level::Error)
+#define sfLogWndWarn()  sfLogWnd(::sf::Log::Level::Warning)
+#define sfLogWndInfo()  sfLogWnd(::sf::Log::Level::Info)
+#define sfLogWndDebug() sfLogWnd(::sf::Log::Level::Debug)
+
+/// \see sfLog()
+#define sfLogGra(level) sfLog(::sf::Log::Channel::Graphics, level)
+#define sfLogGraErr()   sfLogGra(::sf::Log::Level::Error)
+#define sfLogGraWarn()  sfLogGra(::sf::Log::Level::Warning)
+#define sfLogGraInfo()  sfLogGra(::sf::Log::Level::Info)
+#define sfLogGraDebug() sfLogGra(::sf::Log::Level::Debug)
+
+/// \see sfLog()
+#define sfLogNet(level) sfLog(::sf::Log::Channel::Network, level)
+#define sfLogNetErr()   sfLogNet(::sf::Log::Level::Error)
+#define sfLogNetWarn()  sfLogNet(::sf::Log::Level::Warning)
+#define sfLogNetInfo()  sfLogNet(::sf::Log::Level::Info)
+#define sfLogNetDebug() sfLogNet(::sf::Log::Level::Debug)
+
+/// \see sfLog()
+#define sfLogAud(level) sfLog(::sf::Log::Channel::Audio, level)
+#define sfLogAudErr()   sfLogAud(::sf::Log::Level::Error)
+#define sfLogAudWarn()  sfLogAud(::sf::Log::Level::Warning)
+#define sfLogAudInfo()  sfLogAud(::sf::Log::Level::Info)
+#define sfLogAudDebug() sfLogAud(::sf::Log::Level::Debug)
+
+#endif
+
+////////////////////////////////////////////////////////////
+/// \file
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/System/Log.hpp
+++ b/include/SFML/System/Log.hpp
@@ -297,6 +297,9 @@ private:
 
 #include <SFML/System/Log.inl>
 
+#ifdef SFML_DISABLE_LOGGING
+#define sfLog(channel, level, message)
+#else
 ////////////////////////////////////////////////////////////
 /// \brief Adds a log entry of the given category to the
 ///        specified channel
@@ -309,8 +312,8 @@ private:
 ///
 /// You may use this and all derived macros like so:
 /// \code
-/// sfLog(sf::Log::Channel::System, sf::Log::Level::Error)
-///     << "Something failed; additional formatted data: " << data;
+/// sfLog(sf::Log::Channel::System, sf::Log::Level::Error,
+///     "Something failed; additional formatted data: " << data);
 /// \endcode
 /// The default log entry processor would output the following to std::cerr:
 /// \code
@@ -321,48 +324,49 @@ private:
 /// instead of this one.
 ///
 ////////////////////////////////////////////////////////////
-#define sfLog(channel, level) if (::sf::priv::isBelowThreshold(::sf::Log::Channel(channel), ::sf::Log::Level(level))) { } \
-                             else ::sf::priv::Log<(channel), (level)>().get()
+#define sfLog(channel, level, message) do { if (::sf::priv::isBelowThreshold(::sf::Log::Channel(channel), ::sf::Log::Level(level))) { } \
+                                       else ::sf::priv::Log<(channel), (level)>().get() << message; } while (0) 
+#endif
 
-#define sfLogErr(channel)   sfLog(channel, ::sf::Log::Level::Error)
-#define sfLogWarn(channel)  sfLog(channel, ::sf::Log::Level::Warning)
-#define sfLogInfo(channel)  sfLog(channel, ::sf::Log::Level::Info)
-#define sfLogDebug(channel) sfLog(channel, ::sf::Log::Level::Debug)
-
-/// \see sfLog()
-#define sfLogSys(level) sfLog(::sf::Log::Channel::System, level)
-#define sfLogSysErr()   sfLogSys(::sf::Log::Level::Error)
-#define sfLogSysWarn()  sfLogSys(::sf::Log::Level::Warning)
-#define sfLogSysInfo()  sfLogSys(::sf::Log::Level::Info)
-#define sfLogSysDebug() sfLogSys(::sf::Log::Level::Debug)
+#define sfLogErr(channel, message)   sfLog(channel, ::sf::Log::Level::Error, message)
+#define sfLogWarn(channel, message)  sfLog(channel, ::sf::Log::Level::Warning, message)
+#define sfLogInfo(channel, message)  sfLog(channel, ::sf::Log::Level::Info, message)
+#define sfLogDebug(channel, message) sfLog(channel, ::sf::Log::Level::Debug, message)
 
 /// \see sfLog()
-#define sfLogWnd(level) sfLog(::sf::Log::Channel::Window, level)
-#define sfLogWndErr()   sfLogWnd(::sf::Log::Level::Error)
-#define sfLogWndWarn()  sfLogWnd(::sf::Log::Level::Warning)
-#define sfLogWndInfo()  sfLogWnd(::sf::Log::Level::Info)
-#define sfLogWndDebug() sfLogWnd(::sf::Log::Level::Debug)
+#define sfLogSys(level, message) sfLog(::sf::Log::Channel::System, level, message)
+#define sfLogSysErr(message)     sfLogSys(::sf::Log::Level::Error, message)
+#define sfLogSysWarn(message)    sfLogSys(::sf::Log::Level::Warning, message)
+#define sfLogSysInfo(message)    sfLogSys(::sf::Log::Level::Info, message)
+#define sfLogSysDebug(message)   sfLogSys(::sf::Log::Level::Debug, message)
 
 /// \see sfLog()
-#define sfLogGra(level) sfLog(::sf::Log::Channel::Graphics, level)
-#define sfLogGraErr()   sfLogGra(::sf::Log::Level::Error)
-#define sfLogGraWarn()  sfLogGra(::sf::Log::Level::Warning)
-#define sfLogGraInfo()  sfLogGra(::sf::Log::Level::Info)
-#define sfLogGraDebug() sfLogGra(::sf::Log::Level::Debug)
+#define sfLogWnd(level, message) sfLog(::sf::Log::Channel::Window, level, message)
+#define sfLogWndErr(message)     sfLogWnd(::sf::Log::Level::Error, message)
+#define sfLogWndWarn(message)    sfLogWnd(::sf::Log::Level::Warning, message)
+#define sfLogWndInfo(message)    sfLogWnd(::sf::Log::Level::Info, message)
+#define sfLogWndDebug(message)   sfLogWnd(::sf::Log::Level::Debug, message)
 
 /// \see sfLog()
-#define sfLogNet(level) sfLog(::sf::Log::Channel::Network, level)
-#define sfLogNetErr()   sfLogNet(::sf::Log::Level::Error)
-#define sfLogNetWarn()  sfLogNet(::sf::Log::Level::Warning)
-#define sfLogNetInfo()  sfLogNet(::sf::Log::Level::Info)
-#define sfLogNetDebug() sfLogNet(::sf::Log::Level::Debug)
+#define sfLogGra(level, message) sfLog(::sf::Log::Channel::Graphics, level, message)
+#define sfLogGraErr(message)     sfLogGra(::sf::Log::Level::Error, message)
+#define sfLogGraWarn(message)    sfLogGra(::sf::Log::Level::Warning, message)
+#define sfLogGraInfo(message)    sfLogGra(::sf::Log::Level::Info, message)
+#define sfLogGraDebug(message)   sfLogGra(::sf::Log::Level::Debug, message)
 
 /// \see sfLog()
-#define sfLogAud(level) sfLog(::sf::Log::Channel::Audio, level)
-#define sfLogAudErr()   sfLogAud(::sf::Log::Level::Error)
-#define sfLogAudWarn()  sfLogAud(::sf::Log::Level::Warning)
-#define sfLogAudInfo()  sfLogAud(::sf::Log::Level::Info)
-#define sfLogAudDebug() sfLogAud(::sf::Log::Level::Debug)
+#define sfLogNet(level, message) sfLog(::sf::Log::Channel::Network, level, message)
+#define sfLogNetErr(message)     sfLogNet(::sf::Log::Level::Error, message)
+#define sfLogNetWarn(message)    sfLogNet(::sf::Log::Level::Warning, message)
+#define sfLogNetInfo(message)    sfLogNet(::sf::Log::Level::Info, message)
+#define sfLogNetDebug(message)   sfLogNet(::sf::Log::Level::Debug, message)
+
+/// \see sfLog()
+#define sfLogAud(level, message) sfLog(::sf::Log::Channel::Audio, level, message)
+#define sfLogAudErr(message)     sfLogAud(::sf::Log::Level::Error, message)
+#define sfLogAudWarn(message)    sfLogAud(::sf::Log::Level::Warning, message)
+#define sfLogAudInfo(message)    sfLogAud(::sf::Log::Level::Info, message)
+#define sfLogAudDebug(message)   sfLogAud(::sf::Log::Level::Debug, message)
 
 #endif
 

--- a/include/SFML/System/Log.inl
+++ b/include/SFML/System/Log.inl
@@ -1,0 +1,142 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+namespace sf
+{
+namespace Log
+{
+inline Level::Level()
+    : Value(Verbose)
+{
+}
+inline Level::Level(Native value)
+    : Value(value)
+{
+}
+
+inline bool Level::operator==(const Level &right) const
+{
+    return Value == right.Value;
+}
+inline bool Level::operator<(const Level &right) const
+{
+    return Value < right.Value;
+}
+inline bool Level::operator>(const Level &right) const
+{
+    return Value > right.Value;
+}
+inline bool operator!=(const Level &left, const Level &right)
+{
+    return !(left == right);
+}
+
+inline const char * Level::toString() const
+{
+    switch (Value)
+    {
+    case Verbose:
+        return "verbose";
+    case Debug:
+        return "debug";
+    case Info:
+        return "info";
+    case Warning:
+        return "WARNING";
+    case Error:
+        return "ERROR";
+    default:
+        // should we throw an exception?
+        return "INVALID";
+    }
+}
+
+
+inline Channel::Channel(unsigned int id)
+    : m_id(id)
+{
+}
+
+inline bool Channel::operator==(const Channel &right) const
+{
+    return m_id == right.m_id;
+}
+inline bool Channel::operator<(const Channel &right) const
+{
+    return m_id < right.m_id;
+}
+inline bool operator!=(const Channel &left, const Channel &right)
+{
+    return !(left == right);
+}
+
+inline const char * Channel::toString() const
+{
+    switch (m_id)
+    {
+    case Unspecified:
+        return "UNKNOWN";
+    case System:
+        return "SYSTEM";
+    case Window:
+        return "WINDOW";
+    case Graphics:
+        return "GRAPHICS";
+    case Audio:
+        return "AUDIO";
+    case Network:
+        return "NETWORK";
+    case Reserved1:
+    case Reserved2:
+        // should we throw an exception?
+        return "RESERVED";
+    default:
+        return priv::logModuleToString(*this);
+    }
+}
+}
+
+
+namespace priv
+{
+template< sf::Log::Channel::Native Mdl, sf::Log::Level::Native Lvl >
+inline Log<Mdl, Lvl>::Log()
+    : m_messageBuffer()
+{
+}
+
+template<sf::Log::Channel::Native Mdl, sf::Log::Level::Native Lvl >
+inline Log<Mdl, Lvl>::~Log()
+{
+    std::string message = m_messageBuffer.str();
+    processLogEntry(sf::Log::Channel(Mdl), sf::Log::Level(Lvl), message);
+}
+
+template< sf::Log::Channel::Native Mdl, sf::Log::Level::Native Lvl >
+inline std::ostream & Log<Mdl, Lvl>::get()
+{
+    return m_messageBuffer;
+}
+}
+}

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -12,6 +12,9 @@ set(SRC
     ${INCROOT}/InputStream.hpp
     ${SRCROOT}/Lock.cpp
     ${INCROOT}/Lock.hpp
+    ${SRCROOT}/Log.cpp
+    ${INCROOT}/Log.hpp
+    ${INCROOT}/Log.inl
     ${SRCROOT}/Mutex.cpp
     ${INCROOT}/Mutex.hpp
     ${INCROOT}/NonCopyable.hpp

--- a/src/SFML/System/Log.cpp
+++ b/src/SFML/System/Log.cpp
@@ -1,0 +1,132 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2015 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Log.hpp>
+
+#include <map>
+#include <iostream>
+
+namespace
+{
+void defaultLogEntryProcessor(void *, sf::Log::Channel channel, sf::Log::Level level, const std::string &message)
+{
+    size_t nextNL = message.find('\n');
+    if (nextNL == std::string::npos)
+        std::cerr << "SFML " << channel.toString() << " " << level.toString() << ": " << message << std::endl;
+    else
+    {
+        std::string prefix = std::string("SFML ") + channel.toString() + " " + level.toString() + ": ";
+        size_t start = 0;
+        do 
+        {
+            std::cerr << prefix << message.substr(start, ++nextNL);
+            start = nextNL;
+            nextNL = message.find('\n', start);
+        } while (nextNL != std::string::npos);
+        std::cerr << prefix << message.substr(start) << std::endl;
+    }
+    
+}
+
+typedef std::map<sf::Log::Channel, sf::Log::Level> ChannelThresholdMap;
+typedef std::map<sf::Log::Channel, std::string> ChannelNameMap;
+
+struct LogBackend
+{
+    LogBackend()
+        : processor(&defaultLogEntryProcessor)
+#ifdef _DEBUG
+        , globalThreshold(sf::Log::Level::Debug)
+#else
+        , globalThreshold(sf::Log::Level::Error)
+#endif
+        , userData(NULL)
+    {
+        channelThresholds[sf::Log::Channel::Unspecified]
+            = channelThresholds[sf::Log::Channel::System]
+            = channelThresholds[sf::Log::Channel::Window]
+            = channelThresholds[sf::Log::Channel::Graphics]
+            = channelThresholds[sf::Log::Channel::Audio]
+            = channelThresholds[sf::Log::Channel::Network]
+            = globalThreshold;
+
+    }
+
+    ChannelThresholdMap channelThresholds;
+    ChannelNameMap customChannelNames;
+    sf::Log::Manager::LogEntryProcessor processor;
+    void *userData;
+    sf::Log::Level globalThreshold;
+} logBackend;
+}
+
+SFML_SYSTEM_API void sf::priv::processLogEntry(sf::Log::Channel channel, sf::Log::Level level, const std::string &message)
+{
+    logBackend.processor(logBackend.userData, channel, level, message);
+}
+
+SFML_SYSTEM_API const char * sf::priv::logModuleToString(sf::Log::Channel value)
+{
+    ChannelNameMap::const_iterator cIt = logBackend.customChannelNames.find(value);
+    return cIt == logBackend.customChannelNames.cend() ? "UNSPECIFIED" : cIt->second.c_str();
+}
+
+SFML_SYSTEM_API bool sf::priv::isBelowThreshold(sf::Log::Channel channel, sf::Log::Level level)
+{
+    ChannelThresholdMap::const_iterator cIt = logBackend.channelThresholds.insert(std::make_pair(channel, logBackend.globalThreshold)).first;
+    return level < logBackend.globalThreshold || level < cIt->second;
+}
+
+SFML_SYSTEM_API void sf::Log::Manager::setGlobalThreshold(sf::Log::Level threshold)
+{
+    logBackend.globalThreshold = threshold;
+}
+
+SFML_SYSTEM_API void sf::Log::Manager::setModuleThreshold(sf::Log::Channel channel, sf::Log::Level threshold)
+{
+    logBackend.channelThresholds[channel] = threshold;
+}
+
+SFML_SYSTEM_API void sf::Log::Manager::registerCustomModuleName(sf::Log::Channel channel, const std::string &name)
+{
+    logBackend.customChannelNames[channel] = name;
+}
+
+SFML_SYSTEM_API void sf::Log::Manager::setCustomLogEntryProcessor(sf::Log::Manager::LogEntryProcessor processor, void *userData /*= NULL*/)
+{
+    if (processor)
+    {
+        logBackend.processor = processor;
+        logBackend.userData = userData;
+    }
+    else
+    {
+        logBackend.processor = &defaultLogEntryProcessor;
+        logBackend.userData = NULL;
+    }
+}


### PR DESCRIPTION
# Rationale

Currently logging in SFML is done by simply piping strings through sf::err, but most logging frameworks are message oriented and thus it's quite cumbersome to integrate the SFML log with anything else than another std::ostream. Furthermore it's hard to prevent mixing message parts in a multithreaded enviroment. So I made up this approach which serves the following design goals:
1. end user simplicity (as simple as sf::err)
2. message orientation, with metadata based filtering (channel, importance)
3. simple log backend integration
4. extensibility, i.e. SFML addons can log messages using their own channels utilizing the same backend
5. performance; if logging is turned off there should be little overhead caused by dropping messages
# Usage

The public interface is completely documented --- [html version](https://www.notenoughtime.de/SFML/doc/Log_8hpp.html) (you'll probably get a certificate error, because the certificate is issued by cacert.org, so simply ignore it or install the root certificate).

A minimal example would be:

``` C++
#include <SFML/System/Log.hpp>
int main( )
{
    int toBeOutputted = 4;
    sfLogSysWarn("Your log message formatted by a std::ostream " << toBeOutputted);
    return 0;
}
```

This should output the following to std::cerr (if SFML system was compiled with _DEBUG):

```
SFML SYSTEM WARNING: Your log message formatted by a std::ostream 4
```

In order to redirect the log output or format it differently you would do something like this:

``` C++
#include <SFML/System/Log.hpp>
#include <fstream>

void logEntryProcessor(void *, sf::Log::Channel channel, sf::Log::Level level, const std::string &message)
{
    static std::ofstream backend("cerr.txt", std::ios::out | std::ios::trunc);
    backend << "${TIME} SFML" << channel.toString() << " " << level.toString() << " " message << std::endl;
}

int main( )
{
    sf::Log::Manager::setCustomLogEntryProcessor(&logEntryProcessor,  NULL);
    int toBeOutputted = 4;
    sfLogSysWarn("Your log message formatted by a std::ostream " << toBeOutputted);
    return 0;
}
```
# Questions

What do you think of this?
I would like to completely replace `sf::err()` with the appropriate `sfLogXXXXXX()` throughout the library and deprecate the former one, so everyone can profit from this, would this be accepted?

Best wishes
Henrik Gaßmann

Edit: I just want to add that replacing the usage of `sf::err()` with the appropriate `sfLogXXXXXX()` doesn't necessarily has to be a breaking change, because we could pipe all the messages from the default log processor through `sf::err()`, so that existing implementations which redirect `sf::err()` will continue to work until `sf::err()` gets completely removed.
