### PR TITLE
Removed useless cast

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -293,7 +293,7 @@ In Utf<16>::decode(In begin, In end, Uint32& output, Uint32 replacement)
             if ((second >= 0xDC00) && (second <= 0xDFFF))
             {
                 // The second element is valid: convert the two elements to a UTF-32 character
-                output = static_cast<Uint32>(((first - 0xD800) << 10) + (second - 0xDC00) + 0x0010000);
+                output = ((first - 0xD800) << 10) + (second - 0xDC00) + 0x0010000;
             }
             else
             {


### PR DESCRIPTION
## Description

Removed useless cast in SFML/System/Utf.inl at line 296.
This useless cast creates a warning when using -Wuseless-cast as an option in g++ and clang++.
Operations can't be made on types smaller than 4 bytes (32 bits), so types smaller than 4 bytes are converted to at least 4 bytes types, thus rendering the static_cast<Uint32> useless in this particular case.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

This is just to remove a warning