### PR TITLE
Extending Font and Text to support multiple textures

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -37,6 +37,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <list>
 
 
 namespace sf
@@ -250,8 +251,25 @@ public:
     ///
     /// \return Texture containing the glyphs of the requested size
     ///
+    /// \deprecated There may now be multiple textures instead of one.
+    /// Use getGlyph(...).texture instead.
+    ///
+    /// \see getGlyph
+    ///
     ////////////////////////////////////////////////////////////
-    const Texture& getTexture(unsigned int characterSize) const;
+    SFML_DEPRECATED const Texture& getTexture(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Retrieve the texture id
+    ///
+    /// The texture id is used internally by sf::Text.
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return Texture id containing glyphs of the requested size
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint64 getTextureId(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
@@ -298,6 +316,11 @@ private:
     };
 
     ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::list<Page> PageList; ///< List of pages, where each page corresponds to a texture
+
+    ////////////////////////////////////////////////////////////
     /// \brief Free all the internal resources
     ///
     ////////////////////////////////////////////////////////////
@@ -341,7 +364,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////
-    typedef std::map<unsigned int, Page> PageTable; ///< Table mapping a character size to its page (texture)
+    typedef std::map<unsigned int, PageList> PageListTable; ///< Table mapping a character size to its list of pages (textures)
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -352,7 +375,7 @@ private:
     void*                      m_stroker;     ///< Pointer to the stroker (it is typeless to avoid exposing implementation details)
     int*                       m_refCount;    ///< Reference counter used by implicit sharing
     Info                       m_info;        ///< Information about the font
-    mutable PageTable          m_pages;       ///< Table containing the glyphs pages by character size
+    mutable PageListTable      m_pageLists;   ///< Table containing the glyphs page lists by character size
     mutable std::vector<Uint8> m_pixelBuffer; ///< Pixel buffer holding a glyph's pixels before being written to the texture
     #ifdef SFML_SYSTEM_ANDROID
     void*                      m_stream; ///< Asset file streamer (if loaded from file)

--- a/include/SFML/Graphics/Glyph.hpp
+++ b/include/SFML/Graphics/Glyph.hpp
@@ -34,6 +34,8 @@
 
 namespace sf
 {
+class Texture;
+
 ////////////////////////////////////////////////////////////
 /// \brief Structure describing a glyph
 ///
@@ -46,14 +48,15 @@ public:
     /// \brief Default constructor
     ///
     ////////////////////////////////////////////////////////////
-    Glyph() : advance(0) {}
+    Glyph() : advance(0), texture(NULL) {}
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    float     advance;     ///< Offset to move horizontally to the next character
-    FloatRect bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
-    IntRect   textureRect; ///< Texture coordinates of the glyph inside the font's texture
+    float          advance;     ///< Offset to move horizontally to the next character
+    FloatRect      bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
+    const Texture* texture;     ///< Font's texture containing the glyph
+    IntRect        textureRect; ///< Texture coordinates of the glyph inside the font's texture
 };
 
 } // namespace sf
@@ -70,6 +73,7 @@ public:
 ///
 /// The sf::Glyph structure provides the information needed
 /// to handle the glyph:
+/// \li the font's texture containing the glyph
 /// \li its coordinates in the font's texture
 /// \li its bounding rectangle
 /// \li the offset to apply to get the starting position of the next glyph

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -433,22 +433,27 @@ private:
     void ensureGeometryUpdate() const;
 
     ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::map<const Texture*, VertexArray> VertexArrayMap; ///< Map from texture to vertex array containing the text's geometry
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    String              m_string;              ///< String to display
-    const Font*         m_font;                ///< Font used to display the string
-    unsigned int        m_characterSize;       ///< Base size of characters, in pixels
-    float               m_letterSpacingFactor; ///< Spacing factor between letters
-    float               m_lineSpacingFactor;   ///< Spacing factor between lines
-    Uint32              m_style;               ///< Text style (see Style enum)
-    Color               m_fillColor;           ///< Text fill color
-    Color               m_outlineColor;        ///< Text outline color
-    float               m_outlineThickness;    ///< Thickness of the text's outline
-    mutable VertexArray m_vertices;            ///< Vertex array containing the fill geometry
-    mutable VertexArray m_outlineVertices;     ///< Vertex array containing the outline geometry
-    mutable FloatRect   m_bounds;              ///< Bounding rectangle of the text (in local coordinates)
-    mutable bool        m_geometryNeedUpdate;  ///< Does the geometry need to be recomputed?
-    mutable Uint64      m_fontTextureId;       ///< The font texture id
+    String              m_string;                ///< String to display
+    const Font*         m_font;                  ///< Font used to display the string
+    unsigned int        m_characterSize;         ///< Base size of characters, in pixels
+    float               m_letterSpacingFactor;   ///< Spacing factor between letters
+    float               m_lineSpacingFactor;     ///< Spacing factor between lines
+    Uint32              m_style;                 ///< Text style (see Style enum)
+    Color               m_fillColor;             ///< Text fill color
+    Color               m_outlineColor;          ///< Text outline color
+    float               m_outlineThickness;      ///< Thickness of the text's outline
+    mutable VertexArrayMap m_fillVerticesMap;    ///< Vertex arrays containing the fill geometry per texture
+    mutable VertexArrayMap m_outlineVerticesMap; ///< Vertex arrays containing the outline geometry per texture
+    mutable FloatRect   m_bounds;                ///< Bounding rectangle of the text (in local coordinates)
+    mutable bool        m_geometryNeedUpdate;    ///< Does the geometry need to be recomputed?
+    mutable Uint64      m_fontTextureId;         ///< The font texture id
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -38,7 +38,7 @@ namespace sf
 class InputStream;
 class RenderTarget;
 class RenderTexture;
-class Text;
+class Font;
 class Window;
 
 ////////////////////////////////////////////////////////////
@@ -585,7 +585,7 @@ public:
 
 private:
 
-    friend class Text;
+    friend class Font;
     friend class RenderTexture;
     friend class RenderTarget;
 


### PR DESCRIPTION
Extending `Font` and `Text` to support multiple textures so that glyphs are not discarded in case one texture gets filled.
This can be useful in any of the following scenarios:
- Big text
- Large alphabets
- OpenGL implementations with a small maximum texture size (e.g. software renderers)

Reimplementation of #1034 adjusted for #840 and #1119.