### PR TITLE
Updated sf::Window documentation

### DIFF
--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -354,9 +354,7 @@ public:
     /// If set, grabs the mouse cursor inside this window's client
     /// area so it may no longer be moved outside its bounds.
     /// Note that grabbing is only active while the window has
-    /// focus and calling this function for fullscreen windows
-    /// won't have any effect (fullscreen windows always grab the
-    /// cursor).
+    /// focus.
     ///
     /// \param grabbed True to enable, false to disable
     ///


### PR DESCRIPTION
removed part of the sentence that stated that cursor grabbing is different for fullscreen windows as this is not the case.

as mentioned here:
http://en.sfml-dev.org/forums/index.php?topic=20671.msg148597#msg148597