### PR TITLE
Applied ZeroMemory to DEVMODE struct in Win32 to prevent Uninitialized…

### DIFF
--- a/src/SFML/Window/Win32/VideoModeImpl.cpp
+++ b/src/SFML/Window/Win32/VideoModeImpl.cpp
@@ -42,6 +42,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     // Enumerate all available video modes for the primary display adapter
     DEVMODE win32Mode;
     win32Mode.dmSize = sizeof(win32Mode);
+    win32Mode.dmDriverExtra = 0;
     for (int count = 0; EnumDisplaySettings(NULL, count, &win32Mode); ++count)
     {
         // Convert to sf::VideoMode
@@ -61,6 +62,7 @@ VideoMode VideoModeImpl::getDesktopMode()
 {
     DEVMODE win32Mode;
     win32Mode.dmSize = sizeof(win32Mode);
+    win32Mode.dmDriverExtra = 0;
     EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &win32Mode);
 
     return VideoMode(win32Mode.dmPelsWidth, win32Mode.dmPelsHeight, win32Mode.dmBitsPerPel);


### PR DESCRIPTION
… Read.

While working on my game, I ran my executable through [Dr.Memory ](http://www.drmemory.org/)to keep an eye on memory issues. I noticed an Uninitialized Read error being reported where the DEVMODE struct is being used, particularly under the Win32 switchToFullscreen method.  I ran the DEVMODE struct through ZeroMemory and it corrected the issue.

Microsoft's [DEVMODE documentation ](https://msdn.microsoft.com/en-us/library/windows/desktop/dd183565(v=vs.85).aspx) states that many of the struct members need to be initialized to something. I browsed the display code of a few other projects, and running DEVMODE through ZeroMemory is common practice.