### PR TITLE
Add methods to get and set shader attribute locations

### DIFF
--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -559,6 +559,48 @@ public:
     SFML_DEPRECATED void setParameter(const std::string& name, CurrentTextureType);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Set the location of a shader attribute
+    ///
+    /// Binds shader attribute \a name to a known location (index)
+    /// \a location.
+    ///
+    /// This method must be called before loading the shader source.
+    ///
+    /// Example:
+    /// \code
+    /// attribute vec3 position; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// shader.setAttribLocation("position", 0);
+    /// \endcode
+    ///
+    /// \param name Name of the attribute in the shader
+    /// \param location Location to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setAttribLocation(const std::string& name, int location);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the location of a shader attribute
+    ///
+    /// Get the location of a shader attribute, either the location
+    /// assigned by the user beforehand, or by OpenGL when the shader
+    /// is compiled.
+    ///
+    /// Example:
+    /// \code
+    /// attribute vec3 position; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// int location = shader.getAttribLocation("position");
+    /// \endcode
+    ///
+    /// \param name Name of the attribute in the shader
+    ///
+    ////////////////////////////////////////////////////////////
+    int getAttribLocation(const std::string& name);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Get the underlying OpenGL handle of the shader.
     ///
     /// You shouldn't need to use this function, unless you have
@@ -654,6 +696,7 @@ private:
     ////////////////////////////////////////////////////////////
     typedef std::map<int, const Texture*> TextureTable;
     typedef std::map<std::string, int> UniformTable;
+    typedef std::map<std::string, int> AttribTable;
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -662,6 +705,7 @@ private:
     int          m_currentTexture; ///< Location of the current texture in the shader
     TextureTable m_textures;       ///< Texture variables in the shader, mapped to their location
     UniformTable m_uniforms;       ///< Parameters location cache
+    AttribTable  m_attribs;        ///< Attributes location cache
 };
 
 } // namespace sf

--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -192,6 +192,8 @@
 
     // Core since 2.0 - ARB_vertex_shader
     #define GLEXT_vertex_shader                       sfogl_ext_ARB_vertex_shader
+    #define GLEXT_glGetAttribLocation                 glGetAttribLocationARB
+    #define GLEXT_glBindAttribLocation                glBindAttribLocationARB
     #define GLEXT_GL_VERTEX_SHADER                    GL_VERTEX_SHADER_ARB
     #define GLEXT_GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS_ARB
 


### PR DESCRIPTION
Implements #987 ([forum post](http://en.sfml-dev.org/forums/index.php?topic=19107.0)).

Fixed attribute locations may be assigned before loading the shader source, and/or the locations assigned by the shader compiler may be retrieved afterward.

Usage:
```
    // Vertex shader
    #version 330
    uniform mat4 projection;
    uniform mat4 modelview;
    in vec2 position;
    in vec2 texCoord;
    out vec2 v_position;
    out vec2 v_texCoord;
    void main() {
        gl_Position = projection * modelview * vec4(position, 0, 1);
        v_position = position;
        v_texCoord = texCoord;
    }
```
```
    // Assign locations before loading
    sf::Shader myShader;
    myShader.setAttribLocation("position", 0);
    myShader.setAttribLocation("texCoord", 1);
    myShader.loadFromFile("shaders/tilemap.vert", "shaders/tilemap.frag");
    glEnableVertexAttribArray(0);
    glEnableVertexAttribArray(1);
    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 16, 0);
    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 16, 8);
```
```
    // Retrieve locations after loading
    sf::Shader myShader;
    myShader.loadFromFile("shaders/tilemap.vert", "shaders/tilemap.frag");
    int loc_position = myShader.getAttribLocation("position");
    int loc_texCoord = myShader.getAttribLocation("texCoord");
    glEnableVertexAttribArray(loc_position);
    glEnableVertexAttribArray(loc_texCoord);
    glVertexAttribPointer(loc_position, 2, GL_FLOAT, GL_FALSE, 16, 0);
    glVertexAttribPointer(loc_texCoord, 2, GL_FLOAT, GL_FALSE, 16, 8);
```