### PR TITLE
Wrong fullscreen resolution fix

### DIFF
--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -80,6 +80,7 @@ struct ActivityStates
     bool mainOver;
 
     Vector2i screenSize;
+    Vector2i fullScreenSize;
 
     bool initialized;
     bool terminated;

--- a/src/SFML/Window/Android/VideoModeImpl.cpp
+++ b/src/SFML/Window/Android/VideoModeImpl.cpp
@@ -38,7 +38,15 @@ namespace priv
 ////////////////////////////////////////////////////////////
 std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 {
-    VideoMode desktop = getDesktopMode();
+    // Get the activity states
+    priv::ActivityStates& states = priv::getActivity();
+
+    VideoMode desktop;
+
+    {
+        Lock lock(states.mutex);
+        desktop = VideoMode(static_cast<unsigned int>(states.fullScreenSize.x), static_cast<unsigned int>(states.fullScreenSize.y));
+    }
 
     // Return both portrait and landscape resolutions
     std::vector<VideoMode> modes;


### PR DESCRIPTION
## Description

A new field `fullScreenSize` has been added to the `ActivityStates`, which will hold the screen size when in full-screen mode (more precisely, immersive mode) as opposed to the default mode. This variable is set using a new function `getFullScreenSizeInPixels` which calls [`getRealMetrics`](https://developer.android.com/reference/android/view/Display#getRealMetrics(android.util.DisplayMetrics)) through JNI. The value of this new field is returned in `getFullscreenModes`. Previously, this method returned the same value as `getDesktopMode` which is incorrect, because the usable screen size in full-screen mode is always larger.

This PR will close #1349

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [X] Tested on Android

## How to test this PR?

Set the screen orientation in `AndroidManifest.xml` to landscape:
```xml
android:screenOrientation="landscape"
```

```cpp
#include <SFML/System.hpp>
#include <SFML/Window.hpp>
#include <SFML/Graphics.hpp>
#include <SFML/Audio.hpp>
#include <SFML/Network.hpp>

int main(int argc, char *argv[])
{
    sf::VideoMode screen(sf::VideoMode::getFullscreenModes()[0]);

    sf::RenderWindow window(screen, "", sf::Style::Fullscreen);
    window.setFramerateLimit(30);

    sf::RectangleShape rightRectangle{{50,50}}; //this should appear on the right edge of the screen
    rightRectangle.setPosition(screen.width - 50, 100);
    rightRectangle.setFillColor(sf::Color::Red);

    sf::View view = window.getDefaultView();

    sf::Color background = sf::Color::White;

    // We shouldn't try drawing to the screen while in background
    // so we'll have to track that. You can do minor background
    // work, but keep battery life in mind.
    bool active = true;

    while (window.isOpen())
    {
        sf::Event event;

        while (active ? window.pollEvent(event) : window.waitEvent(event))
        {
            switch (event.type)
            {
                case sf::Event::Closed:
                    window.close();
                    break;
                case sf::Event::KeyPressed:
                    if (event.key.code == sf::Keyboard::Escape)
                        window.close();
                    break;
                case sf::Event::Resized:
                    view.setSize(event.size.width, event.size.height);
                    view.setCenter(event.size.width/2, event.size.height/2);
                    window.setView(view);
                    break;
                case sf::Event::LostFocus:
                    background = sf::Color::Black;
                    break;
                case sf::Event::GainedFocus:
                    background = sf::Color::White;
                    break;

                // On Android MouseLeft/MouseEntered are (for now) triggered,
                // whenever the app loses or gains focus.
                case sf::Event::MouseLeft:
                    active = false;
                    break;
                case sf::Event::MouseEntered:
                    active = true;
                    break;
                default:
                    break;
            }
        }

        if (active)
        {
            window.clear(background);
            window.draw(rightRectangle);
            window.display();
        }
        else {
            sf::sleep(sf::milliseconds(100));
        }
    }
}
```