### PR TITLE
Fixed stack overflow in SoundStream::fillAndPushBuffer() when the underlying stream fails.

### DIFF
--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -282,7 +282,8 @@ private:
 
     enum
     {
-        BufferCount = 3 ///< Number of audio buffers used by the streaming loop
+        BufferCount = 3,    ///< Number of audio buffers used by the streaming loop
+        BufferRetries = 2   ///< Number of retries (excluding initial try) for onGetData()
     };
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
While I was testing #1118, I decided to see what happened when I made the underlying file used by a `SoundStream` unavailable mid-play, (for example, putting the audio file on a flash drive and yanking it while my test program was running). The program promptly segfaulted. My debugger showed that the `SoundStream`'s processor thread had hundreds of frames in `fillAndPushBuffer()`.

The underlying issue was with `fillAndPushBuffer`'s retry mechanism. For a looping sound, a read that returns false is assumed to be at the EOF, so the function triggers a seek to the beginning and retries. But when that read contains 0 samples, it tries to reuse that buffer by calling itself recursively.

The issue arises when the underlying stream fails. Like any sane implementation that can only return a `UInt64` to `read()` calls, it will start returning 0 to all requests for data once it errors out. `Music::onGetData()` correctly handles the zero-read and returns false, but `SoundStream::fillAndPushBuffer` expects this to mean it can retry, and it chokes. Specifically, it keeps calling itself recursively and burns through its stack, segfaulting the whole program.

Since I can't change the `onGetData()` and `read()` signatures to propagate the error status in a minor version, the most practical fix is to interpret multiple consecutive zero-reads as an error. I did this by converting the false-read handling code into a retry loop. Currently I have a `BufferRetries` enum constant, set to 2, for 3 tries total. If the third read fails, it leaves the loop and sets `requestStop`, which shuts the thread down as if a non-looping sound had finished playing. My [test program's](http://pastebin.com/W85LkrAX) polling loop sees the `SoundStream` stop, and quits cleanly.

Since this modifies some of the same code as #1118, I fully expect a merge conflict. I will rebase this PR to account for the `immediateLoop` parameter once the other one is merged.
