### PR TITLE
Add move semantics to sf::WindowBase and sf::Window

### DIFF
--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -97,6 +97,15 @@ public:
     explicit Window(WindowHandle handle, const ContextSettings& settings = ContextSettings());
 
     ////////////////////////////////////////////////////////////
+    /// \brief Move constructor
+    ///
+    /// \param moved instance to move from. Behaves like a
+    ///              default-constructed object after the move.
+    ///
+    ////////////////////////////////////////////////////////////
+    Window(Window&& moved) noexcept;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     /// Closes the window and frees all the resources attached to it.
@@ -250,6 +259,25 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     void display();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move assignment operator
+    ///
+    /// \param moved instance to move from. Behaves like a
+    ///              default-constructed object after the move.
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    Window& operator =(Window&& moved);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Swap the contents of this window with those of another
+    ///
+    /// \param right Instance to swap with
+    ///
+    ////////////////////////////////////////////////////////////
+    void swap(Window& right);
 
 private:
 

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -91,6 +91,15 @@ public:
     explicit WindowBase(WindowHandle handle);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Move constructor
+    ///
+    /// \param moved instance to move from. Behaves like a
+    ///              default-constructed object after the move.
+    ///
+    ////////////////////////////////////////////////////////////
+    WindowBase(WindowBase&& moved) noexcept;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     /// Closes the window and frees all the resources attached to it.
@@ -379,6 +388,25 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     bool hasFocus() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move assignment operator
+    ///
+    /// \param moved instance to move from. Behaves like a
+    ///              default-constructed object after the move.
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    WindowBase& operator =(WindowBase&& moved);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Swap the contents of this window with those of another
+    ///
+    /// \param right Instance to swap with
+    ///
+    ////////////////////////////////////////////////////////////
+    void swap(WindowBase& right);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the OS-specific handle of the window

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -62,6 +62,14 @@ m_frameTimeLimit(Time::Zero)
 
 
 ////////////////////////////////////////////////////////////
+Window::Window(Window&& moved) noexcept :
+Window()
+{
+    swap(moved);
+}
+
+
+////////////////////////////////////////////////////////////
 Window::~Window()
 {
     close();
@@ -224,6 +232,27 @@ void Window::display()
         sleep(m_frameTimeLimit - m_clock.getElapsedTime());
         m_clock.restart();
     }
+}
+
+
+////////////////////////////////////////////////////////////
+Window& Window::operator =(Window&& moved)
+{
+    Window temp(std::move(moved));
+    swap(temp);
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+void Window::swap(Window& right)
+{
+    WindowBase::swap(right);
+
+    std::swap(m_context,        right.m_context);
+    std::swap(m_clock,          right.m_clock);
+    std::swap(m_frameTimeLimit, right.m_frameTimeLimit);
 }
 
 

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -30,7 +30,6 @@
 #include <SFML/Window/WindowImpl.hpp>
 #include <SFML/System/Err.hpp>
 
-
 namespace
 {
     const sf::WindowBase* fullscreenWindow = NULL;
@@ -63,6 +62,13 @@ m_impl          (NULL),
 m_size          (0, 0)
 {
     WindowBase::create(handle);
+}
+
+////////////////////////////////////////////////////////////
+WindowBase::WindowBase(WindowBase&& moved) noexcept :
+WindowBase()
+{
+    swap(moved);
 }
 
 
@@ -298,6 +304,24 @@ void WindowBase::requestFocus()
 bool WindowBase::hasFocus() const
 {
     return m_impl && m_impl->hasFocus();
+}
+
+
+////////////////////////////////////////////////////////////
+WindowBase& WindowBase::operator =(WindowBase&& moved)
+{
+    WindowBase temp(std::move(moved));
+    swap(temp);
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+void WindowBase::swap(WindowBase& right)
+{
+    std::swap(m_impl, right.m_impl);
+    std::swap(m_size, right.m_size);
 }
 
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [x] If you have additional steps which need to be performed list them as tasks!

----

## Description

Added move semantics to sf::WindowBase and sf::Window class based on the strategy discussed in the forums:
https://en.sfml-dev.org/forums/index.php?topic=27116.0

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

The following code can be used to test this PR. Success is indicated by the following cli output, followed by a stable, open window:

Window 1 open: 0
Window 2 open: 1
Window 3 open: 0

```cpp
#include <SFML/Window.hpp>
#include <iostream>

int main()
{
    sf::Window window1(sf::VideoMode(800, 600), "My window");
    sf::Window window2(std::move(window1));
    sf::Window window3;

    std::cout << "Window 1 open: " << window1.isOpen() << std::endl;
    std::cout << "Window 2 open: " << window2.isOpen() << std::endl;
    std::cout << "Window 3 open: " << window3.isOpen() << std::endl;

    window3 = std::move(window2);

    while (window3.isOpen())
    {
        sf::Event event;
        while (window3.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
            {
                window3.close();
            }
        }
    }
}
```