### PR TITLE
Fix CMake scripts to install and find doxygen's generated SFML.tag file

### DIFF
--- a/cmake/SFMLConfig.cmake.in
+++ b/cmake/SFMLConfig.cmake.in
@@ -77,7 +77,7 @@ set(FIND_SFML_PATHS
     /opt)
 
 find_path(SFML_DOC_DIR SFML.tag
-          PATH_SUFFIXES SFML/doc share/SFML/doc
+          PATH_SUFFIXES SFML/doc share/doc/SFML
           PATHS ${FIND_SFML_PATHS})
 
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -52,6 +52,9 @@ add_custom_target(doc ALL
                   WORKING_DIRECTORY ${DOXYGEN_INPUT_DIR})
 
 # setup install rules
+install(FILES ${DOXYGEN_OUTPUT_DIR}/SFML.tag
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}
+        COMPONENT doc)
 install(DIRECTORY ${DOXYGEN_OUTPUT_DIR}/html
         DESTINATION ${CMAKE_INSTALL_DOCDIR}
         COMPONENT doc)


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Since PR #1327 , doxygen tag file generation is enabled.

However, the CMake installation rule for the generated SFML.tag file was not added.

In addition, when the SFML.tag file is installed as it should (by adding an install rule), SFMLConfig.cmake will not find it because path suffixes provided to the `find_path` command do not match the installation tree.

This PR solves this problem on Ubuntu 18.04.
I am not sure about other platforms.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS

* [ ] ~Tested on iOS~ (irrelevant)
* [ ] ~Tested on Android~ (irrelevant)

## How to test this PR?

- Build this branch with CMake, with the SFML_BUILD_DOC option enabled.
- Install.
- Create a test folder containing the following CMakeLists.txt
- Run CMake and make sure the happy message gets printed about SFML_DOC_DIR.

```cmake
cmake_minimum_required(VERSION 3.10)
find_package(SFML 2.5 COMPONENTS system)
if(SFML_DOC_DIR)
    message("SFML_DOC_DIR found: ${SFML_DOC_DIR}")
else()
    message(WARNING "SFML_DOC_DIR was not found!")
endif()
```