### PR TITLE
replace dead link in Config.hpp file

### DIFF
--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -36,7 +36,7 @@
 
 ////////////////////////////////////////////////////////////
 // Identify the operating system
-// see http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system
+// see https://sourceforge.net/p/predef/wiki/Home/
 ////////////////////////////////////////////////////////////
 #if defined(_WIN32)
 


### PR DESCRIPTION
Replace dead link in comment with working link containing information about predefined macros
