### PR TITLE
Install extlibs on iOS if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,15 +503,20 @@ elseif(SFML_OS_MACOSX)
 elseif(SFML_OS_IOS)
 
     # fix CMake install rules broken for iOS (see http://public.kitware.com/Bug/view.php?id=12506)
-    if(SFML_OS_IOS)
-        install(DIRECTORY "${CMAKE_BINARY_DIR}/lib/\$ENV{CONFIGURATION}/" DESTINATION lib${LIB_SUFFIX})
-    endif()
+    install(DIRECTORY "${CMAKE_BINARY_DIR}/lib/\$ENV{CONFIGURATION}/" DESTINATION lib${LIB_SUFFIX})
 
     if(NOT SFML_USE_SYSTEM_DEPS)
         # since the iOS libraries are built as static, we must install the SFML dependencies
         # too so that the end user can easily link them to its final application
         if(SFML_BUILD_GRAPHICS)
             install(FILES extlibs/libs-ios/libfreetype.a DESTINATION lib)
+        endif()
+
+        if(SFML_BUILD_AUDIO)
+            install(FILES extlibs/libs-ios/libflac.a 
+                          extlibs/libs-ios/libvorbis.a
+                          extlibs/libs-ios/libogg.a
+                          DESTINATION lib)
         endif()
     endif()
 


### PR DESCRIPTION
Audio extlibs specifically.

I also removed a seemingly superfluous check for `SFML_OS_IOS` as it's already in a block which checks that