### PR TITLE
Threading issue in sf::SoundRecorder

### DIFF
--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -32,10 +32,22 @@ public:
     {
     }
 
+    ////////////////////////////////////////////////////////////
+    /// Destructor
+    ///
+    /// \see SoundRecorder::~SoundRecorder()
+    ///
+    ////////////////////////////////////////////////////////////
+    ~NetworkRecorder()
+    {
+        // Make sure to stop the recording thread
+        stop();
+    }
+
 private:
 
     ////////////////////////////////////////////////////////////
-    /// /see SoundRecorder::OnStart
+    /// \see SoundRecorder::onStart
     ///
     ////////////////////////////////////////////////////////////
     virtual bool onStart()
@@ -52,7 +64,7 @@ private:
     }
 
     ////////////////////////////////////////////////////////////
-    /// /see SoundRecorder::ProcessSamples
+    /// \see SoundRecorder::onProcessSamples
     ///
     ////////////////////////////////////////////////////////////
     virtual bool onProcessSamples(const sf::Int16* samples, std::size_t sampleCount)
@@ -67,7 +79,7 @@ private:
     }
 
     ////////////////////////////////////////////////////////////
-    /// /see SoundRecorder::OnStop
+    /// \see SoundRecorder::onStop
     ///
     ////////////////////////////////////////////////////////////
     virtual void onStop()
@@ -98,7 +110,7 @@ private:
 void doClient(unsigned short port)
 {
     // Check that the device can capture audio
-    if (sf::SoundRecorder::isAvailable() == false)
+    if (!sf::SoundRecorder::isAvailable())
     {
         std::cout << "Sorry, audio capture is not supported by your system" << std::endl;
         return;

--- a/include/SFML/Audio/SoundBufferRecorder.hpp
+++ b/include/SFML/Audio/SoundBufferRecorder.hpp
@@ -46,6 +46,12 @@ class SFML_AUDIO_API SoundBufferRecorder : public SoundRecorder
 public:
 
     ////////////////////////////////////////////////////////////
+    /// \brief destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~SoundBufferRecorder();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Get the sound buffer containing the captured audio data
     ///
     /// The sound buffer is valid only after the capture has ended.

--- a/include/SFML/Audio/SoundRecorder.hpp
+++ b/include/SFML/Audio/SoundRecorder.hpp
@@ -316,11 +316,20 @@ private:
 /// from this separate thread. It is important to keep this in
 /// mind, because you may have to take care of synchronization
 /// issues if you share data between threads.
+/// Another thing to bear in mind is that you must call stop()
+/// in the destructor of your derived class, so that the recording
+/// thread finishes before your object is destroyed.
 ///
 /// Usage example:
 /// \code
 /// class CustomRecorder : public sf::SoundRecorder
 /// {
+///     ~CustomRecorder()
+///     {
+///         // Make sure to stop the recording thread
+///         stop();
+///     }
+///
 ///     virtual bool onStart() // optional
 ///     {
 ///         // Initialize whatever has to be done before the capture starts

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -33,6 +33,14 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
+SoundBufferRecorder::~SoundBufferRecorder()
+{
+    // Make sure to stop the recording thread
+    stop();
+}
+
+
+////////////////////////////////////////////////////////////
 bool SoundBufferRecorder::onStart()
 {
     m_samples.clear();


### PR DESCRIPTION
When you destroy a `sf::SoundBufferRecorder` while it's still recording you get the following crash
```
pure virtual method called
terminate called without an active exception
```
This is because the `sf::SoundBufferRecorder::onProcessSamples()` method gets deleted while the capturing thread in `sf::SoundRecorder` i still running and calling it (destructor of derived class
get called first). Simply calling `stop()` in the destructor fixes it. 

This reproduces the crash:
```cpp
int main() {
    // create the recorder
    sf::SoundBufferRecorder recorder;

    // start the capture
    recorder.start();

    return 0;
}
```

Once this is merged I will write a little section for the tutorials metioning that you have to call `stop()` in the destructor of the class deriving from `sf::SoundRecorder`.