### PR TITLE
Fixed performance issue with reading WAV files

### DIFF
--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -155,7 +155,11 @@ Uint64 SoundFileReaderWav::read(Int16* samples, Uint64 maxCount)
     assert(m_stream);
 
     Uint64 count = 0;
-    while ((count < maxCount) && (static_cast<Uint64>(m_stream->tell()) < m_dataEnd))
+    Uint64 startPos = m_stream->tell();
+
+    // Tracking of m_dataEnd is important to prevent sf::Music from reading
+    // data until EOF, as WAV files may have metadata at the end.
+    while ((count < maxCount) && (startPos + count * m_bytesPerSample < m_dataEnd))
     {
         switch (m_bytesPerSample)
         {


### PR DESCRIPTION
## Description

Calling tell() and thus std::ftell() for every reading iteration ate up 80-90% of the whole read call. As the check is redundant anyways (see the analogous OGG implementation), it should be safely removed. Please comment if it's not safe!

As brought up on [the forum](https://en.sfml-dev.org/forums/index.php?topic=24127.0).

I only tested this with Visual Studio 2017 (Debug & Release), it might well be that other compilers have a more performant ´std::ftell()´.

## How to test this PR?

Run the following code and time the load-time. With master it will take up to 30s to load the 10 WAV files.

```cpp
#include <SFML/Audio.hpp>
#include <vector>

int main()
{
	std::vector<sf::SoundBuffer> buffers;
	buffers.reserve(10);
	for(std::size_t i = 1; i < 11; ++i)
	{
		buffers.emplace_back();
		buffers.back().loadFromFile("assets/" + std::to_string(i) + ".wav");
	}

	sf::Sound sound;
	sound.setBuffer(buffers[0]);
	sound.play();
}
```