### PR TITLE
Removed unused variable.

### DIFF
--- a/src/SFML/Window/OSX/ClipboardImpl.mm
+++ b/src/SFML/Window/OSX/ClipboardImpl.mm
@@ -57,7 +57,7 @@ void ClipboardImpl::setString(const String& text)
 
     NSPasteboard* pboard = [NSPasteboard generalPasteboard];
     [pboard declareTypes:@[NSPasteboardTypeString] owner:nil];
-    BOOL ok = [pboard setString:data forType:NSPasteboardTypeString];
+    [pboard setString:data forType:NSPasteboardTypeString];
 
     [data release];
 }


### PR DESCRIPTION
As discussed this fixes an unused variable warning on OSX.
Now the last warning remaining is #1122 😄