### PR TITLE
Propagate library dependencies

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -1,3 +1,6 @@
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
+
 include(CMakeParseArguments)
 
 # add a new target which is a SFML library
@@ -89,7 +92,7 @@ macro(sfml_add_library target)
 
     # link the target to its SFML dependencies
     if(THIS_DEPENDS)
-        target_link_libraries(${target} ${THIS_DEPENDS})
+        target_link_libraries(${target} PUBLIC ${THIS_DEPENDS})
     endif()
 
     # build frameworks or dylibs
@@ -129,7 +132,7 @@ macro(sfml_add_library target)
 
     # link the target to its external dependencies
     if(THIS_EXTERNAL_LIBS)
-        target_link_libraries(${target} ${THIS_EXTERNAL_LIBS})
+        target_link_libraries(${target} PUBLIC ${THIS_EXTERNAL_LIBS})
     endif()
 
     # add the install rule

--- a/examples/X11/CMakeLists.txt
+++ b/examples/X11/CMakeLists.txt
@@ -1,16 +1,12 @@
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
 
 set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/X11)
 
 # all source files
 set(SRC ${SRCROOT}/X11.cpp)
 
-# find OpenGL and X11
-find_package(OpenGL REQUIRED)
-include_directories(${OPENGL_INCLUDE_DIR})
-find_package(X11 REQUIRED)
-include_directories(${X11_INCLUDE_DIR})
-
 # define the X11 target
 sfml_add_example(X11 GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-window sfml-system ${OPENGL_LIBRARIES} ${X11_LIBRARIES})
+                 DEPENDS sfml-window)


### PR DESCRIPTION
PUBLIC can be added to target_link_libraries to show the fact that when we
linking our library to something we need to link dependencies too.

See documentation for details:
* https://cmake.org/cmake/help/v2.8.12/cmake.html#command:target_link_libraries

Reduce dependencies list for example/X11 to show how it works.