### PR TITLE
Use the simulator for iOS by default

### DIFF
--- a/cmake/toolchains/iOS.toolchain.cmake
+++ b/cmake/toolchains/iOS.toolchain.cmake
@@ -103,7 +103,7 @@ endif (NOT DEFINED CMAKE_INSTALL_NAME_TOOL)
 
 # Setup iOS platform unless specified manually with IOS_PLATFORM
 if (NOT DEFINED IOS_PLATFORM)
-	set (IOS_PLATFORM "OS")
+	set (IOS_PLATFORM "SIMULATOR")
 endif (NOT DEFINED IOS_PLATFORM)
 set (IOS_PLATFORM ${IOS_PLATFORM} CACHE STRING "Type of iOS Platform")
 


### PR DESCRIPTION
* [ ] Waiting for [SFML-Buildbot/pull/16](https://github.com/SFML/SFML-Buildbot/pull/16) to be merged.

As mentioned by @Ceylo in #1378, this should be using the simulator by default.

Should fix the CI build.

@JonnyPtn 