### PR TITLE
windows: add resource.rc files to dll builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+resource.rc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake)
 set(VERSION_MAJOR 2)
 set(VERSION_MINOR 4)
 set(VERSION_PATCH 2)
+set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
 # add an option for choosing the build type (shared or static)
 if(NOT (SFML_OS_IOS OR SFML_OS_ANDROID))

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -58,6 +58,11 @@ source_group("codecs" FILES ${CODECS_SRC})
 # let CMake know about our additional audio libraries paths (on Windows and OSX)
 if(SFML_OS_WINDOWS)
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/AL")
+    CONFIGURE_FILE(
+        "${SRCROOT}/resource.rc.in"
+        "${SRCROOT}/resource.rc"
+        @ONLY)
+    list(APPEND SRC "${SRCROOT}/resource.rc")
 elseif(SFML_OS_MACOSX)
     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-osx/Frameworks")
 elseif(SFML_OS_ANDROID)

--- a/src/SFML/Audio/resource.rc.in
+++ b/src/SFML/Audio/resource.rc.in
@@ -1,0 +1,32 @@
+#include "winresrc.h"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ PRODUCTVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef DEBUG
+ FILEFLAGS 1
+#else
+ FILEFLAGS 0
+#endif
+ FILEOS VOS_NT
+ FILETYPE VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "\0"
+            VALUE "FileDescription", "sfml-audio @VERSION_STRING@\0"
+            VALUE "InternalName", "sfml-audio-@VERSION_MAJOR@.dll\0"
+            VALUE "LegalCopyright", "Copyright (C) 2007-2018 Laurent Gomila\0"
+            VALUE "OriginalFilename", "sfml-audio-@VERSION_MAJOR@.dll\0"
+            VALUE "ProductName", "Simple Fast Multimedia Library Audio Module\0"
+            VALUE "ProductVersion", "@VERSION_STRING@\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1252 //en-US
+    END
+END

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -102,6 +102,11 @@ target_include_directories(sfml-graphics PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/
 # let CMake know about our additional graphics libraries paths
 if(SFML_OS_WINDOWS)
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/freetype2")
+    CONFIGURE_FILE(
+        "${SRCROOT}/resource.rc.in"
+        "${SRCROOT}/resource.rc"
+        @ONLY)
+    list(APPEND SRC "${SRCROOT}/resource.rc")
 elseif(SFML_OS_MACOSX)
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/freetype2")
     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-osx/Frameworks")

--- a/src/SFML/Graphics/resource.rc.in
+++ b/src/SFML/Graphics/resource.rc.in
@@ -1,0 +1,32 @@
+#include "winresrc.h"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ PRODUCTVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef DEBUG
+ FILEFLAGS 1
+#else
+ FILEFLAGS 0
+#endif
+ FILEOS VOS_NT
+ FILETYPE VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "\0"
+            VALUE "FileDescription", "sfml-graphics @VERSION_STRING@\0"
+            VALUE "InternalName", "sfml-graphics-@VERSION_MAJOR@.dll\0"
+            VALUE "LegalCopyright", "Copyright (C) 2007-2018 Laurent Gomila\0"
+            VALUE "OriginalFilename", "sfml-graphics-@VERSION_MAJOR@.dll\0"
+            VALUE "ProductName", "Simple Fast Multimedia Library Graphics Module\0"
+            VALUE "ProductVersion", "@VERSION_STRING@\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1252 //en-US
+    END
+END

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -29,10 +29,15 @@ set(SRC
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
+    CONFIGURE_FILE(
+        "${SRCROOT}/Win32/resource.rc.in"
+        "${SRCROOT}/Win32/resource.rc"
+        @ONLY)
     set(SRC
         ${SRC}
         ${SRCROOT}/Win32/SocketImpl.cpp
         ${SRCROOT}/Win32/SocketImpl.hpp
+        ${SRCROOT}/Win32/resource.rc
     )
 else()
     set(SRC

--- a/src/SFML/Network/Win32/resource.rc.in
+++ b/src/SFML/Network/Win32/resource.rc.in
@@ -1,0 +1,32 @@
+#include "winresrc.h"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ PRODUCTVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef DEBUG
+ FILEFLAGS 1
+#else
+ FILEFLAGS 0
+#endif
+ FILEOS VOS_NT
+ FILETYPE VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "\0"
+            VALUE "FileDescription", "sfml-network @VERSION_STRING@\0"
+            VALUE "InternalName", "sfml-network-@VERSION_MAJOR@.dll\0"
+            VALUE "LegalCopyright", "Copyright (C) 2007-2018 Laurent Gomila\0"
+            VALUE "OriginalFilename", "sfml-network-@VERSION_MAJOR@.dll\0"
+            VALUE "ProductName", "Simple Fast Multimedia Library Network Module\0"
+            VALUE "ProductVersion", "@VERSION_STRING@\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1252 //en-US
+    END
+END

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -45,6 +45,10 @@ source_group("" FILES ${SRC})
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
+    CONFIGURE_FILE(
+        "${SRCROOT}/Win32/resource.rc.in"
+        "${SRCROOT}/Win32/resource.rc"
+        @ONLY)
     set(PLATFORM_SRC
         ${SRCROOT}/Win32/ClockImpl.cpp
         ${SRCROOT}/Win32/ClockImpl.hpp
@@ -56,6 +60,7 @@ if(SFML_OS_WINDOWS)
         ${SRCROOT}/Win32/ThreadImpl.hpp
         ${SRCROOT}/Win32/ThreadLocalImpl.cpp
         ${SRCROOT}/Win32/ThreadLocalImpl.hpp
+        ${SRCROOT}/Win32/resource.rc
     )
     source_group("windows" FILES ${PLATFORM_SRC})
 else()

--- a/src/SFML/System/Win32/resource.rc.in
+++ b/src/SFML/System/Win32/resource.rc.in
@@ -1,0 +1,32 @@
+#include "winresrc.h"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ PRODUCTVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef DEBUG
+ FILEFLAGS 1
+#else
+ FILEFLAGS 0
+#endif
+ FILEOS VOS_NT
+ FILETYPE VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "\0"
+            VALUE "FileDescription", "sfml-system @VERSION_STRING@\0"
+            VALUE "InternalName", "sfml-system-@VERSION_MAJOR@.dll\0"
+            VALUE "LegalCopyright", "Copyright (C) 2007-2018 Laurent Gomila\0"
+            VALUE "OriginalFilename", "sfml-system-@VERSION_MAJOR@.dll\0"
+            VALUE "ProductName", "Simple Fast Multimedia Library System Module\0"
+            VALUE "ProductVersion", "@VERSION_STRING@\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1252 //en-US
+    END
+END

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -56,6 +56,10 @@ source_group("" FILES ${SRC})
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
+    CONFIGURE_FILE(
+        "${SRCROOT}/Win32/resource.rc.in"
+	"${SRCROOT}/Win32/resource.rc"
+	@ONLY)
     set(PLATFORM_SRC
         ${SRCROOT}/Win32/CursorImpl.hpp
         ${SRCROOT}/Win32/CursorImpl.cpp
@@ -73,7 +77,8 @@ if(SFML_OS_WINDOWS)
         ${SRCROOT}/Win32/SensorImpl.cpp
         ${SRCROOT}/Win32/VideoModeImpl.cpp
         ${SRCROOT}/Win32/WindowImplWin32.cpp
-        ${SRCROOT}/Win32/WindowImplWin32.hpp
+	${SRCROOT}/Win32/WindowImplWin32.hpp
+	${SRCROOT}/Win32/resource.rc
     )
     source_group("windows" FILES ${PLATFORM_SRC})
 

--- a/src/SFML/Window/Win32/resource.rc.in
+++ b/src/SFML/Window/Win32/resource.rc.in
@@ -1,0 +1,32 @@
+#include "winresrc.h"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ PRODUCTVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef DEBUG
+ FILEFLAGS 1
+#else
+ FILEFLAGS 0
+#endif
+ FILEOS VOS_NT
+ FILETYPE VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "\0"
+            VALUE "FileDescription", "sfml-window @VERSION_STRING@\0"
+            VALUE "InternalName", "sfml-window-@VERSION_MAJOR@.dll\0"
+            VALUE "LegalCopyright", "Copyright (C) 2007-2018 Laurent Gomila\0"
+            VALUE "OriginalFilename", "sfml-window-@VERSION_MAJOR@.dll\0"
+            VALUE "ProductName", "Simple Fast Multimedia Library Window Module\0"
+            VALUE "ProductVersion", "@VERSION_STRING@\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1252 //en-US
+    END
+END


### PR DESCRIPTION
Windows uses a mechanism known as 'resource files' which provides, among
other things, metadata to a given executable/dll/driver/etc, and add a
layer of polish to a project which it would otherwise lack.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>