### PR TITLE
Fix CMP0072 CMake warning - also allow user to set OpenGL_GL_PREFERENCE

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -235,6 +235,13 @@ if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OPENBSD)
     target_link_libraries(sfml-window PRIVATE X11)
 endif()
 
+# CMake 3.11 and later prefer to choose GLVND, but we choose legacy OpenGL for backward compability
+# (unless the OpenGL_GL_PREFERENCE was explicitly set)
+# See CMP0072 for more details (cmake --help-policy CMP0072)
+if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
+    set(OpenGL_GL_PREFERENCE "LEGACY")
+endif()
+
 if(SFML_OPENGL_ES)
     if(SFML_OS_IOS)
         target_link_libraries(sfml-window PRIVATE "-framework OpenGLES")
@@ -242,7 +249,7 @@ if(SFML_OPENGL_ES)
         target_link_libraries(sfml-window PRIVATE EGL GLESv1_CM)
     endif()
 else()
-    sfml_find_package(OpenGL INCLUDE "OPENGL_INCLUDE_DIR" LINK "OPENGL_gl_LIBRARY")
+    sfml_find_package(OpenGL INCLUDE "OPENGL_INCLUDE_DIR" LINK "OPENGL_LIBRARIES")
     target_link_libraries(sfml-window PRIVATE OpenGL)
 endif()
 


### PR DESCRIPTION
Hello, everyone. Since CMake 3.11, CMake prefers to choose GLVND (libOpenGL.so) - new Linux OpenGL ABI by default when you do find_package(OpenGL). This issued a warning when building with CMake version >= 3.11. 

Since we support CMake from 3.0.2, we probably want the old behaviour - choose legacy OpenGL (libGL.so).

Testing this is simple. But you need to have GLVND installed which should be installed on Nvidia drivers version >=361.16.

First run cmake without any parameters:

```cmake
cmake /path/to/SFML
```

Then

```cmake
cmake --build .
```

Check that libsfml-window.so is linked to libGL.so:

```sh
ldd lib/libsfml-window.so | grep GL
```

This should have a line like this:

```libGL.so.1 => /usr/lib/x86_64-linux-gnu/libGL.so.1```. This means that we linked to legacy GL as expected.

Now do:

```sh
cmake /path/to/SFML -DOpenGL_GL_PREFERENCE=GLVND
cmake --build .
```

Check for linking again. Should be:

```sh
libOpenGL.so.0 => /usr/lib/x86_64-linux-gnu/libOpenGL.so.0
```

Finally, check:

```sh
cmake /path/to/SFML -DOpenGL_GL_PREFERENCE=LEGACY
```

This should link to libGL.so.

---

By the way, I'm still not sure what to do with EGL. FindOpenGL.cmake now says:

```# For EGL targets the client must rely on GLVND support on the user's system.
# Linking should use the ``OpenGL::OpenGL OpenGL::EGL`` targets.  Using GLES*
# libraries is theoretically possible in place of ``OpenGL::OpenGL``, but this
# module does not currently support that; contributions welcome.
```

Unfortunately, I can't test EGL and this will make things complicated, so it seems the users won't be able to use GLVND for now, as it complicates the logic a lot.