### PR TITLE
fix gcc 5 bug

### DIFF
--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -153,6 +153,12 @@ if(SFML_COMPILER_GCC)
     set_source_files_properties(${SRCROOT}/ImageLoader.cpp PROPERTIES COMPILE_FLAGS -fno-strict-aliasing)
 endif()
 
+# see https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
+if(SFML_COMPILER_GCC AND BUILD_SHARED_LIBS)
+    message(WARNING "Applying workaround for https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899")
+    list(APPEND GRAPHICS_EXT_LIBS "-lgcc_s -lgcc")
+endif()
+
 # define the sfml-graphics target
 sfml_add_library(sfml-graphics
                  SOURCES ${SRC} ${DRAWABLES_SRC} ${RENDER_TEXTURE_SRC} ${STB_SRC}


### PR DESCRIPTION
Unfortunately is not possible build SFML on Ubuntu Xenial (16.04) due to a GCC bug.
Further information on [this link](https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899).