### PR TITLE
Fixed opengl error 1282(INVALID_OPERATION) on window.setActive(true)

### DIFF
--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -205,7 +205,17 @@ unsigned int RenderTextureImplFBO::getMaximumAntialiasingLevel()
 ////////////////////////////////////////////////////////////
 void RenderTextureImplFBO::unbind()
 {
-    glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
+    GLint drawFboId = 0, readFboId = 0;
+    glGetIntegerv(GLEXT_GL_DRAW_FRAMEBUFFER_BINDING, &drawFboId);
+    glGetIntegerv(GLEXT_GL_READ_FRAMEBUFFER_BINDING, &readFboId);
+
+    if (drawFboId != 0) {
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, 0));
+    }
+
+    if (readFboId != 0) {
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_READ_FRAMEBUFFER, 0));
+    }
 }
 
 


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Prevents OpenGL error 1282 which is INVALID_OPERATION when making a window active.
It's fix for fix, changes nothing except error in console.
I was confused by this error message, I thought there's a problem with my code.
After some investigation, I've found what was causing 1282.
I compiled SFML with SFML_DEBUG to make sure error produced by SFML, and error was confirmed.

This PR is related to the issue #

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

sf::RenderWindow *createWindow(
  const std::string &title,
  uint width,
  uint height,
  sf::ContextSettings settings
) {
  auto* window = new sf::RenderWindow();

  sf::VideoMode vm(width, height, 16);

  window->setVerticalSyncEnabled(true);
  window->create(vm, title, sf::Style::Default, settings);
  window->display();
  glViewport(0, 0, width, height);

  return window;
}

int main()
{
  sf::ContextSettings creatorSettings(0, 0, 4, 4, 5, sf::ContextSettings::Core, false);
  sf::ContextSettings linkerSettings(0, 0, 1, 1, 5, sf::ContextSettings::Default, false);

  // works with 330 shaders
  auto* creatorWindow = createWindow(
    "Icons Creator",
    windowSize,
    windowSize,
    creatorSettings
  );

  // works with sf::Image/Sprite/Texture
  auto* linkerWindow = createWindow(
    "Icons Linker",
    windowSize,
    windowSize,
    linkerSettings
  );

  // Before it'd produce OpenGL 1282(INVALID_OPERATION) error
  creatorWindow->setActive(true);

  // And here I compile 330 shader, which cannot be compiled without
  // window activation.
  //...
}
```

P.S. I tried look deeper, I tried to find what's wrong with architecture, and I couldn't find any weak/wrong code.
P.P.S. I saw PR which fixes same error, and it doesn't work for me since I'm on 2.5.1, and the PR was merged.