### PR TITLE
Clarify documentation on Rect::contains function bounds

### DIFF
--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -96,7 +96,7 @@ public:
     /// \brief Check if a point is inside the rectangle's area
     ///
     /// This check is non-inclusive. If the point lies on the
-    /// border of the rect, this function will return false.
+    /// edge of the rectangle, this function will return false.
     ///
     /// \param x X coordinate of the point to test
     /// \param y Y coordinate of the point to test
@@ -112,7 +112,7 @@ public:
     /// \brief Check if a point is inside the rectangle's area
     ///
     /// This check is non-inclusive. If the point lies on the
-    /// border of the rect, this function will return false.
+    /// edge of the rectangle, this function will return false.
     ///
     /// \param point Point to test
     ///

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -95,6 +95,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check if a point is inside the rectangle's area
     ///
+    /// This check is non-inclusive. If the point lies on the
+    /// border of the rect, this function will return false.
+    ///
     /// \param x X coordinate of the point to test
     /// \param y Y coordinate of the point to test
     ///
@@ -107,6 +110,9 @@ public:
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if a point is inside the rectangle's area
+    ///
+    /// This check is non-inclusive. If the point lies on the
+    /// border of the rect, this function will return false.
     ///
     /// \param point Point to test
     ///


### PR DESCRIPTION
Add documentation clarifying that points on a Rect's "border" will not be considered as if they were contained by the Rect.

Perhaps this behaviour could be changed? Or another function could be added? For now this should suffice.

Thanks