### PR TITLE
Fixed mapCoordsToPixel twitching occasionally when zoom is less than 1.f

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -71,6 +71,7 @@ Font::Font() :
 m_library  (NULL),
 m_face     (NULL),
 m_streamRec(NULL),
+m_stroker  (NULL),
 m_refCount (NULL),
 m_info     ()
 {
@@ -85,6 +86,7 @@ Font::Font(const Font& copy) :
 m_library    (copy.m_library),
 m_face       (copy.m_face),
 m_streamRec  (copy.m_streamRec),
+m_stroker    (copy.m_stroker),
 m_refCount   (copy.m_refCount),
 m_info       (copy.m_info),
 m_pages      (copy.m_pages),
@@ -448,6 +450,7 @@ Font& Font::operator =(const Font& right)
     std::swap(m_library,     temp.m_library);
     std::swap(m_face,        temp.m_face);
     std::swap(m_streamRec,   temp.m_streamRec);
+    std::swap(m_stroker,     temp.m_stroker);
     std::swap(m_refCount,    temp.m_refCount);
     std::swap(m_info,        temp.m_info);
     std::swap(m_pages,       temp.m_pages);

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -180,12 +180,21 @@ Vector2i RenderTarget::mapCoordsToPixel(const Vector2f& point, const View& view)
     Vector2f normalized = view.getTransform().transformPoint(point);
 
     // Then convert to viewport coordinates
-    Vector2i pixel;
+    Vector2i viewport_pixel;
     IntRect viewport = getViewport(view);
-    pixel.x = static_cast<int>(( normalized.x + 1.f) / 2.f * viewport.width  + viewport.left);
-    pixel.y = static_cast<int>((-normalized.y + 1.f) / 2.f * viewport.height + viewport.top);
 
-    return pixel;
+	 sf::Vector2f pixel(
+		 ( normalized.x + 1.f) / 2.f * viewport.width  + viewport.left,
+		 (-normalized.y + 1.f) / 2.f * viewport.height + viewport.top);
+
+	 // Round the pixel to prevent shaky behavior when zoomed in
+	 pixel.x += pixel.x < 0.f ? -0.5f : 0.5f;
+	 pixel.y += pixel.y < 0.f ? -0.5f : 0.5f;
+
+    viewport_pixel.x = static_cast<int>(pixel.x);
+    viewport_pixel.y = static_cast<int>(pixel.y);
+
+    return viewport_pixel;
 }
 
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -188,8 +188,8 @@ Vector2i RenderTarget::mapCoordsToPixel(const Vector2f& point, const View& view)
 		 (-normalized.y + 1.f) / 2.f * viewport.height + viewport.top);
 
 	 // Round the pixel to prevent shaky behavior when zoomed in
-	 pixel.x += pixel.x < 0.f ? -0.5f : 0.5f;
-	 pixel.y += pixel.y < 0.f ? -0.5f : 0.5f;
+	 pixel.x += pixel.x < 0.f ? -0.25f : 0.25f;
+	 pixel.y += pixel.y < 0.f ? -0.25f : 0.25f;
 
     viewport_pixel.x = static_cast<int>(pixel.x);
     viewport_pixel.y = static_cast<int>(pixel.y);


### PR DESCRIPTION
mapCoordsToPixel does not round up properly due to floating point inaccuracies due to the explicit floor from the int cast. Adding 0.5f rounds the numbers, fixing the problem.
Here's the bug in action (view is centered on character and the text is placed above it): http://img.cleroth.com/2016-02-04_18-10-50.webm

For some reason it seems to mostly only be vertical twitching... I'm not sure why.
