### PR TITLE
Generate shape outline vertices only if necessary.

### DIFF
--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -251,6 +251,14 @@ void Shape::updateTexCoords()
 ////////////////////////////////////////////////////////////
 void Shape::updateOutline()
 {
+    // Return if there is no outline
+    if (m_outlineThickness == 0.f)
+    {
+        m_outlineVertices.clear();
+        m_bounds = m_insideBounds;
+        return;
+    }
+
     std::size_t count = m_vertices.getVertexCount() - 2;
     m_outlineVertices.resize((count + 1) * 2);
 


### PR DESCRIPTION
Improved the logic of the shape class so that the outline vertices are only updated if they exist.

Original, now abandoned #925 