### PR TITLE
Fixed two conversion warnings (C4267)

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -708,7 +708,7 @@ void RenderTarget::drawPrimitives(PrimitiveType type, std::size_t firstVertex, s
     GLenum mode = modes[type];
 
     // Draw the primitives
-    glCheck(glDrawArrays(mode, firstVertex, static_cast<GLsizei>(vertexCount)));
+    glCheck(glDrawArrays(mode, static_cast<GLint>(firstVertex), static_cast<GLsizei>(vertexCount)));
 }
 
 

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -246,7 +246,7 @@ Socket::Status TcpSocket::send(const void* data, std::size_t size, std::size_t& 
     for (sent = 0; sent < size; sent += result)
     {
         // Send a chunk of data
-        result = ::send(getHandle(), static_cast<const char*>(data) + sent, size - sent, flags);
+        result = ::send(getHandle(), static_cast<const char*>(data) + sent, static_cast<int>(size - sent), flags);
 
         // Check for errors
         if (result < 0)


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Two small fixes for two argument conversion warnings (C4267) appearing on Microsoft Visual C++, Version MSVC 19.13.26128.0, x64 and x86.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Compile the code with the mentioned compiler and check that these two warnings don't appear
![image](https://user-images.githubusercontent.com/9303244/41372731-6f7bfe0a-6f4e-11e8-950d-5f4ad882888e.png)

