### PR TITLE
Removed internal OpenGL contexts

### DIFF
--- a/include/SFML/Window/GlResource.hpp
+++ b/include/SFML/Window/GlResource.hpp
@@ -29,10 +29,14 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
 
 
 namespace sf
 {
+
+class Context;
+
 ////////////////////////////////////////////////////////////
 /// \brief Base class for classes that require an OpenGL context
 ///
@@ -54,10 +58,27 @@ protected:
     ~GlResource();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Make sure that a valid OpenGL context exists in the current thread
+    /// \brief RAII helper class to temporarily lock an available context for use
     ///
     ////////////////////////////////////////////////////////////
-    static void ensureGlContext();
+    class SFML_WINDOW_API TransientContextLock : NonCopyable
+    {
+    public:
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        ////////////////////////////////////////////////////////////
+        TransientContextLock();
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Destructor
+        ///
+        ////////////////////////////////////////////////////////////
+        ~TransientContextLock();
+
+    private:
+        Context* m_context; ///< Temporary context, in case we needed to create one
+    };
 };
 
 } // namespace sf

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -645,10 +645,6 @@ Glyph Font::loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, f
     // Delete the FT glyph
     FT_Done_Glyph(glyphDesc);
 
-    // Force an OpenGL flush, so that the font's texture will appear updated
-    // in all contexts immediately (solves problems in multi-threaded apps)
-    glCheck(glFlush());
-
     // Done :)
     return glyph;
 }

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -48,7 +48,7 @@ m_depthBuffer(0)
 ////////////////////////////////////////////////////////////
 RenderTextureImplFBO::~RenderTextureImplFBO()
 {
-    ensureGlContext();
+    m_context->setActive(true);
 
     // Destroy the depth buffer
     if (m_depthBuffer)
@@ -72,7 +72,7 @@ RenderTextureImplFBO::~RenderTextureImplFBO()
 ////////////////////////////////////////////////////////////
 bool RenderTextureImplFBO::isAvailable()
 {
-    ensureGlContext();
+    TransientContextLock lock;
 
     // Make sure that extensions are initialized
     priv::ensureExtensionsInit();

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -56,7 +56,8 @@
 
 namespace
 {
-    sf::Mutex mutex;
+    sf::Mutex maxTextureUnitsMutex;
+    sf::Mutex isAvailableMutex;
 
     GLint checkMaxTextureUnits()
     {
@@ -70,7 +71,7 @@ namespace
     GLint getMaxTextureUnits()
     {
         // TODO: Remove this lock when it becomes unnecessary in C++11
-        sf::Lock lock(mutex);
+        sf::Lock lock(maxTextureUnitsMutex);
 
         static GLint maxUnits = checkMaxTextureUnits();
 
@@ -114,53 +115,6 @@ namespace
         }
         buffer.push_back('\0');
         return success;
-    }
-
-    bool checkShadersAvailable()
-    {
-        // Create a temporary context in case the user checks
-        // before a GlResource is created, thus initializing
-        // the shared context
-        if (!sf::Context::getActiveContext())
-        {
-            sf::Context context;
-
-            // Make sure that extensions are initialized
-            sf::priv::ensureExtensionsInit();
-
-            bool available = GLEXT_multitexture         &&
-                             GLEXT_shading_language_100 &&
-                             GLEXT_shader_objects       &&
-                             GLEXT_vertex_shader        &&
-                             GLEXT_fragment_shader;
-
-            return available;
-        }
-
-        // Make sure that extensions are initialized
-        sf::priv::ensureExtensionsInit();
-
-        bool available = GLEXT_multitexture         &&
-                         GLEXT_shading_language_100 &&
-                         GLEXT_shader_objects       &&
-                         GLEXT_vertex_shader        &&
-                         GLEXT_fragment_shader;
-
-        return available;
-    }
-    bool checkGeometryShadersAvailable()
-    {
-        // Create a temporary context in case the user checks
-        // before a GlResource is created, thus initializing
-        // the shared context
-        sf::Context context;
-
-        // Make sure that extensions are initialized
-        sf::priv::ensureExtensionsInit();
-
-        bool available = checkShadersAvailable() && GLEXT_geometry_shader4;
-
-        return available;
     }
 
     // Transforms an array of 2D vectors into a contiguous array of scalars
@@ -236,8 +190,6 @@ struct Shader::UniformBinder : private NonCopyable
     {
         if (currentProgram)
         {
-            ensureGlContext();
-
             // Enable program object
             glCheck(savedProgram = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
             if (currentProgram != savedProgram)
@@ -259,9 +211,10 @@ struct Shader::UniformBinder : private NonCopyable
             glCheck(GLEXT_glUseProgramObject(savedProgram));
     }
 
-    GLEXT_GLhandle savedProgram;   ///< Handle to the previously active program object
-    GLEXT_GLhandle currentProgram; ///< Handle to the program object of the modified sf::Shader instance
-    GLint          location;       ///< Uniform location, used by the surrounding sf::Shader code
+    TransientContextLock lock;           ///< Lock to keep context active while uniform is bound
+    GLEXT_GLhandle       savedProgram;   ///< Handle to the previously active program object
+    GLEXT_GLhandle       currentProgram; ///< Handle to the program object of the modified sf::Shader instance
+    GLint                location;       ///< Uniform location, used by the surrounding sf::Shader code
 };
 
 
@@ -278,7 +231,7 @@ m_uniforms      ()
 ////////////////////////////////////////////////////////////
 Shader::~Shader()
 {
-    ensureGlContext();
+    TransientContextLock lock;
 
     // Destroy effect program
     if (m_shaderProgram)
@@ -592,7 +545,7 @@ void Shader::setUniform(const std::string& name, const Texture& texture)
 {
     if (m_shaderProgram)
     {
-        ensureGlContext();
+        TransientContextLock lock;
 
         // Find the location of the variable in the shader
         int location = getUniformLocation(name);
@@ -627,7 +580,7 @@ void Shader::setUniform(const std::string& name, CurrentTextureType)
 {
     if (m_shaderProgram)
     {
-        ensureGlContext();
+        TransientContextLock lock;
 
         // Find the location of the variable in the shader
         m_currentTexture = getUniformLocation(name);
@@ -787,7 +740,7 @@ unsigned int Shader::getNativeHandle() const
 ////////////////////////////////////////////////////////////
 void Shader::bind(const Shader* shader)
 {
-    ensureGlContext();
+    TransientContextLock lock;
 
     // Make sure that we can use shaders
     if (!isAvailable())
@@ -820,10 +773,26 @@ void Shader::bind(const Shader* shader)
 ////////////////////////////////////////////////////////////
 bool Shader::isAvailable()
 {
-    // TODO: Remove this lock when it becomes unnecessary in C++11
-    Lock lock(mutex);
+    Lock lock(isAvailableMutex);
 
-    static bool available = checkShadersAvailable();
+    static bool checked = false;
+    static bool available = false;
+
+    if (!checked)
+    {
+        checked = true;
+
+        TransientContextLock contextLock;
+
+        // Make sure that extensions are initialized
+        sf::priv::ensureExtensionsInit();
+
+        available = GLEXT_multitexture         &&
+                    GLEXT_shading_language_100 &&
+                    GLEXT_shader_objects       &&
+                    GLEXT_vertex_shader        &&
+                    GLEXT_fragment_shader;
+    }
 
     return available;
 }
@@ -832,10 +801,22 @@ bool Shader::isAvailable()
 ////////////////////////////////////////////////////////////
 bool Shader::isGeometryAvailable()
 {
-    // TODO: Remove this lock when it becomes unnecessary in C++11
-    Lock lock(mutex);
+    Lock lock(isAvailableMutex);
 
-    static bool available = checkGeometryShadersAvailable();
+    static bool checked = false;
+    static bool available = false;
+
+    if (!checked)
+    {
+        checked = true;
+
+        TransientContextLock contextLock;
+
+        // Make sure that extensions are initialized
+        sf::priv::ensureExtensionsInit();
+
+        available = isAvailable() && GLEXT_geometry_shader4;
+    }
 
     return available;
 }
@@ -844,7 +825,7 @@ bool Shader::isGeometryAvailable()
 ////////////////////////////////////////////////////////////
 bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCode, const char* fragmentShaderCode)
 {
-    ensureGlContext();
+    TransientContextLock lock;
 
     // First make sure that we can use shaders
     if (!isAvailable())

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -28,24 +28,6 @@
 #include <SFML/Window/Context.hpp>
 #include <SFML/Window/GlContext.hpp>
 #include <SFML/System/ThreadLocalPtr.hpp>
-#include <SFML/OpenGL.hpp>
-#include <algorithm>
-#include <vector>
-#include <string>
-
-#if defined(SFML_SYSTEM_WINDOWS)
-
-    typedef const GLubyte* (APIENTRY *glGetStringiFuncType)(GLenum, GLuint);
-
-#else
-
-    typedef const GLubyte* (*glGetStringiFuncType)(GLenum, GLuint);
-
-#endif
-
-#if !defined(GL_NUM_EXTENSIONS)
-    #define GL_NUM_EXTENSIONS 0x821D
-#endif
 
 
 namespace
@@ -99,70 +81,16 @@ const Context* Context::getActiveContext()
 
 
 ////////////////////////////////////////////////////////////
-GlFunctionPointer Context::getFunction(const char* name)
+bool Context::isExtensionAvailable(const char* name)
 {
-    return priv::GlContext::getFunction(name);
+    return priv::GlContext::isExtensionAvailable(name);
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Context::isExtensionAvailable(const char* name)
+GlFunctionPointer Context::getFunction(const char* name)
 {
-    static std::vector<std::string> extensions;
-    static bool loaded = false;
-
-    if (!loaded)
-    {
-        const Context* context = getActiveContext();
-
-        if (!context)
-            return false;
-
-        const char* extensionString = NULL;
-
-        if(context->getSettings().majorVersion < 3)
-        {
-            // Try to load the < 3.0 way
-            extensionString = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
-
-            do
-            {
-                const char* extension = extensionString;
-
-                while(*extensionString && (*extensionString != ' '))
-                    extensionString++;
-
-                extensions.push_back(std::string(extension, extensionString));
-            }
-            while (*extensionString++);
-        }
-        else
-        {
-            // Try to load the >= 3.0 way
-            glGetStringiFuncType glGetStringiFunc = NULL;
-            glGetStringiFunc = reinterpret_cast<glGetStringiFuncType>(getFunction("glGetStringi"));
-
-            if (glGetStringiFunc)
-            {
-                int numExtensions = 0;
-                glGetIntegerv(GL_NUM_EXTENSIONS, &numExtensions);
-
-                if (numExtensions)
-                {
-                    for (unsigned int i = 0; i < static_cast<unsigned int>(numExtensions); ++i)
-                    {
-                        extensionString = reinterpret_cast<const char*>(glGetStringiFunc(GL_EXTENSIONS, i));
-
-                        extensions.push_back(extensionString);
-                    }
-                }
-            }
-        }
-
-        loaded = true;
-    }
-
-    return std::find(extensions.begin(), extensions.end(), name) != extensions.end();
+    return priv::GlContext::getFunction(name);
 }
 
 

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -173,9 +173,12 @@ EglContext::~EglContext()
 
 
 ////////////////////////////////////////////////////////////
-bool EglContext::makeCurrent()
+bool EglContext::makeCurrent(bool current)
 {
-    return m_surface != EGL_NO_SURFACE && eglCheck(eglMakeCurrent(m_display, m_surface, m_surface, m_context));
+    if (current)
+        return m_surface != EGL_NO_SURFACE && eglCheck(eglMakeCurrent(m_display, m_surface, m_surface, m_context));
+
+    return m_surface != EGL_NO_SURFACE && eglCheck(eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT));
 }
 
 
@@ -208,6 +211,9 @@ void EglContext::createContext(EglContext* shared)
         toShared = shared->m_context;
     else
         toShared = EGL_NO_CONTEXT;
+
+    if (toShared != EGL_NO_CONTEXT)
+        eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 
     // Create EGL context
     m_context = eglCheck(eglCreateContext(m_display, m_config, toShared, contextVersion));

--- a/src/SFML/Window/EglContext.hpp
+++ b/src/SFML/Window/EglContext.hpp
@@ -83,10 +83,12 @@ public:
     /// \brief Activate the context as the current target
     ///        for rendering
     ///
+    /// \param current Whether to make the context current or no longer current
+    ///
     /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool makeCurrent();
+    virtual bool makeCurrent(bool current);
 
     ////////////////////////////////////////////////////////////
     /// \brief Display what has been rendered to the context so far

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -73,10 +73,16 @@ public:
     static void globalCleanup();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Ensures that an OpenGL context is active in the current thread
+    /// \brief Acquires a context for short-term use on the current thread
     ///
     ////////////////////////////////////////////////////////////
-    static void ensureContext();
+    static void acquireTransientContext();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Releases a context after short-term use on the current thread
+    ///
+    ////////////////////////////////////////////////////////////
+    static void releaseTransientContext();
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new context, not associated to a window
@@ -120,6 +126,16 @@ public:
     static GlContext* create(const ContextSettings& settings, unsigned int width, unsigned int height);
 
 public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Check whether a given OpenGL extension is available
+    ///
+    /// \param name Name of the extension to check for
+    ///
+    /// \return True if available, false if unavailable
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isExtensionAvailable(const char* name);
+
     ////////////////////////////////////////////////////////////
     /// \brief Get the address of an OpenGL function
     ///
@@ -197,10 +213,12 @@ protected:
     /// \brief Activate the context as the current target
     ///        for rendering
     ///
+    /// \param current Whether to make the context current or no longer current
+    ///
     /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool makeCurrent() = 0;
+    virtual bool makeCurrent(bool current) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Evaluate a pixel format configuration

--- a/src/SFML/Window/OSX/SFContext.hpp
+++ b/src/SFML/Window/OSX/SFContext.hpp
@@ -137,10 +137,12 @@ protected:
     /// \brief Activate the context as the current target
     ///        for rendering
     ///
+    /// \param current Whether to make the context current or no longer current
+    ///
     /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool makeCurrent();
+    virtual bool makeCurrent(bool current);
 
 private:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -26,6 +26,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Mutex.hpp>
+#include <SFML/System/Lock.hpp>
 #include <SFML/Window/Unix/Display.hpp>
 #include <X11/keysym.h>
 #include <cassert>
@@ -38,6 +40,7 @@ namespace
     // The shared display and its reference counter
     Display* sharedDisplay = NULL;
     unsigned int referenceCount = 0;
+    sf::Mutex mutex;
 
     typedef std::map<std::string, Atom> AtomMap;
     AtomMap atoms;
@@ -50,6 +53,8 @@ namespace priv
 ////////////////////////////////////////////////////////////
 Display* OpenDisplay()
 {
+    Lock lock(mutex);
+
     if (referenceCount == 0)
     {
         sharedDisplay = XOpenDisplay(NULL);
@@ -71,6 +76,8 @@ Display* OpenDisplay()
 ////////////////////////////////////////////////////////////
 void CloseDisplay(Display* display)
 {
+    Lock lock(mutex);
+
     assert(display == sharedDisplay);
 
     referenceCount--;

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -211,7 +211,7 @@ GlFunctionPointer GlxContext::getFunction(const char* name)
 
 
 ////////////////////////////////////////////////////////////
-bool GlxContext::makeCurrent()
+bool GlxContext::makeCurrent(bool current)
 {
     if (!m_context)
         return false;
@@ -222,13 +222,20 @@ bool GlxContext::makeCurrent()
 
     bool result = false;
 
-    if (m_pbuffer)
+    if (current)
     {
-        result = glXMakeContextCurrent(m_display, m_pbuffer, m_pbuffer, m_context);
+        if (m_pbuffer)
+        {
+            result = glXMakeContextCurrent(m_display, m_pbuffer, m_pbuffer, m_context);
+        }
+        else if (m_window)
+        {
+            result = glXMakeCurrent(m_display, m_window, m_context);
+        }
     }
-    else if (m_window)
+    else
     {
-        result = glXMakeCurrent(m_display, m_window, m_context);
+        result = glXMakeCurrent(m_display, None, NULL);
     }
 
 #if defined(GLX_DEBUGGING)
@@ -686,6 +693,15 @@ void GlxContext::createContext(GlxContext* shared)
             // On an error, glXCreateContextAttribsARB will return 0 anyway
             GlxErrorHandler handler(m_display);
 
+            if (toShare)
+            {
+                if (!glXMakeCurrent(m_display, None, NULL))
+                {
+                    err() << "Failed to deactivate shared context before sharing" << std::endl;
+                    return;
+                }
+            }
+
             // Create the context
             m_context = glXCreateContextAttribsARB(m_display, *config, toShare, true, &attributes[0]);
 
@@ -731,6 +747,15 @@ void GlxContext::createContext(GlxContext* shared)
 #if defined(GLX_DEBUGGING)
     GlxErrorHandler handler(m_display);
 #endif
+
+        if (toShare)
+        {
+            if (!glXMakeCurrent(m_display, None, NULL))
+            {
+                err() << "Failed to deactivate shared context before sharing" << std::endl;
+                return;
+            }
+        }
 
         // Create the context, using the target window's visual
         m_context = glXCreateContext(m_display, visualInfo, toShare, true);

--- a/src/SFML/Window/Unix/GlxContext.hpp
+++ b/src/SFML/Window/Unix/GlxContext.hpp
@@ -94,10 +94,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Activate the context as the current target for rendering
     ///
+    /// \param current Whether to make the context current or no longer current
+    ///
     /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool makeCurrent();
+    virtual bool makeCurrent(bool current);
 
     ////////////////////////////////////////////////////////////
     /// \brief Display what has been rendered to the context so far

--- a/src/SFML/Window/Win32/WglContext.hpp
+++ b/src/SFML/Window/Win32/WglContext.hpp
@@ -93,10 +93,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Activate the context as the current target for rendering
     ///
+    /// \param current Whether to make the context current or no longer current
+    ///
     /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool makeCurrent();
+    virtual bool makeCurrent(bool current);
 
     ////////////////////////////////////////////////////////////
     /// \brief Display what has been rendered to the context so far

--- a/src/SFML/Window/iOS/EaglContext.hpp
+++ b/src/SFML/Window/iOS/EaglContext.hpp
@@ -126,10 +126,12 @@ protected:
     /// \brief Activate the context as the current target
     ///        for rendering
     ///
+    /// \param current Whether to make the context current or no longer current
+    ///
     /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool makeCurrent();
+    virtual bool makeCurrent(bool current);
 
 private:
 

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -107,6 +107,9 @@ EaglContext::~EaglContext()
 
         // Restore the previous context
         [EAGLContext setCurrentContext:previousContext];
+
+        if (m_context == [EAGLContext currentContext])
+            [EAGLContext setCurrentContext:nil];
     }
 }
 
@@ -167,9 +170,12 @@ void EaglContext::recreateRenderBuffers(SFView* glView)
 
 
 ////////////////////////////////////////////////////////////
-bool EaglContext::makeCurrent()
+bool EaglContext::makeCurrent(bool current)
 {
-    return [EAGLContext setCurrentContext:m_context];
+    if (current)
+        return [EAGLContext setCurrentContext:m_context];
+
+    return [EAGLContext setCurrentContext:nil];
 }
 
 
@@ -215,12 +221,18 @@ void EaglContext::createContext(EaglContext* shared,
 
     // Create the context
     if (shared)
+    {
+        [EAGLContext setCurrentContext:nil];
+
         m_context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES1 sharegroup:[shared->m_context sharegroup]];
+    }
     else
+    {
         m_context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES1];
+    }
 
     // Activate it
-    makeCurrent();
+    makeCurrent(true);
 
     // Create the framebuffer (this is the only allowed drawable on iOS)
     glGenFramebuffersOES(1, &m_framebuffer);
@@ -230,6 +242,9 @@ void EaglContext::createContext(EaglContext* shared,
 
     // Attach the context to the GL view for future updates
     window->getGlView().context = this;
+
+    // Deactivate it
+    makeCurrent(false);
 }
 
 } // namespace priv


### PR DESCRIPTION
Discussion prior to this pull request: http://en.sfml-dev.org/forums/index.php?topic=19106.0

Overview of changes:
* Removed SFML's requirement of constantly having to keep a context active on each thread in order to manage GL objects
* Implement _actual_ context deactivation as a replacement for "activate something else to implicitly deactivate" (this will require changes in user code if they assumed this behaviour)
* Requires more explicit context management in user code (i.e. activate before GL and deactivate after GL) as opposed to "activate once and forget". This leads to more predictable context behaviour i.e. you can be sure the context you activate will still be active after a call into a GLResource object
* Reduced the number of temporary contexts that get created when an application starts up in some cases
* Made context activation/deactivation behaviour during construction/destruction uniform across all platform context implementations