### PR TITLE
Added Unicode Support

### DIFF
--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -34,6 +34,17 @@
 #include <locale>
 #include <string>
 
+#ifndef SFML_FORCE_I18N
+#if __cplusplus >= 201103L // C++ 11 introduced utf-x strings
+#define SFML_FORCE_I18N
+#endif
+#endif
+
+#ifdef SFML_FORCE_I18N
+#include <codecvt>
+#include <sstream>
+#endif
+
 
 namespace sf
 {
@@ -103,7 +114,14 @@ public:
     /// \param locale     Locale to use for conversion
     ///
     ////////////////////////////////////////////////////////////
-    String(const char* ansiString, const std::locale& locale = std::locale());
+    String(const char* ansiString, const std::locale& locale = std::locale(
+#ifdef SFML_FORCE_I18N
+		std::locale(),
+		new std::codecvt_utf8<char32_t>
+		// please do not worry about memory leak caused by using "new"
+		// see here: http://www.cplusplus.com/reference/locale/codecvt/codecvt/
+#endif
+		));
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct from an ANSI string and a locale
@@ -140,6 +158,26 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     String(const Uint32* utf32String);
+
+#ifdef SFML_FORCE_I18N
+
+	////////////////////////////////////////////////////////////
+	/// \brief Construct from a C++11 Utf-32 String (U"text")
+	///
+	/// \param utf32String UTF-32 string to assign
+	///
+	////////////////////////////////////////////////////////////
+	String(const char32_t* utf32String);
+
+	////////////////////////////////////////////////////////////
+	/// \brief Construct from a C++11 Utf-16 String (u"text")
+	///
+	/// \param utf32String UTF-16 string to assign
+	///
+	////////////////////////////////////////////////////////////
+	String(const char16_t* utf16String);
+
+#endif // !SFML_FORCE_I18N
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct from an UTF-32 string

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -117,6 +117,24 @@ String::String(const Uint32* utf32String)
         m_string = utf32String;
 }
 
+#ifdef SFML_FORCE_I18N
+
+String::String(const char32_t* utf32String) {
+	if (utf32String)
+		m_string = (Uint32*)utf32String;
+}
+
+String::String(const char16_t * utf16String) {
+	if (utf16String) {
+		std::locale loc(std::locale(), new std::codecvt_utf16<char32_t>);
+		std::basic_stringstream<uint32_t> oss;
+		oss.imbue(loc);
+		oss << utf16String;
+		m_string = oss.str();
+	}
+}
+
+#endif // !SFML_FORCE_I18N
 
 ////////////////////////////////////////////////////////////
 String::String(const std::basic_string<Uint32>& utf32String) :


### PR DESCRIPTION
The ugliest thing in C++ is **signed** char[]. “Oh really is there somebody not using English?”

The second ugliest? “widened char”.

---

**Added utf-8, utf-16, UCS-2 and UCS-4 (C++11 standard) support without compatibility break to C++0x .**

But, I have not tested these code yet.

When it's done, please remember to update the doc of `sf::String`.