### PR TITLE
Fixed EGL incorrectly being passed the anti-aliasing level as EGL_SAMPLE_BUFFERS instead of EGL_SAMPLES.

### DIFF
--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -249,7 +249,8 @@ EGLConfig EglContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
         EGL_BUFFER_SIZE, static_cast<EGLint>(bitsPerPixel),
         EGL_DEPTH_SIZE, static_cast<EGLint>(settings.depthBits),
         EGL_STENCIL_SIZE, static_cast<EGLint>(settings.stencilBits),
-        EGL_SAMPLE_BUFFERS, static_cast<EGLint>(settings.antialiasingLevel),
+        EGL_SAMPLE_BUFFERS, static_cast<EGLint>(settings.antialiasingLevel ? 1 : 0),
+        EGL_SAMPLES, static_cast<EGLint>(settings.antialiasingLevel),
         EGL_SURFACE_TYPE, EGL_WINDOW_BIT | EGL_PBUFFER_BIT,
         EGL_RENDERABLE_TYPE, EGL_OPENGL_ES_BIT,
         EGL_NONE


### PR DESCRIPTION
Fixes #1533.

According to [eglChooseConfig documentation](https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglChooseConfig.xhtml) passing a value other than 0 or 1 in EGL_SAMPLE_BUFFERS causes undefined behaviour. When anti-aliasing is enabled, we should instead request 1 sample buffer and set the anti-aliasing level (number of samples) via EGL_SAMPLES.