### PR TITLE
Worked around render target bug on macOS

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -373,6 +373,12 @@ void RenderTarget::resetGLStates()
     // Check here to make sure a context change does not happen after activate(true)
     bool shaderAvailable = Shader::isAvailable();
 
+    // Workaround for states not being properly reset on
+    // macOS unless a context switch really takes place
+    #if defined(SFML_SYSTEM_MACOS)
+        setActive(false);
+    #endif
+
     if (setActive(true))
     {
         // Make sure that extensions are initialized


### PR DESCRIPTION
Fixes #1132

I thought to open this PR here, so we can discuss if it works or not here and either merge it or reject it. 🙂 

@mantognini [mentioned](https://github.com/SFML/SFML/issues/1132#issuecomment-342885505)
> I invite others to test this as well by checking out the bugfix/osx_render_target branch.

@achpile [mentioned](https://github.com/SFML/SFML/issues/1132#issuecomment-344192612)
>this patch didn't fixed my issue.
everything renders normally if there's something drawn on RenderWindow except the sprite with RenderTexture (as in my example code).