### PR TITLE
Fixed window menu not working on OS X

### DIFF
--- a/src/SFML/Window/OSX/SFWindow.m
+++ b/src/SFML/Window/OSX/SFWindow.m
@@ -93,7 +93,7 @@
 ////////////////////////////////////////////////////////
 -(BOOL)validateMenuItem:(NSMenuItem*)menuItem
 {
-    return [menuItem action] == @selector(performClose:);
+    return [menuItem action] == @selector(performClose:) || [super validateMenuItem:menuItem];
 }
 
 


### PR DESCRIPTION
This is an alternative implementation of #1180 that doesn't reintroduce #527. The issue is described in #1091.