### PR TITLE
Fixed not being able to set the window icon properly on some Unix window managers

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -329,6 +329,8 @@ private:
     bool                              m_fullscreen;      ///< Is the window in fullscreen?
     bool                              m_cursorGrabbed;   ///< Is the mouse cursor trapped?
     bool                              m_windowMapped;    ///< Has the window been mapped by the window manager?
+    xcb_pixmap_t                      m_iconPixmap;      ///< The current icon pixmap if in use
+    xcb_pixmap_t                      m_iconMaskPixmap;  ///< The current icon mask pixmap if in use
 };
 
 } // namespace priv


### PR DESCRIPTION
Fixes #1087.

Also added support for setting the window icon via ICCCM (_NET_WM_ICON) which provides a higher quality icon in window managers that support icon alpha blending.