### PR TITLE
Update doxygen.css

### DIFF
--- a/doc/doxygen.css
+++ b/doc/doxygen.css
@@ -1441,3 +1441,6 @@ div.contents ul li {
     top: 50%;
     margin-top: -11px;
 }
+.arrow {
+    cursor: pointer;
+}


### PR DESCRIPTION
Set pointer cursor for arrows in doxygen
![arrow](https://user-images.githubusercontent.com/10784674/38447787-4f327104-3a08-11e8-9d56-d3deac2c9c96.png)
instead of
![old_arrow](https://user-images.githubusercontent.com/10784674/38448148-e4ad1b88-3a0a-11e8-96e1-72c4a69e6d3c.png)
in classes list