### PR TITLE
Fixed various type conversion/comparison warnings.

### DIFF
--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -463,7 +463,7 @@ Ftp::Response Ftp::getResponse()
                         }
 
                         // Save the remaining data for the next time getResponse() is called
-                        m_receiveBuffer.assign(buffer + static_cast<std::streamoff>(in.tellg()), length - static_cast<std::size_t>(in.tellg()));
+                        m_receiveBuffer.assign(buffer + static_cast<std::size_t>(in.tellg()), length - static_cast<std::size_t>(in.tellg()));
 
                         // Return the response code and message
                         return Response(static_cast<Response::Status>(code), message);


### PR DESCRIPTION
I have applied some fixed for the various type conversion/comparison warnings Visual Studio has been complaining about for a while now.

I wasn't certain for every place if the change was done properly and for some places it certainly raises the question if the chosen type is good.

There's one remaining warning that we can't easily fix. It's in the network module when calling `::send()`. [Linux](http://man7.org/linux/man-pages/man2/send.2.html) implements the socket send function with a `size_t`, while [Windows](https://msdn.microsoft.com/en-us/library/windows/desktop/ms740149(v=vs.85).aspx) uses `int`, causing a mismatch between platforms.