### PR TITLE
Include gl2ext.h when building on Android

### DIFF
--- a/include/SFML/OpenGL.hpp
+++ b/include/SFML/OpenGL.hpp
@@ -67,6 +67,7 @@
 
     #include <GLES/gl.h>
     #include <GLES/glext.h>
+    #include <GLES2/gl2ext.h>
 
 #endif
 


### PR DESCRIPTION
This header is needed to make sure newer GL extension tokens such as
GL_EXT_sRGB are defined. This fixes issue #1079.

Note: You'll still need to build against android-21
(-DANDROID_API_MIN=21) or later to ensure GL_EXT_sRGB specifically is
present.