### PR TITLE
Fixed sometimes failing to read floats and doubles from Packet on Android.

### DIFF
--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -240,7 +240,7 @@ Packet& Packet::operator >>(float& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = *reinterpret_cast<const float*>(&m_data[m_readPos]);
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
         m_readPos += sizeof(data);
     }
 
@@ -253,7 +253,7 @@ Packet& Packet::operator >>(double& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = *reinterpret_cast<const double*>(&m_data[m_readPos]);
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
         m_readPos += sizeof(data);
     }
 

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -116,7 +116,7 @@ Packet& Packet::operator >>(Int8& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = *reinterpret_cast<const Int8*>(&m_data[m_readPos]);
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
         m_readPos += sizeof(data);
     }
 
@@ -129,7 +129,7 @@ Packet& Packet::operator >>(Uint8& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = *reinterpret_cast<const Uint8*>(&m_data[m_readPos]);
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
         m_readPos += sizeof(data);
     }
 
@@ -142,7 +142,8 @@ Packet& Packet::operator >>(Int16& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = ntohs(*reinterpret_cast<const Int16*>(&m_data[m_readPos]));
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
+        data = ntohs(data);
         m_readPos += sizeof(data);
     }
 
@@ -155,7 +156,8 @@ Packet& Packet::operator >>(Uint16& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = ntohs(*reinterpret_cast<const Uint16*>(&m_data[m_readPos]));
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
+        data = ntohs(data);
         m_readPos += sizeof(data);
     }
 
@@ -168,7 +170,8 @@ Packet& Packet::operator >>(Int32& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = ntohl(*reinterpret_cast<const Int32*>(&m_data[m_readPos]));
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
+        data = ntohl(data);
         m_readPos += sizeof(data);
     }
 
@@ -181,7 +184,8 @@ Packet& Packet::operator >>(Uint32& data)
 {
     if (checkSize(sizeof(data)))
     {
-        data = ntohl(*reinterpret_cast<const Uint32*>(&m_data[m_readPos]));
+        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
+        data = ntohl(data);
         m_readPos += sizeof(data);
     }
 
@@ -196,7 +200,8 @@ Packet& Packet::operator >>(Int64& data)
     {
         // Since ntohll is not available everywhere, we have to convert
         // to network byte order (big endian) manually
-        const Uint8* bytes = reinterpret_cast<const Uint8*>(&m_data[m_readPos]);
+        Uint8 bytes[sizeof(data)];
+        std::memcpy(bytes, &m_data[m_readPos], sizeof(data));
         data = (static_cast<Int64>(bytes[0]) << 56) |
                (static_cast<Int64>(bytes[1]) << 48) |
                (static_cast<Int64>(bytes[2]) << 40) |
@@ -219,7 +224,8 @@ Packet& Packet::operator >>(Uint64& data)
     {
         // Since ntohll is not available everywhere, we have to convert
         // to network byte order (big endian) manually
-        const Uint8* bytes = reinterpret_cast<const Uint8*>(&m_data[m_readPos]);
+        Uint8 bytes[sizeof(data)];
+        std::memcpy(bytes, &m_data[m_readPos], sizeof(data));
         data = (static_cast<Uint64>(bytes[0]) << 56) |
                (static_cast<Uint64>(bytes[1]) << 48) |
                (static_cast<Uint64>(bytes[2]) << 40) |


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [X] Have you provided some example/test code for your changes? -> in the issue
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This PR closes #1565. `reinterpret_cast` has been replaced with `memcopy` so the alignment rules for floats and doubles are not violated.

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows (server)
* [ ] Tested on macOS
* [ ] Tested on iOS
* [X] Tested on Android (client)

## How to test this PR?

The detailed test case is described in the issue that this PR will close.