### PR TITLE
Fixed possible hang when setting visibility if external window source…

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1003,7 +1003,7 @@ void WindowImplX11::setVisible(bool visible)
 
         // Before continuing, make sure the WM has
         // internally marked the window as viewable
-        while (!m_windowMapped)
+        while (!m_windowMapped && !m_isExternal)
             processEvents();
     }
     else
@@ -1023,7 +1023,7 @@ void WindowImplX11::setVisible(bool visible)
 
         // Before continuing, make sure the WM has
         // internally marked the window as unviewable
-        while (m_windowMapped)
+        while (m_windowMapped && !m_isExternal)
             processEvents();
     }
 }


### PR DESCRIPTION
Some window sources e.g. Qt don't bother to forward all events to us. This breaks the assumption that we will eventually get a VisibilityNotify event when we set the window's visibility ourselves. This fix disables tracking the mapping state of the window if it comes from an external source since they are the ones who should take care of mapping and visibility state.

See: http://en.sfml-dev.org/forums/index.php?topic=20725.0