### PR TITLE
Initialize Font::m_stroker

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -71,6 +71,7 @@ Font::Font() :
 m_library  (NULL),
 m_face     (NULL),
 m_streamRec(NULL),
+m_stroker  (NULL),
 m_refCount (NULL),
 m_info     ()
 {
@@ -85,6 +86,7 @@ Font::Font(const Font& copy) :
 m_library    (copy.m_library),
 m_face       (copy.m_face),
 m_streamRec  (copy.m_streamRec),
+m_stroker    (copy.m_stroker),
 m_refCount   (copy.m_refCount),
 m_info       (copy.m_info),
 m_pages      (copy.m_pages),
@@ -448,6 +450,7 @@ Font& Font::operator =(const Font& right)
     std::swap(m_library,     temp.m_library);
     std::swap(m_face,        temp.m_face);
     std::swap(m_streamRec,   temp.m_streamRec);
+    std::swap(m_stroker,     temp.m_stroker);
     std::swap(m_refCount,    temp.m_refCount);
     std::swap(m_info,        temp.m_info);
     std::swap(m_pages,       temp.m_pages);

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -456,6 +456,10 @@ Font& Font::operator =(const Font& right)
     std::swap(m_pages,       temp.m_pages);
     std::swap(m_pixelBuffer, temp.m_pixelBuffer);
 
+    #ifdef SFML_SYSTEM_ANDROID
+        std::swap(m_stream, temp.m_stream);
+    #endif
+
     return *this;
 }
 


### PR DESCRIPTION
The following code crashes on android with the latest SFML version. The bug was introduced in 957cabb816f69a3d7a3909d24b9e773ffc9a65b5, earlier sfml versions don't crash on this code.
```c++
#include <SFML/Graphics.hpp>
#include <memory>

int main()
{
    std::shared_ptr<sf::Font> font3;

    sf::Font font1;
    font1.loadFromFile("sansation.ttf");

    font3 = std::make_shared<sf::Font>(font1);

    sf::Font font2;
    font2.loadFromFile("sansation.ttf");

    font3 = std::make_shared<sf::Font>(font2);
}
```

The backtrace in adb logcat:
```
02-09 18:10:35.218   949   949 F DEBUG   : backtrace:
02-09 18:10:35.218   949   949 F DEBUG   :     #00 pc 00058eef  /data/app/com.example.tgui-1/lib/x86/libsfml-graphics.so (FT_Stroker_Done+31)
02-09 18:10:35.218   949   949 F DEBUG   :     #01 pc 00019ea6  /data/app/com.example.tgui-1/lib/x86/libsfml-graphics.so (sf::Font::cleanup()+310)
02-09 18:10:35.218   949   949 F DEBUG   :     #02 pc 0001b91e  /data/app/com.example.tgui-1/lib/x86/libsfml-graphics.so (sf::Font::~Font()+30)
02-09 18:10:35.218   949   949 F DEBUG   :     #03 pc 00002dee  /data/app/com.example.tgui-1/lib/x86/libtgui-example.so (std::__1::__shared_ptr_emplace<sf::Font, std::__1::allocator<sf::Font> >::__on_zero_shared()+30)
02-09 18:10:35.218   949   949 F DEBUG   :     #04 pc 00089315  /data/app/com.example.tgui-1/lib/x86/libc++_shared.so (std::__1::__shared_weak_count::__release_shared()+53)
02-09 18:10:35.218   949   949 F DEBUG   :     #05 pc 00002b26  /data/app/com.example.tgui-1/lib/x86/libtgui-example.so (main+422)
02-09 18:10:35.218   949   949 F DEBUG   :     #06 pc 00002c98  /data/app/com.example.tgui-1/lib/x86/libtgui-example.so (sf::priv::main(sf::priv::ActivityStates*)+152)
02-09 18:10:35.218   949   949 F DEBUG   :     #07 pc 00002fd0  /data/app/com.example.tgui-1/lib/x86/libtgui-example.so (sf::priv::ThreadFunctorWithArg<void* (*)(sf::priv::ActivityStates*), sf::priv::ActivityStates*>::run()+16)
02-09 18:10:35.218   949   949 F DEBUG   :     #08 pc 0000e392  /data/app/com.example.tgui-1/lib/x86/libsfml-system.so (sf::Thread::run()+18)
02-09 18:10:35.218   949   949 F DEBUG   :     #09 pc 0000f54b  /data/app/com.example.tgui-1/lib/x86/libsfml-system.so
02-09 18:10:35.218   949   949 F DEBUG   :     #10 pc 00080a93  /system/lib/libc.so (__pthread_start(void*)+56)
02-09 18:10:35.218   949   949 F DEBUG   :     #11 pc 00021952  /system/lib/libc.so (__start_thread+25)
02-09 18:10:35.218   949   949 F DEBUG   :     #12 pc 000170b6  /system/lib/libc.so (__bionic_clone+70)
```

After looking at the SFML source code the following seems to happen: When font1 is loaded, its m_stroker member variable is set, but when making a copy and putting it in font3, the variable is left uninitialized. When reassigning font3, the font that it contained is destructed and it crashes in the [cleanup function](https://github.com/SFML/SFML/blob/master/src/SFML/Graphics/Font.cpp#L476-L477) because m_stroker was not initialized.

The fix is to simply initialize m_stroker in the constructor and also copying its value in the copy constructor.

Forum post: http://en.sfml-dev.org/forums/index.php?topic=19776.msg142320#msg142320