### PR TITLE
Add sfml include directory to target interface

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -12,7 +12,8 @@ macro(sfml_add_library target)
 
     # create the target
     add_library(${target} ${THIS_SOURCES})
-
+    target_include_directories(${target} INTERFACE ${PROJECT_SOURCE_DIR}/include) 
+    MESSAGE(${PROJECT_SOURCE_ROOT}/include)
     # define the export symbol of the module
     string(REPLACE "-" "_" NAME_UPPER "${target}")
     string(TOUPPER "${NAME_UPPER}" NAME_UPPER)

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -13,7 +13,7 @@ macro(sfml_add_library target)
     # create the target
     add_library(${target} ${THIS_SOURCES})
     target_include_directories(${target} INTERFACE ${PROJECT_SOURCE_DIR}/include) 
-    MESSAGE(${PROJECT_SOURCE_ROOT}/include)
+
     # define the export symbol of the module
     string(REPLACE "-" "_" NAME_UPPER "${target}")
     string(TOUPPER "${NAME_UPPER}" NAME_UPPER)


### PR DESCRIPTION
Adding the sfml include directory to the target interface makes using sfml as a subproject in cmake easier, because linking against one of the sfml libraries then pulls in the sfml include directory automatically to the target include directories.
