### PR TITLE
Fix iOS example bundle names

### DIFF
--- a/examples/assets/Info.plist
+++ b/examples/assets/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string>2.5.1</string>
 	<key>CFBundleName</key>
-	<string>window</string>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
The bundle name should match the executable, rather than hardcoded string "window"