### PR TITLE
Allow changing processing interval in SoundStream

### DIFF
--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -251,6 +251,24 @@ protected:
     ////////////////////////////////////////////////////////////
     virtual Int64 onLoop();
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the processing interval
+    ///
+    /// The processing interval controls the period
+    /// between calls to the fillAndPushBuffer function. You may
+    /// want to use a small interval if you want to process the
+    /// captured data in real time, for example.
+    ///
+    /// Note: this is only a hint, the actual period may vary.
+    /// So don't rely on this parameter to implement precise timing.
+    ///
+    /// The default processing interval is 10 ms.
+    ///
+    /// \param interval Processing interval
+    ///
+    ////////////////////////////////////////////////////////////
+    void setProcessingInterval(Time interval);
+
 private:
 
     ////////////////////////////////////////////////////////////
@@ -317,6 +335,7 @@ private:
     bool          m_loop;                     ///< Loop flag (true to loop, false to play once)
     Uint64        m_samplesProcessed;         ///< Number of buffers processed since beginning of the stream
     Int64         m_bufferSeeks[BufferCount]; ///< If buffer is an "end buffer", holds next seek position, else NoLoop. For play offset calculation.
+    Time          m_processingInterval;       ///< Time period between calls to fillAndPushBuffer
 };
 
 } // namespace sf

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -41,17 +41,18 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 SoundStream::SoundStream() :
-m_thread          (&SoundStream::streamData, this),
-m_threadMutex     (),
-m_threadStartState(Stopped),
-m_isStreaming     (false),
-m_buffers         (),
-m_channelCount    (0),
-m_sampleRate      (0),
-m_format          (0),
-m_loop            (false),
-m_samplesProcessed(0),
-m_bufferSeeks     ()
+m_thread            (&SoundStream::streamData, this),
+m_threadMutex       (),
+m_threadStartState  (Stopped),
+m_isStreaming       (false),
+m_buffers           (),
+m_channelCount      (0),
+m_sampleRate        (0),
+m_format            (0),
+m_loop              (false),
+m_samplesProcessed  (0),
+m_bufferSeeks       (),
+m_processingInterval(milliseconds(10))
 {
 
 }
@@ -266,6 +267,13 @@ Int64 SoundStream::onLoop()
 
 
 ////////////////////////////////////////////////////////////
+void SoundStream::setProcessingInterval(Time interval)
+{
+    m_processingInterval = interval;
+}
+
+
+////////////////////////////////////////////////////////////
 void SoundStream::streamData()
 {
     bool requestStop = false;
@@ -384,7 +392,7 @@ void SoundStream::streamData()
 
         // Leave some time for the other threads if the stream is still playing
         if (SoundSource::getStatus() != Stopped)
-            sleep(milliseconds(10));
+            sleep(m_processingInterval);
     }
 
     // Stop the playback


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This patch bring similar functionality that is available in SoundRecorder. It is useful to be able to change it when you have your own waiting/blocking calls in onGetData function. That way sleep in SoundRecorder don't get in your way. After this patch default behaviour is the same.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

```cpp
#include <SFML/Audio/SoundStream.hpp>
class FastSoundStreamt: public sf::SoundStream
{
    FastSoundStream()
    {
         sf::SoundRecorder::setProcessingInterval(sf::Time::Zero);
    }
    void onSeek(sf::Time timeOffset) {}
    bool onGetData(sf::SoundStream::Chunk& data)
    {
        //custom blocking calls for samples
    }
};
```