### PR TITLE
Fix an issue when sf::Clock is constructed in a global scope leading to crashes

### DIFF
--- a/src/SFML/System/Win32/ClockImpl.cpp
+++ b/src/SFML/System/Win32/ClockImpl.cpp
@@ -33,8 +33,6 @@
 
 namespace
 {
-    sf::Mutex oldWindowsMutex;
-
     LARGE_INTEGER getFrequency()
     {
         LARGE_INTEGER frequency;
@@ -67,6 +65,8 @@ Time ClockImpl::getCurrentTime()
 
     if (oldWindows)
     {
+        static sf::Mutex oldWindowsMutex;
+
         // Acquire a lock (CRITICAL_SECTION) to prevent travelling back in time
         Lock lock(oldWindowsMutex);
 


### PR DESCRIPTION
Having the mutex initialized in the global scope leads to problems if `sf::Clock` is initialized in the global scope as well, because the order of global initialization is undefined.

First reported on [the forum](https://en.sfml-dev.org/forums/index.php?topic=22315.0), confirmed that his fixes it.