### PR TITLE
Fixed socket reuse not conforming to documentation

### DIFF
--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -65,14 +65,16 @@ public:
     unsigned short getLocalPort() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Start listening for connections
+    /// \brief Start listening for incoming connection attempts
     ///
-    /// This functions makes the socket listen to the specified
-    /// port, waiting for new connections.
-    /// If the socket was previously listening to another port,
-    /// it will be stopped first and bound to the new port.
+    /// This function makes the socket start listening on the
+    /// specified port, waiting for incoming connection attempts.
     ///
-    /// \param port    Port to listen for new connections
+    /// If the socket is already listening on a port when this
+    /// function is called, it will stop listening on the old
+    /// port before starting to listen on the new port.
+    ///
+    /// \param port    Port to listen on for incoming connection attempts
     /// \param address Address of the interface to listen on
     ///
     /// \return Status code

--- a/include/SFML/Network/TcpSocket.hpp
+++ b/include/SFML/Network/TcpSocket.hpp
@@ -97,7 +97,8 @@ public:
     /// In blocking mode, this function may take a while, especially
     /// if the remote peer is not reachable. The last parameter allows
     /// you to stop trying to connect after a given timeout.
-    /// If the socket was previously connected, it is first disconnected.
+    /// If the socket is already connected, the connection is
+    /// forcibly disconnected before attempting to connect again.
     ///
     /// \param remoteAddress Address of the remote peer
     /// \param remotePort    Port of the remote peer

--- a/include/SFML/Network/UdpSocket.hpp
+++ b/include/SFML/Network/UdpSocket.hpp
@@ -82,6 +82,11 @@ public:
     /// system to automatically pick an available port, and then
     /// call getLocalPort to retrieve the chosen port.
     ///
+    /// Since the socket can only be bound to a single port at
+    /// any given moment, if it is already bound when this
+    /// function is called, it will be unbound from the previous
+    /// port before being bound to the new one.
+    ///
     /// \param port    Port to bind the socket to
     /// \param address Address of the interface to bind to
     ///

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -63,6 +63,9 @@ unsigned short TcpListener::getLocalPort() const
 ////////////////////////////////////////////////////////////
 Socket::Status TcpListener::listen(unsigned short port, const IpAddress& address)
 {
+    // Close the socket if it is already bound
+    close();
+
     // Create the internal socket if it doesn't exist
     create();
 

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -118,6 +118,9 @@ unsigned short TcpSocket::getRemotePort() const
 ////////////////////////////////////////////////////////////
 Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout)
 {
+    // Disconnect the socket if it is already connected
+    disconnect();
+
     // Create the internal socket if it doesn't exist
     create();
 

--- a/src/SFML/Network/UdpSocket.cpp
+++ b/src/SFML/Network/UdpSocket.cpp
@@ -66,6 +66,9 @@ unsigned short UdpSocket::getLocalPort() const
 ////////////////////////////////////////////////////////////
 Socket::Status UdpSocket::bind(unsigned short port, const IpAddress& address)
 {
+    // Close the socket if it is already bound
+    close();
+
     // Create the internal socket if it doesn't exist
     create();
 


### PR DESCRIPTION
Fixes #1346 and the scenarios listed [here](https://en.sfml-dev.org/forums/index.php?topic=22682.0).

Test with:
```cpp
#include <SFML/Network.hpp>
#include <iostream>

#define TEST1

int main()
{

#if defined(TEST1)

    sf::TcpListener l;
    l.listen(2016);
    l.listen(2017);

    sf::TcpSocket s;
    if (s.connect(sf::IpAddress::LocalHost, 2017) == sf::Socket::Done)
        std::cout << "This message should be displayed\n";

#elif defined(TEST2)

    sf::TcpListener l;
    l.listen(2017);

    sf::TcpSocket sock;
    if (sock.connect(sf::IpAddress::LocalHost, 2017) == sf::Socket::Done)
        std::cout << "This message should be displayed\n";

    if (sock.connect({1,2,3,4}, 2017) == sf::Socket::Done)
        std::cout << "This message should NOT be displayed\n";

#elif defined(TEST3)

    sf::TcpListener l;
    l.listen(2017);

    sf::TcpSocket s;
    if (s.connect({1,2,3,4}, 2017, sf::milliseconds(200)) == sf::Socket::Done)
        std::cout << "This message should NOT be displayed\n";

    if (s.connect(sf::IpAddress::LocalHost, 2017) == sf::Socket::Done)
        std::cout << "This message should be displayed\n";

#elif defined(TEST4)

    char data[5];
    std::size_t size = sizeof(data);
    sf::IpAddress address;
    unsigned short port;

    sf::UdpSocket s;
    s.bind(2016);
    s.bind(2017);

    if (s.send("Test", 5, sf::IpAddress::LocalHost, 2017) == sf::Socket::Done)
        std::cout << "This message should be displayed\n";

    if (s.receive(reinterpret_cast<void*>(data), size, size, address, port) == sf::Socket::Done)
        std::cout << "This message should be displayed\n";

#endif

    char ch;
    std::cin >> ch;
}
```
All test scenarios should print or not print the corresponding messages. Without this patch they would all fail.