### PR TITLE
Use C++11 std::unique_ptr

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -107,7 +107,7 @@ bool AudioDevice::isExtensionSupported(const std::string& extension)
     // This device will not be used in this function and merely
     // makes sure there is a valid OpenAL device for extension
     // queries if none has been created yet.
-    std::auto_ptr<AudioDevice> device;
+    std::unique_ptr<AudioDevice> device;
     if (!audioDevice)
         device.reset(new AudioDevice);
 
@@ -125,7 +125,7 @@ int AudioDevice::getFormatFromChannelCount(unsigned int channelCount)
     // This device will not be used in this function and merely
     // makes sure there is a valid OpenAL device for format
     // queries if none has been created yet.
-    std::auto_ptr<AudioDevice> device;
+    std::unique_ptr<AudioDevice> device;
     if (!audioDevice)
         device.reset(new AudioDevice);
 


### PR DESCRIPTION
## Description

The std::auto_ptr class will be removed in C++17 and has been deprecated
since C++11.

Fix warning:

```
/home/markand/SFML/src/SFML/Audio/AudioDevice.cpp: In static member function ‘static int sf::priv::AudioDevice::getFormatFromChannelCount(unsigned int)’:
/home/markand/SFML/src/SFML/Audio/AudioDevice.cpp:128:10: warning: ‘template<class> class std::auto_ptr’ is deprecated [-Wdeprecated-declarations]
     std::auto_ptr<AudioDevice> device;
          ^~~~~~~~
In file included from /usr/include/c++/8.2.1/memory:80,
                 from /home/markand/SFML/src/SFML/Audio/AudioDevice.cpp:32:
/usr/include/c++/8.2.1/bits/unique_ptr.h:53:28: note: declared here
   template<typename> class auto_ptr;
```

## Tasks

* [x] Tested on Linux