### PR TITLE
Fixed stale FBOs not being erased from the staleFramebuffers set after they have been deleted.

### DIFF
--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -60,12 +60,18 @@ namespace
     {
         sf::Uint64 contextId = sf::Context::getActiveContextId();
 
-        for (std::set<std::pair<sf::Uint64, unsigned int> >::iterator iter = staleFrameBuffers.begin(); iter != staleFrameBuffers.end(); ++iter)
+        for (std::set<std::pair<sf::Uint64, unsigned int> >::iterator iter = staleFrameBuffers.begin(); iter != staleFrameBuffers.end();)
         {
             if (iter->first == contextId)
             {
                 GLuint frameBuffer = static_cast<GLuint>(iter->second);
                 glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
+
+                staleFrameBuffers.erase(iter++);
+            }
+            else
+            {
+                ++iter;
             }
         }
     }


### PR DESCRIPTION
Title explains everything.

Without this patch, eventually a collision will happen which would lead to newer, active FBOs which happen to have the same id as the older FBOs to be deleted as well. If no FBOs exist with the given ID, we would request OpenGL to delete a non-existing FBO which would cause OpenGL errors to be spammed to the console.

Test with this:
```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode(100, 100), "Test");
    window.setFramerateLimit(60);

    sf::CircleShape c(16);

    {
        sf::RenderTexture t;
        t.create(1, 1);

        sf::RenderTexture u;
        u.create(1, 1);
    }

    sf::RenderTexture t;
    t.create(1, 1);

    sf::RenderTexture u;
    u.create(1, 1);

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }

        sf::RenderTexture v;
        v.create(1, 1);

        t.draw(c);
        t.display();

        u.draw(c);
        u.display();

        window.clear();
        window.display();
    }
}
```