### PR TITLE
Use bit-packing for booleans in Packet

### DIFF
--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -413,10 +413,12 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::vector<char> m_data;    //!< Data stored in the packet
-    std::size_t       m_readPos; //!< Current reading position in the packet
-    std::size_t       m_sendPos; //!< Current send position in the packet (for handling partial sends)
-    bool              m_isValid; //!< Reading state of the packet
+    std::vector<char> m_data;        //!< Data stored in the packet
+    std::size_t       m_readPos;     //!< Current reading position in the packet
+    std::size_t       m_sendPos;     //!< Current send position in the packet (for handling partial sends)
+    std::size_t       m_boolReadPos; //!< Current reading bit position (for sending booleans)
+    std::size_t       m_boolSendPos; //!< Current send bit position (for sending booleans)
+    bool              m_isValid;     //!< Reading state of the packet
 };
 
 } // namespace sf


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This PR adds a bit-packer that reduces packet size when appending multiple booleans in succession. The implementation is very simple and most of the internals of sf::Packet are not changed. 

I believe this change could significantly reduce bandwidth usage in some cases, while also adding  virtually no overhead in the rest.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Network/Packet.hpp>
#include <iostream>

int main()
{
    sf::Packet packet;

    packet << true << true << false << true;

    // Size is 1 byte (would've been 4 bytes with previous implementation)
    std::cout << packet.getDataSize() << std::endl;

    // Bit-packing is not used with other types
    packet << sf::Int16(133) << true << false << false;

    // Size is 4 bytes now (would've been 9 bytes with previous implementation)
    std::cout << packet.getDataSize() << std::endl;

    return 0;
}
```