### PR TITLE
Fixed inconsistent seek behavior in SoundStream

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -32,6 +32,7 @@
 #include <SFML/System/NonCopyable.hpp>
 #include <SFML/System/Time.hpp>
 #include <string>
+#include <algorithm>
 
 
 namespace sf
@@ -147,6 +148,22 @@ public:
     Time getDuration() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the read offset of the file in time
+    ///
+    /// \return Time position
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getTimeOffset() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the read offset of the file in samples
+    ///
+    /// \return Sample position
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint64 getSampleOffset() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset
     ///
     /// This function takes a sample offset to provide maximum
@@ -203,6 +220,7 @@ private:
     SoundFileReader* m_reader;       ///< Reader that handles I/O on the file's format
     InputStream*     m_stream;       ///< Input stream used to access the file's data
     bool             m_streamOwned;  ///< Is the stream internal or external?
+    Uint64           m_sampleOffset; ///< Sample Read Position
     Uint64           m_sampleCount;  ///< Total number of samples in the file
     unsigned int     m_channelCount; ///< Number of channels of the sound
     unsigned int     m_sampleRate;   ///< Number of samples per second

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -168,10 +168,9 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    InputSoundFile     m_file;     ///< The streamed music file
-    Time               m_duration; ///< Music duration
-    std::vector<Int16> m_samples;  ///< Temporary buffer of samples
-    Mutex              m_mutex;    ///< Mutex protecting the data
+    InputSoundFile     m_file;    ///< The streamed music file
+    std::vector<Int16> m_samples; ///< Temporary buffer of samples
+    Mutex              m_mutex;   ///< Mutex protecting the data
 };
 
 } // namespace sf

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -254,11 +254,12 @@ private:
     /// playing queue.
     ///
     /// \param bufferNum Number of the buffer to fill (in [0, BufferCount])
+    /// \param immediateLoop Treat empty buffers as spent, and act on loops immediately
     ///
     /// \return True if the stream source has requested to stop, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool fillAndPushBuffer(unsigned int bufferNum);
+    bool fillAndPushBuffer(unsigned int bufferNum, bool immediateLoop = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Fill the audio buffers and put them all into the playing queue

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -36,8 +36,7 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 Music::Music() :
-m_file    (),
-m_duration()
+m_file    ()
 {
 
 }
@@ -105,7 +104,7 @@ bool Music::openFromStream(InputStream& stream)
 ////////////////////////////////////////////////////////////
 Time Music::getDuration() const
 {
-    return m_duration;
+    return m_file.getDuration();
 }
 
 
@@ -118,8 +117,8 @@ bool Music::onGetData(SoundStream::Chunk& data)
     data.samples     = &m_samples[0];
     data.sampleCount = static_cast<std::size_t>(m_file.read(&m_samples[0], m_samples.size()));
 
-    // Check if we have reached the end of the audio file
-    return data.sampleCount == m_samples.size();
+    // Check if we have stopped obtaining samples or reached the end of the audio file
+    return (data.sampleCount != 0) && (m_file.getSampleOffset() < m_file.getSampleCount());
 }
 
 
@@ -135,9 +134,6 @@ void Music::onSeek(Time timeOffset)
 ////////////////////////////////////////////////////////////
 void Music::initialize()
 {
-    // Compute the music duration
-    m_duration = m_file.getDuration();
-
     // Resize the internal buffer so that it can contain 1 second of audio samples
     m_samples.resize(m_file.getSampleRate() * m_file.getChannelCount());
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -77,7 +77,9 @@ SoundStream::~SoundStream()
 void SoundStream::initialize(unsigned int channelCount, unsigned int sampleRate)
 {
     m_channelCount = channelCount;
-    m_sampleRate   = sampleRate;
+    m_sampleRate = sampleRate;
+    m_samplesProcessed = 0;
+    m_isStreaming = false;
 
     // Deduce the format from the number of channels
     m_format = priv::AudioDevice::getFormatFromChannelCount(channelCount);
@@ -127,11 +129,7 @@ void SoundStream::play()
         stop();
     }
 
-    // Move to the beginning
-    onSeek(Time::Zero);
-
     // Start updating the stream in a separate thread to avoid blocking the application
-    m_samplesProcessed = 0;
     m_isStreaming = true;
     m_threadStartState = Playing;
     m_thread.launch();
@@ -397,7 +395,7 @@ void SoundStream::streamData()
 
 
 ////////////////////////////////////////////////////////////
-bool SoundStream::fillAndPushBuffer(unsigned int bufferNum)
+bool SoundStream::fillAndPushBuffer(unsigned int bufferNum, bool immediateLoop)
 {
     bool requestStop = false;
 
@@ -417,6 +415,13 @@ bool SoundStream::fillAndPushBuffer(unsigned int bufferNum)
             // If we previously had no data, try to fill the buffer once again
             if (!data.samples || (data.sampleCount == 0))
             {
+                // If immediateLoop is specified, we have to immediately adjust the sample count
+                if (immediateLoop)
+                {
+                    // We just tried to begin preloading at EOF: reset the sample count
+                    m_samplesProcessed = 0;
+                    m_endBuffers[bufferNum] = false;
+                }
                 return fillAndPushBuffer(bufferNum);
             }
         }
@@ -451,7 +456,9 @@ bool SoundStream::fillQueue()
     bool requestStop = false;
     for (int i = 0; (i < BufferCount) && !requestStop; ++i)
     {
-        if (fillAndPushBuffer(i))
+        // Since no sound has been loaded yet, we can't schedule loop seeks preemptively,
+        // So if we start on EOF or Loop End, we let fillAndPushBuffer() adjust the sample count
+        if (fillAndPushBuffer(i, (i == 0)))
             requestStop = true;
     }
 


### PR DESCRIPTION
Sorry for being so spotty with my updates to the Loop Points. One of the things I was tasked to do was isolate my bugfixes for `sf::SoundStream` into a separate PR so that #629 could be decided independently.

Now, for anyone who doesn't know what this is about, here's a summary of what I addressed in this PR, namely two edge-cases that break the consistency of `m_samplesProcessed` and one regression when `setPlayingOffset()` and `play()` are used when the sound is stopped:

I only found the first one because I was using a file that was an exact numbers of seconds long, which matches the SoundStream buffer size. Currently, if `onGetData()` reads to the exact end of the file, it will return `true` due to the full read, even though there's no more data available afterward. However, this means that the buffer isn't properly marked as an "end". When it's time to read the next buffer after that, it will read 0 bytes and return `false`. This will trigger a seek to 0 (in the current version without loop points), and flag the buffer as an "end". But since the read was 0, the buffer then gets refilled with 1 second of post-seek data. The two buffers get played normally, but now the *2nd* one is flagged as the end, even though it contains beginning data. And when it gets unloaded, the sample counter gets reset one second too late. This creates a "lag" that persists over the playback, forever reporting an incorrect play position.

My fix involved adding `m_tellPos`, in `sf::Music` to keep track of the sample position in the underlying file. Now, if the position afterwards lands on the EOF, `onGetData()` will return false, even if the a read fills the whole buffer. I couldn't fix it in `sf::SoundStream` itself, because modifying the signature of `onSeek()` would break the API. But `sf::Music` is close enough to the underlying file to track its position, and has enough leverage with its return value from `onGetData()` so it can force a zero-seek at the right time.

A slightly different case involved a similar error when the play position starts at the end-of-file. It causes the same "delayed zero-read" effect, though the offset corrects itself after a loop iteration. Since no sound is loaded yet, there's no rightful owner of the "end" status, so my solution is the `immediateLoop` parameter in `fillAndPushBuffer()` it's only set to `true` during the `fillQueue()` call as the thread starts up. It essentially gives `fillAndPushBuffer()` permission to immediately adjust `m_samplesProcessed` to the correct post-loop value, instead of deferring things until the refilled buffer gets unloaded a second too late.

These fixes combined lead to an included easy-fix of #966, since `sf::Music()` can now clamp a seek overrun to the EOF, invoking the new reset behavior at the next `onGetData()`.

I'd argue that the last "bug" is a regression. `setPlayingOffset()` used to always begin playing the sound when it was called. But when that behavior was removed, the ability to manually start playing afterward from the new offset wasn't added. I found this issue during my Loop Point testing, when I tried to set the "play start" by calling `setPlayingOffset()` between `openFromFile()` and `play()`. I noticed that the music always began from the start regardless, due to the `onSeek(Time::Zero);` call in `play()` and I didn't see any proper reason for it. The paused and playing cases were already covered, and if the music was stopped, then there are 3 possibilities. Either the music was newly loaded (already 0), newly-stopped (already 0), or had its offset explicitly adjusted after loading or stopping (why would you overrule that?). So I removed the `onSeek(Time::Zero);` line, and moved the `m_samplesProcessed = 0;` line to `initialize()`, to make sure case 1 is still covered.

So that's my summary of the bugs, in isolation from #629. I'll replace the code in that PR with fast-forward from this one soon.

EDIT: Here's a new [test.cpp](http://pastebin.com/Ae6AyLkW). It's just my newest Loop Point one with the actual loop point calls disabled by a commented-out macro at the top. I still recommend using it with [count.wav](https://dl.dropboxusercontent.com/u/82878780/Misc/count.wav).


EDIT by @mantognini: [both the source code and sound file in one archive](https://github.com/SFML/SFML/files/392428/test.material.zip)
