### PR TITLE
Fixed small typos in the xcode template

### DIFF
--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -1,6 +1,6 @@
 
 //
-// Disclamer:
+// Disclaimer:
 // ----------
 //
 // This code will work only if you selected window, graphics and audio.

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -1,6 +1,6 @@
 
 //
-// Disclamer:
+// Disclaimer:
 // ----------
 //
 // This code will work only if you selected window, graphics and audio.


### PR DESCRIPTION
This is a rather trivial issue, but I found typos in the xcode templates. In the main.cpp files for both the Application template and the Command Line Tool template, the disclaimer part had a typo at the beginning. I know that this is a small issue, but I think it would look nicer if the typos were fixed.