### PR TITLE
Fixed GLX extensions being loaded too late

### DIFF
--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -105,10 +105,11 @@ m_ownsWindow(false)
     // Save the creation settings
     m_settings = ContextSettings();
 
-    // Make sure that extensions are initialized if this is not the shared context
-    // The shared context is the context used to initialize the extensions
-    if (shared && shared->m_display)
-        ensureExtensionsInit(shared->m_display, DefaultScreen(shared->m_display));
+    // Open the connection with the X server
+    m_display = OpenDisplay();
+
+    // Make sure that extensions are initialized
+    ensureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface (window or pbuffer if supported)
     createSurface(shared, 1, 1, VideoMode::getDesktopMode().bitsPerPixel);
@@ -129,10 +130,11 @@ m_ownsWindow(false)
     // Save the creation settings
     m_settings = settings;
 
-    // Make sure that extensions are initialized if this is not the shared context
-    // The shared context is the context used to initialize the extensions
-    if (shared && shared->m_display)
-        ensureExtensionsInit(shared->m_display, DefaultScreen(shared->m_display));
+    // Open the connection with the X server
+    m_display = OpenDisplay();
+
+    // Make sure that extensions are initialized
+    ensureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface from the owner window
     createSurface(static_cast< ::Window>(owner->getSystemHandle()));
@@ -153,10 +155,11 @@ m_ownsWindow(false)
     // Save the creation settings
     m_settings = settings;
 
-    // Make sure that extensions are initialized if this is not the shared context
-    // The shared context is the context used to initialize the extensions
-    if (shared && shared->m_display)
-        ensureExtensionsInit(shared->m_display, DefaultScreen(shared->m_display));
+    // Open the connection with the X server
+    m_display = OpenDisplay();
+
+    // Make sure that extensions are initialized
+    ensureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface (window or pbuffer if supported)
     createSurface(shared, width, height, VideoMode::getDesktopMode().bitsPerPixel);
@@ -269,9 +272,6 @@ void GlxContext::display()
 ////////////////////////////////////////////////////////////
 void GlxContext::setVerticalSyncEnabled(bool enabled)
 {
-    // Make sure that extensions are initialized
-    ensureExtensionsInit(m_display, DefaultScreen(m_display));
-
     int result = 0;
 
     // Prioritize the EXT variant and fall back to MESA or SGI if needed
@@ -310,6 +310,9 @@ void GlxContext::setVerticalSyncEnabled(bool enabled)
 ////////////////////////////////////////////////////////////
 XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPerPixel, const ContextSettings& settings)
 {
+    // Make sure that extensions are initialized
+    ensureExtensionsInit(display, DefaultScreen(display));
+
     // Retrieve all the visuals
     int count;
     XVisualInfo* visuals = XGetVisualInfo(display, 0, NULL, &count);
@@ -450,8 +453,6 @@ void GlxContext::updateSettingsFromWindow()
 ////////////////////////////////////////////////////////////
 void GlxContext::createSurface(GlxContext* shared, unsigned int width, unsigned int height, unsigned int bitsPerPixel)
 {
-    m_display = OpenDisplay();
-
     // Choose the visual according to the context settings
     XVisualInfo visualInfo = selectBestVisual(m_display, bitsPerPixel, m_settings);
 
@@ -545,8 +546,6 @@ void GlxContext::createSurface(GlxContext* shared, unsigned int width, unsigned 
 ////////////////////////////////////////////////////////////
 void GlxContext::createSurface(::Window window)
 {
-    m_display = OpenDisplay();
-
     // A window already exists, so just use it
     m_window = window;
 


### PR DESCRIPTION
Fixes issue described [here](http://en.sfml-dev.org/forums/index.php?topic=21384.0) in which multisampling information could not be read out of framebuffer configurations because the extension was not yet loaded when GlxContext::selectBestVisual is called from WindowImplX11.