### PR TITLE
Remove link in documentation main page

### DIFF
--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -3,7 +3,7 @@
 ///
 /// \section welcome Welcome
 /// Welcome to the official SFML documentation. Here you will find a detailed
-/// view of all the SFML <a href="./annotated.php">classes</a> and functions. <br/>
+/// view of all the SFML classes and functions. <br/>
 /// If you are looking for tutorials, you can visit the official website
 /// at <a href="https://www.sfml-dev.org/">www.sfml-dev.org</a>.
 ///


### PR DESCRIPTION
For locally generated documentation the link should not point to a PHP page. 
The easiest solution is to remove it, given that the same link is available in the navigation.

Fixes #1652 

## How to test this PR?

- Generate documentation locally
- Link should not appear anymore