### PR TITLE
UdpSocket.hpp typo in comment for void unbind()

### DIFF
--- a/include/SFML/Network/UdpSocket.hpp
+++ b/include/SFML/Network/UdpSocket.hpp
@@ -95,9 +95,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Unbind the socket from the local port to which it is bound
     ///
-    /// The port that the socket was previously using is immediately
-    /// available after this function is called. If the
-    /// socket is not bound to a port, this function has no effect.
+    /// The port that the socket was previously bound to is immediately
+    /// made available to the operating system after this function is called.
+    /// This means that a subsequent call to bind() will be able to re-bind
+    /// the port if no other process has done so in the mean time.
+    /// If the socket is not bound to a port, this function has no effect.
     ///
     /// \see bind
     ///


### PR DESCRIPTION
Function  **void unbind()**;
Commentary:
 /// The port that the socket was previously using is immediately
 /// **_available_** after this function is called.

Typo in word "available" contradicts with function's designation:
Should be:
/// The port that the socket was previously using is immediately
/// **_unavailable_** after this function is called.