### PR TITLE
Added a VertexBuffer implementation to all Drawables that were rendered via VertexArrays

### DIFF
--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -32,6 +32,7 @@
 #include <SFML/Graphics/Drawable.hpp>
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
+#include <SFML/Graphics/VertexBuffer.hpp>
 #include <SFML/System/Vector2.hpp>
 
 
@@ -305,15 +306,17 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    const Texture* m_texture;          ///< Texture of the shape
-    IntRect        m_textureRect;      ///< Rectangle defining the area of the source texture to display
-    Color          m_fillColor;        ///< Fill color
-    Color          m_outlineColor;     ///< Outline color
-    float          m_outlineThickness; ///< Thickness of the shape's outline
-    VertexArray    m_vertices;         ///< Vertex array containing the fill geometry
-    VertexArray    m_outlineVertices;  ///< Vertex array containing the outline geometry
-    FloatRect      m_insideBounds;     ///< Bounding rectangle of the inside (fill)
-    FloatRect      m_bounds;           ///< Bounding rectangle of the whole shape (outline + fill)
+    const Texture* m_texture;               ///< Texture of the shape
+    IntRect        m_textureRect;           ///< Rectangle defining the area of the source texture to display
+    Color          m_fillColor;             ///< Fill color
+    Color          m_outlineColor;          ///< Outline color
+    float          m_outlineThickness;      ///< Thickness of the shape's outline
+    VertexArray    m_vertices;              ///< Vertex array containing the fill geometry
+    VertexArray    m_outlineVertices;       ///< Vertex array containing the outline geometry
+    VertexBuffer   m_verticesBuffer;        ///< Vertex buffer containing the fill geometry
+    VertexBuffer   m_outlineVerticesBuffer; ///< Vertex buffer containing the outline geometry
+    FloatRect      m_insideBounds;          ///< Bounding rectangle of the inside (fill)
+    FloatRect      m_bounds;                ///< Bounding rectangle of the whole shape (outline + fill)
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -33,6 +33,7 @@
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/Vertex.hpp>
 #include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/VertexBuffer.hpp>
 
 
 namespace sf
@@ -215,9 +216,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Vertex         m_vertices[4]; ///< Vertices defining the sprite's geometry
-    const Texture* m_texture;     ///< Texture of the sprite
-    IntRect        m_textureRect; ///< Rectangle defining the area of the source texture to display
+    Vertex         m_vertices[4];    ///< Vertices defining the sprite's geometry
+    VertexBuffer   m_verticesBuffer; ///< Vertex buffer containing the sprite's geometry
+    const Texture* m_texture;        ///< Texture of the sprite
+    IntRect        m_textureRect;    ///< Rectangle defining the area of the source texture to display
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -34,6 +34,7 @@
 #include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
+#include <SFML/Graphics/VertexBuffer.hpp>
 #include <SFML/System/String.hpp>
 #include <string>
 #include <vector>
@@ -435,20 +436,22 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    String              m_string;              ///< String to display
-    const Font*         m_font;                ///< Font used to display the string
-    unsigned int        m_characterSize;       ///< Base size of characters, in pixels
-    float               m_letterSpacingFactor; ///< Spacing factor between letters
-    float               m_lineSpacingFactor;   ///< Spacing factor between lines
-    Uint32              m_style;               ///< Text style (see Style enum)
-    Color               m_fillColor;           ///< Text fill color
-    Color               m_outlineColor;        ///< Text outline color
-    float               m_outlineThickness;    ///< Thickness of the text's outline
-    mutable VertexArray m_vertices;            ///< Vertex array containing the fill geometry
-    mutable VertexArray m_outlineVertices;     ///< Vertex array containing the outline geometry
-    mutable FloatRect   m_bounds;              ///< Bounding rectangle of the text (in local coordinates)
-    mutable bool        m_geometryNeedUpdate;  ///< Does the geometry need to be recomputed?
-    mutable Uint64      m_fontTextureId;       ///< The font texture id
+    String               m_string;                ///< String to display
+    const Font*          m_font;                  ///< Font used to display the string
+    unsigned int         m_characterSize;         ///< Base size of characters, in pixels
+    float                m_letterSpacingFactor;   ///< Spacing factor between letters
+    float                m_lineSpacingFactor;     ///< Spacing factor between lines
+    Uint32               m_style;                 ///< Text style (see Style enum)
+    Color                m_fillColor;             ///< Text fill color
+    Color                m_outlineColor;          ///< Text outline color
+    float                m_outlineThickness;      ///< Thickness of the text's outline
+    mutable VertexArray  m_vertices;              ///< Vertex array containing the fill geometry
+    mutable VertexArray  m_outlineVertices;       ///< Vertex array containing the outline geometry
+    mutable VertexBuffer m_verticesBuffer;        ///< Vertex buffer containing the fill geometry
+    mutable VertexBuffer m_outlineVerticesBuffer; ///< Vertex buffer containing the outline geometry
+    mutable FloatRect    m_bounds;                ///< Bounding rectangle of the text (in local coordinates)
+    mutable bool         m_geometryNeedUpdate;    ///< Does the geometry need to be recomputed?
+    mutable Uint64       m_fontTextureId;         ///< The font texture id
 };
 
 } // namespace sf

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -87,6 +87,10 @@ void Shape::setTextureRect(const IntRect& rect)
 {
     m_textureRect = rect;
     updateTexCoords();
+
+    // Update the vertex buffers if they are being used
+    if (m_verticesBuffer.getVertexCount())
+        m_verticesBuffer.update(&m_vertices[0]);
 }
 
 
@@ -102,6 +106,10 @@ void Shape::setFillColor(const Color& color)
 {
     m_fillColor = color;
     updateFillColors();
+
+    // Update the vertex buffers if they are being used
+    if (m_verticesBuffer.getVertexCount())
+        m_verticesBuffer.update(&m_vertices[0]);
 }
 
 
@@ -117,6 +125,10 @@ void Shape::setOutlineColor(const Color& color)
 {
     m_outlineColor = color;
     updateOutlineColors();
+
+    // Update the vertex buffers if they are being used
+    if (m_outlineVerticesBuffer.getVertexCount())
+        m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
 }
 
 
@@ -158,15 +170,17 @@ FloatRect Shape::getGlobalBounds() const
 
 ////////////////////////////////////////////////////////////
 Shape::Shape() :
-m_texture         (NULL),
-m_textureRect     (),
-m_fillColor       (255, 255, 255),
-m_outlineColor    (255, 255, 255),
-m_outlineThickness(0),
-m_vertices        (TriangleFan),
-m_outlineVertices (TriangleStrip),
-m_insideBounds    (),
-m_bounds          ()
+m_texture              (NULL),
+m_textureRect          (),
+m_fillColor            (255, 255, 255),
+m_outlineColor         (255, 255, 255),
+m_outlineThickness     (0),
+m_vertices             (TriangleFan),
+m_outlineVertices      (TriangleStrip),
+m_verticesBuffer       (TriangleFan, VertexBuffer::Static),
+m_outlineVerticesBuffer(TriangleStrip, VertexBuffer::Static),
+m_insideBounds         (),
+m_bounds               ()
 {
 }
 
@@ -180,6 +194,16 @@ void Shape::update()
     {
         m_vertices.resize(0);
         m_outlineVertices.resize(0);
+
+        if (VertexBuffer::isAvailable())
+        {
+            if (m_verticesBuffer.getVertexCount())
+                m_verticesBuffer.create(0);
+
+            if (m_outlineVerticesBuffer.getVertexCount())
+                m_outlineVerticesBuffer.create(0);
+        }
+
         return;
     }
 
@@ -206,6 +230,21 @@ void Shape::update()
 
     // Outline
     updateOutline();
+
+    // Update the vertex buffers if they are being used
+    if (VertexBuffer::isAvailable())
+    {
+        if (m_verticesBuffer.getVertexCount() != m_vertices.getVertexCount())
+            m_verticesBuffer.create(m_vertices.getVertexCount());
+
+        m_verticesBuffer.update(&m_vertices[0]);
+
+        if (m_outlineVerticesBuffer.getVertexCount() != m_outlineVertices.getVertexCount())
+            m_outlineVerticesBuffer.create(m_outlineVertices.getVertexCount());
+
+        if (m_outlineVertices.getVertexCount())
+            m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
+    }
 }
 
 
@@ -216,13 +255,29 @@ void Shape::draw(RenderTarget& target, RenderStates states) const
 
     // Render the inside
     states.texture = m_texture;
-    target.draw(m_vertices, states);
+
+    if (VertexBuffer::isAvailable())
+    {
+        target.draw(m_verticesBuffer, states);
+    }
+    else
+    {
+        target.draw(m_vertices, states);
+    }
 
     // Render the outline
     if (m_outlineThickness != 0)
     {
         states.texture = NULL;
-        target.draw(m_outlineVertices, states);
+
+        if (VertexBuffer::isAvailable())
+        {
+            target.draw(m_outlineVerticesBuffer, states);
+        }
+        else
+        {
+            target.draw(m_outlineVertices, states);
+        }
     }
 }
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -35,26 +35,37 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 Sprite::Sprite() :
-m_texture    (NULL),
-m_textureRect()
+m_verticesBuffer(TrianglesStrip, VertexBuffer::Stream),
+m_texture       (NULL),
+m_textureRect   ()
 {
+    if (VertexBuffer::isAvailable())
+        m_verticesBuffer.create(4);
 }
 
 
 ////////////////////////////////////////////////////////////
 Sprite::Sprite(const Texture& texture) :
-m_texture    (NULL),
-m_textureRect()
+m_verticesBuffer(TrianglesStrip, VertexBuffer::Stream),
+m_texture       (NULL),
+m_textureRect   ()
 {
+    if (VertexBuffer::isAvailable())
+        m_verticesBuffer.create(4);
+
     setTexture(texture);
 }
 
 
 ////////////////////////////////////////////////////////////
 Sprite::Sprite(const Texture& texture, const IntRect& rectangle) :
-m_texture    (NULL),
-m_textureRect()
+m_verticesBuffer(TrianglesStrip, VertexBuffer::Stream),
+m_texture       (NULL),
+m_textureRect   ()
 {
+    if (VertexBuffer::isAvailable())
+        m_verticesBuffer.create(4);
+
     setTexture(texture);
     setTextureRect(rectangle);
 }
@@ -80,6 +91,10 @@ void Sprite::setTextureRect(const IntRect& rectangle)
         m_textureRect = rectangle;
         updatePositions();
         updateTexCoords();
+
+        // Update the vertex buffer if it is being used
+        if (VertexBuffer::isAvailable())
+            m_verticesBuffer.update(m_vertices);
     }
 }
 
@@ -92,6 +107,10 @@ void Sprite::setColor(const Color& color)
     m_vertices[1].color = color;
     m_vertices[2].color = color;
     m_vertices[3].color = color;
+
+    // Update the vertex buffer if it is being used
+    if (VertexBuffer::isAvailable())
+        m_verticesBuffer.update(m_vertices);
 }
 
 
@@ -140,7 +159,15 @@ void Sprite::draw(RenderTarget& target, RenderStates states) const
     {
         states.transform *= getTransform();
         states.texture = m_texture;
-        target.draw(m_vertices, 4, TriangleStrip, states);
+
+        if (VertexBuffer::isAvailable())
+        {
+            target.draw(m_verticesBuffer, states);
+        }
+        else
+        {
+            target.draw(m_vertices, 4, TriangleStrip, states);
+        }
     }
 }
 


### PR DESCRIPTION
As promised...

__DISCLAIMER: Save important work before testing. Your PC might not like this kind of GPU stress.__

Test with:
```cpp
#include <SFML/Graphics.hpp>
#include <sstream>
#include <cstdlib>

#define TESTTEXT

int main()
{
    sf::RenderWindow window(sf::VideoMode(800, 800), "Test");
    window.setVerticalSyncEnabled(false);

#if defined(TESTTEXT)

    sf::Font font;
    if (!font.loadFromFile("resources/sansation.ttf"))
        return EXIT_FAILURE;

    sf::Text drawable;
    drawable.setFont(font);

    std::string str;

    for (int i = 0; i < 1024 * 1024; ++i)
        str += (std::rand() % 0x80);

    drawable.setString(str);

#elif defined(TESTSHAPE)

    sf::CircleShape drawable(1, 4096 * 4096);

#elif defined(TESTSPRITE)

    sf::Image image;
    image.create(1, 1, sf::Color::White);

    sf::Texture texture;
    texture.loadFromImage(image);

    sf::Sprite drawable(texture);

#endif

    sf::Clock clock;
    std::ostringstream sstr;

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }

        window.clear();

#if defined(TESTSPRITE)

        for (int i = 0; i < 1024 * 256; ++i)
            window.draw(drawable);

#else

        window.draw(drawable);

#endif

        window.display();

        sstr.str("");
        sstr << "Test -- Frame: " << clock.restart().asSeconds() << " sec";

        window.setTitle(sstr.str());
    }
}
```
Performance improvement with `sf::Text` and any `sf::Shape` is so large that mentioning the values doesn't even make any sense. With `sf::Sprite` in order to notice any difference I had to push draw call count to something so stupid that the CPU overhead of the VBO binding/unbinding ends up dominating and making the VBO implementation slower, take with a grain of salt, no sane person would do something like this.

Test using this code by going into VertexBuffer.cpp and temporarily returning false from `isAvailable()`.

Results from real world tests are of course highly appreciated.