### PR TITLE
Fixed unable to build SFML with latest Android NDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ endif()
 
 # Android options
 if(SFML_OS_ANDROID)
+    # avoid missing libraries when building SFML for Android with NDK r19c and later
+    set(CMAKE_FIND_ROOT_PATH "${PROJECT_SOURCE_DIR};${CMAKE_FIND_ROOT_PATH}")
+
     # make sure there's the android library available
     if (CMAKE_ANDROID_API LESS 14)
         message(FATAL_ERROR "Android API level (${CMAKE_ANDROID_API}) must be equal or greater than 14.")


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

SFML could not be built using the latest NDK, since CMake did not find any libraries (such as OpenAL).
This PR will fix this.
The problem was caused by the the changes added in NDK r19b. Since then, NDK adds its root path to `CMAKE_FIND_ROOT_PATH`. To tell CMake to also search for the libraries in SFML's directory, we have to add it to `CMAKE_FIND_ROOT_PATH` too.

## Tasks

* [X] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Try to build SFML using the [latest (r19c) Android NDK](https://developer.android.com/ndk/downloads). Without this PR, it will fail.