### PR TITLE
CMake: create SFML_LIB_SUFFIX option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if(SFML_OS_ANDROID)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_ANDROID_NDK}/sources/third_party/sfml)
 
     # we install libs in a subdirectory named after the ABI (lib/mips/*.so)
-    set(LIB_SUFFIX "/${CMAKE_ANDROID_ARCH_ABI}")
+    set(DEFAULT_LIB_SUFFIX "/${CMAKE_ANDROID_ARCH_ABI}")
 
     # pass shared STL configuration (if any)
     if (CMAKE_ANDROID_STL_TYPE MATCHES "_shared")
@@ -150,6 +150,8 @@ endif()
 # add an option to let the user specify a custom directory for doc, examples, licence, readme and other miscellaneous files
 sfml_set_option(SFML_MISC_INSTALL_PREFIX "${DEFAULT_INSTALL_MISC_DIR}" PATH "Prefix installation path for miscellaneous files")
 
+# optional directory suffix for libraries
+sfml_set_option(SFML_LIB_SUFFIX "${DEFAULT_LIB_SUFFIX}" STRING "Optional directory suffix for libraries (e.g. armeabi-v7a)")
 
 # force building sfml-window, if sfml-graphics module is built
 if(SFML_BUILD_GRAPHICS AND NOT SFML_BUILD_WINDOW)
@@ -479,7 +481,7 @@ elseif(SFML_OS_MACOSX)
 elseif(SFML_OS_IOS)
 
     # fix CMake install rules broken for iOS (see http://public.kitware.com/Bug/view.php?id=12506)
-    install(DIRECTORY "${CMAKE_BINARY_DIR}/lib/\$ENV{CONFIGURATION}/" DESTINATION lib${LIB_SUFFIX})
+    install(DIRECTORY "${CMAKE_BINARY_DIR}/lib/\$ENV{CONFIGURATION}/" DESTINATION lib${SFML_LIB_SUFFIX})
 
     if(NOT SFML_USE_SYSTEM_DEPS)
         # since the iOS libraries are built as static, we must install the SFML dependencies

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -71,7 +71,7 @@ endif()
 
 # set pkgconfig install directory
 # this could be e.g. macports on mac or msys2 on windows etc.
-set(SFML_PKGCONFIG_DIR "/lib${LIB_SUFFIX}/pkgconfig")
+set(SFML_PKGCONFIG_DIR "/lib${SFML_LIB_SUFFIX}/pkgconfig")
 
 if(SFML_OS_FREEBSD OR SFML_OS_OPENBSD)
     set(SFML_PKGCONFIG_DIR "/libdata/pkgconfig")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -160,8 +160,8 @@ macro(sfml_add_library target)
     # add the install rule
     install(TARGETS ${target} EXPORT SFMLConfigExport
             RUNTIME DESTINATION bin COMPONENT bin
-            LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT bin
-            ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT devel
+            LIBRARY DESTINATION lib${SFML_LIB_SUFFIX} COMPONENT bin
+            ARCHIVE DESTINATION lib${SFML_LIB_SUFFIX} COMPONENT devel
             FRAMEWORK DESTINATION "." COMPONENT bin)
 
     # add <project>/include as public include directory
@@ -325,7 +325,7 @@ function(sfml_export_targets)
     if (SFML_BUILD_FRAMEWORKS)
         set(config_package_location "SFML.framework/Resources/CMake")
     else()
-        set(config_package_location lib${LIB_SUFFIX}/cmake/SFML)
+        set(config_package_location lib${SFML_LIB_SUFFIX}/cmake/SFML)
     endif()
     configure_package_config_file("${CURRENT_DIR}/SFMLConfig.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/SFMLConfig.cmake"
         INSTALL_DESTINATION "${config_package_location}")

--- a/tools/pkg-config/sfml-all.pc.in
+++ b/tools/pkg-config/sfml-all.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/lib@SFML_LIB_SUFFIX@
 includedir=${prefix}/include
 
 Name: SFML-all

--- a/tools/pkg-config/sfml-audio.pc.in
+++ b/tools/pkg-config/sfml-audio.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/lib@SFML_LIB_SUFFIX@
 includedir=${prefix}/include
 
 Name: SFML-audio

--- a/tools/pkg-config/sfml-graphics.pc.in
+++ b/tools/pkg-config/sfml-graphics.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/lib@SFML_LIB_SUFFIX@
 includedir=${prefix}/include
 
 Name: SFML-graphics

--- a/tools/pkg-config/sfml-network.pc.in
+++ b/tools/pkg-config/sfml-network.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/lib@SFML_LIB_SUFFIX@
 includedir=${prefix}/include
 
 Name: SFML-network

--- a/tools/pkg-config/sfml-system.pc.in
+++ b/tools/pkg-config/sfml-system.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/lib@SFML_LIB_SUFFIX@
 includedir=${prefix}/include
 
 Name: SFML-system

--- a/tools/pkg-config/sfml-window.pc.in
+++ b/tools/pkg-config/sfml-window.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/lib@SFML_LIB_SUFFIX@
 includedir=${prefix}/include
 
 Name: SFML-window


### PR DESCRIPTION
* [x] Have you provided some example/test code for your changes?
----

## Description

Make the hardcoded LIB_SUFFIX a first class citizen to let the user pass
a new value if needed.

## Tasks

* [x] Tested on Linux
* [x] Tested on Android

## How to test this PR?

This will install in lib64

```
cmake .. -DSFML_LIB_SUFFIX="64" && make && make install
```

This will install in subdirectory lib/armeabi-v7a

```
cmake .. -DSFML_LIB_SUFFIX="/armeabi-v7a" && make && make install
```

Not specifying a value keep the old behaviour set with DEFAULT_LIB_SUFFIX.