### PR TITLE
Correctly add XCB components if no components are requested

### DIFF
--- a/cmake/Modules/FindXCB.cmake
+++ b/cmake/Modules/FindXCB.cmake
@@ -68,7 +68,7 @@ IF(NOT WIN32)
         endif()
     ELSE()
         # Add component name to the component list
-        set(${XCB_COMPONENTS} ${XCB_FIND_COMPONENTS})
+        set(XCB_COMPONENTS ${XCB_FIND_COMPONENTS})
     ENDIF()
 
     # Loop through requested xcb components (does not contain xlib_xcb)


### PR DESCRIPTION
This commit fixes the FindXCB.cmake module for the case no components
are requested. The previous version assigned `XCB_FIND_COMPONENTS`
list to an empty variable name.

I was lucky enough to catch the bug in a corner case where both
`XCB_COMPONENTS` and `XCB_FIND_COMPONENTS` were empty and `set()`
command failed, but note this awesome CMake language supports more annoying
corner cases like `XCB_COMPONENTS` empty and `XCB_FIND_COMPONENTS`
with two elements, which results in the following `set()` invocation:

``` cmake
set(${XCB_FIND_COMPONENTS[0]} ${XCB_FIND_COMPONENTS[1]})
```

So always beware of CMake secret charms...