### PR TITLE
Added method to get the current read position of sf::Packet

### DIFF
--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -72,9 +72,20 @@ public:
     /// \param sizeInBytes Number of bytes to append
     ///
     /// \see clear
+    /// \see readCurrentReadPosition
     ///
     ////////////////////////////////////////////////////////////
     void append(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a current reading position
+    ///
+    /// \return Current position
+    ///
+    /// \see append
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t getReadPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear the packet

--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -72,15 +72,17 @@ public:
     /// \param sizeInBytes Number of bytes to append
     ///
     /// \see clear
-    /// \see readCurrentReadPosition
+    /// \see getReadPosition
     ///
     ////////////////////////////////////////////////////////////
     void append(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get a current reading position
+    /// \brief Get the current reading position in the packet
     ///
-    /// \return Current position
+    /// The next read operation will read data from this position
+    ///
+    /// \return The byte offset of the current read position
     ///
     /// \see append
     ///

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -64,6 +64,13 @@ void Packet::append(const void* data, std::size_t sizeInBytes)
 
 
 ////////////////////////////////////////////////////////////
+std::size_t Packet::getReadPosition() const
+{
+    return m_readPos;
+}
+
+
+////////////////////////////////////////////////////////////
 void Packet::clear()
 {
     m_data.clear();


### PR DESCRIPTION
A rebase and fix up of #1382 