### PR TITLE
Remove unused/leftover openForWriting function in InputSoundFile.

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -101,18 +101,6 @@ public:
     bool openFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Open the sound file from the disk for writing
-    ///
-    /// \param filename     Path of the sound file to write
-    /// \param channelCount Number of channels in the sound
-    /// \param sampleRate   Sample rate of the sound
-    ///
-    /// \return True if the file was successfully opened
-    ///
-    ////////////////////////////////////////////////////////////
-    bool openForWriting(const std::string& filename, unsigned int channelCount, unsigned int sampleRate);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Get the total number of audio samples in the file
     ///
     /// \return Number of samples


### PR DESCRIPTION
As mentioned [on the forum](https://en.sfml-dev.org/forums/index.php?topic=22339.0) it looks like the `openForWriting` function in `InputSoundFile` was just forgotten/leftover. It doesn't have an definition and is used nowhere. This PR simply removes the function from the header file.