### PR TITLE
Modernize iOS toolchain file

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -1,5 +1,10 @@
 include(CMakeParseArguments)
 
+# This little macro lets you set any Xcode specific property
+macro (sfml_set_xcode_property TARGET XCODE_PROPERTY XCODE_VALUE)
+    set_property (TARGET ${TARGET} PROPERTY XCODE_ATTRIBUTE_${XCODE_PROPERTY} ${XCODE_VALUE})
+endmacro ()
+
 # set the appropriate standard library on each platform for the given target
 # ex: sfml_set_stdlib(sfml-system)
 function(sfml_set_stdlib target)
@@ -14,7 +19,7 @@ function(sfml_set_stdlib target)
 
     if (SFML_OS_MACOSX)
         if (${CMAKE_GENERATOR} MATCHES "Xcode")
-            set_property(TARGET ${target} PROPERTY XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+            sfml_set_xcode_property(${target} CLANG_CXX_LIBRARY "libc++")
         else()
             target_compile_options(${target} PRIVATE "-stdlib=libc++")
             target_link_libraries(${target} PRIVATE "-stdlib=libc++")

--- a/examples/iOS/CMakeLists.txt
+++ b/examples/iOS/CMakeLists.txt
@@ -22,5 +22,5 @@ sfml_add_example(ios_demo GUI_APP
                          "-framework OpenGLES")
 
 # The app needs an identifier and signing to work correctly
-SET_XCODE_PROPERTY(ios_demo CODE_SIGN_IDENTITY "iPhone Developer")
+sfml_set_xcode_property(ios_demo CODE_SIGN_IDENTITY "iPhone Developer")
 set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.sfml.ios_demo")


### PR DESCRIPTION
- Unused BUILD_ARM64 variable is removed
- Support for Xcode < 4.3 (!!) is removed
- Renamed all variables prefixed with CMAKE_
- Made the toolchain file much less verbose (you still get the SDK being used and you can check other values from CMake cache displayed in CMake GUI)

If CI build is ok this should be ok. There is no expected side effect on SFML behavior itself.