### PR TITLE
Make the process to set a DirectInput device's axis mode more conservative

### DIFF
--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -186,12 +186,20 @@ public:
     JoystickCaps getCapabilitiesDInput() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Update the joystick and get its new state (DInput)
+    /// \brief Update the joystick and get its new state (DInput, Buffered)
     ///
     /// \return Joystick state
     ///
     ////////////////////////////////////////////////////////////
-    JoystickState updateDInput();
+    JoystickState updateDInputBuffered();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the joystick and get its new state (DInput, Polled)
+    ///
+    /// \return Joystick state
+    ///
+    ////////////////////////////////////////////////////////////
+    JoystickState updateDInputPolled();
 
 private:
 
@@ -227,6 +235,8 @@ private:
     int                      m_axes[Joystick::AxisCount];      //!< Offsets to the bytes containing the axes states, -1 if not available
     int                      m_buttons[Joystick::ButtonCount]; //!< Offsets to the bytes containing the button states, -1 if not available
     Joystick::Identification m_identification;                 //!< Joystick identification
+    JoystickState            m_state;                          //!< Buffered joystick state
+    bool                     m_buffered;                       //!< true if the device uses buffering, false if the device uses polling
 };
 
 } // namespace priv


### PR DESCRIPTION
This patch changes the DirectInput device initialization process to only attempt setting the device's axis mode if the device reports having axes and its axis mode is not already set to absolute. This should help when dealing with broken device drivers that report being game controllers and not fully supporting game controller functionality such as was reported [here](https://en.sfml-dev.org/forums/index.php?topic=25361.0).

In order to test whether the negative case handling is improved, find someone with such a broken device driver. 😁
