### PR TITLE
Make sure setActive(false) is called before the surface is destroyed in EglContext.

### DIFF
--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -233,11 +233,11 @@ void EglContext::createSurface(EGLNativeWindowType window)
 ////////////////////////////////////////////////////////////
 void EglContext::destroySurface()
 {
+    // Ensure that this context is no longer active since our surface is going to be destroyed
+    setActive(false);
+
     eglCheck(eglDestroySurface(m_display, m_surface));
     m_surface = EGL_NO_SURFACE;
-
-    // Ensure that this context is no longer active since our surface is now destroyed
-    setActive(false);
 }
 
 


### PR DESCRIPTION
Fixes #1530.

How to test?

According to #1530, just create an app, pause and resume it and the issue should be present without this patch and gone after applying it.