### PR TITLE
Fixed Wave file writer writing wrong header values

### DIFF
--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -86,9 +86,7 @@ bool SoundFileWriterWav::check(const std::string& filename)
 
 ////////////////////////////////////////////////////////////
 SoundFileWriterWav::SoundFileWriterWav() :
-m_file        (),
-m_sampleCount (0),
-m_channelCount(0)
+m_file()
 {
 }
 
@@ -118,9 +116,6 @@ bool SoundFileWriterWav::open(const std::string& filename, unsigned int sampleRa
         return false;
     }
 
-    // Save the channel count
-    m_channelCount = channelCount;
-
     return true;
 }
 
@@ -129,8 +124,6 @@ bool SoundFileWriterWav::open(const std::string& filename, unsigned int sampleRa
 void SoundFileWriterWav::write(const Int16* samples, Uint64 count)
 {
     assert(m_file.good());
-
-    m_sampleCount += count;
 
     while (count--)
         encode(m_file, *samples++);
@@ -191,8 +184,9 @@ void SoundFileWriterWav::close()
         m_file.flush();
 
         // Update the main chunk size and data sub-chunk size
-        Uint32 dataChunkSize = static_cast<Uint32>(m_sampleCount * m_channelCount * 2);
-        Uint32 mainChunkSize = dataChunkSize + 36;
+        Uint32 fileSize = static_cast<Uint32>(m_file.tellp());
+        Uint32 mainChunkSize = fileSize - 8;  // 8 bytes RIFF header
+        Uint32 dataChunkSize = fileSize - 44; // 44 bytes RIFF + WAVE headers
         m_file.seekp(4);
         encode(m_file, mainChunkSize);
         m_file.seekp(40);

--- a/src/SFML/Audio/SoundFileWriterWav.hpp
+++ b/src/SFML/Audio/SoundFileWriterWav.hpp
@@ -113,8 +113,6 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     std::ofstream m_file;         ///< File stream to write to
-    Uint64        m_sampleCount;  ///< Total number of samples written to the file
-    unsigned int  m_channelCount; ///< Number of channels of the sound
 };
 
 } // namespace priv


### PR DESCRIPTION
Fixes #1280.

Previously when updating the header fields, SFML assumed the number of samples written would be the number of samples per channel, which wasn't the case. Therefore for stereo files the written file length was actually twice the correct value. This fix uses the file size written as a basis, no longer counting the samples written altogether.