### PR TITLE
Added XFlush call to WindowImplX11::setMouseCursor

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1112,6 +1112,7 @@ void WindowImplX11::setMouseCursor(const CursorImpl& cursor)
 {
     m_lastCursor = cursor.m_cursor;
     XDefineCursor(m_display, m_window, m_lastCursor);
+    XFlush(m_display);
 }
 
 


### PR DESCRIPTION
Changing the mouse cursor on Linux with SFML doesn't happen instantaneously.
When an application calls XDefineCursor directly shortly after having set the cursor via SFML (e.g. in order to use a system cursor that SFML doesn't support), then the calls will be executed in the wrong order. (If the same Display was used then they would be in the correct order, but the application can't access the display that SFML uses internally)
By calling XFlush after the call to XDefineCursor, the change is made immediately and external calls to XDefineCursor can no longer occur in the wrong order.

The XFlush call is already there in setMouseCursorVisible and other functions in WindowImplX11, it is just missing in setMouseCursor.