### PR TITLE
Removed time-based poll for joysticks and replaced with manual update

### DIFF
--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -78,6 +78,20 @@ public:
     static bool isConnected(unsigned int index);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable lazy enumeration updates
+    ///
+    /// \param status Whether to rely on windows triggering enumeration updates
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setLazyUpdates(bool status);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the connection status of all joysticks
+    ///
+    ////////////////////////////////////////////////////////////
+    static void updateConnections();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the joystick
     ///
     /// \param index Index assigned to the joystick


### PR DESCRIPTION
Added updateConnections() to JoystickImpl which is called when WM_DEVICECHANGE message is received, this replaces the old functionality of just polling every controller every 0.5s, in the hope of addressing #1179