### PR TITLE
Add support for creating Color from HSVA

### DIFF
--- a/include/SFML/Graphics/Color.hpp
+++ b/include/SFML/Graphics/Color.hpp
@@ -88,7 +88,7 @@ public:
     /// \return An sf:Color with the equivalent RGBA components
     ///
     ////////////////////////////////////////////////////////////
-    static Color fromHSVA(Uint16 hue, double sat, double val, Uint8 alpha = 255);
+    static Color fromHSVA(Uint16 hue, float sat, float val, Uint8 alpha = 255);
 
     ////////////////////////////////////////////////////////////
     // Static member data

--- a/include/SFML/Graphics/Color.hpp
+++ b/include/SFML/Graphics/Color.hpp
@@ -78,6 +78,19 @@ public:
     Uint32 toInteger() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Create a new sf::Color from 4 HSVA components
+    ///
+    /// \param hue   Hue component (in the range [0, 360])
+    /// \param sat   Saturation component (in the range [0, 1])
+    /// \param val   Value component (in the range [0, 1])
+    /// \param alpha Alpha (opacity) component (in the range [0, 255])
+    ///
+    /// \return An sf:Color with the equivalent RGBA components
+    ///
+    ////////////////////////////////////////////////////////////
+    static Color fromHSVA(Uint16 hue, double sat, double val, Uint8 alpha = 255);
+
+    ////////////////////////////////////////////////////////////
     // Static member data
     ////////////////////////////////////////////////////////////
     static const Color Black;       ///< Black predefined color

--- a/src/SFML/Graphics/Color.cpp
+++ b/src/SFML/Graphics/Color.cpp
@@ -88,8 +88,6 @@ Uint32 Color::toInteger() const
 Color Color::fromHSVA(Uint16 hue, double sat, double val, Uint8 alpha)
 {
     hue %= 360;
-    while (hue < 0)
-        hue += 360;
 
     if (sat < 0)
         sat = 0;

--- a/src/SFML/Graphics/Color.cpp
+++ b/src/SFML/Graphics/Color.cpp
@@ -85,7 +85,7 @@ Uint32 Color::toInteger() const
 }
 
 ////////////////////////////////////////////////////////////
-Color Color::fromHSVA(Uint16 hue, double sat, double val, Uint8 alpha)
+Color Color::fromHSVA(Uint16 hue, float sat, float val, Uint8 alpha)
 {
     hue %= 360;
 
@@ -100,10 +100,10 @@ Color Color::fromHSVA(Uint16 hue, double sat, double val, Uint8 alpha)
         val = 1;
 
     int h = hue / 60;
-    double f = float(hue) / 60 - h;
-    double p = val * (1 - sat);
-    double q = val * (1 - sat * f);
-    double t = val * (1 - (1 - f) * sat);
+    float f = float(hue) / 60 - h;
+    float p = val * (1 - sat);
+    float q = val * (1 - sat * f);
+    float t = val * (1 - (1 - f) * sat);
 
     switch (h)
     {

--- a/src/SFML/Graphics/Color.cpp
+++ b/src/SFML/Graphics/Color.cpp
@@ -84,6 +84,41 @@ Uint32 Color::toInteger() const
     return (r << 24) | (g << 16) | (b << 8) | a;
 }
 
+////////////////////////////////////////////////////////////
+Color Color::fromHSVA(Uint16 hue, double sat, double val, Uint8 alpha)
+{
+    hue %= 360;
+    while (hue < 0)
+        hue += 360;
+
+    if (sat < 0)
+        sat = 0;
+    else if (sat > 1)
+        sat = 1;
+
+    if (val < 0)
+        val = 0;
+    else if (val > 1)
+        val = 1;
+
+    int h = hue / 60;
+    double f = float(hue) / 60 - h;
+    double p = val * (1 - sat);
+    double q = val * (1 - sat * f);
+    double t = val * (1 - (1 - f) * sat);
+
+    switch (h)
+    {
+        default:
+        case 0: return sf::Color(val * 255, t * 255, p * 255, alpha);
+        case 1: return sf::Color(q * 255, val * 255, p * 255, alpha);
+        case 2: return sf::Color(p * 255, val * 255, t * 255, alpha);
+        case 3: return sf::Color(p * 255, q * 255, val * 255, alpha);
+        case 4: return sf::Color(t * 255, p * 255, val * 255, alpha);
+        case 5: return sf::Color(val * 255, p * 255, q * 255, alpha);
+    }
+}
+
 
 ////////////////////////////////////////////////////////////
 bool operator ==(const Color& left, const Color& right)


### PR DESCRIPTION
Adds a static sf::Color::fromHSVA method to create a colour using HSVA values.

This PR is related to [this forum post](https://en.sfml-dev.org/forums/index.php?topic=7313.0).

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode(600, 200), "HSVA Example");

    sf::CircleShape red(100.f);
    red.setFillColor(sf::Color::fromHSVA(0, 1, 1));

    sf::CircleShape yellow(100.f);
    yellow.setFillColor(sf::Color::fromHSVA(50, 1, 1));
    yellow.setPosition(200, 0);

    sf::CircleShape green(100.f);
    green.setFillColor(sf::Color::fromHSVA(100, 1, 1));
    green.setPosition(400, 0);

    window.clear();
    window.draw(red);
    window.draw(yellow);
    window.draw(green);
    window.display();

    sf::sleep(sf::seconds(3));

}
```