### PR TITLE
Examples: Set startup folder for debugging in Visual Studio

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -217,6 +217,9 @@ macro(sfml_add_example target)
     # set the target flags to use the appropriate C++ standard library
     sfml_set_stdlib(${target})
 
+    # set the Visual Studio startup path for debugging
+    set_target_properties(${target} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
     # link the target to its SFML dependencies
     if(THIS_DEPENDS)
         target_link_libraries(${target} PRIVATE ${THIS_DEPENDS})


### PR DESCRIPTION
A very trivial change that will allow direct running/debugging of the examples in Visual Studio using the proper working directories, so all resources can be found.

This requires CMake 3.8 or newer, but should be silently ignored in older versions (can't test this right now).