### PR TITLE
Fallback for fonts were the height is not equal to the width

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -777,7 +777,7 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                 err() << "Failed to set bitmap font size to " << characterSize << std::endl;
                 err() << "Available sizes are: ";
                 for (int i = 0; i < face->num_fixed_sizes; ++i)
-                    err() << face->available_sizes[i].height << " ";
+                    err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
                 err() << std::endl;
             }
         }

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -782,16 +782,21 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                         result = FT_Set_Pixel_Sizes(face, face->available_sizes[i].width, characterSize);
                     }
                 }
-            }
 
-            // Check if we found a way to fallback to a valid size. If we couldn't, log the error.
-            if (result == FT_Err_Invalid_Pixel_Size)
+				// Check if we found a way to fallback to a valid size. If we couldn't, log the error
+                if (result == FT_Err_Invalid_Pixel_Size)
+                {
+                    err() << "Failed to set bitmap font size to " << characterSize << std::endl;
+                    err() << "Available sizes are: ";
+                    for (int i = 0; i < face->num_fixed_sizes; ++i)
+                        err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
+                    err() << std::endl;
+                }
+			}
+            // If the font is scalable but we had an error
+			else if (result == FT_Err_Invalid_Pixel_Size) 
             {
-                err() << "Failed to set bitmap font size to " << characterSize << std::endl;
-                err() << "Available sizes are: ";
-                for (int i = 0; i < face->num_fixed_sizes; ++i)
-                    err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
-                err() << std::endl;
+                err() << "Failed to set font size to " << characterSize << std::endl;
             }
         }
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -775,13 +775,11 @@ bool Font::setCurrentSize(unsigned int characterSize) const
             if (!FT_IS_SCALABLE(face))
             {
                 // Look for an available size with a matching height
-                bool sizeFound = false;
-                for (int i = 0; i < face->num_fixed_sizes && !sizeFound; ++i)
+                for (int i = 0; i < face->num_fixed_sizes && result != FT_Err_Invalid_Pixel_Size; ++i)
                 {
                     if (face->available_sizes[i].height == characterSize)
                     {
                         result = FT_Set_Pixel_Sizes(face, face->available_sizes[i].width, characterSize);
-                        sizeFound = true;
                     }
                 }
             }

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -779,6 +779,22 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                 for (int i = 0; i < face->num_fixed_sizes; ++i)
                     err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
                 err() << std::endl;
+				
+				// Look for an available size with a matching height
+				bool sizeFound = false;
+				for (int i = 0; i < face->num_fixed_sizes && !sizeFound; ++i)
+				{
+					if (face->available_sizes[i].height == characterSize)
+					{
+						result = FT_Set_Pixel_Sizes(face, , characterSize);
+						sizeFound = true;
+					}
+				}
+				
+				if (result == FT_Err_Invalid_Pixel_Size || !sizeFound)
+				{
+					err() << "Failed to fallback on an available size." << std::endl;
+				}
             }
         }
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -780,21 +780,21 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                     err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
                 err() << std::endl;
 				
-				// Look for an available size with a matching height
-				bool sizeFound = false;
-				for (int i = 0; i < face->num_fixed_sizes && !sizeFound; ++i)
-				{
-					if (face->available_sizes[i].height == characterSize)
-					{
-						result = FT_Set_Pixel_Sizes(face, , characterSize);
-						sizeFound = true;
-					}
-				}
-				
-				if (result == FT_Err_Invalid_Pixel_Size || !sizeFound)
-				{
-					err() << "Failed to fallback on an available size." << std::endl;
-				}
+                // Look for an available size with a matching height
+                bool sizeFound = false;
+                for (int i = 0; i < face->num_fixed_sizes && !sizeFound; ++i)
+                {
+                    if (face->available_sizes[i].height == characterSize)
+                    {
+                        result = FT_Set_Pixel_Sizes(face, , characterSize);
+                        sizeFound = true;
+                    }
+                }
+
+                if (result == FT_Err_Invalid_Pixel_Size || !sizeFound)
+                {
+                    err() << "Failed to fallback on an available size." << std::endl;
+                }
             }
         }
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -783,7 +783,7 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                     }
                 }
 
-				// Check if we found a way to fallback to a valid size. If we couldn't, log the error
+                // Check if we found a way to fallback to a valid size. If we couldn't, log the error
                 if (result == FT_Err_Invalid_Pixel_Size)
                 {
                     err() << "Failed to set bitmap font size to " << characterSize << std::endl;
@@ -792,9 +792,9 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                         err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
                     err() << std::endl;
                 }
-			}
+            }
             // If the font is scalable but we had an error
-			else if (result == FT_Err_Invalid_Pixel_Size) 
+            else 
             {
                 err() << "Failed to set font size to " << characterSize << std::endl;
             }

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -786,7 +786,7 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                 {
                     if (face->available_sizes[i].height == characterSize)
                     {
-                        result = FT_Set_Pixel_Sizes(face, , characterSize);
+                        result = FT_Set_Pixel_Sizes(face, face->available_sizes[i].width, characterSize);
                         sizeFound = true;
                     }
                 }

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -774,12 +774,6 @@ bool Font::setCurrentSize(unsigned int characterSize) const
             // fail if the requested size is not available
             if (!FT_IS_SCALABLE(face))
             {
-                err() << "Failed to set bitmap font size to " << characterSize << std::endl;
-                err() << "Available sizes are: ";
-                for (int i = 0; i < face->num_fixed_sizes; ++i)
-                    err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
-                err() << std::endl;
-				
                 // Look for an available size with a matching height
                 bool sizeFound = false;
                 for (int i = 0; i < face->num_fixed_sizes && !sizeFound; ++i)
@@ -790,11 +784,16 @@ bool Font::setCurrentSize(unsigned int characterSize) const
                         sizeFound = true;
                     }
                 }
+            }
 
-                if (result == FT_Err_Invalid_Pixel_Size || !sizeFound)
-                {
-                    err() << "Failed to fallback on an available size." << std::endl;
-                }
+            // Check if we found a way to fallback to a valid size. If we couldn't, log the error.
+            if (result == FT_Err_Invalid_Pixel_Size)
+            {
+                err() << "Failed to set bitmap font size to " << characterSize << std::endl;
+                err() << "Available sizes are: ";
+                for (int i = 0; i < face->num_fixed_sizes; ++i)
+                    err() << face->available_sizes[i].width << "x" << face->available_sizes[i].height << " ";
+                err() << std::endl;
             }
         }
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -775,7 +775,7 @@ bool Font::setCurrentSize(unsigned int characterSize) const
             if (!FT_IS_SCALABLE(face))
             {
                 // Look for an available size with a matching height
-                for (int i = 0; i < face->num_fixed_sizes && result != FT_Err_Invalid_Pixel_Size; ++i)
+                for (int i = 0; i < face->num_fixed_sizes && result != FT_Err_Ok; ++i)
                 {
                     if (face->available_sizes[i].height == characterSize)
                     {


### PR DESCRIPTION
This PR is related to the issue #1456. In this PR we propose a way to fallback when a font does not have the same height and width. We look for the first available width size for the given height.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Get `aqui.pcf` from here: https://sourceforge.net/projects/artwizaleczapka/

```c++
#include <SFML/Graphics.hpp>

int main()
{
	sf::RenderWindow window(sf::VideoMode(1280, 720), "Minimal, complete and verifiable example");
	window.setFramerateLimit(60);

	sf::Font font;
	font.loadFromFile("aqui.pcf");

	sf::Text text;
	text.setFont(font);
	text.setCharacterSize(12);
	text.setString("Hello, world");
	text.setFillColor(sf::Color::White);

	while (window.isOpen())
	{
		sf::Event event;
		while (window.pollEvent(event))
		{
			if (event.type == sf::Event::Closed)
				window.close();
		}

		window.clear();
		window.draw(text);
		window.display();
	}
}
```