### PR TITLE
cmake/Macros.cmake: Do not alter default naming

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -56,10 +56,8 @@ macro(sfml_add_library target)
             set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)
         endif()
         if (SFML_OS_WINDOWS AND SFML_COMPILER_GCC)
-            # on Windows/gcc get rid of "lib" prefix for shared libraries,
-            # and transform the ".dll.a" suffix into ".a" for import libraries
+            # on Windows/gcc get rid of "lib" prefix for shared libraries
             set_target_properties(${target} PROPERTIES PREFIX "")
-            set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".a")
         endif()
     else()
         set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -s-d)


### PR DESCRIPTION
In just about any library which is compilable for both linux and
mingw-w64, import libraries are called *.dll.a and static libraries are
called *.a; there is no benefit from changing the naming, and could
cause confusion.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>