### PR TITLE
Added CFBundleSupportedPlatforms key-value

### DIFF
--- a/extlibs/libs-osx/Frameworks/FLAC.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/FLAC.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,7 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array><string>MacOSX</string></array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/OpenAL.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/OpenAL.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,7 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array><string>MacOSX</string></array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/freetype.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/freetype.framework/Versions/A/Resources/Info.plist
@@ -2,19 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
-	<key>CFBundleExecutable</key>
-	<string>freetype</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.sfml-dev.freetype</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>1.0</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>freetype</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.sfml-dev.freetype</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array><string>MacOSX</string></array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/ogg.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/ogg.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,7 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array><string>MacOSX</string></array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbis.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbis.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,7 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array><string>MacOSX</string></array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbisenc.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbisenc.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,7 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array><string>MacOSX</string></array>
 </dict>
 </plist>

--- a/extlibs/libs-osx/Frameworks/vorbisfile.framework/Versions/A/Resources/Info.plist
+++ b/extlibs/libs-osx/Frameworks/vorbisfile.framework/Versions/A/Resources/Info.plist
@@ -16,5 +16,7 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array><string>MacOSX</string></array>
 </dict>
 </plist>


### PR DESCRIPTION
This should improve the signing process of Mac Applications.

This improves the frameworks of external dependencies used by SFML. To
patch sfml-*.framework, one would need to customised the
`MACOSX_FRAMEWORK_INFO_PLIST` cmake property and provide a custom
Info.plist file with CFBundleSupportedPlatforms property set. See
https://cmake.org/cmake/help/latest/prop_tgt/FRAMEWORK.html

This is however not required (probably) if one used dylibs instead.

Related to #1020 and #1036. Credits go to @kipbits.

----

This can be merged anytime.