### PR TITLE
Fixed RenderTexture::display() dereferencing a NULL pointer when being called before RenderTexture::create().

### DIFF
--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -161,7 +161,7 @@ bool RenderTexture::setActive(bool active)
 void RenderTexture::display()
 {
     // Update the target texture
-    if (priv::RenderTextureImplFBO::isAvailable() || setActive(true))
+    if (m_impl && (priv::RenderTextureImplFBO::isAvailable() || setActive(true)))
     {
         m_impl->updateTexture(m_texture.m_texture);
         m_texture.m_pixelsFlipped = true;


### PR DESCRIPTION
See what happens for yourself. 😁 

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderTexture t;
    t.display();
}
```