### PR TITLE
Added missing <iterator> include in String.hpp

### DIFF
--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Export.hpp>
 #include <SFML/System/Utf.hpp>
+#include <iterator>
 #include <locale>
 #include <string>
 


### PR DESCRIPTION
This include is required for std::back_inserter.

#1068, @Higestromm