### PR TITLE
Caps lock detection

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -148,7 +148,8 @@ public:
         F13,          ///< The F13 key
         F14,          ///< The F14 key
         F15,          ///< The F15 key
-        Pause,        ///< The Pause key
+        Pause,        ///< The Pause key,
+        CAPS,          ///< Whether or not caps lock is on
 
         KeyCount      ///< Keep last -- the total number of keyboard keys
     };

--- a/src/SFML/Window/OSX/HIDInputManager.mm
+++ b/src/SFML/Window/OSX/HIDInputManager.mm
@@ -45,6 +45,7 @@ HIDInputManager& HIDInputManager::getInstance()
 ////////////////////////////////////////////////////////////
 bool HIDInputManager::isKeyPressed(Keyboard::Key key)
 {
+	if(key==Keyboard::CAPS)return false;
     return isPressed(m_keys[key]);
 }
 

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -30,8 +30,8 @@
 #include <SFML/Window/Unix/Display.hpp>
 #include <SFML/System/Err.hpp>
 #include <X11/Xlib.h>
+#include <X11/XKBlib.h>
 #include <X11/keysym.h>
-
 
 namespace sf
 {
@@ -41,7 +41,16 @@ namespace priv
 bool InputImpl::isKeyPressed(Keyboard::Key key)
 {
     // Get the corresponding X11 keysym
-    KeySym keysym = 0;
+
+    if(key==Keyboard::CAPS){
+		Display* display = OpenDisplay();
+		unsigned int n;
+        XkbGetIndicatorState(display, XkbUseCoreKbd, &n);
+        CloseDisplay(display);
+        return (n&0x01)==1;
+	}
+
+    KeySym keysym;
     switch (key)
     {
         case Keyboard::LShift:     keysym = XK_Shift_L;      break;
@@ -177,7 +186,6 @@ bool InputImpl::isKeyPressed(Keyboard::Key key)
         return false;
     }
 }
-
 
 ////////////////////////////////////////////////////////////
 void InputImpl::setVirtualKeyboardVisible(bool /*visible*/)

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -45,7 +45,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 bool InputImpl::isKeyPressed(Keyboard::Key key)
 {
-    int vkey = 0;
+    int vkey;
     switch (key)
     {
         default:                   vkey = 0;             break;
@@ -150,6 +150,7 @@ bool InputImpl::isKeyPressed(Keyboard::Key key)
         case Keyboard::F14:        vkey = VK_F14;        break;
         case Keyboard::F15:        vkey = VK_F15;        break;
         case Keyboard::Pause:      vkey = VK_PAUSE;      break;
+        case Keyboard::CAPS:       return (GetKeyState(VK_CAPITAL) & 1) !=0;
     }
 
     return (GetAsyncKeyState(vkey) & 0x8000) != 0;


### PR DESCRIPTION
Add the ability to check if caps lock is on to Windows and Linux. Mac always returns false (unable to find documentation for the check on OS X), and mobile implementations don't seem to have a isKeyPressed function.