### PR TITLE
Set CMake minimum version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 2.8.3)
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
+
+cmake_minimum_required(VERSION 2.8.12)
 
 # define a macro that helps defining an option
 macro(sfml_set_option var default type docstring)


### PR DESCRIPTION
CMake 2.8.3 can't find X11 on Linux. Changing version to 2.8.12 helps.
Tested on Ubuntu 14.04.