### PR TITLE
Added support for specifying optional ThreadLocal destructor functions

### DIFF
--- a/include/SFML/System/ThreadLocal.hpp
+++ b/include/SFML/System/ThreadLocal.hpp
@@ -40,6 +40,8 @@ namespace priv
     class ThreadLocalImpl;
 }
 
+typedef void(*ThreadLocalDestructorPointer)(void*);
+
 ////////////////////////////////////////////////////////////
 /// \brief Defines variables with thread-local storage
 ///
@@ -51,10 +53,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
-    /// \param value Optional value to initialize the variable
+    /// \param value      Optional value to initialize the variable
+    /// \param destructor Optional destructor used to clean up a stored object
     ///
     ////////////////////////////////////////////////////////////
-    ThreadLocal(void* value = NULL);
+    ThreadLocal(void* value = NULL, ThreadLocalDestructorPointer destructor = NULL);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -77,6 +80,14 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     void* getValue() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the system supports calling destructors on thread-local storage
+    ///
+    /// \return True if the system supports calling destructors on thread-local storage, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isDestructorSupported();
 
 private:
 

--- a/include/SFML/System/ThreadLocalPtr.hpp
+++ b/include/SFML/System/ThreadLocalPtr.hpp
@@ -45,10 +45,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
-    /// \param value Optional value to initialize the variable
+    /// \param value      Optional value to initialize the variable
+    /// \param destructor Optional destructor used to clean up a stored object
     ///
     ////////////////////////////////////////////////////////////
-    ThreadLocalPtr(T* value = NULL);
+    ThreadLocalPtr(T* value = NULL, ThreadLocalDestructorPointer destructor = NULL);
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of unary operator *

--- a/include/SFML/System/ThreadLocalPtr.inl
+++ b/include/SFML/System/ThreadLocalPtr.inl
@@ -27,8 +27,8 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 template <typename T>
-ThreadLocalPtr<T>::ThreadLocalPtr(T* value) :
-ThreadLocal(value)
+ThreadLocalPtr<T>::ThreadLocalPtr(T* value, ThreadLocalDestructorPointer destructor) :
+ThreadLocal(value, destructor)
 {
 }
 

--- a/src/SFML/System/ThreadLocal.cpp
+++ b/src/SFML/System/ThreadLocal.cpp
@@ -37,9 +37,9 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-ThreadLocal::ThreadLocal(void* value)
+ThreadLocal::ThreadLocal(void* value, ThreadLocalDestructorPointer destructor)
 {
-    m_impl = new priv::ThreadLocalImpl;
+    m_impl = new priv::ThreadLocalImpl(destructor);
     setValue(value);
 }
 
@@ -62,6 +62,13 @@ void ThreadLocal::setValue(void* value)
 void* ThreadLocal::getValue() const
 {
     return m_impl->getValue();
+}
+
+
+////////////////////////////////////////////////////////////
+bool ThreadLocal::isDestructorSupported()
+{
+    return priv::ThreadLocalImpl::isDestructorSupported();
 }
 
 } // namespace sf

--- a/src/SFML/System/Unix/ThreadLocalImpl.cpp
+++ b/src/SFML/System/Unix/ThreadLocalImpl.cpp
@@ -33,10 +33,10 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-ThreadLocalImpl::ThreadLocalImpl() :
+ThreadLocalImpl::ThreadLocalImpl(ThreadLocalDestructorPointer destructor) :
 m_key(0)
 {
-    pthread_key_create(&m_key, NULL);
+    pthread_key_create(&m_key, destructor);
 }
 
 
@@ -58,6 +58,13 @@ void ThreadLocalImpl::setValue(void* value)
 void* ThreadLocalImpl::getValue() const
 {
     return pthread_getspecific(m_key);
+}
+
+
+////////////////////////////////////////////////////////////
+bool ThreadLocalImpl::isDestructorSupported()
+{
+    return true;
 }
 
 } // namespace priv

--- a/src/SFML/System/Unix/ThreadLocalImpl.hpp
+++ b/src/SFML/System/Unix/ThreadLocalImpl.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/ThreadLocal.hpp>
 #include <pthread.h>
 
 
@@ -46,8 +47,10 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor -- allocate the storage
     ///
+    /// \param destructor Optional destructor used to clean up a stored object
+    ///
     ////////////////////////////////////////////////////////////
-    ThreadLocalImpl();
+    ThreadLocalImpl(ThreadLocalDestructorPointer destructor);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor -- free the storage
@@ -70,6 +73,14 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     void* getValue() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the system supports calling destructors on thread-local storage
+    ///
+    /// \return True if the system supports calling destructors on thread-local storage, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isDestructorSupported();
 
 private:
 

--- a/src/SFML/System/Win32/ThreadLocalImpl.cpp
+++ b/src/SFML/System/Win32/ThreadLocalImpl.cpp
@@ -26,6 +26,71 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Win32/ThreadLocalImpl.hpp>
+#include <SFML/System/Err.hpp>
+
+
+namespace
+{
+    // Since we need to convert from WINAPI to the user's calling convention
+    // and Windows doesn't support specifying custom user data, we need
+    // to store the destructor in FLS as well
+    struct FlsControlBlock
+    {
+        sf::ThreadLocalDestructorPointer destructor;
+        void* data;
+    };
+
+    // FLS entry points
+    typedef void (WINAPI* FlsCallback)(void*);
+
+    typedef DWORD (WINAPI* FlsAllocFunc)(FlsCallback);
+    typedef BOOL (WINAPI* FlsFreeFunc)(DWORD);
+    typedef BOOL (WINAPI* FlsSetValueFunc)(DWORD, PVOID);
+    typedef PVOID (WINAPI* FlsGetValueFunc)(DWORD);
+
+    FlsAllocFunc flsAlloc = NULL;
+    FlsFreeFunc flsFree = NULL;
+    FlsSetValueFunc flsSetValue = NULL;
+    FlsGetValueFunc flsGetValue = NULL;
+
+    bool flsInitialized = false;
+    bool hasFls = false;
+
+    // Try to load the FLS entry points
+    void initializeFls()
+    {
+        HINSTANCE kernel32Dll = LoadLibraryA("kernel32.dll");
+
+        if (kernel32Dll)
+        {
+            flsAlloc = reinterpret_cast<FlsAllocFunc>(GetProcAddress(kernel32Dll, "FlsAlloc"));
+            flsFree = reinterpret_cast<FlsFreeFunc>(GetProcAddress(kernel32Dll, "FlsFree"));
+            flsSetValue = reinterpret_cast<FlsSetValueFunc>(GetProcAddress(kernel32Dll, "FlsSetValue"));
+            flsGetValue = reinterpret_cast<FlsGetValueFunc>(GetProcAddress(kernel32Dll, "FlsGetValue"));
+
+            hasFls = (flsAlloc != NULL) && (flsFree != NULL) && (flsSetValue != NULL) && (flsGetValue != NULL);
+
+            FreeLibrary(kernel32Dll);
+        }
+
+        flsInitialized = true;
+    }
+
+    // This function is called by the operating system when a thread terminates
+    void WINAPI flsCallback(void* arg)
+    {
+        // We mustn't forget to delete the control block if one was allocated
+        if (arg)
+        {
+            FlsControlBlock* controlBlock = static_cast<FlsControlBlock*>(arg);
+
+            if (controlBlock->destructor)
+                controlBlock->destructor(controlBlock->data);
+
+            delete controlBlock;
+        }
+    }
+}
 
 
 namespace sf
@@ -33,30 +98,92 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-ThreadLocalImpl::ThreadLocalImpl()
+ThreadLocalImpl::ThreadLocalImpl(ThreadLocalDestructorPointer destructor) :
+m_destructor(destructor)
 {
-    m_index = TlsAlloc();
+    if (!flsInitialized)
+        initializeFls();
+
+    if (hasFls)
+    {
+        m_index = flsAlloc(flsCallback);
+    }
+    else
+    {
+        if (destructor)
+            sf::err() << "Warning: Thread local destructors are not supported on this system" << std::endl;
+
+        m_index = TlsAlloc();
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
 ThreadLocalImpl::~ThreadLocalImpl()
 {
-    TlsFree(m_index);
+    if (hasFls)
+    {
+        flsFree(m_index);
+    }
+    else
+    {
+        TlsFree(m_index);
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
 void ThreadLocalImpl::setValue(void* value)
 {
-    TlsSetValue(m_index, value);
+    if (hasFls)
+    {
+        // We are forced to read-modify-write here since there is no other way in Windows
+        FlsControlBlock* controlBlock = static_cast<FlsControlBlock*>(flsGetValue(m_index));
+
+        // Initialize the control block if it doesn't already exist
+        if (!controlBlock)
+        {
+            controlBlock = new FlsControlBlock;
+            controlBlock->destructor = m_destructor;
+        }
+
+        controlBlock->data = value;
+
+        flsSetValue(m_index, controlBlock);
+    }
+    else
+    {
+        TlsSetValue(m_index, value);
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
 void* ThreadLocalImpl::getValue() const
 {
-    return TlsGetValue(m_index);
+    if (hasFls)
+    {
+        FlsControlBlock* controlBlock = static_cast<FlsControlBlock*>(flsGetValue(m_index));
+
+        if (controlBlock)
+            return controlBlock->data;
+
+        return NULL;
+    }
+    else
+    {
+        return TlsGetValue(m_index);
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+bool ThreadLocalImpl::isDestructorSupported()
+{
+    if (!flsInitialized)
+        initializeFls();
+
+    return hasFls;
 }
 
 } // namespace priv

--- a/src/SFML/System/Win32/ThreadLocalImpl.hpp
+++ b/src/SFML/System/Win32/ThreadLocalImpl.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/ThreadLocal.hpp>
 #include <windows.h>
 
 
@@ -46,8 +47,10 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor -- allocate the storage
     ///
+    /// \param destructor Optional destructor used to clean up a stored object
+    ///
     ////////////////////////////////////////////////////////////
-    ThreadLocalImpl();
+    ThreadLocalImpl(ThreadLocalDestructorPointer destructor);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor -- free the storage
@@ -71,12 +74,21 @@ public:
     ////////////////////////////////////////////////////////////
     void* getValue() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the system supports calling destructors on thread-local storage
+    ///
+    /// \return True if the system supports calling destructors on thread-local storage, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isDestructorSupported();
+
 private:
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    DWORD m_index; ///< Index of our thread-local storage slot
+    DWORD                        m_index;      ///< Index of our thread-local storage slot
+    ThreadLocalDestructorPointer m_destructor; ///< Destructor to be called passing the stored value whenever a thread terminates
 };
 
 } // namespace priv


### PR DESCRIPTION
Added support for specifying optional ThreadLocal destructor functions when they are supported by the platform.

This can be useful when managing RAII resources that can't be shared across threads without having to resort to complex and fragile cleanup machinery.

Test with:
```cpp
#include <SFML/System.hpp>
#include <iostream>

struct S
{
    S(int i)
    {
        std::cout << "S(" << i << ")" << std::endl;
    }

    ~S()
    {
        std::cout << "~S()" << std::endl;
    }
};

void destructor(void* s)
{
    delete static_cast<S*>(s);
}

sf::ThreadLocalPtr<S> s(0, destructor);

void threadFunction(int i)
{
    s = new S(i);
}

int main()
{
    sf::Thread t1(threadFunction, 1);
    sf::Thread t2(threadFunction, 2);

    t1.launch();
    t2.launch();
}
```