### PR TITLE
Adjustable processing interval in SoundStream #1517

### DIFF
--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -251,6 +251,20 @@ protected:
     ////////////////////////////////////////////////////////////
     virtual Int64 onLoop();
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the processing interval
+    ///
+    /// The processing interval controls the period at which the
+    /// audio buffers are filled by calls to onGetData. A smaller
+    /// interval may be useful for low-latency streams. Note that
+    /// the given period is only a hint and the actual period may
+    /// vary. The default processing interval is 10 ms.
+    ///
+    /// \param interval Processing interval
+    ///
+    ////////////////////////////////////////////////////////////
+    void setProcessingInterval(Time interval);
+
 private:
 
     ////////////////////////////////////////////////////////////
@@ -315,8 +329,9 @@ private:
     unsigned int  m_sampleRate;               //!< Frequency (samples / second)
     Uint32        m_format;                   //!< Format of the internal sound buffers
     bool          m_loop;                     //!< Loop flag (true to loop, false to play once)
-    Uint64        m_samplesProcessed;         //!< Number of buffers processed since beginning of the stream
+    Uint64        m_samplesProcessed;         //!< Number of samples processed since beginning of the stream
     Int64         m_bufferSeeks[BufferCount]; //!< If buffer is an "end buffer", holds next seek position, else NoLoop. For play offset calculation.
+    Time          m_processingInterval;       //!< Interval for checking and filling the internal sound buffers.
 };
 
 } // namespace sf

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -51,7 +51,8 @@ m_sampleRate      (0),
 m_format          (0),
 m_loop            (false),
 m_samplesProcessed(0),
-m_bufferSeeks     ()
+m_bufferSeeks     (),
+m_processingInterval(milliseconds(10))
 {
 
 }
@@ -264,6 +265,11 @@ Int64 SoundStream::onLoop()
     return 0;
 }
 
+////////////////////////////////////////////////////////////
+void SoundStream::setProcessingInterval(Time interval)
+{
+    m_processingInterval = interval;
+}
 
 ////////////////////////////////////////////////////////////
 void SoundStream::streamData()
@@ -384,7 +390,7 @@ void SoundStream::streamData()
 
         // Leave some time for the other threads if the stream is still playing
         if (SoundSource::getStatus() != Stopped)
-            sleep(milliseconds(10));
+            sleep(m_processingInterval);
     }
 
     // Stop the playback


### PR DESCRIPTION
Resurrection of previous PR with updated documentation. Added setter to
adjust processing interval in SoundStream for low-latency streams.

Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [x] If you have additional steps which need to be performed list them as tasks!

----

## Description

Resurrection of previous PR with updated documentation. Added setter to
adjust processing interval in SoundStream for low-latency streams.

This PR is related to the issue #1517

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Audio.hpp>
#include <iostream>
#include <limits>
#include <vector>
#include <cmath>

class SignalGenerator : public sf::SoundStream
{
public:

    SignalGenerator(const sf::Time& processingInterval, const sf::Time& chunkDuration)
    : m_buffer()
    , m_samplePeriod(0)
    , m_sampleTime(0)
    {
        unsigned int channelCount = 1;
        unsigned int sampleRate = 44100;
        m_samplePeriod = 1.0 / sampleRate;

        size_t bufferLength = chunkDuration.asSeconds() * sampleRate;
        m_buffer.resize(bufferLength);

        SoundStream::initialize(channelCount, sampleRate);
        SoundStream::setProcessingInterval(processingInterval);
    }

protected:

    bool onGetData(sf::SoundStream::Chunk& data)
    {
        for (auto& sample : m_buffer)
        {
            constexpr double amplitude = 0.5 * std::numeric_limits<sf::Int16>::max();
            sample = amplitude * std::sin(330.0 * 2.0 * M_PI * m_sampleTime);
            m_sampleTime += m_samplePeriod;
        }

        data.sampleCount = m_buffer.size();
        data.samples = m_buffer.data();
        return true;
    }
    
    void onSeek(sf::Time timeOffset) { }

private:

    std::vector<sf::Int16> m_buffer;
    double m_samplePeriod;
    double m_sampleTime;
};

int main()
{
  SignalGenerator generator(sf::milliseconds(1000), sf::milliseconds(50));
  generator.play();
  std::cin.get();
}

```