### PR TITLE
Install CMake config files into lib${LIB_SIFFIX}

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -320,7 +320,7 @@ function(sfml_export_targets)
     if (SFML_BUILD_FRAMEWORKS)
         set(config_package_location "SFML.framework/Resources/CMake")
     else()
-        set(config_package_location lib/cmake/SFML)
+        set(config_package_location lib${LIB_SUFFIX}/cmake/SFML)
     endif()
     configure_package_config_file("${CURRENT_DIR}/SFMLConfig.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/SFMLConfig.cmake"
         INSTALL_DESTINATION "${config_package_location}")


### PR DESCRIPTION
The CMake config files should be installed in the same location as the libraries and pkg-config files.

Dispite what the documentation for `find_package` states, CMake will look into directories like `/usr/lib32` for CMake config files (and has done for ages). The documentation has been fixed in the latest git master:
https://cmake.org/cmake/help/git-master/command/find_package.html