### PR TITLE
OSX: Tilde and Dash Fix

### DIFF
--- a/src/SFML/Window/OSX/HIDInputManager.mm
+++ b/src/SFML/Window/OSX/HIDInputManager.mm
@@ -763,14 +763,16 @@ Keyboard::Key HIDInputManager::nonLocalizedKeys(UniChar virtualKeycode)
         case 0x2c:                      return sf::Keyboard::Slash;
         case 0x2a:                      return sf::Keyboard::BackSlash;
 
-#warning sf::Keyboard::Tilde might be in conflict with some other key.
+//#warning sf::Keyboard::Tilde might be in conflict with some other key.?DELETE??DELETE??DELETE??DELETE??DELETE??DELETE?
             // 0x0a is for "Non-US Backslash" according to HID Calibrator,
             // a sample provided by Apple.
-        case 0x0a:                      return sf::Keyboard::Tilde;
+        //case 0x0a:                      return sf::Keyboard::Tilde;
+        case 0x32:                      return sf::Keyboard::Tilde;
 
         case 0x51: /* keypad         */ return sf::Keyboard::Equal;
         case 0x18: /* keyboard       */ return sf::Keyboard::Equal;
-        case 0x32:                      return sf::Keyboard::Dash;
+        //case 0x32:                      return sf::Keyboard::Dash;
+        case 0x1b:                      return sf::Keyboard::Dash;
         case 0x31:                      return sf::Keyboard::Space;
         case 0x4c: /* keypad         */ return sf::Keyboard::Return;
         case 0x24: /* keyboard       */ return sf::Keyboard::Return;
@@ -855,7 +857,7 @@ Keyboard::Key HIDInputManager::nonLocalizedKeys(UniChar virtualKeycode)
 
         case NSPauseFunctionKey:        return sf::Keyboard::Pause;
 
-#warning keycode 0x1b is not bound to any key.
+//#warning keycode 0x1b is not bound to any key.?DELETE??DELETE??DELETE??DELETE??DELETE??DELETE??DELETE?
             // This key is ' on CH-FR, ) on FR and - on US layouts.
 
             // An unknown key.


### PR DESCRIPTION
After investigating some funniness with Tilde and Dash, I found that Dash was being mapped to the GraveAccent/Tilde key, and Tilde wasn't being mapped to its virtual hardware key. Between the two functions usageToVirtualCode() & nonLocalizedKeys(), I changed Dash to match Hyphen, and Tilde to match itself. 
After this edit, I don't think the warning about tilde (line 766) is necessary . Also the warning about hyphen(line 860) seems to contradict some comments earlier(lines 278-286). I went with the hyphen value suggested in the comments despite the warning. Is this really a problem?