### PR TITLE
Added missing setActive virtual method to sf::RenderTarget, added set…

### DIFF
--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -63,6 +63,9 @@ int main()
         // mipmapping is purely optional in this example
         texture.generateMipmap();
 
+        // Make the window the active window for OpenGL calls
+        window.setActive(true);
+
         // Enable Z-buffer read and write
         glEnable(GL_DEPTH_TEST);
         glDepthMask(GL_TRUE);
@@ -141,6 +144,9 @@ int main()
         glDisableClientState(GL_NORMAL_ARRAY);
         glDisableClientState(GL_COLOR_ARRAY);
 
+        // Make the window no longer the active window for OpenGL calls
+        window.setActive(false);
+
         // Create a clock for measuring the time elapsed
         sf::Clock clock;
 
@@ -196,13 +202,24 @@ int main()
 
                 // Adjust the viewport when the window is resized
                 if (event.type == sf::Event::Resized)
+                {
+                    // Make the window the active window for OpenGL calls
+                    window.setActive(true);
+
                     glViewport(0, 0, event.size.width, event.size.height);
+
+                    // Make the window no longer the active window for OpenGL calls
+                    window.setActive(false);
+                }
             }
 
             // Draw the background
             window.pushGLStates();
             window.draw(background);
             window.popGLStates();
+
+            // Make the window the active window for OpenGL calls
+            window.setActive(true);
 
             // Clear the depth buffer
             glClear(GL_DEPTH_BUFFER_BIT);
@@ -221,6 +238,9 @@ int main()
 
             // Draw the cube
             glDrawArrays(GL_TRIANGLES, 0, 36);
+
+            // Make the window no longer the active window for OpenGL calls
+            window.setActive(false);
 
             // Draw some text on top of our OpenGL object
             window.pushGLStates();

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -256,6 +256,28 @@ public:
     virtual Vector2u getSize() const = 0;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Activate or deactivate the render target for rendering
+    ///
+    /// This function makes the render target's context current for
+    /// future OpenGL rendering operations (so you shouldn't care
+    /// about it if you're not doing direct OpenGL stuff).
+    /// A render target's context is active only on the current thread,
+    /// if you want to make it active on another thread you have
+    /// to deactivate it on the previous thread first if it was active.
+    /// Only one context can be current in a thread, so if you
+    /// want to draw OpenGL geometry to another render target
+    /// don't forget to activate it again. Activating a render
+    /// target will automatically deactivate the previously active
+    /// context (if any).
+    ///
+    /// \param active True to activate, false to deactivate
+    ///
+    /// \return True if operation was successful, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool setActive(bool active = true) = 0;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Save the current OpenGL render states and matrices
     ///
     /// This function can be used when you mix SFML drawing
@@ -379,20 +401,6 @@ private:
     ///
     ////////////////////////////////////////////////////////////
     void applyShader(const Shader* shader);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Activate the target for rendering
-    ///
-    /// This function must be implemented by derived classes to make
-    /// their OpenGL context current; it is called by the base class
-    /// everytime it's going to use OpenGL calls.
-    ///
-    /// \param active True to make the target active, false to deactivate it
-    ///
-    /// \return True if the function succeeded
-    ///
-    ////////////////////////////////////////////////////////////
-    virtual bool activate(bool active) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Render states cache

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -205,19 +205,6 @@ public:
 private:
 
     ////////////////////////////////////////////////////////////
-    /// \brief Activate the target for rendering
-    ///
-    /// This function is called by the base class
-    /// everytime it's going to use OpenGL calls.
-    ///
-    /// \param active True to make the target active, false to deactivate it
-    ///
-    /// \return True if the function succeeded
-    ///
-    ////////////////////////////////////////////////////////////
-    virtual bool activate(bool active);
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     priv::RenderTextureImpl* m_impl;    ///< Platform/hardware specific implementation

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -113,6 +113,24 @@ public:
     virtual Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Activate or deactivate the window as the current target
+    ///        for OpenGL rendering
+    ///
+    /// A window is active only on the current thread, if you want to
+    /// make it active on another thread you have to deactivate it
+    /// on the previous thread first if it was active.
+    /// Only one window can be active on a thread at a time, thus
+    /// the window previously active (if any) automatically gets deactivated.
+    /// This is not to be confused with requestFocus().
+    ///
+    /// \param active True to activate, false to deactivate
+    ///
+    /// \return True if operation was successful, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool setActive(bool active = true);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Copy the current contents of the window to an image
     ///
     /// \deprecated
@@ -159,18 +177,6 @@ protected:
     ///
     ////////////////////////////////////////////////////////////
     virtual void onResize();
-
-private:
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Activate the target for rendering
-    ///
-    /// \param active True to make the target active, false to deactivate it
-    ///
-    /// \return True if the function succeeded
-    ///
-    ////////////////////////////////////////////////////////////
-    virtual bool activate(bool active);
 };
 
 } // namespace sf

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -98,7 +98,7 @@ RenderTarget::~RenderTarget()
 ////////////////////////////////////////////////////////////
 void RenderTarget::clear(const Color& color)
 {
-    if (activate(true))
+    if (setActive(true))
     {
         // Unbind texture to fix RenderTexture preventing clear
         applyTexture(NULL);
@@ -214,7 +214,7 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
         #define GL_QUADS 0
     #endif
 
-    if (activate(true))
+    if (setActive(true))
     {
         // First set the persistent OpenGL states if it's the very first call
         if (!m_cache.glStatesSet)
@@ -304,7 +304,7 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
 ////////////////////////////////////////////////////////////
 void RenderTarget::pushGLStates()
 {
-    if (activate(true))
+    if (setActive(true))
     {
         #ifdef SFML_DEBUG
             // make sure that the user didn't leave an unchecked OpenGL error
@@ -336,7 +336,7 @@ void RenderTarget::pushGLStates()
 ////////////////////////////////////////////////////////////
 void RenderTarget::popGLStates()
 {
-    if (activate(true))
+    if (setActive(true))
     {
         glCheck(glMatrixMode(GL_PROJECTION));
         glCheck(glPopMatrix());
@@ -358,7 +358,7 @@ void RenderTarget::resetGLStates()
     // Check here to make sure a context change does not happen after activate(true)
     bool shaderAvailable = Shader::isAvailable();
 
-    if (activate(true))
+    if (setActive(true))
     {
         // Make sure that extensions are initialized
         priv::ensureExtensionsInit();

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -156,11 +156,4 @@ const Texture& RenderTexture::getTexture() const
     return m_texture;
 }
 
-
-////////////////////////////////////////////////////////////
-bool RenderTexture::activate(bool active)
-{
-    return setActive(active);
-}
-
 } // namespace sf

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -62,16 +62,16 @@ RenderWindow::~RenderWindow()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderWindow::activate(bool active)
+Vector2u RenderWindow::getSize() const
 {
-    return setActive(active);
+    return Window::getSize();
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2u RenderWindow::getSize() const
+bool RenderWindow::setActive(bool active)
 {
-    return Window::getSize();
+    return Window::setActive(active);
 }
 
 


### PR DESCRIPTION
Added missing `setActive()` virtual method to `sf::RenderTarget` and added `setActive()` calls to the OpenGL example to demonstrate proper explicit context management.

Discussions [here](http://en.sfml-dev.org/forums/index.php?topic=20946.0) and [here](https://github.com/SFML/SFML/pull/1002#issuecomment-251581707).