### PR TITLE
Made WAV file reader no longer assume that data chunk goes till end of file to prevent reading trailing metadata as samples.

### DIFF
--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -110,7 +110,8 @@ bool SoundFileReaderWav::check(InputStream& stream)
 SoundFileReaderWav::SoundFileReaderWav() :
 m_stream        (NULL),
 m_bytesPerSample(0),
-m_dataStart     (0)
+m_dataStart     (0),
+m_dataEnd       (0)
 {
 }
 
@@ -145,7 +146,7 @@ Uint64 SoundFileReaderWav::read(Int16* samples, Uint64 maxCount)
     assert(m_stream);
 
     Uint64 count = 0;
-    while (count < maxCount)
+    while ((count < maxCount) && (m_stream->tell() < m_dataEnd))
     {
         switch (m_bytesPerSample)
         {
@@ -285,8 +286,9 @@ bool SoundFileReaderWav::parseHeader(Info& info)
             // Compute the total number of samples
             info.sampleCount = subChunkSize / m_bytesPerSample;
 
-            // Store the starting position of samples in the file
+            // Store the start and end position of samples in the file
             m_dataStart = m_stream->tell();
+            m_dataEnd = m_dataStart + info.sampleCount * m_bytesPerSample;
 
             dataChunkFound = true;
         }

--- a/src/SFML/Audio/SoundFileReaderWav.hpp
+++ b/src/SFML/Audio/SoundFileReaderWav.hpp
@@ -111,6 +111,7 @@ private:
     InputStream* m_stream;         ///< Source stream to read from
     unsigned int m_bytesPerSample; ///< Size of a sample, in bytes
     Uint64       m_dataStart;      ///< Starting position of the audio data in the open file
+    Uint64       m_dataEnd;        ///< Position one byte past the end of the audio data in the open file
 };
 
 } // namespace priv


### PR DESCRIPTION
Some programs (FL Studio) make wav files that have trailing metadata (program name, ect.) at end of file, so when SFML assumed that samples go till end of file, it read that metadata as samples which caused stuttering and OpenAL errors.
See http://en.sfml-dev.org/forums/index.php?topic=19381.0