### PR TITLE
Android: No longer try to free the native activity when toggling the virtual keyboard

### DIFF
--- a/src/SFML/Window/Android/InputImpl.cpp
+++ b/src/SFML/Window/Android/InputImpl.cpp
@@ -125,7 +125,6 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
             MethodHideSoftInput, lBinder, lFlags);
         lJNIEnv->DeleteLocalRef(lBinder);
     }
-    lJNIEnv->DeleteLocalRef(lNativeActivity);
     lJNIEnv->DeleteLocalRef(ClassNativeActivity);
     lJNIEnv->DeleteLocalRef(ClassInputMethodManager);
     lJNIEnv->DeleteLocalRef(lDecorView);


### PR DESCRIPTION
This fixes the issue described [here](http://en.sfml-dev.org/forums/index.php?topic=19805).

In short, the line is an error, since we don't copy the `clazz` member/object, so it shouldn't be freed.