### PR TITLE
Fixed Win32 requestFocus in multithreaded environment

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -431,8 +431,9 @@ void WindowImplWin32::setKeyRepeatEnabled(bool enabled)
 void WindowImplWin32::requestFocus()
 {
     // Allow focus stealing only within the same process; compare PIDs of current and foreground window
-    DWORD thisPid       = GetWindowThreadProcessId(m_handle, NULL);
-    DWORD foregroundPid = GetWindowThreadProcessId(GetForegroundWindow(), NULL);
+    DWORD thisPid, foregroundPid;
+    GetWindowThreadProcessId(m_handle, &thisPid);
+    GetWindowThreadProcessId(GetForegroundWindow(), &foregroundPid);
 
     if (thisPid == foregroundPid)
     {


### PR DESCRIPTION
Minor fix in Win32 implementation of requestFocus() so that it works when the process creates multiple windows from different threads, which seems to be the original intention.