### PR TITLE
Fixed two issues with glyph sub-pixel positioning

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -727,6 +727,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
                 // Make the texture 2 times bigger
                 Texture newTexture;
                 newTexture.create(textureWidth * 2, textureHeight * 2);
+                newTexture.setSmooth(true);
                 newTexture.update(page.texture);
                 page.texture.swap(newTexture);
             }

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -50,15 +50,17 @@ namespace
     // Add a glyph quad to the vertex array
     void addGlyphQuad(sf::VertexArray& vertices, sf::Vector2f position, const sf::Color& color, const sf::Glyph& glyph, float italicShear, float outlineThickness = 0)
     {
-        float left   = glyph.bounds.left;
-        float top    = glyph.bounds.top;
-        float right  = glyph.bounds.left + glyph.bounds.width;
-        float bottom = glyph.bounds.top  + glyph.bounds.height;
+        float padding = 1.0;
 
-        float u1 = static_cast<float>(glyph.textureRect.left);
-        float v1 = static_cast<float>(glyph.textureRect.top);
-        float u2 = static_cast<float>(glyph.textureRect.left + glyph.textureRect.width);
-        float v2 = static_cast<float>(glyph.textureRect.top  + glyph.textureRect.height);
+        float left   = glyph.bounds.left - padding;
+        float top    = glyph.bounds.top - padding;
+        float right  = glyph.bounds.left + glyph.bounds.width + padding;
+        float bottom = glyph.bounds.top  + glyph.bounds.height + padding;
+
+        float u1 = static_cast<float>(glyph.textureRect.left) - padding;
+        float v1 = static_cast<float>(glyph.textureRect.top) - padding;
+        float u2 = static_cast<float>(glyph.textureRect.left + glyph.textureRect.width) + padding;
+        float v2 = static_cast<float>(glyph.textureRect.top  + glyph.textureRect.height) + padding;
 
         vertices.append(sf::Vertex(sf::Vector2f(position.x + left  - italicShear * top    - outlineThickness, position.y + top    - outlineThickness), color, sf::Vector2f(u1, v1)));
         vertices.append(sf::Vertex(sf::Vector2f(position.x + right - italicShear * top    - outlineThickness, position.y + top    - outlineThickness), color, sf::Vector2f(u2, v1)));


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

A new method of swapping glyphs on the GPU, introduced a while ago, disabled smoothing of the glyph textures. The result of that is the sub-pixel positioning of bigger fonts stopped working, so we have to re-enable it.
Added 1 pixel padding for glyph uv's  and increased glyph quads boundaries by 1 pixel so the glyphs aren't cropped when text is being scrolled with sub-pixel increments

Here's a little video showing what I fixed:
https://youtu.be/4r7MQ_O7Fvg

This is the commit that have identified that caused the glyph textures to loose smoothing:
https://github.com/SFML/SFML/commit/6b71456a55c9cce3eae12ee9cdacbf96fe1c1a71

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
