### PR TITLE
Mac External Frameworks Info.plist Update for AppStore Validation

### DIFF
--- a/extlibs/libs-osx/Frameworks/FLAC.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/FLAC.framework/Versions/A/Resources/Info.plist
@@ -16,9 +16,5 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>MacOSX</string>
-    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/FLAC.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/FLAC.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,9 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/OpenAL.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/OpenAL.framework/Versions/A/Resources/Info.plist
@@ -16,9 +16,5 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>MacOSX</string>
-    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/OpenAL.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/OpenAL.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,9 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/freetype.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/freetype.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,9 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/freetype.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/freetype.framework/Versions/A/Resources/Info.plist
@@ -16,9 +16,5 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
-	<key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>MacOSX</string>
-    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/ogg.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/ogg.framework/Versions/A/Resources/Info.plist
@@ -16,9 +16,5 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>MacOSX</string>
-    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/ogg.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/ogg.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,9 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbis.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbis.framework/Versions/A/Resources/Info.plist
@@ -16,9 +16,5 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>MacOSX</string>
-    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbis.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbis.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,9 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbisenc.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbisenc.framework/Versions/A/Resources/Info.plist
@@ -16,9 +16,5 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>MacOSX</string>
-    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbisenc.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbisenc.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,9 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbisfile.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbisfile.framework/Versions/A/Resources/Info.plist
@@ -16,9 +16,5 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
-    <key>CFBundleSupportedPlatforms</key>
-    <array>
-        <string>MacOSX</string>
-    </array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbisfile.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbisfile.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,9 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Sorry for previous confusion. 
I added some lines defining CFBundleSupportedPlatforms to all the Info.plist for mac external frameworks. This allows a project using those frameworks to pass validation phase on submit to the app store review. this is related to [issue 1020](https://github.com/SFML/SFML/issues/1020) based on the forum thread [[SOLVED]Mac App Upload Error: (freetype)](http://en.sfml-dev.org/forums/index.php?topic=19498.msg140542#msg140542).