### PR TITLE
Fixed leak of XVisualInfo objects during GlxContext creation.

### DIFF
--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -482,8 +482,11 @@ void GlxContext::createSurface(GlxContext* shared, unsigned int width, unsigned 
                 if (visual->visualid == visualInfo.visualid)
                 {
                     config = &configs[i];
+                    XFree(visual);
                     break;
                 }
+
+                XFree(visual);
             }
 
             if (config)
@@ -640,8 +643,11 @@ void GlxContext::createContext(GlxContext* shared)
             if (visual->visualid == visualInfo->visualid)
             {
                 config = &configs[i];
+                XFree(visual);
                 break;
             }
+
+            XFree(visual);
         }
 
         if (!config)


### PR DESCRIPTION
See corresponding forum post:
http://en.sfml-dev.org/forums/index.php?topic=20728.0