### PR TITLE
Optimized RenderTexture performance

### DIFF
--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -296,7 +296,7 @@ public:
     /// \return True if operation was successful, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool setActive(bool active = true) = 0;
+    virtual bool setActive(bool active = true);
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the current OpenGL render states and matrices
@@ -458,6 +458,7 @@ private:
     {
         enum {VertexCacheSize = 4};
 
+        bool      enable;         ///< Is the cache enabled?
         bool      glStatesSet;    ///< Are our internal GL states set yet?
         bool      viewChanged;    ///< Has the current view changed since last draw?
         BlendMode lastBlendMode;  ///< Cached blending mode
@@ -473,6 +474,7 @@ private:
     View        m_defaultView; ///< Default view
     View        m_view;        ///< Current view
     StatesCache m_cache;       ///< Render states cache
+    Uint64      m_id;          ///< Unique number that identifies the RenderTarget
 };
 
 } // namespace sf

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -112,10 +112,25 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the currently active context
     ///
+    /// This function will only return sf::Context objects.
+    /// Contexts created e.g. by RenderTargets or for internal
+    /// use will not be returned by this function.
+    ///
     /// \return The currently active context or NULL if none is active
     ///
     ////////////////////////////////////////////////////////////
     static const Context* getActiveContext();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the currently active context's ID
+    ///
+    /// The context ID is used to identify contexts when
+    /// managing unshareable OpenGL resources.
+    ///
+    /// \return The active context's ID or 0 if no context is currently active
+    ///
+    ////////////////////////////////////////////////////////////
+    static Uint64 getActiveContextId();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct a in-memory context

--- a/include/SFML/Window/GlResource.hpp
+++ b/include/SFML/Window/GlResource.hpp
@@ -37,6 +37,8 @@ namespace sf
 
 class Context;
 
+typedef void(*ContextDestroyCallback)(void*);
+
 ////////////////////////////////////////////////////////////
 /// \brief Base class for classes that require an OpenGL context
 ///
@@ -56,6 +58,19 @@ protected:
     ///
     ////////////////////////////////////////////////////////////
     ~GlResource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Register a function to be called when a context is destroyed
+    ///
+    /// This is used for internal purposes in order to properly
+    /// clean up OpenGL resources that cannot be shared between
+    /// contexts.
+    ///
+    /// \param callback Function to be called when a context is destroyed
+    /// \param arg      Argument to pass when calling the function
+    ///
+    ////////////////////////////////////////////////////////////
+    static void registerContextDestroyCallback(ContextDestroyCallback callback, void* arg);
 
     ////////////////////////////////////////////////////////////
     /// \brief RAII helper class to temporarily lock an available context for use

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -147,7 +147,13 @@ bool RenderTexture::generateMipmap()
 ////////////////////////////////////////////////////////////
 bool RenderTexture::setActive(bool active)
 {
-    return m_impl && m_impl->activate(active);
+    bool result = m_impl && m_impl->activate(active);
+
+    // Update RenderTarget tracking
+    if (result)
+        RenderTarget::setActive(active);
+
+    return result;
 }
 
 
@@ -155,7 +161,7 @@ bool RenderTexture::setActive(bool active)
 void RenderTexture::display()
 {
     // Update the target texture
-    if (setActive(true))
+    if (priv::RenderTextureImplFBO::isAvailable() || setActive(true))
     {
         m_impl->updateTexture(m_texture.m_texture);
         m_texture.m_pixelsFlipped = true;

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -28,7 +28,67 @@
 #include <SFML/Graphics/RenderTextureImplFBO.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/GLCheck.hpp>
+#include <SFML/System/Mutex.hpp>
+#include <SFML/System/Lock.hpp>
 #include <SFML/System/Err.hpp>
+#include <utility>
+#include <set>
+
+
+namespace
+{
+    // Set to track all active FBO mappings
+    // This is used to free active FBOs while their owning
+    // RenderTextureImplFBO is still alive
+    std::set<std::map<sf::Uint64, unsigned int>*> frameBuffers;
+
+    // Set to track all stale FBOs
+    // This is used to free stale FBOs after their owning
+    // RenderTextureImplFBO has already been destroyed
+    // An FBO cannot be destroyed until it's containing context
+    // becomes active, so the destruction of the RenderTextureImplFBO
+    // has to be decoupled from the destruction of the FBOs themselves
+    std::set<std::pair<sf::Uint64, unsigned int> > staleFrameBuffers;
+
+    // Mutex to protect both active and stale frame buffer sets
+    sf::Mutex mutex;
+
+    // Callback that is called every time a context is destroyed
+    void contextDestroyCallback(void* arg)
+    {
+        sf::Lock lock(mutex);
+
+        sf::Uint64 contextId = sf::Context::getActiveContextId();
+
+        // Destroy active frame buffer objects
+        for (std::set<std::map<sf::Uint64, unsigned int>*>::iterator frameBuffersIter = frameBuffers.begin(); frameBuffersIter != frameBuffers.end(); ++frameBuffersIter)
+        {
+            for (std::map<sf::Uint64, unsigned int>::iterator iter = (*frameBuffersIter)->begin(); iter != (*frameBuffersIter)->end(); ++iter)
+            {
+                if (iter->first == contextId)
+                {
+                    GLuint frameBuffer = static_cast<GLuint>(iter->second);
+                    glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
+
+                    // Erase the entry from the RenderTextureImplFBO's map
+                    (*frameBuffersIter)->erase(iter);
+
+                    break;
+                }
+            }
+        }
+
+        // Destroy stale frame buffer objects
+        for (std::set<std::pair<sf::Uint64, unsigned int> >::iterator iter = staleFrameBuffers.begin(); iter != staleFrameBuffers.end(); ++iter)
+        {
+            if (iter->first == contextId)
+            {
+                GLuint frameBuffer = static_cast<GLuint>(iter->second);
+                glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
+            }
+        }
+    }
+}
 
 
 namespace sf
@@ -37,22 +97,36 @@ namespace priv
 {
 ////////////////////////////////////////////////////////////
 RenderTextureImplFBO::RenderTextureImplFBO() :
-m_context               (NULL),
-m_frameBuffer           (0),
-m_multisampleFrameBuffer(0),
-m_depthStencilBuffer    (0),
-m_colorBuffer           (0),
-m_width                 (0),
-m_height                (0)
+m_depthStencilBuffer(0),
+m_colorBuffer       (0),
+m_width             (0),
+m_height            (0),
+m_context           (NULL),
+m_textureId         (0),
+m_multisample       (false),
+m_stencil           (false)
 {
+    Lock lock(mutex);
 
+    // Register the context destruction callback
+    registerContextDestroyCallback(contextDestroyCallback, 0);
+
+    // Insert the new frame buffer mapping into the set of all active mappings
+    frameBuffers.insert(&m_frameBuffers);
+    frameBuffers.insert(&m_multisampleFrameBuffers);
 }
 
 
 ////////////////////////////////////////////////////////////
 RenderTextureImplFBO::~RenderTextureImplFBO()
 {
-    m_context->setActive(true);
+    TransientContextLock contextLock;
+
+    Lock lock(mutex);
+
+    // Remove the frame buffer mapping from the set of all active mappings
+    frameBuffers.erase(&m_frameBuffers);
+    frameBuffers.erase(&m_multisampleFrameBuffers);
 
     // Destroy the color buffer
     if (m_colorBuffer)
@@ -68,21 +142,17 @@ RenderTextureImplFBO::~RenderTextureImplFBO()
         glCheck(GLEXT_glDeleteRenderbuffers(1, &depthStencilBuffer));
     }
 
-    // Destroy the multisample frame buffer
-    if (m_multisampleFrameBuffer)
-    {
-        GLuint multisampleFrameBuffer = static_cast<GLuint>(m_multisampleFrameBuffer);
-        glCheck(GLEXT_glDeleteFramebuffers(1, &multisampleFrameBuffer));
-    }
+    // Move all frame buffer objects to stale set
+    for (std::map<Uint64, unsigned int>::iterator iter = m_frameBuffers.begin(); iter != m_frameBuffers.end(); ++iter)
+        staleFrameBuffers.insert(std::make_pair(iter->first, iter->second));
 
-    // Destroy the frame buffer
-    if (m_frameBuffer)
-    {
-        GLuint frameBuffer = static_cast<GLuint>(m_frameBuffer);
-        glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
-    }
+    for (std::map<Uint64, unsigned int>::iterator iter = m_multisampleFrameBuffers.begin(); iter != m_multisampleFrameBuffers.end(); ++iter)
+        staleFrameBuffers.insert(std::make_pair(iter->first, iter->second));
 
-    // Delete the context
+    // Clean up FBOs
+    contextDestroyCallback(0);
+
+    // Delete the backup context if we had to create one
     delete m_context;
 }
 
@@ -102,6 +172,8 @@ bool RenderTextureImplFBO::isAvailable()
 ////////////////////////////////////////////////////////////
 unsigned int RenderTextureImplFBO::getMaximumAntialiasingLevel()
 {
+    TransientContextLock lock;
+
     GLint samples = 0;
 
 #ifndef SFML_OPENGL_ES
@@ -115,244 +187,401 @@ unsigned int RenderTextureImplFBO::getMaximumAntialiasingLevel()
 
 
 ////////////////////////////////////////////////////////////
+void RenderTextureImplFBO::unbind()
+{
+    glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
+}
+
+
+////////////////////////////////////////////////////////////
 bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsigned int textureId, const ContextSettings& settings)
 {
     // Store the dimensions
     m_width = width;
     m_height = height;
 
-    // Disable creation of depth/stencil surfaces in the context
-    ContextSettings contextSettings(settings);
-    contextSettings.depthBits = 0;
-    contextSettings.stencilBits = 0;
-    contextSettings.antialiasingLevel = 0;
-    contextSettings.sRgbCapable = false;
+    {
+        TransientContextLock lock;
 
-    // Create the context
-    m_context = new Context(contextSettings, 1, 1);
+        // Make sure that extensions are initialized
+        priv::ensureExtensionsInit();
 
-    if (settings.antialiasingLevel && !(GLEXT_framebuffer_multisample && GLEXT_framebuffer_blit))
-        return false;
+        if (settings.antialiasingLevel && !(GLEXT_framebuffer_multisample && GLEXT_framebuffer_blit))
+            return false;
 
-    if (settings.stencilBits && !GLEXT_packed_depth_stencil)
-        return false;
+        if (settings.stencilBits && !GLEXT_packed_depth_stencil)
+            return false;
 
 #ifndef SFML_OPENGL_ES
 
-    // Check if the requested anti-aliasing level is supported
-    if (settings.antialiasingLevel)
-    {
-        GLint samples = 0;
-        glCheck(glGetIntegerv(GLEXT_GL_MAX_SAMPLES, &samples));
-
-        if (settings.antialiasingLevel > static_cast<unsigned int>(samples))
+        // Check if the requested anti-aliasing level is supported
+        if (settings.antialiasingLevel)
         {
-            err() << "Impossible to create render texture (unsupported anti-aliasing level)";
-            err() << " Requested: " << settings.antialiasingLevel << " Maximum supported: " << samples << std::endl;
+            GLint samples = 0;
+            glCheck(glGetIntegerv(GLEXT_GL_MAX_SAMPLES, &samples));
+
+            if (settings.antialiasingLevel > static_cast<unsigned int>(samples))
+            {
+                err() << "Impossible to create render texture (unsupported anti-aliasing level)";
+                err() << " Requested: " << settings.antialiasingLevel << " Maximum supported: " << samples << std::endl;
+                return false;
+            }
+        }
+
+#endif
+
+
+        if (!settings.antialiasingLevel)
+        {
+            // Create the depth/stencil buffer if requested
+            if (settings.stencilBits)
+            {
+
+#ifndef SFML_OPENGL_ES
+
+                GLuint depthStencil = 0;
+                glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
+                m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
+                if (!m_depthStencilBuffer)
+                {
+                    err() << "Impossible to create render texture (failed to create the attached depth/stencil buffer)" << std::endl;
+                    return false;
+                }
+                glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+                glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH24_STENCIL8, width, height));
+
+#else
+
+                err() << "Impossible to create render texture (failed to create the attached depth/stencil buffer)" << std::endl;
+                return false;
+
+#endif // SFML_OPENGL_ES
+
+                m_stencil = true;
+
+            }
+            else if (settings.depthBits)
+            {
+                GLuint depthStencil = 0;
+                glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
+                m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
+                if (!m_depthStencilBuffer)
+                {
+                    err() << "Impossible to create render texture (failed to create the attached depth buffer)" << std::endl;
+                    return false;
+                }
+                glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+                glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH_COMPONENT, width, height));
+            }
+        }
+        else
+        {
+
+#ifndef SFML_OPENGL_ES
+
+            // Create the multisample color buffer
+            GLuint color = 0;
+            glCheck(GLEXT_glGenRenderbuffers(1, &color));
+            m_colorBuffer = static_cast<unsigned int>(color);
+            if (!m_colorBuffer)
+            {
+                err() << "Impossible to create render texture (failed to create the attached multisample color buffer)" << std::endl;
+                return false;
+            }
+            glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_colorBuffer));
+            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, GL_RGBA, width, height));
+
+            // Create the multisample depth/stencil buffer if requested
+            if (settings.stencilBits)
+            {
+                GLuint depthStencil = 0;
+                glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
+                m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
+                if (!m_depthStencilBuffer)
+                {
+                    err() << "Impossible to create render texture (failed to create the attached multisample depth/stencil buffer)" << std::endl;
+                    return false;
+                }
+                glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+                glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, GLEXT_GL_DEPTH24_STENCIL8, width, height));
+
+                m_stencil = true;
+            }
+            else if (settings.depthBits)
+            {
+                GLuint depthStencil = 0;
+                glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
+                m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
+                if (!m_depthStencilBuffer)
+                {
+                    err() << "Impossible to create render texture (failed to create the attached multisample depth buffer)" << std::endl;
+                    return false;
+                }
+                glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+                glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, GLEXT_GL_DEPTH_COMPONENT, width, height));
+            }
+
+#else
+
+            err() << "Impossible to create render texture (failed to create the multisample render buffers)" << std::endl;
             return false;
+
+#endif // SFML_OPENGL_ES
+
+            m_multisample = true;
+
+        }
+    }
+
+    // Save our texture ID in order to be able to attach it to an FBO at any time
+    m_textureId = textureId;
+
+    // We can't create an FBO now if there is no active context
+    if (!Context::getActiveContextId())
+        return true;
+
+#ifndef SFML_OPENGL_ES
+
+    // Save the current bindings so we can restore them after we are done
+    GLint readFramebuffer = 0;
+    GLint drawFramebuffer = 0;
+
+    glCheck(glGetIntegerv(GLEXT_GL_READ_FRAMEBUFFER_BINDING, &readFramebuffer));
+    glCheck(glGetIntegerv(GLEXT_GL_DRAW_FRAMEBUFFER_BINDING, &drawFramebuffer));
+
+    if (createFrameBuffer())
+    {
+        // Restore previously bound framebuffers
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_READ_FRAMEBUFFER, readFramebuffer));
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, drawFramebuffer));
+
+        return true;
+    }
+
+#else
+
+    // Save the current binding so we can restore them after we are done
+    GLint frameBuffer = 0;
+
+    glCheck(glGetIntegerv(GLEXT_GL_FRAMEBUFFER_BINDING, &frameBuffer));
+
+    if (createFrameBuffer())
+    {
+        // Restore previously bound framebuffer
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, frameBuffer));
+
+        return true;
+    }
+
+#endif
+
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool RenderTextureImplFBO::createFrameBuffer()
+{
+    // Create the framebuffer object
+    GLuint frameBuffer = 0;
+    glCheck(GLEXT_glGenFramebuffers(1, &frameBuffer));
+
+    if (!frameBuffer)
+    {
+        err() << "Impossible to create render texture (failed to create the frame buffer object)" << std::endl;
+        return false;
+    }
+    glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, frameBuffer));
+
+    // Link the depth/stencil renderbuffer to the frame buffer
+    if (!m_multisample && m_depthStencilBuffer)
+    {
+        glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_DEPTH_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+
+#ifndef SFML_OPENGL_ES
+
+        if (m_stencil)
+        {
+            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_STENCIL_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+        }
+
+#endif
+
+    }
+
+    // Link the texture to the frame buffer
+    glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_textureId, 0));
+
+    // A final check, just to be sure...
+    GLenum status;
+    glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
+    if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
+    {
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
+        glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
+        err() << "Impossible to create render texture (failed to link the target texture to the frame buffer)" << std::endl;
+        return false;
+    }
+
+    {
+        Lock lock(mutex);
+
+        // Insert the FBO into our map
+        m_frameBuffers.insert(std::make_pair(Context::getActiveContextId(), static_cast<unsigned int>(frameBuffer)));
+    }
+
+#ifndef SFML_OPENGL_ES
+
+    if (m_multisample)
+    {
+        // Create the multisample framebuffer object
+        GLuint multisampleFrameBuffer = 0;
+        glCheck(GLEXT_glGenFramebuffers(1, &multisampleFrameBuffer));
+
+        if (!multisampleFrameBuffer)
+        {
+            err() << "Impossible to create render texture (failed to create the multisample frame buffer object)" << std::endl;
+            return false;
+        }
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, multisampleFrameBuffer));
+
+        // Link the multisample color buffer to the frame buffer
+        glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_colorBuffer));
+        glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GLEXT_GL_RENDERBUFFER, m_colorBuffer));
+
+        // Link the depth/stencil renderbuffer to the frame buffer
+        if (m_depthStencilBuffer)
+        {
+            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_DEPTH_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+
+            if (m_stencil)
+            {
+                glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_STENCIL_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
+            }
+        }
+
+        // A final check, just to be sure...
+        glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
+        if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
+        {
+            glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
+            glCheck(GLEXT_glDeleteFramebuffers(1, &multisampleFrameBuffer));
+            err() << "Impossible to create render texture (failed to link the render buffers to the multisample frame buffer)" << std::endl;
+            return false;
+        }
+
+        {
+            Lock lock(mutex);
+
+            // Insert the FBO into our map
+            m_multisampleFrameBuffers.insert(std::make_pair(Context::getActiveContextId(), static_cast<unsigned int>(multisampleFrameBuffer)));
         }
     }
 
 #endif
 
-    if (!settings.antialiasingLevel)
-    {
-        // Create the framebuffer object
-        GLuint frameBuffer = 0;
-        glCheck(GLEXT_glGenFramebuffers(1, &frameBuffer));
-        m_frameBuffer = static_cast<unsigned int>(frameBuffer);
-        if (!m_frameBuffer)
-        {
-            err() << "Impossible to create render texture (failed to create the frame buffer object)" << std::endl;
-            return false;
-        }
-        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, m_frameBuffer));
-
-        // Create the depth/stencil buffer if requested
-        if (settings.stencilBits)
-        {
-
-#ifndef SFML_OPENGL_ES
-
-            GLuint depthStencil = 0;
-            glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
-            m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
-            if (!m_depthStencilBuffer)
-            {
-                err() << "Impossible to create render texture (failed to create the attached depth/stencil buffer)" << std::endl;
-                return false;
-            }
-            glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-            glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH24_STENCIL8, width, height));
-            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_DEPTH_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_STENCIL_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-#else
-
-            err() << "Impossible to create render texture (failed to create the attached depth/stencil buffer)" << std::endl;
-            return false;
-
-#endif // SFML_OPENGL_ES
-
-        }
-        else if (settings.depthBits)
-        {
-            GLuint depthStencil = 0;
-            glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
-            m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
-            if (!m_depthStencilBuffer)
-            {
-                err() << "Impossible to create render texture (failed to create the attached depth buffer)" << std::endl;
-                return false;
-            }
-            glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-            glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH_COMPONENT, width, height));
-            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_DEPTH_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-        }
-
-        // Link the texture to the frame buffer
-        glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureId, 0));
-
-        // A final check, just to be sure...
-        GLenum status;
-        glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
-        if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
-        {
-            glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
-            err() << "Impossible to create render texture (frame buffer incomplete)" << std::endl;
-            return false;
-        }
-
-        return true;
-    }
-    else
-    {
-
-#ifndef SFML_OPENGL_ES
-
-        // Create the framebuffer object
-        GLuint frameBuffer = 0;
-        glCheck(GLEXT_glGenFramebuffers(1, &frameBuffer));
-        m_frameBuffer = static_cast<unsigned int>(frameBuffer);
-        if (!m_frameBuffer)
-        {
-            err() << "Impossible to create render texture (failed to create the frame buffer object)" << std::endl;
-            return false;
-        }
-        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, m_frameBuffer));
-
-        // Link the texture to the frame buffer
-        glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, textureId, 0));
-
-        // A final check, just to be sure...
-        GLenum status;
-        glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
-        if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
-        {
-            glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
-            err() << "Impossible to create render texture (frame buffer incomplete)" << std::endl;
-            return false;
-        }
-
-        // Create the multisample framebuffer object
-        frameBuffer = 0;
-        glCheck(GLEXT_glGenFramebuffers(1, &frameBuffer));
-        m_multisampleFrameBuffer = static_cast<unsigned int>(frameBuffer);
-        if (!m_multisampleFrameBuffer)
-        {
-            err() << "Impossible to create render texture (failed to create the multisample frame buffer object)" << std::endl;
-            return false;
-        }
-        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, m_multisampleFrameBuffer));
-
-        // Create the multisample color buffer
-        GLuint color = 0;
-        glCheck(GLEXT_glGenRenderbuffers(1, &color));
-        m_colorBuffer = static_cast<unsigned int>(color);
-        if (!m_colorBuffer)
-        {
-            err() << "Impossible to create render texture (failed to create the attached multisample color buffer)" << std::endl;
-            return false;
-        }
-        glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_colorBuffer));
-        glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, GL_RGBA, width, height));
-        glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GLEXT_GL_RENDERBUFFER, m_colorBuffer));
-
-        // Create the multisample depth/stencil buffer if requested
-        if (settings.stencilBits)
-        {
-            GLuint depthStencil = 0;
-            glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
-            m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
-            if (!m_depthStencilBuffer)
-            {
-                err() << "Impossible to create render texture (failed to create the attached multisample depth/stencil buffer)" << std::endl;
-                return false;
-            }
-            glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, GLEXT_GL_DEPTH24_STENCIL8, width, height));
-            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_DEPTH_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_STENCIL_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-        }
-        else if (settings.depthBits)
-        {
-            GLuint depthStencil = 0;
-            glCheck(GLEXT_glGenRenderbuffers(1, &depthStencil));
-            m_depthStencilBuffer = static_cast<unsigned int>(depthStencil);
-            if (!m_depthStencilBuffer)
-            {
-                err() << "Impossible to create render texture (failed to create the attached multisample depth buffer)" << std::endl;
-                return false;
-            }
-            glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, GLEXT_GL_DEPTH_COMPONENT, width, height));
-            glCheck(GLEXT_glFramebufferRenderbuffer(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_DEPTH_ATTACHMENT, GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-        }
-
-        // A final check, just to be sure...
-        glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
-        if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
-        {
-            glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
-            err() << "Impossible to create render texture (multisample frame buffer incomplete)" << std::endl;
-            return false;
-        }
-
-        return true;
-
-#else
-
-        err() << "Impossible to create render texture (failed to create the multisample frame buffer object)" << std::endl;
-        return false;
-
-#endif // SFML_OPENGL_ES
-
-    }
+    return true;
 }
 
 
 ////////////////////////////////////////////////////////////
 bool RenderTextureImplFBO::activate(bool active)
 {
-    return m_context->setActive(active);
+    // Unbind the FBO if requested
+    if (!active)
+    {
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
+        return true;
+    }
+
+    Uint64 contextId = Context::getActiveContextId();
+
+    // In the odd case we have to activate and there is no active
+    // context yet, we have to create one
+    if (!contextId)
+    {
+        if (!m_context)
+            m_context = new Context;
+
+        m_context->setActive(true);
+
+        contextId = Context::getActiveContextId();
+
+        if (!contextId)
+        {
+            err() << "Impossible to activate render texture (failed to create backup context)" << std::endl;
+
+            return false;
+        }
+    }
+
+    // Lookup the FBO corresponding to the currently active context
+    // If none is found, there is no FBO corresponding to the
+    // currently active context so we will have to create a new FBO
+    {
+        Lock lock(mutex);
+
+        std::map<Uint64, unsigned int>::iterator iter;
+        
+        if (m_multisample)
+        {
+            iter = m_multisampleFrameBuffers.find(contextId);
+
+            if (iter != m_multisampleFrameBuffers.end())
+            {
+                glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, iter->second));
+
+                return true;
+            }
+        }
+        else
+        {
+            iter = m_frameBuffers.find(contextId);
+
+            if (iter != m_frameBuffers.end())
+            {
+                glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, iter->second));
+
+                return true;
+            }
+        }
+    }
+
+    return createFrameBuffer();
 }
 
 
 ////////////////////////////////////////////////////////////
 void RenderTextureImplFBO::updateTexture(unsigned int)
 {
+    // If multisampling is enabled, we need to resolve by blitting
+    // from our FBO with multisample renderbuffer attachments
+    // to our FBO to which our target texture is attached
 
 #ifndef SFML_OPENGL_ES
 
-    if (m_multisampleFrameBuffer)
+    // In case of multisampling, make sure both FBOs
+    // are already available within the current context
+    if (m_multisample && m_width && m_height && activate(true))
     {
-        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, m_frameBuffer));
-        glCheck(GLEXT_glBlitFramebuffer(0, 0, m_width, m_height, 0, 0, m_width, m_height, GL_COLOR_BUFFER_BIT, GL_NEAREST));
-        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, m_multisampleFrameBuffer));
+        Uint64 contextId = Context::getActiveContextId();
+
+        Lock lock(mutex);
+
+        std::map<Uint64, unsigned int>::iterator iter = m_frameBuffers.find(contextId);
+        std::map<Uint64, unsigned int>::iterator multisampleIter = m_multisampleFrameBuffers.find(contextId);
+
+        if ((iter != m_frameBuffers.end()) && (multisampleIter != m_multisampleFrameBuffers.end()))
+        {
+            // Set up the blit target (draw framebuffer) and blit (from the read framebuffer, our multisample FBO)
+            glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, iter->second));
+            glCheck(GLEXT_glBlitFramebuffer(0, 0, m_width, m_height, 0, 0, m_width, m_height, GL_COLOR_BUFFER_BIT, GL_NEAREST));
+            glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, multisampleIter->second));
+        }
     }
 
 #endif // SFML_OPENGL_ES
 
-    glCheck(glFlush());
 }
 
 } // namespace priv

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -31,6 +31,7 @@
 #include <SFML/Graphics/RenderTextureImpl.hpp>
 #include <SFML/Window/Context.hpp>
 #include <SFML/Window/GlResource.hpp>
+#include <map>
 
 
 namespace sf
@@ -74,6 +75,12 @@ public:
     ////////////////////////////////////////////////////////////
     static unsigned int getMaximumAntialiasingLevel();
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Unbind the currently bound FBO
+    ///
+    ////////////////////////////////////////////////////////////
+    static void unbind();
+
 private:
 
     ////////////////////////////////////////////////////////////
@@ -88,6 +95,14 @@ private:
     ///
     ////////////////////////////////////////////////////////////
     virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, const ContextSettings& settings);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create an FBO in the current context
+    ///
+    /// \return True if creation has been successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool createFrameBuffer();
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering
@@ -110,13 +125,16 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Context*     m_context;                ///< Needs a separate OpenGL context for not messing up the other ones
-    unsigned int m_frameBuffer;            ///< OpenGL frame buffer object
-    unsigned int m_multisampleFrameBuffer; ///< Optional OpenGL frame buffer object with multisample attachments
-    unsigned int m_depthStencilBuffer;     ///< Optional depth/stencil buffer attached to the frame buffer
-    unsigned int m_colorBuffer;            ///< Optional multisample color buffer attached to the frame buffer
-    unsigned int m_width;                  ///< Width of the attachments
-    unsigned int m_height;                 ///< Height of the attachments
+    std::map<Uint64, unsigned int> m_frameBuffers;            ///< OpenGL frame buffer objects per context
+    std::map<Uint64, unsigned int> m_multisampleFrameBuffers; ///< Optional per-context OpenGL frame buffer objects with multisample attachments
+    unsigned int                   m_depthStencilBuffer;      ///< Optional depth/stencil buffer attached to the frame buffer
+    unsigned int                   m_colorBuffer;             ///< Optional multisample color buffer attached to the frame buffer
+    unsigned int                   m_width;                   ///< Width of the attachments
+    unsigned int                   m_height;                  ///< Height of the attachments
+    Context*                       m_context;                 ///< Backup OpenGL context, used when none already exist
+    unsigned int                   m_textureId;               ///< The ID of the texture to attach to the FBO
+    bool                           m_multisample;             ///< Whether we have to create a multisample frame buffer as well
+    bool                           m_stencil;                 ///< Whether we have stencil attachment
 };
 
 } // namespace priv

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/GLCheck.hpp>
+#include <SFML/Graphics/RenderTextureImplFBO.hpp>
 
 
 namespace sf
@@ -71,7 +73,22 @@ Vector2u RenderWindow::getSize() const
 ////////////////////////////////////////////////////////////
 bool RenderWindow::setActive(bool active)
 {
-    return Window::setActive(active);
+    bool result = Window::setActive(active);
+
+    // Update RenderTarget tracking
+    if (result)
+        RenderTarget::setActive(active);
+
+    // If FBOs are available, make sure none are bound when we
+    // try to draw to the default framebuffer of the RenderWindow
+    if (result && priv::RenderTextureImplFBO::isAvailable())
+    {
+        priv::RenderTextureImplFBO::unbind();
+
+        return true;
+    }
+
+    return result;
 }
 
 

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -81,6 +81,13 @@ const Context* Context::getActiveContext()
 
 
 ////////////////////////////////////////////////////////////
+Uint64 Context::getActiveContextId()
+{
+    return priv::GlContext::getActiveContextId();
+}
+
+
+////////////////////////////////////////////////////////////
 bool Context::isExtensionAvailable(const char* name)
 {
     return priv::GlContext::isExtensionAvailable(name);

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -150,6 +150,9 @@ m_config  (NULL)
 ////////////////////////////////////////////////////////////
 EglContext::~EglContext()
 {
+    // Notify unshared OpenGL resources of context destruction
+    cleanupUnsharedResources();
+
     // Deactivate the current context
     EGLContext currentContext = eglCheck(eglGetCurrentContext());
 

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -31,6 +31,7 @@
 #include <SFML/Config.hpp>
 #include <SFML/Window/Context.hpp>
 #include <SFML/Window/ContextSettings.hpp>
+#include <SFML/Window/GlResource.hpp>
 #include <SFML/System/NonCopyable.hpp>
 
 
@@ -68,6 +69,19 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     static void cleanupResource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Register a function to be called when a context is destroyed
+    ///
+    /// This is used for internal purposes in order to properly
+    /// clean up OpenGL resources that cannot be shared bwteen
+    /// contexts.
+    ///
+    /// \param callback Function to be called when a context is destroyed
+    /// \param arg      Argument to pass when calling the function
+    ///
+    ////////////////////////////////////////////////////////////
+    static void registerContextDestroyCallback(ContextDestroyCallback callback, void* arg);
 
     ////////////////////////////////////////////////////////////
     /// \brief Acquires a context for short-term use on the current thread
@@ -144,6 +158,17 @@ public:
     static GlFunctionPointer getFunction(const char* name);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the currently active context's ID
+    ///
+    /// The context ID is used to identify contexts when
+    /// managing unshareable OpenGL resources.
+    ///
+    /// \return The active context's ID or 0 if no context is currently active
+    ///
+    ////////////////////////////////////////////////////////////
+    static Uint64 getActiveContextId();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -218,6 +243,12 @@ protected:
     virtual bool makeCurrent(bool current) = 0;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Notify unshared GlResources of context destruction
+    ///
+    ////////////////////////////////////////////////////////////
+    void cleanupUnsharedResources();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Evaluate a pixel format configuration
     ///
     /// This functions can be used by implementations that have
@@ -259,6 +290,11 @@ private:
     ///
     ////////////////////////////////////////////////////////////
     void checkSettings(const ContextSettings& requestedSettings);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    const Uint64 m_id; ///< Unique number that identifies the context
 };
 
 } // namespace priv

--- a/src/SFML/Window/GlResource.cpp
+++ b/src/SFML/Window/GlResource.cpp
@@ -46,6 +46,13 @@ GlResource::~GlResource()
 
 
 ////////////////////////////////////////////////////////////
+void GlResource::registerContextDestroyCallback(ContextDestroyCallback callback, void* arg)
+{
+    priv::GlContext::registerContextDestroyCallback(callback, arg);
+}
+
+
+////////////////////////////////////////////////////////////
 GlResource::TransientContextLock::TransientContextLock()
 {
     priv::GlContext::acquireTransientContext();

--- a/src/SFML/Window/OSX/SFContext.mm
+++ b/src/SFML/Window/OSX/SFContext.mm
@@ -103,6 +103,9 @@ m_window(0)
 ////////////////////////////////////////////////////////////
 SFContext::~SFContext()
 {
+    // Notify unshared OpenGL resources of context destruction
+    cleanupUnsharedResources();
+
     [m_context clearDrawable];
 
     if (m_context == [NSOpenGLContext currentContext])

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -172,6 +172,9 @@ m_ownsWindow(false)
 ////////////////////////////////////////////////////////////
 GlxContext::~GlxContext()
 {
+    // Notify unshared OpenGL resources of context destruction
+    cleanupUnsharedResources();
+
     // Destroy the context
     if (m_context)
     {

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -154,6 +154,9 @@ m_ownsWindow   (false)
 ////////////////////////////////////////////////////////////
 WglContext::~WglContext()
 {
+    // Notify unshared OpenGL resources of context destruction
+    cleanupUnsharedResources();
+
     // Destroy the OpenGL context
     if (m_context)
     {

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -91,6 +91,9 @@ m_clock       ()
 ////////////////////////////////////////////////////////////
 EaglContext::~EaglContext()
 {
+    // Notify unshared OpenGL resources of context destruction
+    cleanupUnsharedResources();
+
     if (m_context)
     {
         // Activate the context, so that we can destroy the buffers


### PR DESCRIPTION
Optimized RenderTexture performance when using the FBO implementation by removing unnecessary context switches and flushing.

In this change, FBOs no longer live in their own context if they don't have to. This reduces or even eliminates context switching all together in single window applications, giving "near native OpenGL performance". Furthermore, the glFlush() in display() was also removed in favour of explicit rebinding in RenderTarget in order to reduce the time waiting for the driver queue to flush to the GPU queue. This also saves a large amount of time.

In applications that make heavy use of RenderTextures, this can mean a significant performance gain if they were previously CPU-bottlenecked. This change shouldn't have an effect on the actual GPU workload in any way.

Here is a synthetic "benchmark" I used to test the difference with and without this change:
```cpp
#include <SFML/Graphics.hpp>
#include <sstream>

int main()
{
    sf::RenderWindow window(sf::VideoMode(800, 600), "Test", sf::Style::Titlebar | sf::Style::Close);
    window.setVerticalSyncEnabled(false);

    sf::Font font;
    if (!font.loadFromFile("resources/sansation.ttf"))
        return EXIT_FAILURE;

    sf::Text text("Test", font, 20);

    sf::RenderTexture renderTexture[10];

    for (int i = 0; i < 10; ++i)
        renderTexture[i].create(800, 600);

    sf::Sprite sprite;

    sf::Clock clock;
    std::ostringstream sstr;

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();

            if ((event.type == sf::Event::KeyPressed) && (event.key.code == sf::Keyboard::Escape))
                window.close();
        }

        for (int i = 0; i < 20; ++i)
        {
            for (int j = 0; j < 10; ++j)
            {
                renderTexture[j].clear(sf::Color(0, 0, 0));

                for (int j = 0; j < 10; ++j)
                    renderTexture[j].draw(text);

                renderTexture[j].display();
            }

            window.clear(sf::Color(0, 0, 0));

            for (int j = 0; j < 10; ++j)
            {
                sprite.setTexture(renderTexture[j].getTexture());

                for (int k = 0; k < 10; ++k)
                    window.draw(sprite);
            }
        }

        window.display();

        sstr.str("");
        sstr << "Test -- Frame: " << clock.restart().asSeconds() << " sec";

        window.setTitle(sstr.str());
    }

    return EXIT_SUCCESS;
}
```
Frame times on my laptop dropped from 800ms down to 200ms with this change. This is a 4x speedup.
Everybody is free to test this change for bugs and performance deltas using real-world applications. I'd like feedback regarding more realistic workloads as well.