### PR TITLE
Fixed seeking in multi channel FLAC files.

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -153,6 +153,9 @@ public:
     /// precision. If you need to jump to a given time, use the
     /// other overload.
     ///
+    /// The sample offset takes the channels into account.
+    /// Offsets can be calculated like this:
+    /// `sampleNumber * sampleRate * channelCount`
     /// If the given offset exceeds to total number of samples,
     /// this function jumps to the end of the sound file.
     ///

--- a/include/SFML/Audio/SoundFileReader.hpp
+++ b/include/SFML/Audio/SoundFileReader.hpp
@@ -79,6 +79,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset
     ///
+    /// The sample offset takes the channels into account.
+    /// Offsets can be calculated like this:
+    /// `sampleNumber * sampleRate * channelCount`
     /// If the given offset exceeds to total number of samples,
     /// this function must jump to the end of the file.
     ///

--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -210,7 +210,8 @@ bool SoundFileReaderFlac::check(InputStream& stream)
 ////////////////////////////////////////////////////////////
 SoundFileReaderFlac::SoundFileReaderFlac() :
 m_decoder(NULL),
-m_clientData()
+m_clientData(),
+m_channelCount(0)
 {
 }
 
@@ -248,6 +249,9 @@ bool SoundFileReaderFlac::open(InputStream& stream, Info& info)
     // Retrieve the sound properties
     info = m_clientData.info; // was filled in the "metadata" callback
 
+    // We must keep the channel count for the seek function
+    m_channelCount = info.channelCount;
+
     return true;
 }
 
@@ -262,7 +266,8 @@ void SoundFileReaderFlac::seek(Uint64 sampleOffset)
     m_clientData.remaining = 0;
     m_clientData.leftovers.clear();
 
-    FLAC__stream_decoder_seek_absolute(m_decoder, sampleOffset);
+    // FLAC decoder expects absolute sample offset, so we take the channel count out
+    FLAC__stream_decoder_seek_absolute(m_decoder, sampleOffset / m_channelCount);
 }
 
 

--- a/src/SFML/Audio/SoundFileReaderFlac.hpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.hpp
@@ -82,6 +82,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset
     ///
+    /// The sample offset takes the channels into account.
+    /// Offsets can be calculated like this:
+    /// `sampleNumber * sampleRate * channelCount`
     /// If the given offset exceeds to total number of samples,
     /// this function must jump to the end of the file.
     ///
@@ -128,8 +131,9 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    FLAC__StreamDecoder* m_decoder;    ///< FLAC decoder
-    ClientData           m_clientData; ///< Structure passed to the decoder callbacks
+    FLAC__StreamDecoder* m_decoder;      ///< FLAC decoder
+    ClientData           m_clientData;   ///< Structure passed to the decoder callbacks
+    unsigned int         m_channelCount; ///< number of channels of the sound file
 };
 
 } // namespace priv

--- a/src/SFML/Audio/SoundFileReaderOgg.hpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.hpp
@@ -82,6 +82,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset
     ///
+    /// The sample offset takes the channels into account.
+    /// Offsets can be calculated like this:
+    /// `sampleNumber * sampleRate * channelCount`
     /// If the given offset exceeds to total number of samples,
     /// this function must jump to the end of the file.
     ///

--- a/src/SFML/Audio/SoundFileReaderWav.hpp
+++ b/src/SFML/Audio/SoundFileReaderWav.hpp
@@ -74,6 +74,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset
     ///
+    /// The sample offset takes the channels into account.
+    /// Offsets can be calculated like this:
+    /// `sampleNumber * sampleRate * channelCount`
     /// If the given offset exceeds to total number of samples,
     /// this function must jump to the end of the file.
     ///


### PR DESCRIPTION
I was able to reproduce and fix #1040. As suggested in the forum thread you simply had to take out the channel count, because the FLAC decoder expected the absolute sample count.

I have one more improvement though: Update the documentation for [`sf::InputSoundFile::seek`](http://www.sfml-dev.org/documentation/2.3.2/classsf_1_1InputSoundFile.php#aaf97be15020a42e159ff88f76f22af20). There are two overloads. One taking a `sf::Time` and the other one a `sf::UInt64` sample count. I think it would be helpful to make it clear in the doc that the `sf::Time` one uses an absolute value (not taking the channel count into account) and the `sf::UInt64` overload uses a relative offset which considers the channel count. I mean it all makes sense, but I think we should document it a bit better.
Same goes for the [`sf::SoundFileReader::seek()`](http://www.sfml-dev.org/documentation/2.3.2/classsf_1_1SoundFileReader.php#a1e18ade5ffe882bdfa20a2ebe7e2b015). The documentation could give a little heads up that the channel Count has to be taken into account.
I suggest something like this:

```cpp
////////////////////////////////////////////////////////////
/// \brief Change the current read position to the given sample offset
///
/// Attention: Bear in mind that the sample offset takes,
/// the channel count into account. The total number 
/// of samples is caculated like this: 
/// `sampleCount * sampleRate * channelCount`
///
/// If the given offset exceeds to total number of samples,
/// this function must jump to the end of the file.
///
/// \param sampleOffset Index of the sample to jump to, relative to the beginning
///
////////////////////////////////////////////////////////////
```

If nobody has anything against it, I will update the documentation.