### PR TITLE
Define SFML_OS_FREEBSD when compiling for kFreeBSD

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -27,7 +27,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         # don't use the OpenGL ES implementation on Linux
         set(OPENGL_ES 0)
     endif()
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+elseif(CMAKE_SYSTEM_NAME MATCHES "^k?FreeBSD$")
     set(SFML_OS_FREEBSD 1)
     # don't use the OpenGL ES implementation on FreeBSD
     set(OPENGL_ES 0)


### PR DESCRIPTION
As a result of pull request #1102, SFML lost the ability to compile on Debian's kFreeBSD architecture. On this architecture, `CMAKE_SYSTEM_NAME` is "kFreeBSD" because it isn't a real FreeBSD system (only the kernel is from FreeBSD).

This PR converts the FreeBSD check in Config.cmake back to a more restrictive MATCHES if statement.

Failing build log for reference:
https://buildd.debian.org/status/fetch.php?pkg=libsfml&arch=kfreebsd-amd64&ver=2.4.0%2Bdfsg-1&stamp=1470919689