### PR TITLE
CMake: don't set a predefined build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,6 @@ endmacro()
 
 # these options have to be set before CMake detects/configures the toolchain
 
-# determine whether to create a debug or release build
-sfml_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
-
 # Suppress Cygwin legacy warning
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 


### PR DESCRIPTION
## Description

The CMakeLists.txt should not set a CMAKE_BUILD_TYPE by default because
multiple generators do not use this variable (e.g. Visual Studio).

This makes the build process inconsistent between the CMake
configuration and the IDE.

Example with current behaviour:

1. User runs CMake for Visual Studio, CMake generates Release
2. User selects Debug in Visual Studio

The build process is inconsistent.

## Tasks

* [x] Tested on Linux