### PR TITLE
Implement extra cursors on macOS

### DIFF
--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -53,21 +53,21 @@ public:
     /// Refer to the following table to determine which cursor
     /// is available on which platform.
     ///
-    ///  Type                               | Linux | Mac OS X | Windows
-    /// ------------------------------------|:-----:|:--------:|:--------:
-    ///  sf::Cursor::Arrow                  |  yes  |    yes   |   yes
-    ///  sf::Cursor::ArrowWait              |  no   |    no    |   yes
-    ///  sf::Cursor::Wait                   |  yes  |    no    |   yes
-    ///  sf::Cursor::Text                   |  yes  |    yes   |   yes
-    ///  sf::Cursor::Hand                   |  yes  |    yes   |   yes
-    ///  sf::Cursor::SizeHorizontal         |  yes  |    yes   |   yes
-    ///  sf::Cursor::SizeVertical           |  yes  |    yes   |   yes
-    ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    yes*  |   yes
-    ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    yes*  |   yes
-    ///  sf::Cursor::SizeAll                |  yes  |    no    |   yes
-    ///  sf::Cursor::Cross                  |  yes  |    yes   |   yes
-    ///  sf::Cursor::Help                   |  yes  |    yes*  |   yes
-    ///  sf::Cursor::NotAllowed             |  yes  |    yes   |   yes
+    ///  Type                               | Linux | Mac OS X | Windows  |
+    /// ------------------------------------|:-----:|:--------:|:--------:|
+    ///  sf::Cursor::Arrow                  |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::ArrowWait              |  no   |    no    |   yes    |
+    ///  sf::Cursor::Wait                   |  yes  |    no    |   yes    |
+    ///  sf::Cursor::Text                   |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::Hand                   |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::SizeHorizontal         |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::SizeVertical           |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    yes*  |   yes    |
+    ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    yes*  |   yes    |
+    ///  sf::Cursor::SizeAll                |  yes  |    no    |   yes    |
+    ///  sf::Cursor::Cross                  |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::Help                   |  yes  |    yes*  |   yes    |
+    ///  sf::Cursor::NotAllowed             |  yes  |    yes   |   yes    |
     ///
     ///  * These cursor types are undocumented so may not
     ///    be available on all versions, but have been tested on 10.13

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -53,21 +53,24 @@ public:
     /// Refer to the following table to determine which cursor
     /// is available on which platform.
     ///
-    ///  Type                               | Linux | Mac OS X | Windows  |
-    /// ------------------------------------|:-----:|:--------:|:--------:|
-    ///  sf::Cursor::Arrow                  |  yes  |    yes   |   yes    |
-    ///  sf::Cursor::ArrowWait              |  no   |    no    |   yes    |
-    ///  sf::Cursor::Wait                   |  yes  |    no    |   yes    |
-    ///  sf::Cursor::Text                   |  yes  |    yes   |   yes    |
-    ///  sf::Cursor::Hand                   |  yes  |    yes   |   yes    |
-    ///  sf::Cursor::SizeHorizontal         |  yes  |    yes   |   yes    |
-    ///  sf::Cursor::SizeVertical           |  yes  |    yes   |   yes    |
-    ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    no    |   yes    |
-    ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    no    |   yes    |
-    ///  sf::Cursor::SizeAll                |  yes  |    no    |   yes    |
-    ///  sf::Cursor::Cross                  |  yes  |    yes   |   yes    |
-    ///  sf::Cursor::Help                   |  yes  |    no    |   yes    |
-    ///  sf::Cursor::NotAllowed             |  yes  |    yes   |   yes    |
+    ///  Type                               | Linux | Mac OS X | Windows
+    /// ------------------------------------|:-----:|:--------:|:--------:
+    ///  sf::Cursor::Arrow                  |  yes  |    yes   |   yes
+    ///  sf::Cursor::ArrowWait              |  no   |    no    |   yes
+    ///  sf::Cursor::Wait                   |  yes  |    no    |   yes
+    ///  sf::Cursor::Text                   |  yes  |    yes   |   yes
+    ///  sf::Cursor::Hand                   |  yes  |    yes   |   yes
+    ///  sf::Cursor::SizeHorizontal         |  yes  |    yes   |   yes
+    ///  sf::Cursor::SizeVertical           |  yes  |    yes   |   yes
+    ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    yes*  |   yes
+    ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    yes*  |   yes
+    ///  sf::Cursor::SizeAll                |  yes  |    no    |   yes
+    ///  sf::Cursor::Cross                  |  yes  |    yes   |   yes
+    ///  sf::Cursor::Help                   |  yes  |    yes*  |   yes
+    ///  sf::Cursor::NotAllowed             |  yes  |    yes   |   yes
+    ///
+    ///  * These cursor types are undocumented so may not
+    ///    be available on all versions, but have been tested on 10.13
     ///
     ////////////////////////////////////////////////////////////
     enum Type

--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -65,6 +65,16 @@ bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hot
     return m_cursor != nil;
 }
 
+////////////////////////////////////////////////////////////
+bool loadFromSelector(SEL selector, NSCursorRef& cursor)
+{
+    if ([NSCursor respondsToSelector:selector])
+    {
+        cursor = [NSCursor performSelector:selector];
+        return true;
+    }
+    return false;
+}
 
 ////////////////////////////////////////////////////////////
 bool CursorImpl::loadFromSystem(Cursor::Type type)
@@ -80,6 +90,18 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::SizeVertical:    m_cursor = [NSCursor resizeUpDownCursor];        break;
         case Cursor::Cross:           m_cursor = [NSCursor crosshairCursor];           break;
         case Cursor::NotAllowed:      m_cursor = [NSCursor operationNotAllowedCursor]; break;
+            
+        // These cursor types are undocumented, may not be available on some platforms
+        case Cursor::SizeBottomLeftTopRight:
+            return loadFromSelector(@selector(_windowResizeNorthEastSouthWestCursor), m_cursor);
+        case Cursor::SizeTopLeftBottomRight:
+            return loadFromSelector(@selector(_windowResizeNorthWestSouthEastCursor), m_cursor);
+        case Cursor::SizeAll:
+            return loadFromSelector(@selector(_moveCursor), m_cursor);
+        case Cursor::Wait:
+            return loadFromSelector(@selector(_waitCursor), m_cursor);
+        case Cursor::Help:
+            return loadFromSelector(@selector(_helpCursor), m_cursor);
     }
 
     // Since we didn't allocate the cursor ourself, we have to retain it


### PR DESCRIPTION
Superseds #1413 & #1401.

@JonnyPtn when carefully reviewing your PR I noticed a few issues in my original code so I've fixed it here. Feedback welcome.

I've removed Wait and SizeAll cursors as they don't look nice (Wait is not spinning and produces a broken rendering, SizeAll is a simple white cursor as you mentioned.) I think it would be more a disappointment/confusion or a source of bug reports to keep those.

It should also be more robust w.r.t. memory handling and reduce unwanted selector warnings.