### PR TITLE
Changed uniform error message

### DIFF
--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -1022,7 +1022,7 @@ int Shader::getUniformLocation(const std::string& name)
         m_uniforms.insert(std::make_pair(name, location));
 
         if (location == -1)
-            err() << "Parameter \"" << name << "\" not found in shader" << std::endl;
+            err() << "Uniform \"" << name << "\" not found in shader" << std::endl;
 
         return location;
     }


### PR DESCRIPTION
Changed the error message for using uniforms to use the word uniform instead of the word parameter since parameter's deprecation.

A minor text output alteration to keep consistency for the new interface.