### PR TITLE
Postpone generation of the RenderTarget ID to RenderTarget::initialize()

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -129,7 +129,7 @@ RenderTarget::RenderTarget() :
 m_defaultView(),
 m_view       (),
 m_cache      (),
-m_id         (getUniqueId())
+m_id         (0)
 {
     m_cache.glStatesSet = false;
 }
@@ -547,6 +547,10 @@ void RenderTarget::initialize()
 
     // Set GL states only on first draw, so that we don't pollute user's states
     m_cache.glStatesSet = false;
+
+    // Generate a unique ID for this RenderTarget to track
+    // whether it is active within a specific context
+    m_id = getUniqueId();
 }
 
 


### PR DESCRIPTION
Postpone generation of the RenderTarget ID to RenderTarget::initialize() so that a new ID is generated whenever the RenderTarget is re-`create()`ed.

Fixes a bug in which a RenderTexture would not be re-activated after being re-`create()`ed causing a stale FBO to remain bound in subsequent draws.

Test with:
```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window({ 100, 100 }, "SFML Test");
    window.setFramerateLimit(60);

    sf::RenderTexture renderTex;

    renderTex.create(100, 100);
    renderTex.clear();
    renderTex.draw(sf::RectangleShape({ 10.f, 10.f }));
    renderTex.display();

    // renderTex.create(100, 100); // Uncomment this line to see the bug
    renderTex.clear();
    renderTex.draw(sf::RectangleShape({ 30.f, 30.f }));
    renderTex.display();

    sf::Sprite sprite;
    sprite.setTexture(renderTex.getTexture(), true);

    while (window.isOpen())
    {
        sf::Event Event;
        while (window.pollEvent(Event))
        {
            if (Event.type == sf::Event::Closed)
                window.close();
        }

        window.clear();
        window.draw(sprite);
        window.display();
    }
}
```
When the marked line is uncommented, the contents of the re-created RenderTexture are not updated by the draw even though they should be.