### PR TITLE
Android: don't force installation prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,9 @@ if(SFML_OS_ANDROID)
     endif()
 
     # install everything in $NDK/sources/ because this path is appended by the NDK (convenient)
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_ANDROID_NDK}/sources/third_party/sfml)
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+        set(CMAKE_INSTALL_PREFIX ${CMAKE_ANDROID_NDK}/sources/third_party/sfml CACHE PATH "Installation path (should be inside your NDK's 'sources' directory)" FORCE)
+    endif()
 
     # we install libs in a subdirectory named after the ABI (lib/mips/*.so)
     set(LIB_SUFFIX "/${CMAKE_ANDROID_ARCH_ABI}")
@@ -489,7 +491,7 @@ elseif(SFML_OS_IOS)
         endif()
 
         if(SFML_BUILD_AUDIO)
-            install(FILES extlibs/libs-ios/libflac.a 
+            install(FILES extlibs/libs-ios/libflac.a
                           extlibs/libs-ios/libvorbis.a
                           extlibs/libs-ios/libogg.a
                           DESTINATION lib)


### PR DESCRIPTION
* [x] If you have additional steps which need to be performed list them as tasks!

Built on local with NDK, CMAKE_INSTALL_PREFIX is honored if set.

----

## Description

User should be able to change its value to any location.

See: https://cmake.org/cmake/help/v3.12/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [x] Tested on Android