### PR TITLE
Fixed FTP directory listing blocking forever

### DIFF
--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -529,7 +529,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    TcpSocket m_commandSocket; ///< Socket holding the control connection with the server
+    TcpSocket   m_commandSocket; ///< Socket holding the control connection with the server
+    std::string m_receiveBuffer; ///< Received command data that is yet to be processed
 };
 
 } // namespace sf

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -395,8 +395,18 @@ Ftp::Response Ftp::getResponse()
         // Receive the response from the server
         char buffer[1024];
         std::size_t length;
-        if (m_commandSocket.receive(buffer, sizeof(buffer), length) != Socket::Done)
-            return Response(Response::ConnectionClosed);
+
+        if (m_receiveBuffer.empty())
+        {
+            if (m_commandSocket.receive(buffer, sizeof(buffer), length) != Socket::Done)
+                return Response(Response::ConnectionClosed);
+        }
+        else
+        {
+            std::copy(m_receiveBuffer.begin(), m_receiveBuffer.end(), buffer);
+            length = m_receiveBuffer.size();
+            m_receiveBuffer.clear();
+        }
 
         // There can be several lines inside the received buffer, extract them all
         std::istringstream in(std::string(buffer, length), std::ios_base::binary);
@@ -451,6 +461,9 @@ Ftp::Response Ftp::getResponse()
                         {
                             message = separator + line;
                         }
+
+                        // Save the remaining data for the next time getResponse() is called
+                        m_receiveBuffer.assign(buffer + in.tellg(), length - in.tellg());
 
                         // Return the response code and message
                         return Response(static_cast<Response::Status>(code), message);


### PR DESCRIPTION
Fixes #1025.

In certain situations, both the first (150) and second (226) responses to NLST might be read from the command socket in a single call. `getResponse()` would return the 150 response successfully and discard anything else it read from the socket, this could include the full 226 response. When `getResponse()` would be called the second time, it would start a blocking TCP read on the socket that would never complete because the expected data was already read as part of the previous call.

Code and steps to reproduce are already given in #1025.