### PR TITLE
Implement smoothing for fonts

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -276,6 +276,32 @@ public:
     const Texture& getTexture(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable the smooth filter
+    ///
+    /// When the filter is activated, the font appears smoother
+    /// so that pixels are less noticeable. However if you want
+    /// the font to look exactly the same as its source file,
+    /// you should disable it.
+    /// The smooth filter is enabled by default.
+    ///
+    /// \param smooth True to enable smoothing, false to disable it
+    ///
+    /// \see isSmooth
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSmooth(bool smooth);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the smooth filter is enabled or not
+    ///
+    /// \return True if smoothing is enabled, false if it is disabled
+    ///
+    /// \see setSmooth
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isSmooth() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
     ///
     /// \param right Instance to assign
@@ -373,6 +399,7 @@ private:
     void*                      m_streamRec;   //!< Pointer to the stream rec instance (it is typeless to avoid exposing implementation details)
     void*                      m_stroker;     //!< Pointer to the stroker (it is typeless to avoid exposing implementation details)
     int*                       m_refCount;    //!< Reference counter used by implicit sharing
+    bool                       m_isSmooth;    //!< Status of the smooth filter
     Info                       m_info;        //!< Information about the font
     mutable PageTable          m_pages;       //!< Table containing the glyphs pages by character size
     mutable std::vector<Uint8> m_pixelBuffer; //!< Pixel buffer holding a glyph's pixels before being written to the texture

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -88,6 +88,7 @@ m_face     (NULL),
 m_streamRec(NULL),
 m_stroker  (NULL),
 m_refCount (NULL),
+m_isSmooth (true),
 m_info     ()
 {
     #ifdef SFML_SYSTEM_ANDROID
@@ -105,7 +106,8 @@ m_stroker    (copy.m_stroker),
 m_refCount   (copy.m_refCount),
 m_info       (copy.m_info),
 m_pages      (copy.m_pages),
-m_pixelBuffer(copy.m_pixelBuffer)
+m_pixelBuffer(copy.m_pixelBuffer),
+m_isSmooth   (copy.m_isSmooth)
 {
     #ifdef SFML_SYSTEM_ANDROID
         m_stream = NULL;
@@ -468,6 +470,26 @@ const Texture& Font::getTexture(unsigned int characterSize) const
     return m_pages[characterSize].texture;
 }
 
+////////////////////////////////////////////////////////////
+void Font::setSmooth(bool smooth)
+{
+    if (smooth != m_isSmooth)
+    {
+        m_isSmooth = smooth;
+
+        for (sf::Font::PageTable::iterator page = m_pages.begin(); page != m_pages.end(); ++page)
+        {
+            page->second.texture.setSmooth(m_isSmooth);
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////
+bool Font::isSmooth() const
+{
+    return m_isSmooth;
+}
+
 
 ////////////////////////////////////////////////////////////
 Font& Font::operator =(const Font& right)
@@ -482,6 +504,7 @@ Font& Font::operator =(const Font& right)
     std::swap(m_info,        temp.m_info);
     std::swap(m_pages,       temp.m_pages);
     std::swap(m_pixelBuffer, temp.m_pixelBuffer);
+    std::swap(m_isSmooth,    temp.m_isSmooth);
 
     #ifdef SFML_SYSTEM_ANDROID
         std::swap(m_stream, temp.m_stream);
@@ -734,7 +757,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
                 // Make the texture 2 times bigger
                 Texture newTexture;
                 newTexture.create(textureWidth * 2, textureHeight * 2);
-                newTexture.setSmooth(true);
+                newTexture.setSmooth(m_isSmooth);
                 newTexture.update(page.texture);
                 page.texture.swap(newTexture);
             }


### PR DESCRIPTION
## Description

Following on from forum discussion [here](https://en.sfml-dev.org/forums/index.php?topic=21058.0) this implements smoothing for fonts, via `setSmooth();`

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Can test using the following code. Space toggles the font's smoothing

```cpp

#include <SFML/Graphics.hpp>
int main()
{

    sf::RenderWindow window( sf::VideoMode( 800, 600, 32 ), "SFML text smoothing",
                             sf::Style::Titlebar | sf::Style::Close );


    sf::Font font;
    if (!font.loadFromFile("resources/font.ttf"))
        return EXIT_FAILURE;

    sf::Text message;
    message.setFont(font);
    int textSize = 40;
    message.setScale( { 1.5f,1.5f } );
    message.setCharacterSize(textSize);
    message.setFillColor(sf::Color::White);

    message.setString( "Some text about something or other" );
    

    while (window.isOpen())
    {
        // Handle events
        sf::Event event;
        while ( window.pollEvent( event ) )
        {
            // Window closed or escape key pressed: exit
            if ( (event.type == sf::Event::Closed) ||
                 ((event.type == sf::Event::KeyPressed) && (event.key.code == sf::Keyboard::Escape)) )
            {
                window.close();
                break;
            }

            if ( event.type == sf::Event::KeyPressed )
            {
                switch ( event.key.code )
                {
                case sf::Keyboard::Space:
                    font.setSmooth( !font.isSmooth() );
                    break;

                case sf::Keyboard::Up:
                    message.setCharacterSize( ++textSize );
                    break;

                case sf::Keyboard::Down:
                    message.setCharacterSize( --textSize );
                    break;
                }
            }
        }

        window.clear(sf::Color(50, 200, 50));
        window.draw(message);
        window.display();
    }

    return EXIT_SUCCESS;
}

```