### PR TITLE
Copy automatically examples resource folder to binary output location

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -218,6 +218,11 @@ macro(sfml_add_example target)
         set(target_input ${target_input} ${THIS_BUNDLE_RESOURCES})
     endif()
 
+    # copy resource folder to binary output location when needed
+    if(THIS_RESOURCES_DIR)
+        file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${THIS_RESOURCES_DIR} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    endif()
+
     # create the target
     if(THIS_GUI_APP AND SFML_OS_WINDOWS AND NOT DEFINED CMAKE_CONFIGURATION_TYPES AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")
         add_executable(${target} WIN32 ${target_input})


### PR DESCRIPTION

## Description

After compiling examples, I noticed the resource folders where not copied automatically and needed to be manually copied.
I knew it was possible to copy folders with Cmake, so I did it.

## Tasks

The commit is Cmake related, should work on all platforms

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Set SFML_BUILD_EXAMPLES to TRUE in CMakeLists.txt and do the usual build commands.