### PR TITLE
[iOS] Check that <SFML/Main.hpp> is used

### DIFF
--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -56,6 +56,10 @@ namespace
 ////////////////////////////////////////////////////////////
 + (SFAppDelegate*)getInstance
 {
+    NSAssert(delegateInstance,
+             @"SFAppDelegate instance is nil, this means SFML was not properly initialized. "
+             "Make sure that the file defining your main() function includes <SFML/Main.hpp>");
+    
     return delegateInstance;
 }
 


### PR DESCRIPTION
Does not change behavior if the main cpp file includes <SFML/Main.hpp>. Otherwise you get this (both in debug and release):
```
2018-04-09 00:17:39.568184+0200 ios_demo[13149:903652] *** Assertion failure in +[SFAppDelegate getInstance], /Users/ceylo/Development/SFML-ceylo/src/SFML/Window/iOS/SFAppDelegate.mm:61
2018-04-09 00:17:39.575442+0200 ios_demo[13149:903652] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'SFAppDelegate instance is nil, this means SFML was not properly initialized. Make sure that the file defining your main() function includes <SFML/Main.hpp>'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000011085812b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x0000000110ce6f41 objc_exception_throw + 48
	2   CoreFoundation                      0x000000011085d2f2 +[NSException raise:format:arguments:] + 98
	3   Foundation                          0x000000010d42dd69 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 193
	4   ios_demo                            0x000000010cec58a1 +[SFAppDelegate getInstance] + 289
	5   ios_demo                            0x000000010ceccc01 _ZN2sf4priv13VideoModeImpl14getDesktopModeEv + 161
	6   ios_demo                            0x000000010ceb9c2d _ZN2sf9VideoMode14getDesktopModeEv + 13
	7   ios_demo                            0x000000010ceb3cea main + 26
	8   libdyld.dylib                       0x0000000111b4fd81 start + 1
	9   ???                                 0x0000000000000001 0x0 + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

So it makes sure you don't stay stupidly waiting on your device and wondering why the screen remains black :) Which I've seen to be quite a frequent mistake for SFML iOS beginners.