### PR TITLE
Use -stdlib=libc++ on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,9 @@ else()
     # create SFML.framework
     add_library(SFML ${SFML_SOURCES})
 
+    # set the target flags to use the appropriate C++ standard library
+    sfml_set_stdlib(SFML)
+
     # edit target properties
     set_target_properties(SFML PROPERTIES
                           FRAMEWORK TRUE


### PR DESCRIPTION
### Forum thread
https://en.sfml-dev.org/forums/index.php?topic=22786.msg159283#msg159283

### Rationale
The standard library "stdc++" causes warnings when linking on macOS:
`clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9 [-Wdeprecated]`

Build logs in SFML CI show this too. Also current downloads for macOS are built with libc++, so the CI doesn't build with what's currently shipped.

Regarding any possible compatibility issue, note that libc++ is available since macOS 10.7.

@mantognini Should CMAKE_OSX_DEPLOYMENT_TARGET also be changed from 10.7 to 10.9 as suggested by the deprecation warning?