### PR TITLE
Fix RPATH for installed examples on Linux

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -232,7 +232,7 @@ macro(sfml_add_example target)
 
     set(target_install_dir ${SFML_MISC_INSTALL_PREFIX}/examples/${target})
 
-    if(SFML_OS_LINUX OR SFML_OS_FREEBSD)
+    if(BUILD_SHARED_LIBS AND (SFML_OS_LINUX OR SFML_OS_FREEBSD))
         file(RELATIVE_PATH rel_lib_dir
              ${CMAKE_INSTALL_PREFIX}/${target_install_dir}
              ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -230,14 +230,25 @@ macro(sfml_add_example target)
         target_link_libraries(${target} PRIVATE ${THIS_DEPENDS})
     endif()
 
+    set(target_install_dir ${SFML_MISC_INSTALL_PREFIX}/examples/${target})
+
+    if(SFML_OS_LINUX OR SFML_OS_FREEBSD)
+        file(RELATIVE_PATH rel_lib_dir
+             ${CMAKE_INSTALL_PREFIX}/${target_install_dir}
+             ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
+
+        set_target_properties(${target} PROPERTIES
+                              INSTALL_RPATH "$ORIGIN/${rel_lib_dir}")
+    endif()
+
     # add the install rule
     install(TARGETS ${target}
-            RUNTIME DESTINATION ${SFML_MISC_INSTALL_PREFIX}/examples/${target} COMPONENT examples
-            BUNDLE DESTINATION ${SFML_MISC_INSTALL_PREFIX}/examples/${target} COMPONENT examples)
+            RUNTIME DESTINATION ${target_install_dir} COMPONENT examples
+            BUNDLE DESTINATION ${target_install_dir} COMPONENT examples)
 
     # install the example's source code
     install(FILES ${THIS_SOURCES}
-            DESTINATION ${SFML_MISC_INSTALL_PREFIX}/examples/${target}
+            DESTINATION ${target_install_dir}
             COMPONENT examples)
 
     if (THIS_RESOURCES_DIR)
@@ -248,7 +259,7 @@ macro(sfml_add_example target)
             message(FATAL_ERROR "Given resources directory to install does not exist: ${THIS_RESOURCES_DIR}")
         endif()
         install(DIRECTORY ${THIS_RESOURCES_DIR}
-                DESTINATION ${SFML_MISC_INSTALL_PREFIX}/examples/${target}
+                DESTINATION ${target_install_dir}
                 COMPONENT examples)
     endif()
 


### PR DESCRIPTION
## Steps to reproduce

* Configure CMake build with custom CMAKE_INSTALL_PREFIX
* `cmake --build . target --install`
* Go to any example folder and try to launch it - fails with "sfml-xxx.so is not found"
* Check executable via "ldd" - shows that .so modules are not found

```
    libsfml-graphics.so.2.5 => not found
    libsfml-window.so.2.5 => not found
```

## How this fix works

First, it computes relative path from target directory to lib folder. Then it sets it target's INSTALL_RPATH to $ORIGIN + rel_path ($ORIGIN being a location of executable).

And now, when you install the examples, everything will work fine and SFML modules will be found by the relative path. Even if you move the install folder everywhere on the system as long as its internal structure remains the same.