### PR TITLE
Add support for blend color

### DIFF
--- a/include/SFML/Graphics/BlendMode.hpp
+++ b/include/SFML/Graphics/BlendMode.hpp
@@ -29,7 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
-
+#include <SFML/Graphics/Color.hpp>
 
 namespace sf
 {
@@ -57,7 +57,11 @@ struct SFML_GRAPHICS_API BlendMode
         SrcAlpha,         ///< (src.a, src.a, src.a, src.a)
         OneMinusSrcAlpha, ///< (1, 1, 1, 1) - (src.a, src.a, src.a, src.a)
         DstAlpha,         ///< (dst.a, dst.a, dst.a, dst.a)
-        OneMinusDstAlpha  ///< (1, 1, 1, 1) - (dst.a, dst.a, dst.a, dst.a)
+        OneMinusDstAlpha,  ///< (1, 1, 1, 1) - (dst.a, dst.a, dst.a, dst.a)
+        ConstColor,       ///< (Rc, Gc, Bc, Ac) 
+        OneMinusConstColor, ///< (1, 1, 1, 1) - (Rc, Gc, Bc, Ac)
+        ConstAlpha,       ///< (Ac, Ac, Ac, Ac)
+        OneMinusConstAlpha ///< (1, 1, 1, 1) - (Ac, Ac, Ac, Ac)
     };
 
     ////////////////////////////////////////////////////////
@@ -90,9 +94,10 @@ struct SFML_GRAPHICS_API BlendMode
     /// \param sourceFactor      Specifies how to compute the source factor for the color and alpha channels.
     /// \param destinationFactor Specifies how to compute the destination factor for the color and alpha channels.
     /// \param blendEquation     Specifies how to combine the source and destination colors and alpha.
+    /// \param color             Specifies the color that should be used for the constant color blend mode
     ///
     ////////////////////////////////////////////////////////////
-    BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation = Add);
+    BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation = Add, sf::Color color = sf::Color::Black);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the blend mode given the factors and equation.
@@ -103,11 +108,13 @@ struct SFML_GRAPHICS_API BlendMode
     /// \param alphaSourceFactor      Specifies how to compute the source factor.
     /// \param alphaDestinationFactor Specifies how to compute the destination factor.
     /// \param alphaBlendEquation     Specifies how to combine the source and destination alphas.
+    /// \param color                  Specifies the color that should be used for the constant color blend mode
     ///
     ////////////////////////////////////////////////////////////
     BlendMode(Factor colorSourceFactor, Factor colorDestinationFactor,
               Equation colorBlendEquation, Factor alphaSourceFactor,
-              Factor alphaDestinationFactor, Equation alphaBlendEquation);
+              Factor alphaDestinationFactor, Equation alphaBlendEquation,
+              sf::Color color = sf::Color::Black);
 
     ////////////////////////////////////////////////////////////
     // Member Data
@@ -118,6 +125,7 @@ struct SFML_GRAPHICS_API BlendMode
     Factor   alphaSrcFactor; ///< Source blending factor for the alpha channel
     Factor   alphaDstFactor; ///< Destination blending factor for the alpha channel
     Equation alphaEquation;  ///< Blending equation for the alpha channel
+    sf::Color constantColor; ///< Color value for constant color blending mode
 };
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/BlendMode.cpp
+++ b/src/SFML/Graphics/BlendMode.cpp
@@ -48,20 +48,22 @@ colorDstFactor(BlendMode::OneMinusSrcAlpha),
 colorEquation (BlendMode::Add),
 alphaSrcFactor(BlendMode::One),
 alphaDstFactor(BlendMode::OneMinusSrcAlpha),
-alphaEquation (BlendMode::Add)
+alphaEquation (BlendMode::Add),
+constantColor (sf::Color::Black)
 {
 
 }
 
 
 ////////////////////////////////////////////////////////////
-BlendMode::BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation) :
+BlendMode::BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation, sf::Color color) :
 colorSrcFactor(sourceFactor),
 colorDstFactor(destinationFactor),
 colorEquation (blendEquation),
 alphaSrcFactor(sourceFactor),
 alphaDstFactor(destinationFactor),
-alphaEquation (blendEquation)
+alphaEquation (blendEquation),
+constantColor (color)
 {
 
 }
@@ -70,13 +72,15 @@ alphaEquation (blendEquation)
 ////////////////////////////////////////////////////////////
 BlendMode::BlendMode(Factor colorSourceFactor, Factor colorDestinationFactor,
                      Equation colorBlendEquation, Factor alphaSourceFactor,
-                     Factor alphaDestinationFactor, Equation alphaBlendEquation) :
+                     Factor alphaDestinationFactor, Equation alphaBlendEquation,
+                     sf::Color color) :
 colorSrcFactor(colorSourceFactor),
 colorDstFactor(colorDestinationFactor),
 colorEquation (colorBlendEquation),
 alphaSrcFactor(alphaSourceFactor),
 alphaDstFactor(alphaDestinationFactor),
-alphaEquation (alphaBlendEquation)
+alphaEquation (alphaBlendEquation),
+constantColor (color)
 {
 
 }
@@ -90,7 +94,8 @@ bool operator ==(const BlendMode& left, const BlendMode& right)
            (left.colorEquation  == right.colorEquation)  &&
            (left.alphaSrcFactor == right.alphaSrcFactor) &&
            (left.alphaDstFactor == right.alphaDstFactor) &&
-           (left.alphaEquation  == right.alphaEquation);
+           (left.alphaEquation  == right.alphaEquation) &&
+           (left.constantColor  == right.constantColor);
 }
 
 

--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -47,11 +47,17 @@
     #define GLEXT_texture_edge_clamp                  true
     #define GLEXT_EXT_texture_edge_clamp              true
     #define GLEXT_blend_minmax                        true
+    #define GLEXT_blend_color                         true
     #define GLEXT_glClientActiveTexture               glClientActiveTexture
     #define GLEXT_glActiveTexture                     glActiveTexture
     #define GLEXT_GL_TEXTURE0                         GL_TEXTURE0
     #define GLEXT_GL_CLAMP                            GL_CLAMP_TO_EDGE
     #define GLEXT_GL_CLAMP_TO_EDGE                    GL_CLAMP_TO_EDGE
+    #define GLEXT_glBlendColor                        glBlendColor
+    #define GLEXT_GL_CONSTANT_COLOR                   GL_CONSTANT_COLOR
+    #define GLEXT_GL_ONE_MINUS_CONSTANT_COLOR         GL_ONE_MINUS_CONSTANT_COLOR
+    #define GLEXT_GL_CONSTANT_ALPHA                   GL_CONSTANT_ALPHA
+    #define GLEXT_GL_ONE_MINUS_CONSTANT_ALPHA         GL_ONE_MINUS_CONSTANT_ALPHA
 
     // Core since 1.1
     // 1.1 does not support GL_STREAM_DRAW so we just define it to GL_DYNAMIC_DRAW
@@ -175,7 +181,7 @@
     #define GLEXT_glBlendEquation                     glBlendEquationEXT
     #define GLEXT_GL_FUNC_ADD                         GL_FUNC_ADD_EXT
 
-    // Core since 1.? - EXT_blend_color
+    // Core since 1.2 - EXT_blend_color
     #define GLEXT_blend_color                         sfogl_ext_EXT_blend_color
     #define GLEXT_glBlendColor                        glBlendColorEXT
     #define GLEXT_GL_CONSTANT_COLOR                   GL_CONSTANT_COLOR_EXT

--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -175,6 +175,14 @@
     #define GLEXT_glBlendEquation                     glBlendEquationEXT
     #define GLEXT_GL_FUNC_ADD                         GL_FUNC_ADD_EXT
 
+    // Core since 1.? - EXT_blend_color
+    #define GLEXT_blend_color                         sfogl_ext_EXT_blend_color
+    #define GLEXT_glBlendColor                        glBlendColorEXT
+    #define GLEXT_GL_CONSTANT_COLOR                   GL_CONSTANT_COLOR_EXT
+    #define GLEXT_GL_ONE_MINUS_CONSTANT_COLOR         GL_ONE_MINUS_CONSTANT_COLOR_EXT
+    #define GLEXT_GL_CONSTANT_ALPHA                   GL_CONSTANT_ALPHA_EXT
+    #define GLEXT_GL_ONE_MINUS_CONSTANT_ALPHA         GL_ONE_MINUS_CONSTANT_ALPHA_EXT
+
     // Core since 1.2 - EXT_blend_subtract
     #define GLEXT_blend_subtract                      sfogl_ext_EXT_blend_subtract
     #define GLEXT_GL_FUNC_SUBTRACT                    GL_FUNC_SUBTRACT_EXT

--- a/src/SFML/Graphics/GLLoader.cpp
+++ b/src/SFML/Graphics/GLLoader.cpp
@@ -36,6 +36,7 @@ static sf::GlFunctionPointer glLoaderGetProcAddress(const char* name)
 int sfogl_ext_SGIS_texture_edge_clamp = sfogl_LOAD_FAILED;
 int sfogl_ext_EXT_texture_edge_clamp = sfogl_LOAD_FAILED;
 int sfogl_ext_EXT_blend_minmax = sfogl_LOAD_FAILED;
+int sfogl_ext_EXT_blend_color = sfogl_LOAD_FAILED;
 int sfogl_ext_EXT_blend_subtract = sfogl_LOAD_FAILED;
 int sfogl_ext_ARB_multitexture = sfogl_LOAD_FAILED;
 int sfogl_ext_EXT_blend_func_separate = sfogl_LOAD_FAILED;
@@ -62,6 +63,19 @@ static int Load_EXT_blend_minmax()
 
     sf_ptrc_glBlendEquationEXT = reinterpret_cast<void (GL_FUNCPTR *)(GLenum)>(glLoaderGetProcAddress("glBlendEquationEXT"));
     if (!sf_ptrc_glBlendEquationEXT)
+        numFailed++;
+
+    return numFailed;
+}
+
+void (GL_FUNCPTR *sf_ptrc_glBlendColorEXT) (GLfloat, GLfloat, GLfloat, GLfloat) = NULL;
+
+static int Load_EXT_blend_color()
+{
+    int numFailed = 0;
+
+    sf_ptrc_glBlendColorEXT = reinterpret_cast<void (GL_FUNCPTR *) (GLfloat, GLfloat, GLfloat, GLfloat)>(glLoaderGetProcAddress("glBlendColorEXT"));
+    if (!sf_ptrc_glBlendColorEXT)
         numFailed++;
 
     return numFailed;
@@ -943,10 +957,11 @@ typedef struct sfogl_StrToExtMap_s
     PFN_LOADFUNCPOINTERS LoadExtension;
 } sfogl_StrToExtMap;
 
-static sfogl_StrToExtMap ExtensionMap[20] = {
+static sfogl_StrToExtMap ExtensionMap[21] = {
     {"GL_SGIS_texture_edge_clamp", &sfogl_ext_SGIS_texture_edge_clamp, NULL},
     {"GL_EXT_texture_edge_clamp", &sfogl_ext_EXT_texture_edge_clamp, NULL},
     {"GL_EXT_blend_minmax", &sfogl_ext_EXT_blend_minmax, Load_EXT_blend_minmax},
+    {"GL_EXT_blend_color", &sfogl_ext_EXT_blend_color, Load_EXT_blend_color},
     {"GL_EXT_blend_subtract", &sfogl_ext_EXT_blend_subtract, NULL},
     {"GL_ARB_multitexture", &sfogl_ext_ARB_multitexture, Load_ARB_multitexture},
     {"GL_EXT_blend_func_separate", &sfogl_ext_EXT_blend_func_separate, Load_EXT_blend_func_separate},

--- a/src/SFML/Graphics/GLLoader.hpp
+++ b/src/SFML/Graphics/GLLoader.hpp
@@ -173,6 +173,7 @@ extern "C" {
 extern int sfogl_ext_SGIS_texture_edge_clamp;
 extern int sfogl_ext_EXT_texture_edge_clamp;
 extern int sfogl_ext_EXT_blend_minmax;
+extern int sfogl_ext_EXT_blend_color;
 extern int sfogl_ext_EXT_blend_subtract;
 extern int sfogl_ext_ARB_multitexture;
 extern int sfogl_ext_EXT_blend_func_separate;
@@ -199,6 +200,12 @@ extern int sfogl_ext_ARB_geometry_shader4;
 #define GL_FUNC_ADD_EXT 0x8006
 #define GL_MAX_EXT 0x8008
 #define GL_MIN_EXT 0x8007
+
+#define GL_CONSTANT_COLOR_EXT             0x8001
+#define GL_ONE_MINUS_CONSTANT_COLOR_EXT   0x8002
+#define GL_CONSTANT_ALPHA_EXT             0x8003
+#define GL_ONE_MINUS_CONSTANT_ALPHA_EXT   0x8004
+#define GL_BLEND_COLOR_EXT                0x8005
 
 #define GL_FUNC_REVERSE_SUBTRACT_EXT 0x800B
 #define GL_FUNC_SUBTRACT_EXT 0x800A
@@ -990,6 +997,12 @@ extern int sfogl_ext_ARB_geometry_shader4;
 extern void (GL_FUNCPTR *sf_ptrc_glBlendEquationEXT)(GLenum);
 #define glBlendEquationEXT sf_ptrc_glBlendEquationEXT
 #endif // GL_EXT_blend_minmax
+
+#ifndef GL_EXT_blend_color
+#define GL_EXT_blend_color 1
+extern void (GL_FUNCPTR *sf_ptrc_glBlendColorEXT) (GLfloat, GLfloat, GLfloat, GLfloat);
+#define glBlendColorEXT sf_ptrc_glBlendColorEXT
+#endif /* GL_EXT_blend_color */
 
 
 #ifndef GL_ARB_multitexture

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -87,16 +87,20 @@ namespace
     {
         switch (blendFactor)
         {
-            case sf::BlendMode::Zero:             return GL_ZERO;
-            case sf::BlendMode::One:              return GL_ONE;
-            case sf::BlendMode::SrcColor:         return GL_SRC_COLOR;
-            case sf::BlendMode::OneMinusSrcColor: return GL_ONE_MINUS_SRC_COLOR;
-            case sf::BlendMode::DstColor:         return GL_DST_COLOR;
-            case sf::BlendMode::OneMinusDstColor: return GL_ONE_MINUS_DST_COLOR;
-            case sf::BlendMode::SrcAlpha:         return GL_SRC_ALPHA;
-            case sf::BlendMode::OneMinusSrcAlpha: return GL_ONE_MINUS_SRC_ALPHA;
-            case sf::BlendMode::DstAlpha:         return GL_DST_ALPHA;
-            case sf::BlendMode::OneMinusDstAlpha: return GL_ONE_MINUS_DST_ALPHA;
+            case sf::BlendMode::Zero:               return GL_ZERO;
+            case sf::BlendMode::One:                return GL_ONE;
+            case sf::BlendMode::SrcColor:           return GL_SRC_COLOR;
+            case sf::BlendMode::OneMinusSrcColor:   return GL_ONE_MINUS_SRC_COLOR;
+            case sf::BlendMode::DstColor:           return GL_DST_COLOR;
+            case sf::BlendMode::OneMinusDstColor:   return GL_ONE_MINUS_DST_COLOR;
+            case sf::BlendMode::SrcAlpha:           return GL_SRC_ALPHA;
+            case sf::BlendMode::OneMinusSrcAlpha:   return GL_ONE_MINUS_SRC_ALPHA;
+            case sf::BlendMode::DstAlpha:           return GL_DST_ALPHA;
+            case sf::BlendMode::OneMinusDstAlpha:   return GL_ONE_MINUS_DST_ALPHA;
+            case sf::BlendMode::ConstColor:         return GLEXT_GL_CONSTANT_COLOR;
+            case sf::BlendMode::OneMinusConstColor: return GLEXT_GL_ONE_MINUS_CONSTANT_COLOR;
+            case sf::BlendMode::ConstAlpha:         return GLEXT_GL_CONSTANT_ALPHA;
+            case sf::BlendMode::OneMinusConstAlpha: return GLEXT_GL_ONE_MINUS_CONSTANT_ALPHA;
         }
 
         sf::err() << "Invalid value for sf::BlendMode::Factor! Fallback to sf::BlendMode::Zero." << std::endl;
@@ -576,6 +580,12 @@ void RenderTarget::applyCurrentView()
 ////////////////////////////////////////////////////////////
 void RenderTarget::applyBlendMode(const BlendMode& mode)
 {
+    // Set the blending color for constant color and alpha operation
+    if (GLEXT_blend_color)
+    {
+        glCheck(GLEXT_glBlendColor((float)mode.constantColor.r/255., (float)mode.constantColor.g / 255.,
+            (float)mode.constantColor.b / 255., (float)mode.constantColor.a / 255.));
+    }
     // Apply the blend mode, falling back to the non-separate versions if necessary
     if (GLEXT_blend_func_separate)
     {


### PR DESCRIPTION
## Description

Adds support for constant color blending modes, by adding GL_EXT_blend_color OpenGL extension.
Support for OpenGL ES is not implemented yet.

This PR is related to the issue #1503.
Forum: https://en.sfml-dev.org/forums/index.php?topic=24653.0

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?
```cpp
#include <SFML/Graphics.hpp>

int main()
{
    // Create a window for the game
    sf::RenderWindow window(sf::VideoMode(800, 600), "Minimal example");

    sf::CircleShape circle(150);
    circle.setFillColor(sf::Color(255, 255, 255, 255));

    sf::BlendMode mode(sf::BlendMode::ConstColor, sf::BlendMode::Zero, sf::BlendMode::Add, sf::Color::Red);

    for (;;)
    {
        // ---------- Handle Events -----------
        sf::Event event;
        while (window.pollEvent(event))
        {
            // Handle events
            if (event.type == sf::Event::Closed
                || event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape)
                return 0;
        }

        // ---------- Draw the scene ----------
        window.clear();

        window.draw(circle, mode);

        // Display the frame
        window.display();
    }
}
```