### PR TITLE
Remove reference to unused CMAKE_OSX_DEPLOYMENT_TARGET in cocoa example

### DIFF
--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -20,7 +20,7 @@ function(compile_xib)
     endif()
 
     # Default args taken from Xcode 9 when it generates a nib from a xib
-    set(DEFAULT_ARGS --errors --warnings --notices --module cocoa --auto-activate-custom-fonts --target-device mac --minimum-deployment-target ${CMAKE_OSX_DEPLOYMENT_TARGET} --output-format human-readable-text)
+    set(DEFAULT_ARGS --errors --warnings --notices --module cocoa --auto-activate-custom-fonts --target-device mac --output-format human-readable-text)
 
     add_custom_command(OUTPUT "${THIS_OUTPUT}"
         COMMAND "${IBTOOL}" ${DEFAULT_ARGS} "${THIS_INPUT}" --compile "${THIS_OUTPUT}"


### PR DESCRIPTION
The cocoa example uses ibtool to compile the nib file, and for some reason the missing variable causes an issue on macOS 10.13... This causes an error when building:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>com.apple.ibtool.errors</key>
	<array>
		<dict>
			<key>description</key>
			<string>Unrecognized commandline options: "human-readable-text" and "/Users/SFML/Desktop/buildbot/osx-clang-el-capitan/build/examples/cocoa/MainMenu.xib". Either unrecognized options were passed, or multiple input documents were passed when only one was expected.</string>
		</dict>
	</array>
</dict>
</plist>
```

The parameter isn't needed anyway (and as far as I can tell isn't even mentioned on the ibtool man page) so this PR just removes it

To test, just build the cocoa example on macOS 10.13