### PR TITLE
Fix: Win32 no longer hides cursor when hovering title bar.

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -399,14 +399,8 @@ void WindowImplWin32::setVisible(bool visible)
 ////////////////////////////////////////////////////////////
 void WindowImplWin32::setMouseCursorVisible(bool visible)
 {
-    // Don't call twice ShowCursor with the same parameter value;
-    // we don't want to increment/decrement the internal counter
-    // more than once.
-    if (visible != m_cursorVisible)
-    {
-        m_cursorVisible = visible;
-        ShowCursor(visible);
-    }
+    m_cursorVisible = visible;
+    SetCursor(m_cursorVisible ? m_lastCursor : NULL);
 }
 
 
@@ -422,7 +416,7 @@ void WindowImplWin32::setMouseCursorGrabbed(bool grabbed)
 void WindowImplWin32::setMouseCursor(const CursorImpl& cursor)
 {
     m_lastCursor = cursor.m_cursor;
-    SetCursor(m_lastCursor);
+    SetCursor(m_cursorVisible ? m_lastCursor : NULL);
 }
 
 
@@ -586,8 +580,9 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         case WM_SETCURSOR:
         {
             // The mouse has moved, if the cursor is in our window we must refresh the cursor
-            if (LOWORD(lParam) == HTCLIENT)
-                SetCursor(m_lastCursor);
+            if (LOWORD(lParam) == HTCLIENT) {
+                SetCursor(m_cursorVisible ? m_lastCursor : NULL);
+            }
 
             break;
         }


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

## Description

This PR is related to issue #1569.

When you hide the mouse cursor in Windows the cursor does not re-appear when hovering the title bar and window frame. It does re-appear on other platforms and also re-appears if you set a blank image cursor - this patch fixes this inconsistency.

## Tasks

* [x] Tested on Windows

## How to test this PR?

Hover over the title bar or window frame and the cursor should re-appear.

```cpp
#include <SFML/Window.hpp>
int main()
{
    sf::Window window(sf::VideoMode(400, 300), "Cursor Bug");
    window.setMouseCursorVisible(false);
    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }
        window.display();
    }
}
```