### PR TITLE
Unix: Filter X visual by X screen

### DIFF
--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -316,6 +316,8 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
     // Make sure that extensions are initialized
     ensureExtensionsInit(display, DefaultScreen(display));
 
+    const int screen = DefaultScreen(display);
+
     // Retrieve all the visuals
     int count;
     XVisualInfo* visuals = XGetVisualInfo(display, 0, NULL, &count);
@@ -326,6 +328,10 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
         XVisualInfo bestVisual = XVisualInfo();
         for (int i = 0; i < count; ++i)
         {
+            // Filter by screen
+            if (visuals[i].screen != screen)
+                continue;
+
             // Check mandatory attributes
             int doubleBuffer;
             glXGetConfig(display, &visuals[i], GLX_DOUBLEBUFFER, &doubleBuffer);


### PR DESCRIPTION
Hej!

This is a fix for issue #724, which, despite the apparant resolution, is *still* an issue, unfortunately (or possible again?).

Multiple X sessions, which is what I believe @binary1248 tested, won't show the problem, because XGetVisualInfo() isn't returning visuals for different X displays (:0.0, :1.0, ...), but it *is* returning visuals for different X screens (:0.0, :0.1, ...)

With this change, SFML works for me on my two monitors, each running a separate X screen. Without the change, SFML only starts correctly on the first monitor, while it aborts with an X error BadMatch in XCreateColormap() on the second monitor.

I haven't, though, tested it with a Xinerama-enabled multi-monitor set-up. I don't *think* this change will break anything there, but I can't guarantee that. Ideally, someone with such a set-up should test this PR before merging.

The commit message on the actual commit contains my underlying reasoning for the change.

Cheers :)

**EDIT:** Oops, I accidentally a word.