### PR TITLE
Implement extra cursors on macOS

### DIFF
--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -57,17 +57,20 @@ public:
     /// ------------------------------------|:-----:|:--------:|:--------:
     ///  sf::Cursor::Arrow                  |  yes  |    yes   |   yes
     ///  sf::Cursor::ArrowWait              |  no   |    no    |   yes
-    ///  sf::Cursor::Wait                   |  yes  |    no    |   yes
+    ///  sf::Cursor::Wait                   |  yes  |    yes*  |   yes
     ///  sf::Cursor::Text                   |  yes  |    yes   |   yes
     ///  sf::Cursor::Hand                   |  yes  |    yes   |   yes
     ///  sf::Cursor::SizeHorizontal         |  yes  |    yes   |   yes
     ///  sf::Cursor::SizeVertical           |  yes  |    yes   |   yes
-    ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    no    |   yes
-    ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    no    |   yes
-    ///  sf::Cursor::SizeAll                |  yes  |    no    |   yes
+    ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    yes*  |   yes
+    ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    yes*  |   yes
+    ///  sf::Cursor::SizeAll                |  yes  |    yes*  |   yes
     ///  sf::Cursor::Cross                  |  yes  |    yes   |   yes
-    ///  sf::Cursor::Help                   |  yes  |    no    |   yes
+    ///  sf::Cursor::Help                   |  yes  |    yes*  |   yes
     ///  sf::Cursor::NotAllowed             |  yes  |    yes   |   yes
+    ///
+    ///  * These cursor types are undocumented so may not
+    ///    be available on all versions, but have been tested on 10.13
     ///
     ////////////////////////////////////////////////////////////
     enum Type

--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -98,6 +98,10 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
             return loadFromSelector(@selector(_windowResizeNorthWestSouthEastCursor), m_cursor);
         case Cursor::SizeAll:
             return loadFromSelector(@selector(_moveCursor), m_cursor);
+        case Cursor::Wait:
+            return loadFromSelector(@selector(_waitCursor), m_cursor);
+        case Cursor::Help:
+            return loadFromSelector(@selector(_helpCursor), m_cursor);
     }
 
     // Since we didn't allocate the cursor ourself, we have to retain it

--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -65,6 +65,16 @@ bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hot
     return m_cursor != nil;
 }
 
+////////////////////////////////////////////////////////////
+bool loadFromSelector(SEL selector, NSCursorRef& cursor)
+{
+    if ([NSCursor respondsToSelector:selector])
+    {
+        cursor = [NSCursor performSelector:selector];
+        return true;
+    }
+    return false;
+}
 
 ////////////////////////////////////////////////////////////
 bool CursorImpl::loadFromSystem(Cursor::Type type)
@@ -80,6 +90,14 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::SizeVertical:    m_cursor = [NSCursor resizeUpDownCursor];        break;
         case Cursor::Cross:           m_cursor = [NSCursor crosshairCursor];           break;
         case Cursor::NotAllowed:      m_cursor = [NSCursor operationNotAllowedCursor]; break;
+            
+        // These cursor types are undocumented, may not be available on some platforms
+        case Cursor::SizeBottomLeftTopRight:
+            return loadFromSelector(@selector(_windowResizeNorthEastSouthWestCursor), m_cursor);
+        case Cursor::SizeTopLeftBottomRight:
+            return loadFromSelector(@selector(_windowResizeNorthWestSouthEastCursor), m_cursor);
+        case Cursor::SizeAll:
+            return loadFromSelector(@selector(_moveCursor), m_cursor);
     }
 
     // Since we didn't allocate the cursor ourself, we have to retain it


### PR DESCRIPTION
Addresses #1401

The move cursor doesn't look quite as I'd expect (It's basically just a white arrow) but I can't see any better looking alternatives.