### PR TITLE
Disable autocorrect on iOS for issue #1473

### DIFF
--- a/src/SFML/Window/iOS/SFView.mm
+++ b/src/SFML/Window/iOS/SFView.mm
@@ -202,5 +202,11 @@
     return self;
 }
 
+////////////////////////////////////////////////////////////
+- (UITextAutocorrectionType) autocorrectionType
+{
+    return UITextAutocorrectionTypeNo;
+}
+
 
 @end


### PR DESCRIPTION
The best I can do for #1473, I can't work out any reason why the autocorrect window would be bugged like that.