### PR TITLE
Add the possibility to get a glyph by its index in sf::Font

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -160,7 +160,7 @@ public:
     const Info& getInfo() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Retrieve a glyph of the font
+    /// \brief Retrieve a glyph of the font using the glyph's code point
     ///
     /// If the font is a bitmap font, not all character sizes
     /// might be available. If the glyph is not available at the
@@ -178,6 +178,26 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     const Glyph& getGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, float outlineThickness = 0) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Retrieve a glyph of the font using its glyph index
+    ///
+    /// If the font is a bitmap font, not all character sizes
+    /// might be available. If the glyph is not available at the
+    /// requested size, an empty glyph is returned.
+    ///
+    /// Be aware that using a negative value for the outline
+    /// thickness will cause distorted rendering.
+    ///
+    /// \param glyphId          Index of the glyph to get
+    /// \param characterSize    Reference character size
+    /// \param bold             Retrieve the bold version or the regular one?
+    /// \param outlineThickness Thickness of outline (when != 0 the glyph will not be filled)
+    ///
+    /// \return The glyph corresponding to \a codePoint and \a characterSize
+    ///
+    ////////////////////////////////////////////////////////////
+    const Glyph& getGlyphId(Uint32 glyphId, unsigned int characterSize, bool bold, float outlineThickness = 0) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the kerning offset of two glyphs
@@ -306,15 +326,15 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Load a new glyph and store it in the cache
     ///
-    /// \param codePoint        Unicode code point of the character to load
+    /// \param glyphId          Index of the glyph to load
     /// \param characterSize    Reference character size
     /// \param bold             Retrieve the bold version or the regular one?
     /// \param outlineThickness Thickness of outline (when != 0 the glyph will not be filled)
     ///
-    /// \return The glyph corresponding to \a codePoint and \a characterSize
+    /// \return The glyph corresponding to \a glyphId and \a characterSize
     ///
     ////////////////////////////////////////////////////////////
-    Glyph loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, float outlineThickness) const;
+    Glyph loadGlyph(Uint32 glyphId, unsigned int characterSize, bool bold, float outlineThickness) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Find a suitable rectangle within the texture for a glyph


### PR DESCRIPTION
## Description

This pull request adds the feature described in #1615

## How to test this PR?

Unfortunately, I do not have any ready code that can prove this PR does the thing it should do. However, I have used a fork with the exact modification in my [game](https://github.com/JoaoBaptMG/ReboundTheGame), using an adapted text drawable that uses HarfBuzz and needs to load the glyphs by using their index instead of the code point.