### PR TITLE
Fix cast

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1556,7 +1556,7 @@ void WindowImplX11::initialize()
                                    m_window,
                                    XNInputStyle,
                                    XIMPreeditNothing | XIMStatusNothing,
-                                   reinterpret_cast<void*>(NULL));
+                                   NULL);
     }
     else
     {


### PR DESCRIPTION
Fixes clang error:

```
src/SFML/Window/Unix/WindowImplX11.cpp:1559:36: error: reinterpret_cast from 'nullptr_t' to 'void *' is not allowed
                                   reinterpret_cast<void*>(NULL));
                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
