### PR TITLE
Fixed some #define flag problem with ANDROID

### DIFF
--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -35,7 +35,7 @@
 #include <cstdio>
 #include <string>
 
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
 namespace sf
 {
 namespace priv
@@ -122,7 +122,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
     priv::ResourceStream* m_file;
 #else
     std::FILE* m_file; ///< stdio file stream

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -35,7 +35,7 @@
 #include <cstdio>
 #include <string>
 
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
 namespace sf
 {
 namespace priv
@@ -122,7 +122,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
     priv::ResourceStream* m_file;
 #else
     std::FILE* m_file; ///< stdio file stream

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -26,7 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/FileInputStream.hpp>
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
 #include <SFML/System/Android/ResourceStream.hpp>
 #endif
 
@@ -44,7 +44,7 @@ FileInputStream::FileInputStream()
 ////////////////////////////////////////////////////////////
 FileInputStream::~FileInputStream()
 {
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
     if (m_file)
         delete m_file;
 #else
@@ -57,7 +57,7 @@ FileInputStream::~FileInputStream()
 ////////////////////////////////////////////////////////////
 bool FileInputStream::open(const std::string& filename)
 {
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
     if (m_file)
         delete m_file;
     m_file = new priv::ResourceStream(filename);
@@ -76,7 +76,7 @@ bool FileInputStream::open(const std::string& filename)
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::read(void* data, Int64 size)
 {
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
     return m_file->read(data, size);
 #else
     if (m_file)
@@ -90,7 +90,7 @@ Int64 FileInputStream::read(void* data, Int64 size)
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::seek(Int64 position)
 {
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
     return m_file->seek(position);
 #else
     if (m_file)
@@ -111,7 +111,7 @@ Int64 FileInputStream::seek(Int64 position)
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::tell()
 {
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
     return m_file->tell();
 #else
     if (m_file)
@@ -125,7 +125,7 @@ Int64 FileInputStream::tell()
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::getSize()
 {
-#ifdef ANDROID
+#ifdef SFML_SYSTEM_ANDROID
     return m_file->getSize();
 #else
     if (m_file)

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -26,7 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/FileInputStream.hpp>
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
 #include <SFML/System/Android/ResourceStream.hpp>
 #endif
 
@@ -44,7 +44,7 @@ FileInputStream::FileInputStream()
 ////////////////////////////////////////////////////////////
 FileInputStream::~FileInputStream()
 {
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
     if (m_file)
         delete m_file;
 #else
@@ -57,7 +57,7 @@ FileInputStream::~FileInputStream()
 ////////////////////////////////////////////////////////////
 bool FileInputStream::open(const std::string& filename)
 {
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
     if (m_file)
         delete m_file;
     m_file = new priv::ResourceStream(filename);
@@ -76,7 +76,7 @@ bool FileInputStream::open(const std::string& filename)
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::read(void* data, Int64 size)
 {
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
     return m_file->read(data, size);
 #else
     if (m_file)
@@ -90,7 +90,7 @@ Int64 FileInputStream::read(void* data, Int64 size)
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::seek(Int64 position)
 {
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
     return m_file->seek(position);
 #else
     if (m_file)
@@ -111,7 +111,7 @@ Int64 FileInputStream::seek(Int64 position)
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::tell()
 {
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
     return m_file->tell();
 #else
     if (m_file)
@@ -125,7 +125,7 @@ Int64 FileInputStream::tell()
 ////////////////////////////////////////////////////////////
 Int64 FileInputStream::getSize()
 {
-#ifdef SFML_SYSTEM_ANDROID
+#ifdef ANDROID
     return m_file->getSize();
 #else
     if (m_file)


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before? *On Discord, with Mario*
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)? *yup, just corrected  tag name*
* [x] Have you provided some example/test code for your changes? *not required*
* [x] If you have additional steps which need to be performed list them as tasks! *nope*
* [x] *No issue created, just a bug fix*.

----

## Description

A few `#ifdef ANDROID` flags seem to have survived, while the new on I understand is `SFML_SYSTEM_ANDROID`.
Just changed them and now the sound works great on Android.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [x] Tested on Android. *only one relevant here*

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

just compile the android example, voila.

