### PR TITLE
Create and install PDB debug symbols alongside binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 2.8.3)
 
 # define a macro that helps defining an option
 macro(sfml_set_option var default type docstring)
@@ -127,6 +127,16 @@ endif()
 
 # Visual C++: remove warnings regarding SL security and algorithms on pointers
 if(SFML_COMPILER_MSVC)
+    # add an option to choose whether PDB debug symbols should be generated (defaults to true when possible)
+    if(CMAKE_VERSION VERSION_LESS 3.1)
+        sfml_set_option(SFML_GENERATE_PDB FALSE BOOL "True to generate PDB debug symbols, FALSE otherwise. Requires CMake 3.1.")
+        if(SFML_GENERATE_PDB)
+            message(FATAL_ERROR "Generation of PDB files (SFML_GENERATE_PDB) requires at least CMake 3.1.0")
+        endif()
+    else()
+        sfml_set_option(SFML_GENERATE_PDB TRUE BOOL "True to generate PDB debug symbols, FALSE otherwise. Requires CMake 3.1.")
+    endif()
+
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS)
 endif()
 
@@ -232,10 +242,12 @@ if(NOT SFML_BUILD_FRAMEWORKS)
             COMPONENT devel
             FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl")
 
-    install(DIRECTORY ${PROJECT_BINARY_DIR}/lib
-            DESTINATION .
-            COMPONENT devel
-            FILES_MATCHING PATTERN "*.pdb")
+    if(SFML_GENERATE_PDB)
+        install(DIRECTORY ${PROJECT_BINARY_DIR}/lib
+                DESTINATION .
+                COMPONENT devel
+                FILES_MATCHING PATTERN "*.pdb")
+    endif()
 else()
     # find only "root" headers
     file(GLOB SFML_HEADERS RELATIVE ${PROJECT_SOURCE_DIR} "include/SFML/*")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1)
 
 # define a macro that helps defining an option
 macro(sfml_set_option var default type docstring)
@@ -231,6 +231,11 @@ if(NOT SFML_BUILD_FRAMEWORKS)
             DESTINATION .
             COMPONENT devel
             FILES_MATCHING PATTERN "*.hpp" PATTERN "*.inl")
+
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/lib
+            DESTINATION .
+            COMPONENT devel
+            FILES_MATCHING PATTERN "*.pdb")
 else()
     # find only "root" headers
     file(GLOB SFML_HEADERS RELATIVE ${PROJECT_SOURCE_DIR} "include/SFML/*")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -60,7 +60,7 @@ macro(sfml_add_library target)
     endif()
 
     # For Visual Studio on Windows, export debug symbols (PDB files) to lib directory
-    if(SFML_OS_WINDOWS AND SFML_COMPILER_MSVC)
+    if(SFML_GENERATE_PDB)
         # PDB files are only generated in Debug and RelWithDebInfo configurations, find out which one
         if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
             set(SFML_PDB_POSTFIX "-d")


### PR DESCRIPTION
##### Concerns PDB (program database) files -- debug symbols generated by Visual Studio

This modification outputs the generated PDB files alongside the static/import libraries in the `lib` directory. In SFML projects, it resolves the linker warning 4099, which cannot be disabled otherwise.
```
warning LNK4099: PDB 'vc140.pdb' was not found with ...; linking object as if no debug info
```

The minimally required CMake version is raised to 3.1, because the target properties `COMPILE_PDB_NAME` and `COMPILE_PDB_OUTPUT_DIRECTORY` are not available in older versions.

This pull request is a cleaner alternative to #980, as it properly generates the PDB files and doesn't just pack debug information into the static/import libraries.

*Btw, I labeled this as feature and not bugfix because the primary purpose is to provide debug symbols for SFML, the fixed warning is just a side effect... but we can also re-label it, I don't care* ;)