### PR TITLE
Fix launch of cocoa example on macOS

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -151,21 +151,29 @@ endmacro()
 # add a new target which is a SFML example
 # ex: sfml_add_example(ftp
 #                      SOURCES ftp.cpp ...
-#                      DEPENDS sfml-network sfml-system)
+#                      BUNDLE_RESOURCES MainMenu.nib ...    # Files to be added in target but not installed next to the executable
+#                      DEPENDS sfml-network sfml-system
+#                      [INSTALL_RESOURCES_DIR])             # In addition to the sources, also install the "resources" directory
 macro(sfml_add_example target)
 
     # parse the arguments
-    cmake_parse_arguments(THIS "GUI_APP" "" "SOURCES;DEPENDS" ${ARGN})
+    cmake_parse_arguments(THIS "GUI_APP;INSTALL_RESOURCES_DIR" "" "SOURCES;BUNDLE_RESOURCES;DEPENDS" ${ARGN})
 
     # set a source group for the source files
     source_group("" FILES ${THIS_SOURCES})
 
+    # check whether resources must be added in target
+    set(target_input ${THIS_SOURCES})
+    if(THIS_BUNDLE_RESOURCES)
+        set(target_input ${target_input} ${THIS_BUNDLE_RESOURCES})
+    endif()
+
     # create the target
     if(THIS_GUI_APP AND SFML_OS_WINDOWS AND NOT DEFINED CMAKE_CONFIGURATION_TYPES AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")
-        add_executable(${target} WIN32 ${THIS_SOURCES})
+        add_executable(${target} WIN32 ${target_input})
         target_link_libraries(${target} sfml-main)
     else()
-        add_executable(${target} ${THIS_SOURCES})
+        add_executable(${target} ${target_input})
     endif()
 
     # set the debug suffix
@@ -198,12 +206,14 @@ macro(sfml_add_example target)
             DESTINATION ${INSTALL_MISC_DIR}/examples/${target}
             COMPONENT examples)
 
-    # install the example's resources as well
-    set(EXAMPLE_RESOURCES "${CMAKE_SOURCE_DIR}/examples/${target}/resources")
-    if(EXISTS ${EXAMPLE_RESOURCES})
-        install(DIRECTORY ${EXAMPLE_RESOURCES}
-                DESTINATION ${INSTALL_MISC_DIR}/examples/${target}
-                COMPONENT examples)
+    if (THIS_INSTALL_RESOURCES_DIR)
+        # install the example's resources as well
+        set(EXAMPLE_RESOURCES "${CMAKE_SOURCE_DIR}/examples/${target}/resources")
+        if(EXISTS ${EXAMPLE_RESOURCES})
+            install(DIRECTORY ${EXAMPLE_RESOURCES}
+                    DESTINATION ${INSTALL_MISC_DIR}/examples/${target}
+                    COMPONENT examples)
+        endif()
     endif()
 
 endmacro()

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -153,11 +153,11 @@ endmacro()
 #                      SOURCES ftp.cpp ...
 #                      BUNDLE_RESOURCES MainMenu.nib ...    # Files to be added in target but not installed next to the executable
 #                      DEPENDS sfml-network sfml-system
-#                      [INSTALL_RESOURCES_DIR])             # In addition to the sources, also install the "resources" directory
+#                      RESOURCES_DIR resources)             # A directory to install next to the executable and sources
 macro(sfml_add_example target)
 
     # parse the arguments
-    cmake_parse_arguments(THIS "GUI_APP;INSTALL_RESOURCES_DIR" "" "SOURCES;BUNDLE_RESOURCES;DEPENDS" ${ARGN})
+    cmake_parse_arguments(THIS "GUI_APP" "RESOURCES_DIR" "SOURCES;BUNDLE_RESOURCES;DEPENDS" ${ARGN})
 
     # set a source group for the source files
     source_group("" FILES ${THIS_SOURCES})
@@ -206,14 +206,16 @@ macro(sfml_add_example target)
             DESTINATION ${INSTALL_MISC_DIR}/examples/${target}
             COMPONENT examples)
 
-    if (THIS_INSTALL_RESOURCES_DIR)
+    if (THIS_RESOURCES_DIR)
         # install the example's resources as well
-        set(EXAMPLE_RESOURCES "${CMAKE_SOURCE_DIR}/examples/${target}/resources")
-        if(EXISTS ${EXAMPLE_RESOURCES})
-            install(DIRECTORY ${EXAMPLE_RESOURCES}
-                    DESTINATION ${INSTALL_MISC_DIR}/examples/${target}
-                    COMPONENT examples)
+        get_filename_component(THIS_RESOURCES_DIR "${THIS_RESOURCES_DIR}" ABSOLUTE)
+
+        if(NOT EXISTS "${THIS_RESOURCES_DIR}")
+            message(FATAL_ERROR "Given resources directory to install does not exist: ${THIS_RESOURCES_DIR}")
         endif()
+        install(DIRECTORY ${THIS_RESOURCES_DIR}
+                DESTINATION ${INSTALL_MISC_DIR}/examples/${target}
+                COMPONENT examples)
     endif()
 
 endmacro()

--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -1,6 +1,34 @@
 
 set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/cocoa)
 
+# Usage: compile_xib(INPUT path/to/file.xib OUTPUT path/to/file.nib)
+function(compile_xib)
+    cmake_parse_arguments(THIS "" "INPUT;OUTPUT" "" ${ARGN})
+    if (NOT THIS_INPUT)
+        message(FATAL_ERROR "Missing required argument INPUT in call to compile_xib()")
+    endif()
+
+    if (NOT THIS_OUTPUT)
+        message(FATAL_ERROR "Missing required argument OUTPUT in call to compile_xib()")
+    endif()
+
+    if (NOT DEFINED IBTOOL)
+        find_program(IBTOOL ibtool HINTS "/usr/bin" "${OSX_DEVELOPER_ROOT}/usr/bin")
+    endif()
+    if(NOT IBTOOL)
+        message(FATAL_ERROR "ibtool is required to compile .xib files but wasn't found.")
+    endif()
+
+    # Default args taken from Xcode 9 when it generates a nib from a xib
+    set(DEFAULT_ARGS --errors --warnings --notices --module cocoa --auto-activate-custom-fonts --target-device mac --minimum-deployment-target ${CMAKE_OSX_DEPLOYMENT_TARGET} --output-format human-readable-text)
+
+    add_custom_command(OUTPUT "${THIS_OUTPUT}"
+        COMMAND "${IBTOOL}" ${DEFAULT_ARGS} "${THIS_INPUT}" --compile "${THIS_OUTPUT}"
+        DEPENDS "${THIS_INPUT}"
+        COMMENT "Generating ${THIS_OUTPUT}"
+        VERBATIM)
+endfunction()
+
 # all source files
 set(SRC ${SRCROOT}/CocoaAppDelegate.h
         ${SRCROOT}/CocoaAppDelegate.mm
@@ -8,8 +36,7 @@ set(SRC ${SRCROOT}/CocoaAppDelegate.h
         ${SRCROOT}/NSString+stdstring.mm
         ${SRCROOT}/main.m)
 
-# all XIB files
-set(XIBS MainMenu)
+compile_xib(INPUT "${SRCROOT}/MainMenu.xib" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib")
 
 # all resource files
 set(RESOURCES ${SRCROOT}/resources/logo.png
@@ -18,50 +45,17 @@ set(RESOURCES ${SRCROOT}/resources/logo.png
               ${SRCROOT}/resources/blue.png
               ${SRCROOT}/resources/green.png
               ${SRCROOT}/resources/red.png
-              ${SRCROOT}/resources/Credits.rtf)
-
-# define the cocoa target and customize it
-add_executable(cocoa MACOSX_BUNDLE ${SRC} ${RESOURCES})
+              ${SRCROOT}/resources/Credits.rtf
+              ${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib)
 set_source_files_properties(${RESOURCES} PROPERTIES
                             MACOSX_PACKAGE_LOCATION Resources)
+
+# define the cocoa target and customize it
+sfml_add_example(cocoa
+                 SOURCES ${SRC}
+                 BUNDLE_RESOURCES ${RESOURCES}
+                 DEPENDS sfml-system sfml-window sfml-graphics)
 set_target_properties(cocoa PROPERTIES
+                      MACOSX_BUNDLE TRUE
                       MACOSX_BUNDLE_INFO_PLIST ${SRCROOT}/resources/Cocoa-Info.plist)
-target_link_libraries(cocoa "-framework Cocoa -framework Foundation"
-                            sfml-system sfml-window sfml-graphics)
-
-# set the target's folder (for IDEs that support it, e.g. Visual Studio)
-set_target_properties(cocoa PROPERTIES FOLDER "Examples")
-
-# compile XIB files
-find_program(IBTOOL ibtool HINTS "/usr/bin" "${OSX_DEVELOPER_ROOT}/usr/bin")
-if(${IBTOOL} STREQUAL "IBTOOL-NOTFOUND")
-  message(FATAL_ERROR "ibtool is required to compile .xib files but wasn't found.")
-endif()
-set(RESOURCE_PATH "cocoa.app/Contents/Resources")
-set(XIB_OUTPUT_PATH "${RESOURCE_PATH}/")
-set(XIB_INPUT_PATH "${SRCROOT}/")
-foreach(XIB ${XIBS})
-    add_custom_command(TARGET cocoa
-                       POST_BUILD
-                       COMMAND ${IBTOOL} --errors
-                                         --output-format human-readable-text
-                                         --compile ${XIB_OUTPUT_PATH}/${XIB}.nib
-                                         ${XIB_INPUT_PATH}/${XIB}.xib
-                       COMMENT "Compiling ${XIB}.xib")
-                       # deactivated options: --warnings --notices
-endforeach()
-
-# add install rule
-install(TARGETS cocoa
-        BUNDLE DESTINATION ${INSTALL_MISC_DIR}/examples/cocoa
-        COMPONENT examples)
-
-#
-# define the cocoa target
-# sfml_add_example is not compatible with application bundles !
-#
-#sfml_add_example(cocoa
-#                 SOURCES ${SRC}
-#                 DEPENDS sfml-system sfml-window sfml-graphics)
-#
-
+target_link_libraries(cocoa "-framework Cocoa -framework Foundation")

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -13,4 +13,4 @@ set(ADDITIONAL_LIBRARIES ${OPENGL_LIBRARIES})
 sfml_add_example(opengl GUI_APP
                  SOURCES ${SRC}
                  DEPENDS sfml-graphics sfml-window sfml-system ${ADDITIONAL_LIBRARIES}
-                 INSTALL_RESOURCES_DIR)
+                 RESOURCES_DIR resources)

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -12,4 +12,5 @@ set(ADDITIONAL_LIBRARIES ${OPENGL_LIBRARIES})
 # define the opengl target
 sfml_add_example(opengl GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics sfml-window sfml-system ${ADDITIONAL_LIBRARIES})
+                 DEPENDS sfml-graphics sfml-window sfml-system ${ADDITIONAL_LIBRARIES}
+                 INSTALL_RESOURCES_DIR)

--- a/examples/pong/CMakeLists.txt
+++ b/examples/pong/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SRC ${SRCROOT}/Pong.cpp)
 sfml_add_example(pong GUI_APP
                  SOURCES ${SRC}
                  DEPENDS sfml-audio sfml-graphics sfml-window sfml-system
-                 INSTALL_RESOURCES_DIR)
+                 RESOURCES_DIR resources)

--- a/examples/pong/CMakeLists.txt
+++ b/examples/pong/CMakeLists.txt
@@ -7,4 +7,5 @@ set(SRC ${SRCROOT}/Pong.cpp)
 # define the pong target
 sfml_add_example(pong GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-audio sfml-graphics sfml-window sfml-system)
+                 DEPENDS sfml-audio sfml-graphics sfml-window sfml-system
+                 INSTALL_RESOURCES_DIR)

--- a/examples/shader/CMakeLists.txt
+++ b/examples/shader/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SRC
 sfml_add_example(shader GUI_APP
                  SOURCES ${SRC}
                  DEPENDS sfml-graphics sfml-window sfml-system
-                 INSTALL_RESOURCES_DIR)
+                 RESOURCES_DIR resources)

--- a/examples/shader/CMakeLists.txt
+++ b/examples/shader/CMakeLists.txt
@@ -9,4 +9,5 @@ set(SRC
 # define the shader target
 sfml_add_example(shader GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics sfml-window sfml-system)
+                 DEPENDS sfml-graphics sfml-window sfml-system
+                 INSTALL_RESOURCES_DIR)

--- a/examples/sound/CMakeLists.txt
+++ b/examples/sound/CMakeLists.txt
@@ -7,4 +7,5 @@ set(SRC ${SRCROOT}/Sound.cpp)
 # define the sound target
 sfml_add_example(sound
                  SOURCES ${SRC}
-                 DEPENDS sfml-audio sfml-system)
+                 DEPENDS sfml-audio sfml-system
+                 INSTALL_RESOURCES_DIR)

--- a/examples/sound/CMakeLists.txt
+++ b/examples/sound/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SRC ${SRCROOT}/Sound.cpp)
 sfml_add_example(sound
                  SOURCES ${SRC}
                  DEPENDS sfml-audio sfml-system
-                 INSTALL_RESOURCES_DIR)
+                 RESOURCES_DIR resources)

--- a/examples/win32/CMakeLists.txt
+++ b/examples/win32/CMakeLists.txt
@@ -8,4 +8,4 @@ set(SRC ${SRCROOT}/Win32.cpp)
 sfml_add_example(win32 GUI_APP
                  SOURCES ${SRC}
                  DEPENDS sfml-graphics sfml-window sfml-system
-                 INSTALL_RESOURCES_DIR)
+                 RESOURCES_DIR resources)

--- a/examples/win32/CMakeLists.txt
+++ b/examples/win32/CMakeLists.txt
@@ -7,4 +7,5 @@ set(SRC ${SRCROOT}/Win32.cpp)
 # define the win32 target
 sfml_add_example(win32 GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics sfml-window sfml-system)
+                 DEPENDS sfml-graphics sfml-window sfml-system
+                 INSTALL_RESOURCES_DIR)


### PR DESCRIPTION
### Description
The generated bundle application was missing the file "MainMenu.nib" that had been generated but not copied inside the bundle:
`2017-12-29 16:39:10.146 cocoa[6044:84729] Unable to load nib file: MainMenu, exiting`

I also simplified the CMake file, I didn't understand why the xib->nib compilation was done manually as it looks to work automagically when the xib is part of the sources for the target. @mantognini do you remember ? I tested both with CMake 3.10 and 2.8.12 and it worked fine both when running the app from Xcode and in the installed dir (/usr/local/share/SFML/examples/cocoa/cocoa.app)

### GitHub issue link
None
### Forum thread link
None