### PR TITLE
Added support for directional arrow resize cursors on Linux

### DIFF
--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -64,6 +64,14 @@ public:
     ///  sf::Cursor::SizeVertical           |  yes  |    yes   |   yes    |
     ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    yes*  |   yes    |
     ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    yes*  |   yes    |
+    ///  sf::Cursor::SizeLeft               |  yes  |    yes** |   yes**  |
+    ///  sf::Cursor::SizeRight              |  yes  |    yes** |   yes**  |
+    ///  sf::Cursor::SizeTop                |  yes  |    yes** |   yes**  |
+    ///  sf::Cursor::SizeBottom             |  yes  |    yes** |   yes**  |
+    ///  sf::Cursor::SizeTopLeft            |  yes  |    yes** |   yes**  |
+    ///  sf::Cursor::SizeTopRight           |  yes  |    yes** |   yes**  |
+    ///  sf::Cursor::SizeBottomLeft         |  yes  |    yes** |   yes**  |
+    ///  sf::Cursor::SizeBottomRight        |  yes  |    yes** |   yes**  |
     ///  sf::Cursor::SizeAll                |  yes  |    no    |   yes    |
     ///  sf::Cursor::Cross                  |  yes  |    yes   |   yes    |
     ///  sf::Cursor::Help                   |  yes  |    yes*  |   yes    |
@@ -71,6 +79,8 @@ public:
     ///
     ///  * These cursor types are undocumented so may not
     ///    be available on all versions, but have been tested on 10.13
+    ///
+    ///  ** On Windows and macOS, double-headed arrows are used
     ///
     ////////////////////////////////////////////////////////////
     enum Type
@@ -84,6 +94,14 @@ public:
         SizeVertical,           //!< Vertical double arrow cursor
         SizeTopLeftBottomRight, //!< Double arrow cursor going from top-left to bottom-right
         SizeBottomLeftTopRight, //!< Double arrow cursor going from bottom-left to top-right
+        SizeLeft,               //!< Left arrow cursor on Linux, same as SizeHorizontal on other platforms
+        SizeRight,              //!< Right arrow cursor on Linux, same as SizeHorizontal on other platforms
+        SizeTop,                //!< Up arrow cursor on Linux, same as SizeVertical on other platforms
+        SizeBottom,             //!< Down arrow cursor on Linux, same as SizeVertical on other platforms
+        SizeTopLeft,            //!< Top-left arrow cursor on Linux, same as SizeTopLeftBottomRight on other platforms
+        SizeBottomRight,        //!< Bottom-right arrow cursor on Linux, same as SizeTopLeftBottomRight on other platforms
+        SizeBottomLeft,         //!< Bottom-left arrow cursor on Linux, same as SizeBottomLeftTopRight on other platforms
+        SizeTopRight,           //!< Top-right arrow cursor on Linux, same as SizeBottomLeftTopRight on other platforms
         SizeAll,                //!< Combination of SizeHorizontal and SizeVertical
         Cross,                  //!< Crosshair cursor
         Help,                   //!< Help cursor

--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -98,14 +98,22 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::SizeVertical:    m_cursor = [NSCursor resizeUpDownCursor];        break;
         case Cursor::Cross:           m_cursor = [NSCursor crosshairCursor];           break;
         case Cursor::NotAllowed:      m_cursor = [NSCursor operationNotAllowedCursor]; break;
+        case Cursor::SizeLeft:        m_cursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::SizeRight:       m_cursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::SizeTop:         m_cursor = [NSCursor resizeUpDownCursor];        break;
+        case Cursor::SizeBottom:      m_cursor = [NSCursor resizeUpDownCursor];        break;
             
         // These cursor types are undocumented, may not be available on some platforms
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
+        case Cursor::SizeTopRight:
+        case Cursor::SizeBottomLeft:
         case Cursor::SizeBottomLeftTopRight:
             m_cursor = loadFromSelector(@selector(_windowResizeNorthEastSouthWestCursor));
             break;
 
+        case Cursor::SizeTopLeft:
+        case Cursor::SizeBottomRight:
         case Cursor::SizeTopLeftBottomRight:
             m_cursor = loadFromSelector(@selector(_windowResizeNorthWestSouthEastCursor));
             break;

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -122,16 +122,24 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
     {
         default: return false;
 
-        case Cursor::Arrow:          shape = XC_arrow;              break;
-        case Cursor::Wait:           shape = XC_watch;              break;
-        case Cursor::Text:           shape = XC_xterm;              break;
-        case Cursor::Hand:           shape = XC_hand1;              break;
-        case Cursor::SizeHorizontal: shape = XC_sb_h_double_arrow;  break;
-        case Cursor::SizeVertical:   shape = XC_sb_v_double_arrow;  break;
-        case Cursor::SizeAll:        shape = XC_fleur;              break;
-        case Cursor::Cross:          shape = XC_crosshair;          break;
-        case Cursor::Help:           shape = XC_question_arrow;     break;
-        case Cursor::NotAllowed:     shape = XC_X_cursor;           break;
+        case Cursor::Arrow:           shape = XC_arrow;               break;
+        case Cursor::Wait:            shape = XC_watch;               break;
+        case Cursor::Text:            shape = XC_xterm;               break;
+        case Cursor::Hand:            shape = XC_hand1;               break;
+        case Cursor::SizeHorizontal:  shape = XC_sb_h_double_arrow;   break;
+        case Cursor::SizeVertical:    shape = XC_sb_v_double_arrow;   break;
+        case Cursor::SizeLeft:        shape = XC_left_side;           break;
+        case Cursor::SizeRight:       shape = XC_right_side;          break;
+        case Cursor::SizeTop:         shape = XC_top_side;            break;
+        case Cursor::SizeBottom:      shape = XC_bottom_side;         break;
+        case Cursor::SizeTopLeft:     shape = XC_top_left_corner;     break;
+        case Cursor::SizeBottomRight: shape = XC_bottom_right_corner; break;
+        case Cursor::SizeBottomLeft:  shape = XC_bottom_left_corner;  break;
+        case Cursor::SizeTopRight:    shape = XC_top_right_corner;    break;
+        case Cursor::SizeAll:         shape = XC_fleur;               break;
+        case Cursor::Cross:           shape = XC_crosshair;           break;
+        case Cursor::Help:            shape = XC_question_arrow;      break;
+        case Cursor::NotAllowed:      shape = XC_X_cursor;            break;
     }
 
     m_cursor = XCreateFontCursor(m_display, shape);

--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -152,6 +152,14 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::SizeVertical:           shape = IDC_SIZENS;      break;
         case Cursor::SizeTopLeftBottomRight: shape = IDC_SIZENWSE;    break;
         case Cursor::SizeBottomLeftTopRight: shape = IDC_SIZENESW;    break;
+        case Cursor::SizeLeft:               shape = IDC_SIZEWE;      break;
+        case Cursor::SizeRight:              shape = IDC_SIZEWE;      break;
+        case Cursor::SizeTop:                shape = IDC_SIZENS;      break;
+        case Cursor::SizeBottom:             shape = IDC_SIZENS;      break;
+        case Cursor::SizeTopLeft:            shape = IDC_SIZENWSE;    break;
+        case Cursor::SizeBottomRight:        shape = IDC_SIZENWSE;    break;
+        case Cursor::SizeBottomLeft:         shape = IDC_SIZENESW;    break;
+        case Cursor::SizeTopRight:           shape = IDC_SIZENESW;    break;
         case Cursor::SizeAll:                shape = IDC_SIZEALL;     break;
         case Cursor::Cross:                  shape = IDC_CROSS;       break;
         case Cursor::Help:                   shape = IDC_HELP;        break;


### PR DESCRIPTION
This change adds the following mouse cursors:
- SizeLeft
- SizeRight
- SizeTop
- SizeBottom
- SizeTopLeft
- SizeTopRight
- SizeBottomLeft
- SizeBottomRight

Those cursors will only look like directional arrows on Linux, on Windows and macOS it will display the same double-headed arrows that are used by existing cursors (e.g. SizeTopLeftBottomRight is used when SizeTopLeft or SizeBottomRight is requested).

As stated on the [the SFML forum](https://en.sfml-dev.org/forums/index.php?topic=27397), this change is needed to have diagonal resize cursors on Linux.

I have tested all newly added cursors on Linux.
I didn't test on Windows or macOS, but the change is straightforward.

Example code to test the change (will show arrow pointing to bottom right on Linux, and double-headed arrow from top left to bottom right on Windows and macOS):
```
sf::Cursor cursor;
cursor.loadFromSystem(sf::Cursor::SizeBottomRight);
window.setMouseCursor(cursor);
```