### PR TITLE
Replace auto_ptr with unique_ptr to fix build errors when using the C++17 standard

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -107,7 +107,7 @@ bool AudioDevice::isExtensionSupported(const std::string& extension)
     // This device will not be used in this function and merely
     // makes sure there is a valid OpenAL device for extension
     // queries if none has been created yet.
-    std::auto_ptr<AudioDevice> device;
+    std::unique_ptr<AudioDevice> device;
     if (!audioDevice)
         device.reset(new AudioDevice);
 
@@ -125,7 +125,7 @@ int AudioDevice::getFormatFromChannelCount(unsigned int channelCount)
     // This device will not be used in this function and merely
     // makes sure there is a valid OpenAL device for format
     // queries if none has been created yet.
-    std::auto_ptr<AudioDevice> device;
+    std::unique_ptr<AudioDevice> device;
     if (!audioDevice)
         device.reset(new AudioDevice);
 


### PR DESCRIPTION
I was unable to build the Audio component of SFML when using VS2017 with the C++17 standard (/std:c==17 flag or use set(CMAKE_CXX_STANDARD 17) in CMake).  This solved the problem.