### PR TITLE
Implemented saveToMemory and saveImageToMemory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,19 +54,31 @@ matrix:
     os: osx
     osx_image: xcode10
     env:
+<<<<<<< HEAD
      - CMAKE_FLAGS="-DSFML_BUILD_TEST_SUITE=TRUE"
+=======
+     - CMAKE_FLAGS="-DSFML_DEPENDENCIES_INSTALL_PREFIX=../install -DSFML_BUILD_TEST_SUITE=TRUE"
+>>>>>>> d1670924... Implemented saveToMemory and saveImageToMemory.
 
   - name: "macOS Xcode 10 Frameworks"
     os: osx
     osx_image: xcode10
     env:
+<<<<<<< HEAD
      - CMAKE_FLAGS="-DSFML_BUILD_TEST_SUITE=TRUE -DSFML_BUILD_FRAMEWORKS=TRUE"
+=======
+     - CMAKE_FLAGS="-DSFML_DEPENDENCIES_INSTALL_PREFIX=../install -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_BUILD_FRAMEWORKS=TRUE"
+>>>>>>> d1670924... Implemented saveToMemory and saveImageToMemory.
 
   - name: "macOS Xcode 10 Static"
     os: osx
     osx_image: xcode10
     env:
+<<<<<<< HEAD
      - CMAKE_FLAGS="-DSFML_BUILD_TEST_SUITE=TRUE -DBUILD_SHARED_LIBS=FALSE"
+=======
+     - CMAKE_FLAGS="-DSFML_DEPENDENCIES_INSTALL_PREFIX=../install -DSFML_BUILD_TEST_SUITE=TRUE -DBUILD_SHARED_LIBS=FALSE"
+>>>>>>> d1670924... Implemented saveToMemory and saveImageToMemory.
 
   - name: "iOS Xcode 10"
     os: osx

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -156,6 +156,29 @@ public:
     bool saveToFile(const std::string& filename) const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Save the image to a buffer in memory
+    ///
+    /// The format of the image must be specified.
+    /// The supported image formats are bmp, png, tga and jpg.
+    /// This function fails if the image is empty, or if
+    /// the format was invalid.
+    ///
+<<<<<<< HEAD
+    /// \param output Buffer to fill with encoded data
+    /// \param format Encoding format to use
+=======
+>>>>>>> 050f3c42... Adjusted comments and parameter order.
+    /// \param output Buffer to fill with encoded data
+    /// \param format Encoding format to use
+    ///
+    /// \return True if saving was successful
+    ///
+    /// \see create, loadFromFile, loadFromMemory, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    bool saveToMemory(std::vector<sf::Uint8>& output, const std::string& format) const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Return the size (width and height) of the image
     ///
     /// \return Size of the image, in pixels

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -153,6 +153,12 @@ bool Image::saveToFile(const std::string& filename) const
     return priv::ImageLoader::getInstance().saveImageToFile(filename, m_pixels, m_size);
 }
 
+////////////////////////////////////////////////////////////
+bool Image::saveToMemory(std::vector<sf::Uint8>& output, const std::string& format) const
+{
+    return priv::ImageLoader::getInstance().saveImageToMemory(format, output, m_pixels, m_size);
+}
+
 
 ////////////////////////////////////////////////////////////
 Vector2u Image::getSize() const

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -33,6 +33,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 #include <cctype>
+#include <iterator>
 
 
 namespace
@@ -60,6 +61,35 @@ namespace
     {
         sf::InputStream* stream = static_cast<sf::InputStream*>(user);
         return stream->tell() >= stream->getSize();
+    }
+
+    // stb_image callback for constructing a buffer
+    void bufferFromCallback(void* context, void* data, int size)
+    {
+<<<<<<< HEAD
+<<<<<<< HEAD
+        sf::Uint8* source = static_cast<sf::Uint8*>(data);
+        std::vector<sf::Uint8>* dest = static_cast<std::vector<sf::Uint8>*>(context);
+        std::copy(source, source + size, std::back_inserter(*dest));
+=======
+        sf::Uint8* ptr = static_cast<sf::Uint8*>(data);
+<<<<<<< HEAD
+        std::vector<sf::Uint8>* v = static_cast<std::vector<sf::Uint8>*>(context);
+<<<<<<< HEAD
+        for (int i = 0; i < size; i++)
+            v->push_back(ptr[i]);
+>>>>>>> c5551a35... Fixed buffer construction.
+=======
+        std::copy(ptr, ptr + size, std::back_inserter(*v));
+>>>>>>> 3a5829b6... Improved performance by using std::copy.
+=======
+        std::copy(ptr, ptr + size, std::back_inserter(*static_cast<std::vector<sf::Uint8>*>(context)));
+>>>>>>> 8bd6bc5a... Reduced verbosity.
+=======
+        sf::Uint8* source = static_cast<sf::Uint8*>(data);
+        std::vector<sf::Uint8>* dest = static_cast<std::vector<sf::Uint8>*>(context);
+        std::copy(source, source + size, std::back_inserter(*dest));
+>>>>>>> 01b02245... Improved readability. Included <iterator>.
     }
 }
 
@@ -269,6 +299,46 @@ bool ImageLoader::saveImageToFile(const std::string& filename, const std::vector
     }
 
     err() << "Failed to save image \"" << filename << "\"" << std::endl;
+    return false;
+}
+
+////////////////////////////////////////////////////////////
+bool ImageLoader::saveImageToMemory(const std::string& format, std::vector<sf::Uint8>& output, const std::vector<Uint8>& pixels, const Vector2u& size)
+{
+    // Make sure the image is not empty
+    if (!pixels.empty() && (size.x > 0) && (size.y > 0))
+    {
+        // Choose function based on format
+
+        std::string specified = toLower(format);
+
+        if (specified == "bmp")
+        {
+            // BMP format
+            if (stbi_write_bmp_to_func(&bufferFromCallback, &output, size.x, size.y, 4, &pixels[0]))
+                return true;
+        }
+        else if (specified == "tga")
+        {
+            // TGA format
+            if (stbi_write_tga_to_func(&bufferFromCallback, &output, size.x, size.y, 4, &pixels[0]))
+                return true;
+        }
+        else if (specified == "png")
+        {
+            // PNG format
+            if (stbi_write_png_to_func(&bufferFromCallback, &output, size.x, size.y, 4, &pixels[0], 0))
+                return true;
+        }
+        else if (specified == "jpg" || specified == "jpeg")
+        {
+            // JPG format
+            if (stbi_write_jpg_to_func(&bufferFromCallback, &output, size.x, size.y, 4, &pixels[0], 90))
+                return true;
+        }
+    }
+
+    err() << "Failed to save image with format \"" << format << "\"" << std::endl;
     return false;
 }
 

--- a/src/SFML/Graphics/ImageLoader.hpp
+++ b/src/SFML/Graphics/ImageLoader.hpp
@@ -105,6 +105,27 @@ public:
     ////////////////////////////////////////////////////////////
     bool saveImageToFile(const std::string& filename, const std::vector<Uint8>& pixels, const Vector2u& size);
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Save an array of pixels as an encoded image buffer
+    ///
+<<<<<<< HEAD
+<<<<<<< HEAD
+    /// \param format   Must be "bmp", "png", "tga" or "jpg"/"jpeg".
+=======
+    /// \param format   Encoding format to use
+>>>>>>> c5551a35... Fixed buffer construction.
+=======
+    /// \param format   Must be "bmp", "png", "tga" or "jpg"/"jpeg".
+>>>>>>> 050f3c42... Adjusted comments and parameter order.
+    /// \param output   Buffer to fill with encoded data
+    /// \param pixels   Array of pixels to save to image
+    /// \param size     Size of image to save, in pixels
+    ///
+    /// \return True if saving was successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool saveImageToMemory(const std::string& format, std::vector<sf::Uint8>& output, const std::vector<Uint8>& pixels, const Vector2u& size);
+
 private:
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -202,6 +202,18 @@ void Text::setFillColor(const Color& color)
         {
             for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
                 m_vertices[i].color = m_fillColor;
+<<<<<<< HEAD
+=======
+
+            if (VertexBuffer::isAvailable())
+            {
+                if (m_verticesBuffer.getVertexCount() != m_vertices.getVertexCount())
+                    m_verticesBuffer.create(m_vertices.getVertexCount());
+
+                if (m_vertices.getVertexCount() > 0)
+                    m_verticesBuffer.update(&m_vertices[0]);
+            }
+>>>>>>> d1670924... Implemented saveToMemory and saveImageToMemory.
         }
     }
 }
@@ -220,6 +232,18 @@ void Text::setOutlineColor(const Color& color)
         {
             for (std::size_t i = 0; i < m_outlineVertices.getVertexCount(); ++i)
                 m_outlineVertices[i].color = m_outlineColor;
+<<<<<<< HEAD
+=======
+
+            if (VertexBuffer::isAvailable())
+            {
+                if (m_outlineVerticesBuffer.getVertexCount() != m_outlineVertices.getVertexCount())
+                    m_outlineVerticesBuffer.create(m_outlineVertices.getVertexCount());
+
+                if (m_outlineVertices.getVertexCount() > 0)
+                    m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
+            }
+>>>>>>> d1670924... Implemented saveToMemory and saveImageToMemory.
         }
     }
 }
@@ -562,6 +586,25 @@ void Text::ensureGeometryUpdate() const
     m_bounds.top = minY;
     m_bounds.width = maxX - minX;
     m_bounds.height = maxY - minY;
+<<<<<<< HEAD
+=======
+
+    // Update the vertex buffer if it is being used
+    if (VertexBuffer::isAvailable())
+    {
+        if (m_verticesBuffer.getVertexCount() != m_vertices.getVertexCount())
+            m_verticesBuffer.create(m_vertices.getVertexCount());
+
+        if (m_vertices.getVertexCount() > 0)
+            m_verticesBuffer.update(&m_vertices[0]);
+
+        if (m_outlineVerticesBuffer.getVertexCount() != m_outlineVertices.getVertexCount())
+            m_outlineVerticesBuffer.create(m_outlineVertices.getVertexCount());
+
+        if (m_outlineVertices.getVertexCount() > 0)
+            m_outlineVerticesBuffer.update(&m_outlineVertices[0]);
+    }
+>>>>>>> d1670924... Implemented saveToMemory and saveImageToMemory.
 }
 
 } // namespace sf


### PR DESCRIPTION
## Description

Implements `sf::Image::saveToMemory` as discussed in the [forums](https://en.sfml-dev.org/forums/index.php?topic=25005.0).

In the background, it also implements `sf::priv::ImageLoader::saveImageToMemory` and `bufferFromCallback` (for STB Image).

For clarification in regards to the choice of the buffer type:
-The forum discussion showed a general consensus that using `std::vector`, although relatively limiting, is also a lot _simpler_ than other approaches.
-Further discussion on the SFML Discord showed a significant preference for `sf::Uint8` over `sf::Int8` as the template parameter. The choice is further solidified by the internal use of `std::vector<sf::Uint8>` for representing RGBA data (see ImageLoader.hpp).

Please provide constructive criticism if you feel it is needed.

This PR is related to the issue #988 

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

This example demonstrates how to use the method, as well as a potential use case.

```cpp
#include <SFML/Graphics.hpp>

#include <vector>
#include <string>

int main()
{
    //Load or create any image.
    sf::Image image;
    image.loadFromFile("test.png");
    
    //Create a buffer and encode image to it
    std::vector<sf::Uint8> content;
    image.saveToMemory("png", content);

    //Use buffer for anything
    //std::string encodedImage = base64::encode(content);
}
```
![test](https://user-images.githubusercontent.com/11967147/60722940-a5b26f00-9f08-11e9-8c81-8d4e0ca1c1dd.png)
