### PR TITLE
Skip glTexCoordPointer() call if not needed (performance optimization)

### DIFF
--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -406,6 +406,7 @@ private:
         bool      viewChanged;    ///< Has the current view changed since last draw?
         BlendMode lastBlendMode;  ///< Cached blending mode
         Uint64    lastTextureId;  ///< Cached texture
+        bool      texCoordsArrayEnabled; ///< Is GL_TEXTURE_COORD_ARRAY client state enabled?
         bool      useVertexCache; ///< Did we previously use the vertex cache?
         Vertex    vertexCache[VertexCacheSize]; ///< Pre-transformed vertices cache
     };

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -269,13 +269,25 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
                 vertices = NULL;
         }
 
+        // Check if texture coordinates array is needed, and update client state accordingly
+        bool enableTexCoordsArray = (states.texture || states.shader);
+        if (enableTexCoordsArray != m_cache.texCoordsArrayEnabled)
+        {
+            if (enableTexCoordsArray)
+                glCheck(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
+            else
+                glCheck(glDisableClientState(GL_TEXTURE_COORD_ARRAY));
+            m_cache.texCoordsArrayEnabled = enableTexCoordsArray;
+        }
+
         // Setup the pointers to the vertices' components
         if (vertices)
         {
             const char* data = reinterpret_cast<const char*>(vertices);
             glCheck(glVertexPointer(2, GL_FLOAT, sizeof(Vertex), data + 0));
             glCheck(glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Vertex), data + 8));
-            glCheck(glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex), data + 12));
+            if (enableTexCoordsArray)
+                glCheck(glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex), data + 12));
         }
 
         // Find the OpenGL primitive type
@@ -389,6 +401,8 @@ void RenderTarget::resetGLStates()
         applyTexture(NULL);
         if (shaderAvailable)
             applyShader(NULL);
+
+        m_cache.texCoordsArrayEnabled = true;
 
         m_cache.useVertexCache = false;
 


### PR DESCRIPTION
Aimed at saving memory bandwidth for drawing operations not involving textures nor shaders.
More details in [this forum thread](http://en.sfml-dev.org/forums/index.php?topic=19441.0).
