### PR TITLE
Add -ObjC flag to fix static linking on macOS

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -229,6 +229,11 @@ sfml_add_library(sfml-window
                  SOURCES ${SRC} ${PLATFORM_SRC})
 target_link_libraries(sfml-window PUBLIC sfml-system)
 
+# When static linking on macOS, we need to add this flag for objective C to work
+if ((NOT BUILD_SHARED_LIBS) AND SFML_OS_MACOSX)
+    target_link_libraries(sfml-window PRIVATE -ObjC)
+endif()
+
 # find and setup usage for external libraries
 if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OPENBSD)
     sfml_find_package(X11 INCLUDE "X11_INCLUDE_DIR" LINK "X11_X11_LIB" "X11_Xrandr_LIB")


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php?topic=24169.0)
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

## Description

When static linking on macOS you get a runtime error along the lines of:

`Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[SFOpenGLView enableKeyRepeat]: unrecognized selector sent to instance 0x7fe0b762c5c0'`

This is because theres a missing linker flag which is required when using Objective-C code, documentation [here](https://developer.apple.com/library/archive/qa/qa1490/_index.html)

## Tasks
* [x] Tested on macOS
* [x] Tested on iOS

## How to test this PR?

Build SFML with examples and static linking (cmake flag `-DBUILD_SHARED_LIBS=FALSE`), then try to run any example.