### PR TITLE
window: change case of Dbt.h inclusion

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -39,7 +39,10 @@
 #include <GL/gl.h>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Utf.hpp>
-#include <Dbt.h>
+// dbt.h is lowercase here, as a cross-compile on linux with mingw-w64
+// expects lowercase, and a native compile on windows, whether via msvc
+// or mingw-w64 addresses files in a case insensitive manner.
+#include <dbt.h>
 #include <vector>
 #include <cstring>
 


### PR DESCRIPTION
Windows should have no issue with this change, as it addresses
files in a case-insensitve manner. Said header is installed in
lowercase on mingw-w64, and won't build since commit
22f1b85515242c44d7e5a1be1e3960bdf6648b52

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>