### PR TITLE
Enable comparing sf::Transform and optimize resetting OpenGL back to the identity matrix

### DIFF
--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -403,6 +403,35 @@ SFML_GRAPHICS_API Transform& operator *=(Transform& left, const Transform& right
 ////////////////////////////////////////////////////////////
 SFML_GRAPHICS_API Vector2f operator *(const Transform& left, const Vector2f& right);
 
+////////////////////////////////////////////////////////////
+/// \relates sf::Transform
+/// \brief Overload of binary operator == to compare two transforms
+///
+/// Performs an element-wise comparison of the elements of the
+/// left transform with the elements of the right transform.
+///
+/// \param left Left operand (the first transform)
+/// \param right Right operand (the second transform)
+///
+/// \return true if the transforms are equal, false otherwise
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator ==(const Transform& left, const Transform& right);
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Transform
+/// \brief Overload of binary operator != to compare two transforms
+///
+/// This call is equivalent to !(left == right).
+///
+/// \param left Left operand (the first transform)
+/// \param right Right operand (the second transform)
+///
+/// \return true if the transforms are not equal, false otherwise
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator !=(const Transform& left, const Transform& right);
+
 } // namespace sf
 
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -235,7 +235,7 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
 
             // Since vertices are transformed, we must use an identity transform to render them
             if (!m_cache.useVertexCache)
-                applyTransform(Transform::Identity);
+                glCheck(glLoadIdentity());
         }
         else
         {
@@ -393,6 +393,7 @@ void RenderTarget::resetGLStates()
         glCheck(glEnable(GL_TEXTURE_2D));
         glCheck(glEnable(GL_BLEND));
         glCheck(glMatrixMode(GL_MODELVIEW));
+        glCheck(glLoadIdentity());
         glCheck(glEnableClientState(GL_VERTEX_ARRAY));
         glCheck(glEnableClientState(GL_COLOR_ARRAY));
         glCheck(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
@@ -400,7 +401,6 @@ void RenderTarget::resetGLStates()
 
         // Apply the default SFML states
         applyBlendMode(BlendAlpha);
-        applyTransform(Transform::Identity);
         applyTexture(NULL);
         if (shaderAvailable)
             applyShader(NULL);
@@ -499,7 +499,10 @@ void RenderTarget::applyTransform(const Transform& transform)
 {
     // No need to call glMatrixMode(GL_MODELVIEW), it is always the
     // current mode (for optimization purpose, since it's the most used)
-    glCheck(glLoadMatrixf(transform.getMatrix()));
+    if (transform == Transform::Identity)
+        glCheck(glLoadIdentity());
+    else
+        glCheck(glLoadMatrixf(transform.getMatrix()));
 }
 
 

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -269,4 +269,23 @@ Vector2f operator *(const Transform& left, const Vector2f& right)
     return left.transformPoint(right);
 }
 
+
+////////////////////////////////////////////////////////////
+bool operator ==(const Transform& left, const Transform& right)
+{
+    const float* a = left.getMatrix();
+    const float* b = right.getMatrix();
+
+    return ((a[0]  == b[0])  && (a[1]  == b[1])  && (a[3]  == b[3]) &&
+            (a[4]  == b[4])  && (a[5]  == b[5])  && (a[7]  == b[7]) &&
+            (a[12] == b[12]) && (a[13] == b[13]) && (a[15] == b[15]));
+}
+
+
+////////////////////////////////////////////////////////////
+bool operator !=(const Transform& left, const Transform& right)
+{
+    return !(left == right);
+}
+
 } // namespace sf


### PR DESCRIPTION
In cases where the RenderTarget is forced to go in and out of "cache mode", it will end up constantly uploading the matrix of Transform::Identity to OpenGL even though this is most likely a built in constant (and probably highly optimized). This patch makes use of the built-in and reduces CPU/RAM load in cases where the copying is happening excessively.