### PR TITLE
Remove unnecessary glFlush()

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -92,10 +92,6 @@ m_cacheId      (getUniqueId())
         if (create(copy.getSize().x, copy.getSize().y))
         {
             update(copy);
-
-            // Force an OpenGL flush, so that the texture will appear updated
-            // in all contexts immediately (solves problems in multi-threaded apps)
-            glCheck(glFlush());
         }
         else
         {


### PR DESCRIPTION
The `glFlush()` call in `sf::Texture`'s copy constructor became unnecessary after 3871e01a9fd8c9c889eeb9ad56ff6dc386be15d3 was merged after which a `glFlush()` is also called at the end of `sf::Texture::update()`. 

This also fixes `glFlush()` being able to be called in a state in which no context would be active in specific use cases.

This bug was reported on the forum: https://en.sfml-dev.org/forums/index.php?topic=25907.0

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::Image image;
    image.create(2, 2, sf::Color::Red);
    sf::Texture texture1;
    texture1.loadFromImage(image);
    sf::Texture texture2(texture1);
}
```

Test this code running in debug configuration in order to enable OpenGL error checking.