### PR TITLE
Bugfix: Use the mouse button constant instead of 0 to avoid a compiler error on OSX

### DIFF
--- a/src/SFML/Window/OSX/InputImpl.mm
+++ b/src/SFML/Window/OSX/InputImpl.mm
@@ -185,7 +185,7 @@ void InputImpl::setMousePosition(const Vector2i& position)
     CGEventRef event = CGEventCreateMouseEvent(NULL,
                                                kCGEventMouseMoved,
                                                pos,
-                                               /*we don't care about this: */0);
+                                               /* we don't care about this: */ kCGMouseButtonLeft);
     CGEventPost(kCGHIDEventTap, event);
     CFRelease(event);
     // This is a workaround to deprecated CGSetLocalEventsSuppressionInterval.


### PR DESCRIPTION
Simple fix that prevents a compiler error from breaking the build in Xcode 7.0.1