### PR TITLE
Fixed slight memory leak in sf::Font

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -287,6 +287,7 @@ bool Font::loadFromStream(InputStream& stream)
     if (FT_Stroker_New(static_cast<FT_Library>(m_library), &stroker) != 0)
     {
         err() << "Failed to load font from stream (failed to create the stroker)" << std::endl;
+        delete rec;
         return false;
     }
     m_stroker = stroker;

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -151,19 +151,21 @@ bool Font::loadFromFile(const std::string& filename)
     if (FT_Stroker_New(static_cast<FT_Library>(m_library), &stroker) != 0)
     {
         err() << "Failed to load font \"" << filename << "\" (failed to create the stroker)" << std::endl;
+        FT_Done_Face(face);
         return false;
     }
-    m_stroker = stroker;
 
     // Select the unicode character map
     if (FT_Select_Charmap(face, FT_ENCODING_UNICODE) != 0)
     {
         err() << "Failed to load font \"" << filename << "\" (failed to set the Unicode character set)" << std::endl;
+        FT_Stroker_Done(stroker);
         FT_Done_Face(face);
         return false;
     }
 
     // Store the loaded font in our ugly void* :)
+    m_stroker = stroker;
     m_face = face;
 
     // Store the font information
@@ -214,19 +216,21 @@ bool Font::loadFromMemory(const void* data, std::size_t sizeInBytes)
     if (FT_Stroker_New(static_cast<FT_Library>(m_library), &stroker) != 0)
     {
         err() << "Failed to load font from memory (failed to create the stroker)" << std::endl;
+        FT_Done_Face(face);
         return false;
     }
-    m_stroker = stroker;
 
     // Select the Unicode character map
     if (FT_Select_Charmap(face, FT_ENCODING_UNICODE) != 0)
     {
         err() << "Failed to load font from memory (failed to set the Unicode character set)" << std::endl;
+        FT_Stroker_Done(stroker);
         FT_Done_Face(face);
         return false;
     }
 
     // Store the loaded font in our ugly void* :)
+    m_stroker = stroker;
     m_face = face;
 
     // Store the font information
@@ -287,21 +291,23 @@ bool Font::loadFromStream(InputStream& stream)
     if (FT_Stroker_New(static_cast<FT_Library>(m_library), &stroker) != 0)
     {
         err() << "Failed to load font from stream (failed to create the stroker)" << std::endl;
+        FT_Done_Face(face);
         delete rec;
         return false;
     }
-    m_stroker = stroker;
 
     // Select the Unicode character map
     if (FT_Select_Charmap(face, FT_ENCODING_UNICODE) != 0)
     {
         err() << "Failed to load font from stream (failed to set the Unicode character set)" << std::endl;
         FT_Done_Face(face);
+        FT_Stroker_Done(stroker);
         delete rec;
         return false;
     }
 
     // Store the loaded font in our ugly void* :)
+    m_stroker = stroker;
     m_face = face;
     m_streamRec = rec;
 


### PR DESCRIPTION
Nothing much, but apparently it's all i'm good at 😞 ( see #509 )

There is also an inconsistency in the coding style; Either adding objects to the class as soon as they're created so that cleanup() frees them eventually, as is the case with the stroker object, which is cleaner IMO. Or adding them at the very end and having to clean every single one whenever there's an error loading, as it's the case with original code, this frees memory instantly but irrelevant if there's no errors (most of the time).

But I did not touch that.