### PR TITLE
Extending Font and Text to support multiple textures (no more discarded glyphs)

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -37,6 +37,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <list>
 
 
 namespace sf
@@ -238,13 +239,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Retrieve the texture containing the loaded glyphs of a certain size
     ///
-    /// The contents of the returned texture changes as more glyphs
-    /// are requested, thus it is not very relevant. It is mainly
-    /// used internally by sf::Text.
-    ///
-    /// \param characterSize Reference character size
-    ///
-    /// \return Texture containing the glyphs of the requested size
+    /// \deprecated Use getGlyph(Uint32 codePoint, unsigned int characterSize, bool bold).texture instead.
     ///
     ////////////////////////////////////////////////////////////
     const Texture& getTexture(unsigned int characterSize) const;
@@ -294,6 +289,11 @@ private:
     };
 
     ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::list<Page> PageList; ///< List of pages, where each page corresponds to a texture
+
+    ////////////////////////////////////////////////////////////
     /// \brief Free all the internal resources
     ///
     ////////////////////////////////////////////////////////////
@@ -336,7 +336,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////
-    typedef std::map<unsigned int, Page> PageTable; ///< Table mapping a character size to its page (texture)
+    typedef std::map<unsigned int, PageList> PageListTable; ///< Table mapping a character size to its list of pages (textures)
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -346,7 +346,7 @@ private:
     void*                      m_streamRec;   ///< Pointer to the stream rec instance (it is typeless to avoid exposing implementation details)
     int*                       m_refCount;    ///< Reference counter used by implicit sharing
     Info                       m_info;        ///< Information about the font
-    mutable PageTable          m_pages;       ///< Table containing the glyphs pages by character size
+    mutable PageListTable      m_pageLists;   ///< Table containing the glyphs pages by character size
     mutable std::vector<Uint8> m_pixelBuffer; ///< Pixel buffer holding a glyph's pixels before being written to the texture
     #ifdef SFML_SYSTEM_ANDROID
     void*                      m_stream; ///< Asset file streamer (if loaded from file)

--- a/include/SFML/Graphics/Glyph.hpp
+++ b/include/SFML/Graphics/Glyph.hpp
@@ -34,6 +34,8 @@
 
 namespace sf
 {
+class Texture;
+
 ////////////////////////////////////////////////////////////
 /// \brief Structure describing a glyph
 ///
@@ -46,13 +48,14 @@ public:
     /// \brief Default constructor
     ///
     ////////////////////////////////////////////////////////////
-    Glyph() : advance(0) {}
+    Glyph() : advance(0), texture(NULL) {}
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     float     advance;     ///< Offset to move horizontally to the next character
     FloatRect bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
+    Texture*  texture;     ///< Font's texture containing the glyph
     IntRect   textureRect; ///< Texture coordinates of the glyph inside the font's texture
 };
 
@@ -70,6 +73,7 @@ public:
 ///
 /// The sf::Glyph structure provides the information needed
 /// to handle the glyph:
+/// \li the font's texture containing the glyph
 /// \li its coordinates in the font's texture
 /// \li its bounding rectangle
 /// \li the offset to apply to get the starting position of the next glyph

--- a/include/SFML/Graphics/Glyph.hpp
+++ b/include/SFML/Graphics/Glyph.hpp
@@ -53,10 +53,10 @@ public:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    float     advance;     ///< Offset to move horizontally to the next character
-    FloatRect bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
-    Texture*  texture;     ///< Font's texture containing the glyph
-    IntRect   textureRect; ///< Texture coordinates of the glyph inside the font's texture
+    float          advance;     ///< Offset to move horizontally to the next character
+    FloatRect      bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
+    const Texture* texture;     ///< Font's texture containing the glyph
+    IntRect        textureRect; ///< Texture coordinates of the glyph inside the font's texture
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -301,19 +301,19 @@ private:
     ////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////
-    typedef std::map<Texture*, VertexArray> VertexArrayMap; ///< Map from texture to vertex array containing the text's geometry
+    typedef std::map<const Texture*, VertexArray> VertexArrayMap; ///< Map from texture to vertex array containing the text's geometry
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    String              m_string;             ///< String to display
-    const Font*         m_font;               ///< Font used to display the string
-    unsigned int        m_characterSize;      ///< Base size of characters, in pixels
-    Uint32              m_style;              ///< Text style (see Style enum)
-    Color               m_color;              ///< Text color
-    mutable VertexArrayMap m_verticesMap;     ///< Vertex arrays containing the text's geometry per texture
-    mutable FloatRect   m_bounds;             ///< Bounding rectangle of the text (in local coordinates)
-    mutable bool        m_geometryNeedUpdate; ///< Does the geometry need to be recomputed?
+    String                 m_string;             ///< String to display
+    const Font*            m_font;               ///< Font used to display the string
+    unsigned int           m_characterSize;      ///< Base size of characters, in pixels
+    Uint32                 m_style;              ///< Text style (see Style enum)
+    Color                  m_color;              ///< Text color
+    mutable VertexArrayMap m_verticesMap;        ///< Vertex arrays containing the text's geometry per texture
+    mutable FloatRect      m_bounds;             ///< Bounding rectangle of the text (in local coordinates)
+    mutable bool           m_geometryNeedUpdate; ///< Does the geometry need to be recomputed?
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -299,6 +299,11 @@ private:
     void ensureGeometryUpdate() const;
 
     ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::map<Texture*, VertexArray> VertexArrayMap; ///< Map from texture to vertex array containing the text's geometry
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     String              m_string;             ///< String to display
@@ -306,7 +311,7 @@ private:
     unsigned int        m_characterSize;      ///< Base size of characters, in pixels
     Uint32              m_style;              ///< Text style (see Style enum)
     Color               m_color;              ///< Text color
-    mutable VertexArray m_vertices;           ///< Vertex array containing the text's geometry
+    mutable VertexArrayMap m_verticesMap;     ///< Vertex arrays containing the text's geometry per texture
     mutable FloatRect   m_bounds;             ///< Bounding rectangle of the text (in local coordinates)
     mutable bool        m_geometryNeedUpdate; ///< Does the geometry need to be recomputed?
 };

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -79,6 +79,8 @@ void Text::setFont(const Font& font)
     {
         m_font = &font;
         m_geometryNeedUpdate = true;
+
+        // Glyph textures will change, so delete all VertexArray instances
         m_verticesMap.clear();
     }
 }
@@ -91,6 +93,9 @@ void Text::setCharacterSize(unsigned int size)
     {
         m_characterSize = size;
         m_geometryNeedUpdate = true;
+
+        // Glyph textures will change, so delete all VertexArray instances
+        m_verticesMap.clear();
     }
 }
 
@@ -256,7 +261,7 @@ void Text::ensureGeometryUpdate() const
     // Mark geometry as updated
     m_geometryNeedUpdate = false;
 
-    // Clear the previous geometry
+    // Clear the previous geometry but keep all VertexArray instances so they can reuse their allocated memory
     for (VertexArrayMap::iterator it = m_verticesMap.begin(); it != m_verticesMap.end(); ++it)
         it->second.clear();
     m_bounds = FloatRect();

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -79,6 +79,7 @@ void Text::setFont(const Font& font)
     {
         m_font = &font;
         m_geometryNeedUpdate = true;
+        m_verticesMap.clear();
     }
 }
 
@@ -235,8 +236,11 @@ void Text::draw(RenderTarget& target, RenderStates states) const
 
         for (VertexArrayMap::iterator it = m_verticesMap.begin(); it != m_verticesMap.end(); ++it)
         {
-            states.texture = it->first;
-            target.draw(it->second, states);
+            if (it->second.getVertexCount() > 0)
+            {
+                states.texture = it->first;
+                target.draw(it->second, states);
+            }
         }
     }
 }
@@ -253,7 +257,8 @@ void Text::ensureGeometryUpdate() const
     m_geometryNeedUpdate = false;
 
     // Clear the previous geometry
-    m_verticesMap.clear();
+    for (VertexArrayMap::iterator it = m_verticesMap.begin(); it != m_verticesMap.end(); ++it)
+        it->second.clear();
     m_bounds = FloatRect();
 
     // No font: nothing to draw


### PR DESCRIPTION
**SFML Tasks**

* [x] Update code w.r.t. outlined text (#840)
* [x] Reject and close this PR

----

Extending `Font` and `Text` to support multiple textures so that glyphs are not discarded in case one texture gets filled.
This can be useful in any of the following scenarios:
- Big text
- Large alphabets
- OpenGL implementations with a small maximum texture size (e.g. software renderers)

Discussed in this [forum thread](http://en.sfml-dev.org/forums/index.php?topic=19510.0).
