### PR TITLE
Fix iOS build error when using @import in ClipboardImpl.mm

### DIFF
--- a/src/SFML/Window/iOS/ClipboardImpl.mm
+++ b/src/SFML/Window/iOS/ClipboardImpl.mm
@@ -27,7 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/iOS/ClipboardImpl.hpp>
 
-@import UIKit
+#import <UIKit/UIKit.h>
 
 namespace sf
 {
@@ -40,7 +40,7 @@ String ClipboardImpl::getString()
     UIPasteboard* pboard = [UIPasteboard generalPasteboard];
     if (pboard.hasStrings)
     {
-        NSString* data = pboard.string
+        NSString* data = pboard.string;
 
         char const* utf8 = [data cStringUsingEncoding:NSUTF8StringEncoding];
         NSUInteger length = [data lengthOfBytesUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Resolves #1271 
**Description**
When compiling for iOS on master there is a build error in ClipboardImpl.mm (see accompanying issue), this fixes that issue. Seems modules get disabled when using Objective-C++ (see https://stackoverflow.com/questions/29701647/use-of-import-when-modules-are-disabled) even when the build settings enable modules.

**Testing**
Open a terminal in the SFML folder and run these commands:
`mkdir build && mkdir build/ios && mkdir build/ios-install`
`cd build/ios`
`cmake ../.. -DCMAKE_INSTALL_PREFIX=../ios-install/ -DIOS=True -G Xcode`
`cmake --build .`

SFML should compile without any errors.