### PR TITLE
Remove VBO implementations from drawables

### DIFF
--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -32,7 +32,6 @@
 #include <SFML/Graphics/Drawable.hpp>
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
-#include <SFML/Graphics/VertexBuffer.hpp>
 #include <SFML/System/Vector2.hpp>
 
 
@@ -306,17 +305,15 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    const Texture* m_texture;               ///< Texture of the shape
-    IntRect        m_textureRect;           ///< Rectangle defining the area of the source texture to display
-    Color          m_fillColor;             ///< Fill color
-    Color          m_outlineColor;          ///< Outline color
-    float          m_outlineThickness;      ///< Thickness of the shape's outline
-    VertexArray    m_vertices;              ///< Vertex array containing the fill geometry
-    VertexArray    m_outlineVertices;       ///< Vertex array containing the outline geometry
-    VertexBuffer   m_verticesBuffer;        ///< Vertex buffer containing the fill geometry
-    VertexBuffer   m_outlineVerticesBuffer; ///< Vertex buffer containing the outline geometry
-    FloatRect      m_insideBounds;          ///< Bounding rectangle of the inside (fill)
-    FloatRect      m_bounds;                ///< Bounding rectangle of the whole shape (outline + fill)
+    const Texture* m_texture;          ///< Texture of the shape
+    IntRect        m_textureRect;      ///< Rectangle defining the area of the source texture to display
+    Color          m_fillColor;        ///< Fill color
+    Color          m_outlineColor;     ///< Outline color
+    float          m_outlineThickness; ///< Thickness of the shape's outline
+    VertexArray    m_vertices;         ///< Vertex array containing the fill geometry
+    VertexArray    m_outlineVertices;  ///< Vertex array containing the outline geometry
+    FloatRect      m_insideBounds;     ///< Bounding rectangle of the inside (fill)
+    FloatRect      m_bounds;           ///< Bounding rectangle of the whole shape (outline + fill)
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -33,7 +33,6 @@
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/Vertex.hpp>
 #include <SFML/Graphics/Rect.hpp>
-#include <SFML/Graphics/VertexBuffer.hpp>
 
 
 namespace sf
@@ -216,10 +215,9 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Vertex         m_vertices[4];    ///< Vertices defining the sprite's geometry
-    VertexBuffer   m_verticesBuffer; ///< Vertex buffer containing the sprite's geometry
-    const Texture* m_texture;        ///< Texture of the sprite
-    IntRect        m_textureRect;    ///< Rectangle defining the area of the source texture to display
+    Vertex         m_vertices[4]; ///< Vertices defining the sprite's geometry
+    const Texture* m_texture;     ///< Texture of the sprite
+    IntRect        m_textureRect; ///< Rectangle defining the area of the source texture to display
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -34,7 +34,6 @@
 #include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
-#include <SFML/Graphics/VertexBuffer.hpp>
 #include <SFML/System/String.hpp>
 #include <string>
 #include <vector>
@@ -436,22 +435,20 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    String               m_string;                ///< String to display
-    const Font*          m_font;                  ///< Font used to display the string
-    unsigned int         m_characterSize;         ///< Base size of characters, in pixels
-    float                m_letterSpacingFactor;   ///< Spacing factor between letters
-    float                m_lineSpacingFactor;     ///< Spacing factor between lines
-    Uint32               m_style;                 ///< Text style (see Style enum)
-    Color                m_fillColor;             ///< Text fill color
-    Color                m_outlineColor;          ///< Text outline color
-    float                m_outlineThickness;      ///< Thickness of the text's outline
-    mutable VertexArray  m_vertices;              ///< Vertex array containing the fill geometry
-    mutable VertexArray  m_outlineVertices;       ///< Vertex array containing the outline geometry
-    mutable VertexBuffer m_verticesBuffer;        ///< Vertex buffer containing the fill geometry
-    mutable VertexBuffer m_outlineVerticesBuffer; ///< Vertex buffer containing the outline geometry
-    mutable FloatRect    m_bounds;                ///< Bounding rectangle of the text (in local coordinates)
-    mutable bool         m_geometryNeedUpdate;    ///< Does the geometry need to be recomputed?
-    mutable Uint64       m_fontTextureId;         ///< The font texture id
+    String              m_string;              ///< String to display
+    const Font*         m_font;                ///< Font used to display the string
+    unsigned int        m_characterSize;       ///< Base size of characters, in pixels
+    float               m_letterSpacingFactor; ///< Spacing factor between letters
+    float               m_lineSpacingFactor;   ///< Spacing factor between lines
+    Uint32              m_style;               ///< Text style (see Style enum)
+    Color               m_fillColor;           ///< Text fill color
+    Color               m_outlineColor;        ///< Text outline color
+    float               m_outlineThickness;    ///< Thickness of the text's outline
+    mutable VertexArray m_vertices;            ///< Vertex array containing the fill geometry
+    mutable VertexArray m_outlineVertices;     ///< Vertex array containing the outline geometry
+    mutable FloatRect   m_bounds;              ///< Bounding rectangle of the text (in local coordinates)
+    mutable bool        m_geometryNeedUpdate;  ///< Does the geometry need to be recomputed?
+    mutable Uint64      m_fontTextureId;       ///< The font texture id
 };
 
 } // namespace sf

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -87,10 +87,6 @@ void Shape::setTextureRect(const IntRect& rect)
 {
     m_textureRect = rect;
     updateTexCoords();
-
-    // Update the vertex buffers if they are being used
-    if (m_verticesBuffer.getVertexCount())
-        m_verticesBuffer.update(&m_vertices[0]);
 }
 
 
@@ -106,10 +102,6 @@ void Shape::setFillColor(const Color& color)
 {
     m_fillColor = color;
     updateFillColors();
-
-    // Update the vertex buffers if they are being used
-    if (m_verticesBuffer.getVertexCount())
-        m_verticesBuffer.update(&m_vertices[0]);
 }
 
 
@@ -125,10 +117,6 @@ void Shape::setOutlineColor(const Color& color)
 {
     m_outlineColor = color;
     updateOutlineColors();
-
-    // Update the vertex buffers if they are being used
-    if (m_outlineVerticesBuffer.getVertexCount())
-        m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
 }
 
 
@@ -170,17 +158,15 @@ FloatRect Shape::getGlobalBounds() const
 
 ////////////////////////////////////////////////////////////
 Shape::Shape() :
-m_texture              (NULL),
-m_textureRect          (),
-m_fillColor            (255, 255, 255),
-m_outlineColor         (255, 255, 255),
-m_outlineThickness     (0),
-m_vertices             (TriangleFan),
-m_outlineVertices      (TriangleStrip),
-m_verticesBuffer       (TriangleFan, VertexBuffer::Static),
-m_outlineVerticesBuffer(TriangleStrip, VertexBuffer::Static),
-m_insideBounds         (),
-m_bounds               ()
+m_texture         (NULL),
+m_textureRect     (),
+m_fillColor       (255, 255, 255),
+m_outlineColor    (255, 255, 255),
+m_outlineThickness(0),
+m_vertices        (TriangleFan),
+m_outlineVertices (TriangleStrip),
+m_insideBounds    (),
+m_bounds          ()
 {
 }
 
@@ -194,16 +180,6 @@ void Shape::update()
     {
         m_vertices.resize(0);
         m_outlineVertices.resize(0);
-
-        if (VertexBuffer::isAvailable())
-        {
-            if (m_verticesBuffer.getVertexCount())
-                m_verticesBuffer.create(0);
-
-            if (m_outlineVerticesBuffer.getVertexCount())
-                m_outlineVerticesBuffer.create(0);
-        }
-
         return;
     }
 
@@ -230,21 +206,6 @@ void Shape::update()
 
     // Outline
     updateOutline();
-
-    // Update the vertex buffers if they are being used
-    if (VertexBuffer::isAvailable())
-    {
-        if (m_verticesBuffer.getVertexCount() != m_vertices.getVertexCount())
-            m_verticesBuffer.create(m_vertices.getVertexCount());
-
-        m_verticesBuffer.update(&m_vertices[0]);
-
-        if (m_outlineVerticesBuffer.getVertexCount() != m_outlineVertices.getVertexCount())
-            m_outlineVerticesBuffer.create(m_outlineVertices.getVertexCount());
-
-        if (m_outlineVertices.getVertexCount())
-            m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
-    }
 }
 
 
@@ -255,29 +216,13 @@ void Shape::draw(RenderTarget& target, RenderStates states) const
 
     // Render the inside
     states.texture = m_texture;
-
-    if (VertexBuffer::isAvailable())
-    {
-        target.draw(m_verticesBuffer, states);
-    }
-    else
-    {
-        target.draw(m_vertices, states);
-    }
+    target.draw(m_vertices, states);
 
     // Render the outline
     if (m_outlineThickness != 0)
     {
         states.texture = NULL;
-
-        if (VertexBuffer::isAvailable())
-        {
-            target.draw(m_outlineVerticesBuffer, states);
-        }
-        else
-        {
-            target.draw(m_outlineVertices, states);
-        }
+        target.draw(m_outlineVertices, states);
     }
 }
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -35,37 +35,26 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 Sprite::Sprite() :
-m_verticesBuffer(TrianglesStrip, VertexBuffer::Stream),
-m_texture       (NULL),
-m_textureRect   ()
+m_texture    (NULL),
+m_textureRect()
 {
-    if (VertexBuffer::isAvailable())
-        m_verticesBuffer.create(4);
 }
 
 
 ////////////////////////////////////////////////////////////
 Sprite::Sprite(const Texture& texture) :
-m_verticesBuffer(TrianglesStrip, VertexBuffer::Stream),
-m_texture       (NULL),
-m_textureRect   ()
+m_texture    (NULL),
+m_textureRect()
 {
-    if (VertexBuffer::isAvailable())
-        m_verticesBuffer.create(4);
-
     setTexture(texture);
 }
 
 
 ////////////////////////////////////////////////////////////
 Sprite::Sprite(const Texture& texture, const IntRect& rectangle) :
-m_verticesBuffer(TrianglesStrip, VertexBuffer::Stream),
-m_texture       (NULL),
-m_textureRect   ()
+m_texture    (NULL),
+m_textureRect()
 {
-    if (VertexBuffer::isAvailable())
-        m_verticesBuffer.create(4);
-
     setTexture(texture);
     setTextureRect(rectangle);
 }
@@ -91,10 +80,6 @@ void Sprite::setTextureRect(const IntRect& rectangle)
         m_textureRect = rectangle;
         updatePositions();
         updateTexCoords();
-
-        // Update the vertex buffer if it is being used
-        if (VertexBuffer::isAvailable())
-            m_verticesBuffer.update(m_vertices);
     }
 }
 
@@ -107,10 +92,6 @@ void Sprite::setColor(const Color& color)
     m_vertices[1].color = color;
     m_vertices[2].color = color;
     m_vertices[3].color = color;
-
-    // Update the vertex buffer if it is being used
-    if (VertexBuffer::isAvailable())
-        m_verticesBuffer.update(m_vertices);
 }
 
 
@@ -159,15 +140,7 @@ void Sprite::draw(RenderTarget& target, RenderStates states) const
     {
         states.transform *= getTransform();
         states.texture = m_texture;
-
-        if (VertexBuffer::isAvailable())
-        {
-            target.draw(m_verticesBuffer, states);
-        }
-        else
-        {
-            target.draw(m_vertices, 4, TriangleStrip, states);
-        }
+        target.draw(m_vertices, 4, TriangleStrip, states);
     }
 }
 

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -76,22 +76,20 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 Text::Text() :
-m_string               (),
-m_font                 (NULL),
-m_characterSize        (30),
-m_letterSpacingFactor  (1.f),
-m_lineSpacingFactor    (1.f),
-m_style                (Regular),
-m_fillColor            (255, 255, 255),
-m_outlineColor         (0, 0, 0),
-m_outlineThickness     (0),
-m_vertices             (Triangles),
-m_outlineVertices      (Triangles),
-m_verticesBuffer       (Triangles, VertexBuffer::Static),
-m_outlineVerticesBuffer(Triangles, VertexBuffer::Static),
-m_bounds               (),
-m_geometryNeedUpdate   (false),
-m_fontTextureId        (0)
+m_string             (),
+m_font               (NULL),
+m_characterSize      (30),
+m_letterSpacingFactor(1.f),
+m_lineSpacingFactor  (1.f),
+m_style              (Regular),
+m_fillColor          (255, 255, 255),
+m_outlineColor       (0, 0, 0),
+m_outlineThickness   (0),
+m_vertices           (Triangles),
+m_outlineVertices    (Triangles),
+m_bounds             (),
+m_geometryNeedUpdate (false),
+m_fontTextureId      (0)
 {
 
 }
@@ -99,22 +97,20 @@ m_fontTextureId        (0)
 
 ////////////////////////////////////////////////////////////
 Text::Text(const String& string, const Font& font, unsigned int characterSize) :
-m_string               (string),
-m_font                 (&font),
-m_characterSize        (characterSize),
-m_letterSpacingFactor  (1.f),
-m_lineSpacingFactor    (1.f),
-m_style                (Regular),
-m_fillColor            (255, 255, 255),
-m_outlineColor         (0, 0, 0),
-m_outlineThickness     (0),
-m_vertices             (Triangles),
-m_outlineVertices      (Triangles),
-m_verticesBuffer       (Triangles, VertexBuffer::Static),
-m_outlineVerticesBuffer(Triangles, VertexBuffer::Static),
-m_bounds               (),
-m_geometryNeedUpdate   (true),
-m_fontTextureId        (0)
+m_string             (string),
+m_font               (&font),
+m_characterSize      (characterSize),
+m_letterSpacingFactor(1.f),
+m_lineSpacingFactor  (1.f),
+m_style              (Regular),
+m_fillColor          (255, 255, 255),
+m_outlineColor       (0, 0, 0),
+m_outlineThickness   (0),
+m_vertices           (Triangles),
+m_outlineVertices    (Triangles),
+m_bounds             (),
+m_geometryNeedUpdate (true),
+m_fontTextureId      (0)
 {
 
 }
@@ -206,15 +202,6 @@ void Text::setFillColor(const Color& color)
         {
             for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
                 m_vertices[i].color = m_fillColor;
-
-            if (VertexBuffer::isAvailable())
-            {
-                if (m_verticesBuffer.getVertexCount() != m_vertices.getVertexCount())
-                    m_verticesBuffer.create(m_vertices.getVertexCount());
-
-                if (m_vertices.getVertexCount() > 0)
-                    m_verticesBuffer.update(&m_vertices[0]);
-            }
         }
     }
 }
@@ -233,15 +220,6 @@ void Text::setOutlineColor(const Color& color)
         {
             for (std::size_t i = 0; i < m_outlineVertices.getVertexCount(); ++i)
                 m_outlineVertices[i].color = m_outlineColor;
-
-            if (VertexBuffer::isAvailable())
-            {
-                if (m_outlineVerticesBuffer.getVertexCount() != m_outlineVertices.getVertexCount())
-                    m_outlineVerticesBuffer.create(m_outlineVertices.getVertexCount());
-
-                if (m_outlineVertices.getVertexCount() > 0)
-                    m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
-            }
         }
     }
 }
@@ -404,25 +382,9 @@ void Text::draw(RenderTarget& target, RenderStates states) const
 
         // Only draw the outline if there is something to draw
         if (m_outlineThickness != 0)
-        {
-            if (VertexBuffer::isAvailable())
-            {
-                target.draw(m_outlineVerticesBuffer, states);
-            }
-            else
-            {
-                target.draw(m_outlineVertices, states);
-            }
-        }
+            target.draw(m_outlineVertices, states);
 
-        if (VertexBuffer::isAvailable())
-        {
-            target.draw(m_verticesBuffer, states);
-        }
-        else
-        {
-            target.draw(m_vertices, states);
-        }
+        target.draw(m_vertices, states);
     }
 }
 
@@ -446,23 +408,11 @@ void Text::ensureGeometryUpdate() const
     // Clear the previous geometry
     m_vertices.clear();
     m_outlineVertices.clear();
-
     m_bounds = FloatRect();
 
     // No text: nothing to draw
     if (m_string.isEmpty())
-    {
-        if (VertexBuffer::isAvailable())
-        {
-            if (m_verticesBuffer.getVertexCount())
-                m_verticesBuffer.create(0);
-
-            if (m_outlineVerticesBuffer.getVertexCount())
-                m_outlineVerticesBuffer.create(0);
-        }
-
         return;
-    }
 
     // Compute values related to the text style
     bool  isBold             = m_style & Bold;
@@ -612,22 +562,6 @@ void Text::ensureGeometryUpdate() const
     m_bounds.top = minY;
     m_bounds.width = maxX - minX;
     m_bounds.height = maxY - minY;
-
-    // Update the vertex buffer if it is being used
-    if (VertexBuffer::isAvailable())
-    {
-        if (m_verticesBuffer.getVertexCount() != m_vertices.getVertexCount())
-            m_verticesBuffer.create(m_vertices.getVertexCount());
-
-        if (m_vertices.getVertexCount() > 0)
-            m_verticesBuffer.update(&m_vertices[0]);
-
-        if (m_outlineVerticesBuffer.getVertexCount() != m_outlineVertices.getVertexCount())
-            m_outlineVerticesBuffer.create(m_outlineVertices.getVertexCount());
-
-        if (m_outlineVertices.getVertexCount() > 0)
-            m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
-    }
 }
 
 } // namespace sf


### PR DESCRIPTION
Having the VBO code split over all drawables increases maintenance burden over having it in one centralized place. The latter also allows for better global optimization within a rendering backend that is able to do so.

Modular rendering backend support will come around when it is ready™, and is also a pre-requisite for supporting platforms that are not able to render using the old methodology, so it makes more sense to manage vertex data storage within the renderer than each drawable. This also helps to keep the drawable concept as platform independent as possible.

This will also fix the performance regressions reported by some users who make use of a large number of ephemeral drawable objects.