### PR TITLE
Added Exclamation mark/Paragraph (!/§) key handling

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -99,6 +99,7 @@ public:
         SemiColon,    ///< The ; key
         Comma,        ///< The , key
         Period,       ///< The . key
+        Exclamation,  ///< The Exclamation mark / Paragraph key
         Quote,        ///< The ' key
         Slash,        ///< The / key
         BackSlash,    ///< The \ key

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -61,6 +61,7 @@ bool InputImpl::isKeyPressed(Keyboard::Key key)
         case Keyboard::LBracket:   keysym = XK_bracketleft;  break;
         case Keyboard::RBracket:   keysym = XK_bracketright; break;
         case Keyboard::Comma:      keysym = XK_comma;        break;
+        case Keyboard::Exclamation:keysym = XK_exclam;       break;
         case Keyboard::Period:     keysym = XK_period;       break;
         case Keyboard::Quote:      keysym = XK_apostrophe;   break;
         case Keyboard::BackSlash:  keysym = XK_backslash;    break;

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -382,6 +382,7 @@ namespace
             case XK_bracketleft:  return sf::Keyboard::LBracket;
             case XK_bracketright: return sf::Keyboard::RBracket;
             case XK_comma:        return sf::Keyboard::Comma;
+            case XK_exclam:       return sf::Keyboard::Exclamation;
             case XK_period:       return sf::Keyboard::Period;
             case XK_apostrophe:   return sf::Keyboard::Quote;
             case XK_backslash:    return sf::Keyboard::BackSlash;

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -100,6 +100,7 @@ bool InputImpl::isKeyPressed(Keyboard::Key key)
         case Keyboard::SemiColon:  vkey = VK_OEM_1;      break;
         case Keyboard::Comma:      vkey = VK_OEM_COMMA;  break;
         case Keyboard::Period:     vkey = VK_OEM_PERIOD; break;
+        case Keyboard::Exclamation:vkey = VK_OEM_8;      break;
         case Keyboard::Quote:      vkey = VK_OEM_7;      break;
         case Keyboard::Slash:      vkey = VK_OEM_2;      break;
         case Keyboard::BackSlash:  vkey = VK_OEM_5;      break;

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -1022,6 +1022,7 @@ Keyboard::Key WindowImplWin32::virtualKeyCodeToSF(WPARAM key, LPARAM flags)
         case VK_OEM_6:      return Keyboard::RBracket;
         case VK_OEM_COMMA:  return Keyboard::Comma;
         case VK_OEM_PERIOD: return Keyboard::Period;
+        case VK_OEM_8:      return Keyboard::Exclamation;
         case VK_OEM_7:      return Keyboard::Quote;
         case VK_OEM_5:      return Keyboard::BackSlash;
         case VK_OEM_3:      return Keyboard::Tilde;


### PR DESCRIPTION
The !/§ key found on AZERTY keyboards wasn't handled by SFML. This should fix the issue on Windows and Unix. I didn't looked at the other platforms since i'm less familiar with them.

I chose "Exclamation" for the key name but it could be ExclamationMark too, or Paragraph.