### PR TITLE
Added missing import for memcpy in MainAndroid

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -45,6 +45,7 @@
 #include <SFML/System/Err.hpp>
 #include <android/window.h>
 #include <android/native_activity.h>
+#include <cstring>
 
 
 extern int main(int argc, char *argv[]);
@@ -485,7 +486,7 @@ void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_
     {
         states->savedState = malloc(savedStateSize);
         states->savedStateSize = savedStateSize;
-        memcpy(states->savedState, savedState, savedStateSize);
+        std::memcpy(states->savedState, savedState, savedStateSize);
     }
 
     states->mainOver = false;


### PR DESCRIPTION
With the newest android ndk an include is missing for memcpy in MainAndroid.cpp