### PR TITLE
Fixing issue with already defined targets, silently return

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -276,7 +276,7 @@ function(sfml_find_package)
     list(REMOVE_AT ARGN 0)
 
     if (TARGET ${target})
-        message(FATAL_ERROR "Target '${target}' is already defined")
+        return()
     endif()
 
     cmake_parse_arguments(THIS "" "" "INCLUDE;LINK" ${ARGN})


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
https://en.sfml-dev.org/forums/index.php?topic=25001.0
Discussed by a different user, tested and confirmed working.
* [X] Have you provided some example/test code for your changes?
Not provided, but the command used in the forum now works fine.
Small enough change that it shouldn't affect anything else.

## Description
As discussed in Forum https://en.sfml-dev.org/forums/index.php?topic=25001.0 this fixes build for GLES/EGL platforms where sfml-window tries to define targets EGL and GLES again which were already defined.

## Tasks

* [X] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?
cmake -DSFML_OPENGL_ES=1 .
should work without error about already defined targets EGL and GLES.