### PR TITLE
Update travis config for android SDK changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,6 @@ matrix:
     
     install: &androidInstall
       - echo y | sdkmanager "cmake;3.10.2.4988404" 
-      - echo y | sdkmanager "lldb;3.1"
       - sudo ln -sf /usr/local/android-sdk/cmake/3.10.2.4988404/bin/cmake /usr/bin/cmake
       - wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
       - unzip -qq android-ndk-r18b-linux-x86_64.zip


### PR DESCRIPTION
Android changed something about the SDK which meant lldb was no longer a valid package to install, seems as though the fix is just to not install it anymore (I would guess it's probably installed as part of the NDK?)