### PR TITLE
Fixed SIGSEGV after pressing back button on Android

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -84,6 +84,7 @@ WindowImplAndroid::WindowImplAndroid(VideoMode mode, const String& title, unsign
 ////////////////////////////////////////////////////////////
 WindowImplAndroid::~WindowImplAndroid()
 {
+    WindowImplAndroid::singleInstance = NULL;
 }
 
 
@@ -216,22 +217,25 @@ bool WindowImplAndroid::hasFocus() const
 ////////////////////////////////////////////////////////////
 void WindowImplAndroid::forwardEvent(const Event& event)
 {
-    ActivityStates* states = getActivity(NULL);
-
-    if (event.type == Event::GainedFocus)
+    if (WindowImplAndroid::singleInstance != NULL)
     {
-        WindowImplAndroid::singleInstance->m_size.x = ANativeWindow_getWidth(states->window);
-        WindowImplAndroid::singleInstance->m_size.y = ANativeWindow_getHeight(states->window);
-        WindowImplAndroid::singleInstance->m_windowBeingCreated = true;
-        WindowImplAndroid::singleInstance->m_hasFocus = true;
-    }
-    else if (event.type == Event::LostFocus)
-    {
-        WindowImplAndroid::singleInstance->m_windowBeingDestroyed = true;
-        WindowImplAndroid::singleInstance->m_hasFocus = false;
-    }
+        ActivityStates* states = getActivity(NULL);
 
-    WindowImplAndroid::singleInstance->pushEvent(event);
+        if (event.type == Event::GainedFocus)
+        {
+            WindowImplAndroid::singleInstance->m_size.x = ANativeWindow_getWidth(states->window);
+            WindowImplAndroid::singleInstance->m_size.y = ANativeWindow_getHeight(states->window);
+            WindowImplAndroid::singleInstance->m_windowBeingCreated = true;
+            WindowImplAndroid::singleInstance->m_hasFocus = true;
+        }
+        else if (event.type == Event::LostFocus)
+        {
+            WindowImplAndroid::singleInstance->m_windowBeingDestroyed = true;
+            WindowImplAndroid::singleInstance->m_hasFocus = false;
+        }
+
+        WindowImplAndroid::singleInstance->pushEvent(event);
+    }
 }
 
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [X] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

When the back button is pressed in an SFML app on Android, `WindowImplAndroid::singleInstance` is deleted ([here](https://github.com/SFML/SFML/blob/489482a630c5286e488ffc270c10562809056d8e/src/SFML/Window/WindowBase.cpp#L142)) before the native activity callbacks stop sending events ([subscribed here](https://github.com/SFML/SFML/blob/489482a630c5286e488ffc270c10562809056d8e/src/SFML/Main/MainAndroid.cpp#L511)). Because of this, a SIGSEGV error occurs instead of a clean exit. This PR correctly set `WindowImplAndroid::singleInstance` to `NULL` and the callback will only use it when it's not `NULL`.

Fixes #531.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [X] Tested on Android

## How to test this PR?

Build and run the Android example, then press the back button while watching logcat. Without this PR, something like the following message will appear.
`2019-04-25 13:01:47.457 25238-25238/org.sfmldev.android A/libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10 in tid 25238 (sfmldev.android), pid 25238 (sfmldev.android)`

Android example:
```cpp
#include <SFML/System.hpp>
#include <SFML/Window.hpp>
#include <SFML/Graphics.hpp>
#include <SFML/Audio.hpp>
#include <SFML/Network.hpp>

// Do we want to showcase direct JNI/NDK interaction?
// Undefine this to get real cross-platform code.
// Uncomment this to try JNI access; this seems to be broken in latest NDKs
//#define USE_JNI

#if defined(USE_JNI)
// These headers are only needed for direct NDK/JDK interaction
#include <jni.h>
#include <android/native_activity.h>

// Since we want to get the native activity from SFML, we'll have to use an
// extra header here:
#include <SFML/System/NativeActivity.hpp>

// NDK/JNI sub example - call Java code from native code
int vibrate(sf::Time duration)
{
    // First we'll need the native activity handle
    ANativeActivity *activity = sf::getNativeActivity();
    
    // Retrieve the JVM and JNI environment
    JavaVM* vm = activity->vm;
    JNIEnv* env = activity->env;

    // First, attach this thread to the main thread
    JavaVMAttachArgs attachargs;
    attachargs.version = JNI_VERSION_1_6;
    attachargs.name = "NativeThread";
    attachargs.group = NULL;
    jint res = vm->AttachCurrentThread(&env, &attachargs);

    if (res == JNI_ERR)
        return EXIT_FAILURE;

    // Retrieve class information
    jclass natact = env->FindClass("android/app/NativeActivity");
    jclass context = env->FindClass("android/content/Context");
    
    // Get the value of a constant
    jfieldID fid = env->GetStaticFieldID(context, "VIBRATOR_SERVICE", "Ljava/lang/String;");
    jobject svcstr = env->GetStaticObjectField(context, fid);
    
    // Get the method 'getSystemService' and call it
    jmethodID getss = env->GetMethodID(natact, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
    jobject vib_obj = env->CallObjectMethod(activity->clazz, getss, svcstr);
    
    // Get the object's class and retrieve the member name
    jclass vib_cls = env->GetObjectClass(vib_obj);
    jmethodID vibrate = env->GetMethodID(vib_cls, "vibrate", "(J)V"); 
    
    // Determine the timeframe
    jlong length = duration.asMilliseconds();
    
    // Bzzz!
    env->CallVoidMethod(vib_obj, vibrate, length);

    // Free references
    env->DeleteLocalRef(vib_obj);
    env->DeleteLocalRef(vib_cls);
    env->DeleteLocalRef(svcstr);
    env->DeleteLocalRef(context);
    env->DeleteLocalRef(natact);
    
    // Detach thread again
    vm->DetachCurrentThread();
}
#endif

// This is the actual Android example. You don't have to write any platform
// specific code, unless you want to use things not directly exposed.
// ('vibrate()' in this example; undefine 'USE_JNI' above to disable it)
int main(int argc, char *argv[])
{
    sf::VideoMode screen(sf::VideoMode::getDesktopMode());

    sf::RenderWindow window(screen, "");
    window.setFramerateLimit(30);

    sf::Texture texture;
    if(!texture.loadFromFile("image.png"))
        return EXIT_FAILURE;

    sf::Sprite image(texture);
    image.setPosition(screen.width / 2, screen.height / 2);
    image.setOrigin(texture.getSize().x/2, texture.getSize().y/2);

    sf::Font font;
    if (!font.loadFromFile("sansation.ttf"))
        return EXIT_FAILURE;

    sf::Text text("Tap anywhere to move the logo.", font, 64);
    text.setFillColor(sf::Color::Black);
    text.setPosition(10, 10);

    // Loading canary.wav fails for me for now; haven't had time to test why

    /*sf::Music music;
    if(!music.openFromFile("canary.wav"))
        return EXIT_FAILURE;

    music.play();*/

    sf::View view = window.getDefaultView();

    sf::Color background = sf::Color::White;

    // We shouldn't try drawing to the screen while in background
    // so we'll have to track that. You can do minor background
    // work, but keep battery life in mind.
    bool active = true;

    while (window.isOpen())
    {
        sf::Event event;

        while (active ? window.pollEvent(event) : window.waitEvent(event))
        {
            switch (event.type)
            {
                case sf::Event::Closed:
                    window.close();
                    break;
                case sf::Event::KeyPressed:
                    if (event.key.code == sf::Keyboard::Escape)
                        window.close();
                    break;
                case sf::Event::Resized:
                    view.setSize(event.size.width, event.size.height);
                    view.setCenter(event.size.width/2, event.size.height/2);
                    window.setView(view);
                    break;
                case sf::Event::LostFocus:
                    background = sf::Color::Black;
                    break;
                case sf::Event::GainedFocus:
                    background = sf::Color::White;
                    break;
                
                // On Android MouseLeft/MouseEntered are (for now) triggered,
                // whenever the app loses or gains focus.
                case sf::Event::MouseLeft:
                    active = false;
                    break;
                case sf::Event::MouseEntered:
                    active = true;
                    break;
                case sf::Event::TouchBegan:
                    if (event.touch.finger == 0)
                    {
                        image.setPosition(event.touch.x, event.touch.y);
#if defined(USE_JNI)
                        vibrate(sf::milliseconds(10));
#endif
                    }
                    break;
            }
        }

        if (active)
        {
            window.clear(background);
            window.draw(image);
            window.draw(text);
            window.display();
        }
        else {
            sf::sleep(sf::milliseconds(100));
        }
    }
}

```