### PR TITLE
Bugfix: ALCheck.hpp #include issue for compiling iOS

### DIFF
--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -30,8 +30,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 #ifdef SFML_SYSTEM_IOS
-    #include <OpenAl/al.h>
-    #include <OpenAl/alc.h>
+    #include <AL/al.h>
+    #include <AL/alc.h>
 #else
     #include <al.h>
     #include <alc.h>


### PR DESCRIPTION
**SFML Tasks**

* [ ] Create a corresponding issue & decline this PR

----

Modified the #include paths for OpenAL in ALCheck.hpp inside the #ifdef which checks for iOS. Before this change, attempting to compile SFML's static libs for iOS after building them with CMake would throw an error and fail. This changed fixes this issue, and I can confirm audio works in a compiled iOS project using libraries compiled with this fix.

[Link to forum thread](https://en.sfml-dev.org/forums/index.php?topic=22350.0)

To test, build CMake and compile it with Xcode with these [forum instructions](https://en.sfml-dev.org/forums/index.php?topic=13716.0) to validate that compiling the libraries does not fail.