### PR TITLE
Fix RenderWindow::setActive incorrectly trying to unbind an FBO during deactivation

### DIFF
--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -81,7 +81,7 @@ bool RenderWindow::setActive(bool active)
 
     // If FBOs are available, make sure none are bound when we
     // try to draw to the default framebuffer of the RenderWindow
-    if (result && priv::RenderTextureImplFBO::isAvailable())
+    if (active && result && priv::RenderTextureImplFBO::isAvailable())
     {
         priv::RenderTextureImplFBO::unbind();
 


### PR DESCRIPTION
When we deactivate a `RenderWindow` and possibly end up in a situation where there is no OpenGL context left active, avoid trying to unbind any bound FBO as well since it is unnecessary anyway. An FBO only has to be unbound when we want to target the `RenderWindow` itself for drawing, i.e. only when `setActive()` is called with `true`.

Easy to test, just run the OpenGL example and watch if the console gets spammed with OpenGL errors. 😁