### PR TITLE
Added Glyph::hasGlyph field

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -166,6 +166,10 @@ public:
     /// might be available. If the glyph is not available at the
     /// requested size, an empty glyph is returned.
     ///
+    /// You may want to use \ref hasGlyph to determine if the
+    /// glyph exists before requesting it. If the glyph does not
+    /// exist, a font specific default is returned.
+    ///
     /// Be aware that using a negative value for the outline
     /// thickness will cause distorted rendering.
     ///
@@ -178,6 +182,24 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     const Glyph& getGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, float outlineThickness = 0) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Determine if this font has a glyph representing the requested code point
+    ///
+    /// Most fonts only include a very limited selection of glyphs from
+    /// specific Unicode subsets, like Latin, Cyrillic, or Asian characters.
+    ///
+    /// While code points without representation will return a font specific
+    /// default character, it might be useful to verify whether specific
+    /// code points are included to determine whether a font is suited
+    /// to display text in a specific language.
+    ///
+    /// \param codePoint Unicode code point to check
+    ///
+    /// \return True if the codepoint has a glyph representation, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool hasGlyph(Uint32 codePoint) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the kerning offset of two glyphs

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -366,6 +366,13 @@ const Glyph& Font::getGlyph(Uint32 codePoint, unsigned int characterSize, bool b
 
 
 ////////////////////////////////////////////////////////////
+bool Font::hasGlyph(Uint32 codePoint) const
+{
+    return FT_Get_Char_Index(static_cast<FT_Face>(m_face), codePoint) != 0;
+}
+
+
+////////////////////////////////////////////////////////////
 float Font::getKerning(Uint32 first, Uint32 second, unsigned int characterSize) const
 {
     // Special case where first or second is 0 (null character)


### PR DESCRIPTION
## Description

This is a bare minimum implementation that partially fixes the issue #1536. It clearly isn't the best solution, but at least it gives users a way to handle missing glyphs themselves, with only a few lines of code.

There might be other things to be done. For instance, if multiple missing glyphs are requested in the same font, multiple copies of the same "missing character" glyph (with glyph index zero) are added to the font texture, wasting resources.

## How to test this PR?

Run the following minimum example with a font file (say, "sansation.ttf") in the working directory:
```cpp
sf::Font font;
font.loadFromFile("sansation.ttf");

sf::Glyph glyphA = font.getGlyph('A', 12, false);
std::cout << std::boolalpha << glyphA.isValid << std::endl; // true

sf::Glyph glyphB = font.getGlyph(0x03B1, 12, false); // lower case Greek letter "Alpha"
std::cout << std::boolalpha << glyphB.isValid << std::endl; // false
```