### PR TITLE
Use GNUInstallDirs module for cmake install paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,19 +54,19 @@ matrix:
     os: osx
     osx_image: xcode10
     env:
-     - CMAKE_FLAGS="-DSFML_DEPENDENCIES_INSTALL_PREFIX=../install -DSFML_BUILD_TEST_SUITE=TRUE"
+     - CMAKE_FLAGS="-DSFML_BUILD_TEST_SUITE=TRUE"
 
   - name: "macOS Xcode 10 Frameworks"
     os: osx
     osx_image: xcode10
     env:
-     - CMAKE_FLAGS="-DSFML_DEPENDENCIES_INSTALL_PREFIX=../install -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_BUILD_FRAMEWORKS=TRUE"
+     - CMAKE_FLAGS="-DSFML_BUILD_TEST_SUITE=TRUE -DSFML_BUILD_FRAMEWORKS=TRUE"
 
   - name: "macOS Xcode 10 Static"
     os: osx
     osx_image: xcode10
     env:
-     - CMAKE_FLAGS="-DSFML_DEPENDENCIES_INSTALL_PREFIX=../install -DSFML_BUILD_TEST_SUITE=TRUE -DBUILD_SHARED_LIBS=FALSE"
+     - CMAKE_FLAGS="-DSFML_BUILD_TEST_SUITE=TRUE -DBUILD_SHARED_LIBS=FALSE"
 
   - name: "iOS Xcode 10"
     os: osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ project(SFML)
 # include the configuration file
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake)
 
+# we use the paths from the cmake GNUInstallDirs module as defaults
+# you can override these if you like
+# https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html
+include(GNUInstallDirs)
+
 # setup version numbers
 set(VERSION_MAJOR 2)
 set(VERSION_MINOR 5)
@@ -92,14 +97,8 @@ if(SFML_OS_MACOSX)
     # add an option to build frameworks instead of dylibs (release only)
     sfml_set_option(SFML_BUILD_FRAMEWORKS FALSE BOOL "TRUE to build SFML as frameworks libraries (release only), FALSE to build according to BUILD_SHARED_LIBS")
 
-    # add an option to let the user specify a custom directory for external frameworks installation
-    sfml_set_option(SFML_DEPENDENCIES_INSTALL_PREFIX "/Library/Frameworks" PATH "External frameworks (FLAC, Freetype, Vorbis, ...) installation directory")
-
     # add an option to automatically install Xcode templates
     sfml_set_option(SFML_INSTALL_XCODE_TEMPLATES FALSE BOOL "TRUE to automatically install the Xcode templates, FALSE to do nothing about it. The templates are compatible with Xcode 4 and 5.")
-else()
-    # add an option to let the user specify a custom directory for external libraries installation
-    sfml_set_option(SFML_DEPENDENCIES_INSTALL_PREFIX "." PATH "External libraries (FLAC, Freetype, Vorbis, ...) installation directory")
 endif()
 
 # iOS specific options
@@ -125,9 +124,8 @@ if(SFML_OS_ANDROID)
     # install everything in $NDK/sources/ because this path is appended by the NDK (convenient)
     set(CMAKE_INSTALL_PREFIX ${CMAKE_ANDROID_NDK}/sources/third_party/sfml)
 
-    # we install libs in a subdirectory named after the ABI (lib/mips/*.so)
-    set(LIB_SUFFIX "/${CMAKE_ANDROID_ARCH_ABI}")
-
+    # we install libs in a subdirectory named after the ABI
+    set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/${CMAKE_ANDROID_ARCH_ABI}")
     # pass shared STL configuration (if any)
     if (CMAKE_ANDROID_STL_TYPE MATCHES "_shared")
         add_definitions("-DSTL_LIBRARY=${CMAKE_ANDROID_STL_TYPE}")
@@ -158,9 +156,6 @@ elseif(SFML_OS_MACOSX)
 elseif(SFML_OS_ANDROID)
     set(DEFAULT_INSTALL_MISC_DIR ${CMAKE_ANDROID_NDK}/sources/third_party/sfml)
 endif()
-# add an option to let the user specify a custom directory for doc, examples, licence, readme and other miscellaneous files
-sfml_set_option(SFML_MISC_INSTALL_PREFIX "${DEFAULT_INSTALL_MISC_DIR}" PATH "Prefix installation path for miscellaneous files")
-
 
 # force building sfml-window, if sfml-graphics module is built
 if(SFML_BUILD_GRAPHICS AND NOT SFML_BUILD_WINDOW)
@@ -417,8 +412,8 @@ else()
             COMPONENT devel)
 endif()
 
-install(FILES license.md DESTINATION ${SFML_MISC_INSTALL_PREFIX})
-install(FILES readme.md DESTINATION ${SFML_MISC_INSTALL_PREFIX})
+install(FILES license.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES readme.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 # install 3rd-party libraries and tools
 if(SFML_OS_WINDOWS)
@@ -426,22 +421,22 @@ if(SFML_OS_WINDOWS)
     if(NOT SFML_USE_SYSTEM_DEPS)
         # install the binaries of SFML dependencies
         if(ARCH_32BITS)
-            install(DIRECTORY extlibs/bin/x86/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/bin)
+            install(DIRECTORY extlibs/bin/x86/ DESTINATION ${CMAKE_INSTALL_BINDIR})
             if(SFML_COMPILER_MSVC AND SFML_MSVC_VERSION LESS 14)
-                install(DIRECTORY extlibs/libs-msvc/x86/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/lib)
+                install(DIRECTORY extlibs/libs-msvc/x86/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
             elseif(SFML_COMPILER_MSVC)
-                install(DIRECTORY extlibs/libs-msvc-universal/x86/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/lib)
+                install(DIRECTORY extlibs/libs-msvc-universal/x86/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
             else()
-                install(DIRECTORY extlibs/libs-mingw/x86/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/lib)
+                install(DIRECTORY extlibs/libs-mingw/x86/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
             endif()
         elseif(ARCH_64BITS)
-            install(DIRECTORY extlibs/bin/x64/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/bin)
+            install(DIRECTORY extlibs/bin/x64/ DESTINATION ${CMAKE_INSTALL_BINDIR})
             if(SFML_COMPILER_MSVC AND SFML_MSVC_VERSION LESS 14)
-                install(DIRECTORY extlibs/libs-msvc/x64/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/lib)
+                install(DIRECTORY extlibs/libs-msvc/x64/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
             elseif(SFML_COMPILER_MSVC)
-                install(DIRECTORY extlibs/libs-msvc-universal/x64/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/lib)
+                install(DIRECTORY extlibs/libs-msvc-universal/x64/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
             else()
-                install(DIRECTORY extlibs/libs-mingw/x64/ DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX}/lib)
+                install(DIRECTORY extlibs/libs-mingw/x64/ DESTINATION ${CMAKE_INSTALL_LIBDIR})
             endif()
         endif()
     endif()
@@ -450,33 +445,33 @@ elseif(SFML_OS_MACOSX)
     # install extlibs dependencies only when used
     if(SFML_BUILD_GRAPHICS)
         if(FREETYPE_LIBRARY STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/freetype.framework")
-            install(DIRECTORY extlibs/libs-osx/Frameworks/freetype.framework DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX})
+            install(DIRECTORY extlibs/libs-osx/Frameworks/freetype.framework DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
     endif()
 
     if(SFML_BUILD_AUDIO)
         if(FLAC_LIBRARY STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/FLAC.framework")
-            install(DIRECTORY extlibs/libs-osx/Frameworks/FLAC.framework DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX})
+            install(DIRECTORY extlibs/libs-osx/Frameworks/FLAC.framework DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
 
         if(OGG_LIBRARY STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/ogg.framework")
-            install(DIRECTORY extlibs/libs-osx/Frameworks/ogg.framework DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX})
+            install(DIRECTORY extlibs/libs-osx/Frameworks/ogg.framework DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
 
         if(VORBIS_LIBRARY STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/vorbis.framework")
-            install(DIRECTORY extlibs/libs-osx/Frameworks/vorbis.framework DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX})
+            install(DIRECTORY extlibs/libs-osx/Frameworks/vorbis.framework DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
 
         if(VORBISENC_LIBRARY STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/vorbisenc.framework")
-            install(DIRECTORY extlibs/libs-osx/Frameworks/vorbisenc.framework DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX})
+            install(DIRECTORY extlibs/libs-osx/Frameworks/vorbisenc.framework DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
 
         if(VORBISFILE_LIBRARY STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/vorbisfile.framework")
-            install(DIRECTORY extlibs/libs-osx/Frameworks/vorbisfile.framework DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX})
+            install(DIRECTORY extlibs/libs-osx/Frameworks/vorbisfile.framework DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
 
         if(OPENAL_LIBRARY STREQUAL "${SFML_SOURCE_DIR}/extlibs/libs-osx/Frameworks/OpenAL.framework")
-            install(DIRECTORY "${OPENAL_LIBRARY}" DESTINATION ${SFML_DEPENDENCIES_INSTALL_PREFIX})
+            install(DIRECTORY "${OPENAL_LIBRARY}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
         endif()
     endif()
 
@@ -498,7 +493,7 @@ elseif(SFML_OS_MACOSX)
 elseif(SFML_OS_IOS)
 
     # fix CMake install rules broken for iOS (see http://public.kitware.com/Bug/view.php?id=12506)
-    install(DIRECTORY "${CMAKE_BINARY_DIR}/lib/\$ENV{CONFIGURATION}/" DESTINATION lib${LIB_SUFFIX})
+    install(DIRECTORY "${CMAKE_BINARY_DIR}/lib/\$ENV{CONFIGURATION}/" DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     if(NOT SFML_USE_SYSTEM_DEPS)
         # since the iOS libraries are built as static, we must install the SFML dependencies

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -71,7 +71,7 @@ endif()
 
 # set pkgconfig install directory
 # this could be e.g. macports on mac or msys2 on windows etc.
-set(SFML_PKGCONFIG_DIR "/lib${LIB_SUFFIX}/pkgconfig")
+set(SFML_PKGCONFIG_DIR "/${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 if(SFML_OS_FREEBSD OR SFML_OS_OPENBSD)
     set(SFML_PKGCONFIG_DIR "/libdata/pkgconfig")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -175,9 +175,9 @@ macro(sfml_add_library target)
 
     # add the install rule
     install(TARGETS ${target} EXPORT SFMLConfigExport
-            RUNTIME DESTINATION bin COMPONENT bin
-            LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT bin
-            ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT devel
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT bin
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT bin
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel
             FRAMEWORK DESTINATION "." COMPONENT bin)
 
     # add <project>/include as public include directory
@@ -257,42 +257,8 @@ macro(sfml_add_example target)
         target_link_libraries(${target} PRIVATE ${THIS_DEPENDS})
     endif()
 
-    set(target_install_dir ${SFML_MISC_INSTALL_PREFIX}/examples/${target})
-
-    if(BUILD_SHARED_LIBS AND (SFML_OS_LINUX OR SFML_OS_FREEBSD))
-        file(RELATIVE_PATH rel_lib_dir
-             ${CMAKE_INSTALL_PREFIX}/${target_install_dir}
-             ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX})
-
-        set_target_properties(${target} PROPERTIES
-                              INSTALL_RPATH "$ORIGIN/${rel_lib_dir}")
-    endif()
-
     if (SFML_OS_IOS)
         sfml_set_common_ios_properties(${target})
-    endif()
-
-    # add the install rule
-    install(TARGETS ${target}
-            RUNTIME DESTINATION ${target_install_dir} COMPONENT examples
-            BUNDLE DESTINATION ${target_install_dir} COMPONENT examples
-			RESOURCE DESTINATION ${target_install_dir} COMPONENT examples)
-
-    # install the example's source code
-    install(FILES ${THIS_SOURCES}
-            DESTINATION ${target_install_dir}
-            COMPONENT examples)
-
-    if (THIS_RESOURCES_DIR)
-        # install the example's resources as well
-        get_filename_component(THIS_RESOURCES_DIR "${THIS_RESOURCES_DIR}" ABSOLUTE)
-
-        if(NOT EXISTS "${THIS_RESOURCES_DIR}")
-            message(FATAL_ERROR "Given resources directory to install does not exist: ${THIS_RESOURCES_DIR}")
-        endif()
-        install(DIRECTORY ${THIS_RESOURCES_DIR}
-                DESTINATION ${target_install_dir}
-                COMPONENT examples)
     endif()
 
 endmacro()
@@ -441,7 +407,7 @@ function(sfml_export_targets)
     if (SFML_BUILD_FRAMEWORKS)
         set(config_package_location "SFML.framework/Resources/CMake")
     else()
-        set(config_package_location lib${LIB_SUFFIX}/cmake/SFML)
+        set(config_package_location ${CMAKE_INSTALL_LIBDIR}/cmake/SFML)
     endif()
     configure_package_config_file("${CURRENT_DIR}/SFMLConfig.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/SFMLConfig.cmake"
         INSTALL_DESTINATION "${config_package_location}")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -53,10 +53,10 @@ add_custom_target(doc ALL
 
 # setup install rules
 install(DIRECTORY ${DOXYGEN_OUTPUT_DIR}/html
-        DESTINATION ${SFML_MISC_INSTALL_PREFIX}/doc
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}
         COMPONENT doc)
 if(DOXYGEN_HHC_PROGRAM)
     install(FILES ${DOXYGEN_OUTPUT_DIR}/sfml.chm
-            DESTINATION ${SFML_MISC_INSTALL_PREFIX}/doc
+            DESTINATION ${CMAKE_INSTALL_DOCDIR}
             COMPONENT doc)
 endif()

--- a/tools/pkg-config/sfml-all.pc.in
+++ b/tools/pkg-config/sfml-all.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: SFML-all

--- a/tools/pkg-config/sfml-audio.pc.in
+++ b/tools/pkg-config/sfml-audio.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: SFML-audio

--- a/tools/pkg-config/sfml-graphics.pc.in
+++ b/tools/pkg-config/sfml-graphics.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: SFML-graphics

--- a/tools/pkg-config/sfml-network.pc.in
+++ b/tools/pkg-config/sfml-network.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: SFML-network

--- a/tools/pkg-config/sfml-system.pc.in
+++ b/tools/pkg-config/sfml-system.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: SFML-system

--- a/tools/pkg-config/sfml-window.pc.in
+++ b/tools/pkg-config/sfml-window.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib@LIB_SUFFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: SFML-window


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This replaces our custom install paths with the ones from the cmake GnuInstallDirs module

This PR is related to the issue #1563 

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Build and install SFML (preferably to a custom CMAKE_INSTALL_PREFIX) and check the directory structure.

Seems I'm not able to request reviewers, but @eliasdaler , @fxcoudert and @Ceylo  would be great to take a look