### PR TITLE
Compiler flag is not target library

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -233,7 +233,7 @@ target_link_libraries(sfml-window PUBLIC sfml-system)
 
 # When static linking on macOS, we need to add this flag for objective C to work
 if ((NOT BUILD_SHARED_LIBS) AND SFML_OS_MACOSX)
-    target_link_libraries(sfml-window PRIVATE -ObjC)
+    target_compile_options(sfml-window PRIVATE -ObjC)
 endif()
 
 # find and setup usage for external libraries


### PR DESCRIPTION
When passing -ObjC to apple-clang by CMake, as an option it should be passed by `target_compile_options` and not through `target_link_library`.


Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Please describe your pull request.

This PR is related to the issue #

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Build SFML on OSX with `window` enabled.

    mkdir build && cd build
    cmake .. -DSFML_BUILD_WINDOW=ON -DCMAKE_VERBOSE_MAKEFILE=ON

The flag `-ObjC` must be listed when building Window objects.