### PR TITLE
Force OpenGL states to be reset when RenderTarget detects that a new context has to be tracked.

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -405,6 +405,7 @@ bool RenderTarget::setActive(bool active)
             {
                 contextRenderTargetMap[contextId] = m_id;
 
+                m_cache.glStatesSet = false;
                 m_cache.enable = false;
             }
             else if (iter->second != m_id)


### PR DESCRIPTION
Fixes #1625.

Since the FBO `RenderTexture` implementation makes use of existing contexts where it can in order to reduce context switching, `RenderTexture`s will almost always live in the same context as the context owning `RenderTarget`s such as `sf::RenderWindow`. This also means that they will share the same OpenGL state. The `glStatesSet` flag that tracks whether OpenGL states have been set or not does so per-`RenderTarget`.

When (re-)creating a context the initial states required by SFML will have to be set up. This is normally done in `sf::RenderTarget::initialize()` when `.create()` is called on the corresponding object. The problem is that `sf::RenderTarget::initialize()` is not called on the FBO `RenderTexture`s living on the same context as the `RenderTarget` on which `.create()` was called.

As shown in #1625, drawing to an FBO `RenderTexture` directly after the window owning its context has been re-created will not reset the OpenGL states since the flag was never reset.

This patch forces OpenGL states to be reset whenever the `RenderTarget` tracking detects a new context in which nothing has been activated before, regardless of whether it is a `RenderWindow` or a `RenderTexture`.

Test with code provided in #1625.