### PR TITLE
ANativeActivity_onCreate is not exported in sfml-main (fixes #1457)

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -464,7 +464,7 @@ static void onLowMemory(ANativeActivity* activity)
 
 
 ////////////////////////////////////////////////////////////
-void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_t savedStateSize)
+JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_t savedStateSize)
 {
     // Create an activity states (will keep us in the know, about events we care)
     sf::priv::ActivityStates* states = NULL;


### PR DESCRIPTION
This PR is fixes issue  #1457

The `ANativeActivity_onCreate` function is not exported in `libsfml-example.so` so `dlsym` will either return NULL or recursively call the one from `sfml-activity` (if sfml-activity is being used to load ANativeActivity_onCreate).

Without this fix, SFML doesn't seem to run on android.