### PR TITLE
Squash duplicated sf::Font glyphs to single chars

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -71,10 +71,10 @@ namespace
         return output;
     }
 
-    // Combine outline thickness, boldness and codepoint into a single 64-bit key
-    sf::Uint64 combine(float outlineThickness, bool bold, sf::Uint32 codePoint)
+    // Combine outline thickness, boldness and font glyph index into a single 64-bit key
+    sf::Uint64 combine(float outlineThickness, bool bold, sf::Uint32 index)
     {
-        return (static_cast<sf::Uint64>(reinterpret<sf::Uint32>(outlineThickness)) << 32) | (static_cast<sf::Uint64>(bold) << 31) | codePoint;
+        return (static_cast<sf::Uint64>(reinterpret<sf::Uint32>(outlineThickness)) << 32) | (static_cast<sf::Uint64>(bold) << 31) | index;
     }
 }
 
@@ -346,8 +346,8 @@ const Glyph& Font::getGlyph(Uint32 codePoint, unsigned int characterSize, bool b
     // Get the page corresponding to the character size
     GlyphTable& glyphs = m_pages[characterSize].glyphs;
 
-    // Build the key by combining the code point, bold flag, and outline thickness
-    Uint64 key = combine(outlineThickness, bold, codePoint);
+    // Build the key by combining the glyph index (based on code point), bold flag, and outline thickness
+    Uint64 key = combine(outlineThickness, bold, FT_Get_Char_Index(static_cast<FT_Face>(m_face), codePoint));
 
     // Search the glyph into the cache
     GlyphTable::const_iterator it = glyphs.find(key);


### PR DESCRIPTION
Before this change, `sf::Font` always rendered/provided one character per Unicode code point, even if that character wasn't represented by the current font file or duplicated. This caused more texture space to be used than necessary, which is especially apparent, when trying to render a large amount of unhandled glyphs (the texture would literally fill up with empty squares representing missing characters).

Example code to show the difference:

```cpp
#include <SFML/Graphics.hpp>

const std::size_t size = 20;

int main(int argc, char **argv) {
    sf::Font font;
    font.loadFromFile("monof55.ttf");
    for (wchar_t c = 32; c < 1024; ++c) {
        if (iswalnum(c))
            font.getGlyph(c, size, false);
    }
    font.getTexture(size).copyToImage().saveToFile("font.png");
}
```

*The font I used is [**Monofur**](https://www.dafont.com/de/monofur.font) (this is a repurposed test from some forum issue with broken glyphs).*

Running the example will create a PNG image "font.png" showing the internal texture used by the `sf::Font` when trying to render all alphanumeric characters from code point 32 to code point 1024.

With current master branch, the result will look like this (I tinted the background for better visibility):

![Font texture based on master](https://i.imgur.com/lSdnSDJ.png)

While this is the same texture once the fix is applied:

![Font texture based on the PR](https://i.imgur.com/YQeHLRY.png)