### PR TITLE
Window/Unix: Fix compilation with glxext header versions >=20180525

### DIFF
--- a/src/SFML/Window/Unix/GlxExtensions.hpp
+++ b/src/SFML/Window/Unix/GlxExtensions.hpp
@@ -25,11 +25,12 @@
 #ifndef SF_POINTER_C_GENERATED_HEADER_GLXWIN_HPP
 #define SF_POINTER_C_GENERATED_HEADER_GLXWIN_HPP
 
-#ifdef __glxext_h_
+#if defined(__glxext_h_) || defined(__glx_glxext_h_)
 #error Attempt to include glx_exts after including glxext.h
 #endif
 
 #define __glxext_h_
+#define __glx_glxext_h_
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

When mesa updated their headers, they changed the include guard
from __glxext_h_ to __glx_glxext_h_, which breaks compilation
due to conflicting declarations. This commit modifies the preprocessor
directives to allow for compilation with older and newer mesa header
versions.
Fixes: #1472

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?
Just trying to compile should be enough to test the PR on Linux with mesa should be enough. I tested it with the headers from mesa 18.1.6 and with headers from a current git mesa (9a96bf0ecd071219cb975fbd64f5c68849fd5697).