### PR TITLE
Add append/overwrite parameter to Ftp::upload.

### DIFF
--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -475,16 +475,20 @@ public:
     /// remote path is relative to the current directory of the
     /// FTP server.
     ///
+    /// The append parameter controls whether the remote file is
+    /// appended to or overwritten if it already exists.
+    ///
     /// \param localFile  Path of the local file to upload
     /// \param remotePath The directory in which to put the file on the server
     /// \param mode       Transfer mode
+    /// \param append     Pass true to append to or false to overwrite the remote file if it already exists
     ///
     /// \return Server response to the request
     ///
     /// \see download
     ///
     ////////////////////////////////////////////////////////////
-    Response upload(const std::string& localFile, const std::string& remotePath, TransferMode mode = Binary);
+    Response upload(const std::string& localFile, const std::string& remotePath, TransferMode mode = Binary, bool append = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a command to the FTP server

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -322,7 +322,7 @@ Ftp::Response Ftp::download(const std::string& remoteFile, const std::string& lo
 
 
 ////////////////////////////////////////////////////////////
-Ftp::Response Ftp::upload(const std::string& localFile, const std::string& remotePath, TransferMode mode)
+Ftp::Response Ftp::upload(const std::string& localFile, const std::string& remotePath, TransferMode mode, bool append)
 {
     // Get the contents of the file to send
     std::ifstream file(localFile.c_str(), std::ios_base::binary);
@@ -346,7 +346,7 @@ Ftp::Response Ftp::upload(const std::string& localFile, const std::string& remot
     if (response.isOk())
     {
         // Tell the server to start the transfer
-        response = sendCommand("STOR", path + filename);
+        response = sendCommand(append ? "APPE" : "STOR", path + filename);
         if (response.isOk())
         {
             // Send the file data


### PR DESCRIPTION
Supersedes #1072, since it seems the original author is no longer active.