### PR TITLE
GlyphQuad x position quantized to pixels

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -727,6 +727,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
                 // Make the texture 2 times bigger
                 Texture newTexture;
                 newTexture.create(textureWidth * 2, textureHeight * 2);
+                newTexture.setSmooth(true);
                 newTexture.update(page.texture);
                 page.texture.swap(newTexture);
             }

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -50,15 +50,17 @@ namespace
     // Add a glyph quad to the vertex array
     void addGlyphQuad(sf::VertexArray& vertices, sf::Vector2f position, const sf::Color& color, const sf::Glyph& glyph, float italicShear, float outlineThickness = 0)
     {
-        float left   = glyph.bounds.left;
-        float top    = glyph.bounds.top;
-        float right  = glyph.bounds.left + glyph.bounds.width;
-        float bottom = glyph.bounds.top  + glyph.bounds.height;
+        float padding = 1.0;
 
-        float u1 = static_cast<float>(glyph.textureRect.left);
-        float v1 = static_cast<float>(glyph.textureRect.top);
-        float u2 = static_cast<float>(glyph.textureRect.left + glyph.textureRect.width);
-        float v2 = static_cast<float>(glyph.textureRect.top  + glyph.textureRect.height);
+        float left   = glyph.bounds.left - padding;
+        float top    = glyph.bounds.top - padding;
+        float right  = glyph.bounds.left + glyph.bounds.width + padding;
+        float bottom = glyph.bounds.top  + glyph.bounds.height + padding;
+
+        float u1 = static_cast<float>(glyph.textureRect.left) - padding;
+        float v1 = static_cast<float>(glyph.textureRect.top) - padding;
+        float u2 = static_cast<float>(glyph.textureRect.left + glyph.textureRect.width) + padding;
+        float v2 = static_cast<float>(glyph.textureRect.top  + glyph.textureRect.height) + padding;
 
         vertices.append(sf::Vertex(sf::Vector2f(position.x + left  - italicShear * top    - outlineThickness, position.y + top    - outlineThickness), color, sf::Vector2f(u1, v1)));
         vertices.append(sf::Vertex(sf::Vector2f(position.x + right - italicShear * top    - outlineThickness, position.y + top    - outlineThickness), color, sf::Vector2f(u2, v1)));


### PR DESCRIPTION
To avoid subpixel positioning of small glyphs when character spacing is not 1.0 I propose the following changes. Subpixel positioning does only affect small characters. Quads x positions for large character sizes are quantized anyway.