### PR TITLE
Fixed small joystick movement getting lost due to the set axes threshold

### DIFF
--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -86,7 +86,10 @@ m_joystickThreshold(0.1f)
     // Get the initial joystick states
     JoystickManager::getInstance().update();
     for (unsigned int i = 0; i < Joystick::Count; ++i)
+    {
         m_joystickStates[i] = JoystickManager::getInstance().getState(i);
+        std::fill_n(m_previousAxes[i], static_cast<std::size_t>(Joystick::AxisCount), 0.f);
+    }
 
     // Get the initial sensor states
     for (unsigned int i = 0; i < Sensor::Count; ++i)
@@ -176,6 +179,10 @@ void WindowImpl::processJoystickEvents()
             event.type = connected ? Event::JoystickConnected : Event::JoystickDisconnected;
             event.joystickButton.joystickId = i;
             pushEvent(event);
+
+            // Clear previous axes positions
+            if (connected)
+                std::fill_n(m_previousAxes[i], static_cast<std::size_t>(Joystick::AxisCount), 0.f);
         }
 
         if (connected)
@@ -186,7 +193,7 @@ void WindowImpl::processJoystickEvents()
                 if (caps.axes[j])
                 {
                     Joystick::Axis axis = static_cast<Joystick::Axis>(j);
-                    float prevPos = previousState.axes[axis];
+                    float prevPos = m_previousAxes[i][axis];
                     float currPos = m_joystickStates[i].axes[axis];
                     if (fabs(currPos - prevPos) >= m_joystickThreshold)
                     {
@@ -196,6 +203,8 @@ void WindowImpl::processJoystickEvents()
                         event.joystickMove.axis = axis;
                         event.joystickMove.position = currPos;
                         pushEvent(event);
+
+                        m_previousAxes[i][axis] = currPos;
                     }
                 }
             }

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -270,10 +270,11 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::queue<Event> m_events;                          ///< Queue of available events
-    JoystickState     m_joystickStates[Joystick::Count]; ///< Previous state of the joysticks
-    Vector3f          m_sensorValue[Sensor::Count];      ///< Previous value of the sensors
-    float             m_joystickThreshold;               ///< Joystick threshold (minimum motion for "move" event to be generated)
+    std::queue<Event> m_events;                                              ///< Queue of available events
+    JoystickState     m_joystickStates[Joystick::Count];                     ///< Previous state of the joysticks
+    Vector3f          m_sensorValue[Sensor::Count];                          ///< Previous value of the sensors
+    float             m_joystickThreshold;                                   ///< Joystick threshold (minimum motion for "move" event to be generated)
+    float             m_previousAxes[Joystick::Count][Joystick::AxisCount];  ///< Position of each axis last time a move event triggered, in range [-100, 100]
 };
 
 } // namespace priv


### PR DESCRIPTION
This fixes issue #1329.

Simple test program:

    #include <SFML/Window.hpp>
    #include <iostream>

    int main()
    {
        sf::Window window(sf::VideoMode(100, 100), "SFML");
        window.setVerticalSyncEnabled(true);
    
        window.setJoystickThreshold(5);

        std::vector<std::string> names = {
            "X",    ///< The X axis
            "Y",    ///< The Y axis
            "Z",    ///< The Z axis
            "R",    ///< The R axis
            "U",    ///< The U axis
            "V",    ///< The V axis
            "PovX", ///< The X axis of the point-of-view hat
            "PovY"  ///< The Y axis of the point-of-view hat
        };

        while (window.isOpen()) {
            sf::Event event;
            while (window.pollEvent(event)) {
                switch (event.type) {
                    case sf::Event::Closed:
                        window.close();
                        break;
                    case sf::Event::JoystickMoved:
                        std::cout << names[event.joystickMove.axis] << " " << event.joystickMove.position << std::endl;
                        break;
                    default:
                        break;
                }
            }

            window.display();
        }
    }

The expected result is axis movement in (at least) increments of 5. No movement must be lost, even if you move the stick very tiny steps/slow.