### PR TITLE
Use non-const reference to Font as self documentation

### DIFF
--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -85,7 +85,7 @@ public:
     /// \param characterSize  Base size of characters, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Text(const String& string, const Font& font, unsigned int characterSize = 30);
+    Text(const String& string, Font& font, unsigned int characterSize = 30);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the text's string
@@ -123,7 +123,7 @@ public:
     /// \see getFont
     ///
     ////////////////////////////////////////////////////////////
-    void setFont(const Font& font);
+    void setFont(Font& font);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the character size
@@ -436,7 +436,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     String              m_string;              ///< String to display
-    const Font*         m_font;                ///< Font used to display the string
+    Font*               m_font;                ///< Font used to display the string
     unsigned int        m_characterSize;       ///< Base size of characters, in pixels
     float               m_letterSpacingFactor; ///< Spacing factor between letters
     float               m_lineSpacingFactor;   ///< Spacing factor between lines

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -96,7 +96,7 @@ m_fontTextureId      (0)
 
 
 ////////////////////////////////////////////////////////////
-Text::Text(const String& string, const Font& font, unsigned int characterSize) :
+Text::Text(const String& string, Font& font, unsigned int characterSize) :
 m_string             (string),
 m_font               (&font),
 m_characterSize      (characterSize),
@@ -128,7 +128,7 @@ void Text::setString(const String& string)
 
 
 ////////////////////////////////////////////////////////////
-void Text::setFont(const Font& font)
+void Text::setFont(Font& font)
 {
     if (m_font != &font)
     {


### PR DESCRIPTION
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?

## Description

The Font object has to exist during the lifetime of the Text object. By taking a const reference it's easy for someone to pass a temporary variable and have a dangling pointer afterwards.

In many libraries (including Boost), taking a non-const reference prevents temporary variables and clearly indicates to the programmer that the object must stay alive during the lifetime of the object.

## Tasks

* [x] Tested on Linux