### PR TITLE
Deleted unnecessary "public" in Socket.hpp

### DIFF
--- a/include/SFML/Network/Socket.hpp
+++ b/include/SFML/Network/Socket.hpp
@@ -68,8 +68,6 @@ public:
         AnyPort = 0 ///< Special value that tells the system to pick any available port
     };
 
-public:
-
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///


### PR DESCRIPTION
This modificator doesn't have sense here, this was declared public previously.