### PR TITLE
windows: add resource.rc files to dll builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake)
 set(VERSION_MAJOR 2)
 set(VERSION_MINOR 5)
 set(VERSION_PATCH 0)
+set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
 # add an option for choosing the build type (shared or static)
 if(NOT (SFML_OS_IOS OR SFML_OS_ANDROID))

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -28,6 +28,9 @@ endfunction()
 #                           [STATIC]) # Always create a static library and ignore BUILD_SHARED_LIBS
 macro(sfml_add_library target)
 
+    # add convenience variable
+    set(TARGET_NAME "${target}")
+
     # parse the arguments
     cmake_parse_arguments(THIS "STATIC" "" "SOURCES" ${ARGN})
     if (NOT "${THIS_UNPARSED_ARGUMENTS}" STREQUAL "")
@@ -52,6 +55,11 @@ macro(sfml_add_library target)
             # include the major version number in Windows shared library names (but not import library names)
             set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)
             set_target_properties(${target} PROPERTIES SUFFIX "-${VERSION_MAJOR}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+            configure_file(
+                "${SFML_SOURCE_DIR}/tools/windows/resource.rc.in"
+                "${CMAKE_CURRENT_BINARY_DIR}/${target}.rc"
+            @ONLY)
+            target_sources(${target} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${target}.rc")
         else()
             set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)
         endif()

--- a/tools/windows/resource.rc.in
+++ b/tools/windows/resource.rc.in
@@ -1,0 +1,32 @@
+#include "winresrc.h"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ PRODUCTVERSION @VERSION_MAJOR@,@VERSION_MINOR@,@VERSION_PATCH@
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef DEBUG
+ FILEFLAGS 1
+#else
+ FILEFLAGS 0
+#endif
+ FILEOS VOS_NT
+ FILETYPE VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "\0"
+            VALUE "FileDescription", "@TARGET_NAME@ @VERSION_STRING@\0"
+            VALUE "InternalName", "@TARGET_NAME@-@VERSION_MAJOR@.dll\0"
+            VALUE "LegalCopyright", "Copyright (C) 2007-2018 Laurent Gomila\0"
+            VALUE "OriginalFilename", "@TARGET_NAME@-@VERSION_MAJOR@.dll\0"
+            VALUE "ProductName", "Simple Fast Multimedia Library Module\0"
+            VALUE "ProductVersion", "@VERSION_STRING@\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1252 //en-US
+    END
+END


### PR DESCRIPTION
Windows uses a mechanism known as 'resource files' which provides, among
other things, metadata to a given executable/dll/driver/etc, and add a
layer of polish to a project which it would otherwise lack.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>