### PR TITLE
Android: Removed libsndfile from extlib build scripts

### DIFF
--- a/tools/android/compile_libs.sh
+++ b/tools/android/compile_libs.sh
@@ -48,9 +48,6 @@ rm $DESTDIR/$1/usr/lib/libFLAC*.so*
 cd  $LOCALDIR/build/libvorbis-* && sed -i 's/-version-info/-avoid-version/g' lib/Makefile.in lib/Makefile.am && ./configure $HOST $PREFIX --enable-shared=no && make && make install
 rm $DESTDIR/$1/usr/lib/libvorbis*.so*
 
-# Compile libsndfile (important: --disable-sqlite)
-cd  $LOCALDIR/build/libsndfile-* && sed -i 's/-version-info/-avoid-version/g' src/Makefile.in src/Makefile.am && ./configure $HOST $PREFIX --disable-sqlite && make && make install
-
 # Compile freetype
 cd  $LOCALDIR/build/freetype-* && sed -i 's/-version-info/-avoid-version/g' builds/unix/unix-cc.in && ./configure $HOST $PREFIX && make && make install
 

--- a/tools/android/download_sources.sh
+++ b/tools/android/download_sources.sh
@@ -34,12 +34,6 @@ then
     tar -C build -xf src/$OGG.tar.gz
 fi
 
-wget -nc -P src http://www.mega-nerd.com/libsndfile/files/$SNDFILE.tar.gz
-if [ ! -d "$PWD/tmp/$SNDFILE" ]
-then
-    tar -C build -xf src/$SNDFILE.tar.gz
-fi
-
 wget -nc -P src http://download.savannah.gnu.org/releases/freetype/$FREETYPE.tar.gz
 if [ ! -d "$PWD/tmp/$FREETYPE" ]
 then


### PR DESCRIPTION
This fixes #1355. This change only affects those trying to build SFML's external dependencies using the provided shell scripts.