### PR TITLE
Changed deprecated auto_ptr in AudioDevice to unique_ptr

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -107,9 +107,9 @@ bool AudioDevice::isExtensionSupported(const std::string& extension)
     // This device will not be used in this function and merely
     // makes sure there is a valid OpenAL device for extension
     // queries if none has been created yet.
-    std::auto_ptr<AudioDevice> device;
+    std::unique_ptr<AudioDevice> device;
     if (!audioDevice)
-        device.reset(new AudioDevice);
+        device = std::make_unique<AudioDevice>();
 
     if ((extension.length() > 2) && (extension.substr(0, 3) == "ALC"))
         return alcIsExtensionPresent(audioDevice, extension.c_str()) != AL_FALSE;
@@ -125,9 +125,9 @@ int AudioDevice::getFormatFromChannelCount(unsigned int channelCount)
     // This device will not be used in this function and merely
     // makes sure there is a valid OpenAL device for format
     // queries if none has been created yet.
-    std::auto_ptr<AudioDevice> device;
+    std::unique_ptr<AudioDevice> device;
     if (!audioDevice)
-        device.reset(new AudioDevice);
+        device = std::make_unique<AudioDevice>();
 
     // Find the good format according to the number of channels
     int format = 0;


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
Yes, here: https://en.sfml-dev.org/forums/index.php?topic=24313.0
* [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
I guess so.
* [ ] Have you provided some example/test code for your changes?
None, I've just changed auto_ptr to unique_ptr. I haven't found any unit tests in the repo. I ran cmake with ninja and it compiled.
* [ ] If you have additional steps which need to be performed list them as tasks!
None
----

## Description

I removed deprecated auto_ptr in AudioDevice, so it no longer produces warnings when compiling with -Werror. The fix is tiny, shouldn't change anything, also the pointer is not even really used, at least in my understanding.

## Tasks

* [ ] Tested on Linux
It compiles on Linux, I haven't tested it on different platforms
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?
I don't think it's possible to test, as the pointer is not even used.