### PR TITLE
Add travis android builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,5 +78,28 @@ matrix:
     env:
       - CMAKE_FLAGS="-DBUILD_SHARED_LIBS=FALSE"
 
+  - name: "Android armeabi-v7a"
+    language: android
+    android: &androidComponents
+      components:
+        - tools
+        - platform-tools
+        - build-tools-26.0.1
+    env:
+      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_NDK=/usr/local/android-sdk/ndk-bundle -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+    
+    install: &androidInstall
+      - echo y | sdkmanager "ndk-bundle" 
+      - echo y | sdkmanager "cmake;3.10.2.4988404" 
+      - echo y | sdkmanager "lldb;3.1"
+      - sudo ln -sf /usr/local/android-sdk/cmake/3.10.2.4988404/bin/cmake /usr/bin/cmake
+
+  - name: "Android x86"
+    language: android
+    android: *androidComponents
+    env:
+      - CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_NDK=/usr/local/android-sdk/ndk-bundle -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26"
+    install: *androidInstall
+
 notifications:
   email: false


### PR DESCRIPTION
This adds android builds to travis (x86 and armeabi-v7a)

It targets android API version 26, which is currently the minimum required target version in the [docs](https://support.google.com/googleplay/android-developer/answer/113469#targetsdk)