### PR TITLE
Added some simple messaging when trying to build under Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ endmacro()
 # determine whether to create a debug or release build
 sfml_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
 
+# Suppress Cygwin legacy warning
+set(CMAKE_LEGACY_CYGWIN_WIN32 0)
+
 # set Android specific options
 
 # define the minimum API level to be used
@@ -30,6 +33,8 @@ sfml_set_option(ANDROID_STL c++_shared STRING "Choose the STL implementation to 
 if(NOT ANDROID_ABI)
     set(ANDROID_ABI armeabi-v7a)
 endif()
+
+#end of Android specific options
 
 # project name
 project(SFML)

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -64,6 +64,10 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 
     # use the OpenGL ES implementation on Android
     set(OPENGL_ES 1)
+# comparing CMAKE_SYSTEM_NAME with "CYGWIN" generates a false warning depending on the CMake version
+# let's avoid it so the actual error is more visible
+elseif(${CYGWIN})
+    message(FATAL_ERROR "Unfortunately SFML doesn't support Cygwin's 'hybrid' status between both Windows and Linux derivatives.\nIf you insist on using the GCC, please use a standalone build of MinGW without the Cygwin environment instead.")
 else()
     message(FATAL_ERROR "Unsupported operating system or environment")
     return()


### PR DESCRIPTION
While this doesn't change anything directly, it makes it more clear why CMake is actually failing and prevents [situations such as the one described here](http://gamedev.stackexchange.com/questions/130255/setting-up-sfml-with-clion-on-windows-10).