### PR TITLE
Fix `sf::Music` sometimes failing to loop after seeking

### DIFF
--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -225,11 +225,11 @@ Uint64 InputSoundFile::getSampleOffset() const
 ////////////////////////////////////////////////////////////
 void InputSoundFile::seek(Uint64 sampleOffset)
 {
-    if (m_reader)
+    if (m_reader && m_channelCount != 0)
     {
         // The reader handles an overrun gracefully, but we
         // pre-check to keep our known position consistent
-        m_sampleOffset = std::min(sampleOffset, m_sampleCount);
+        m_sampleOffset = std::min(sampleOffset / m_channelCount * m_channelCount, m_sampleCount);
         m_reader->seek(m_sampleOffset);
     }
 }
@@ -238,7 +238,7 @@ void InputSoundFile::seek(Uint64 sampleOffset)
 ////////////////////////////////////////////////////////////
 void InputSoundFile::seek(Time timeOffset)
 {
-    seek(static_cast<Uint64>(timeOffset.asSeconds() * m_sampleRate * m_channelCount));
+    seek(static_cast<Uint64>(timeOffset.asSeconds() * m_sampleRate) * m_channelCount);
 }
 
 


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [x] If you have additional steps which need to be performed list them as tasks!

----

## Description

This PR addresses a bug that caused `sf::Music` to cease looping after certain seeks due to the sample offset misaligning with the sound file's channel count. To fix this issue, the "physical" sample offset is now rounded down to the nearest "logical" sample for multi-channel sound files, ensuring that `sf::InputSoundFile`'s sample offset always points at the beginning of a logical sample.

The bug was previously reported and discussed in the following forum thread: https://en.sfml-dev.org/forums/index.php?topic=25298.0

The [change proposed by Laurent](https://en.sfml-dev.org/forums/index.php?topic=25298.msg167772#msg167772) is also integrated in this PR, ensuring that the sample offset is rounded correctly in both overloads of `InputSoundFile::seek()`.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

Some cursory Windows testing was carried out through Wine. OSX, iOS and Android have not been tested.

## How to test this PR?

The following example code reproduces the issue on the latest (as of [59df9d0d8](https://github.com/SFML/SFML/commit/59df9d0d887f11724679f2c99dec0f05d6caeaf4)) SFML. A C++14-compliant compiler and [testsound.ogg](https://rankcheck.marukyu.de/files/testsound.ogg) is required.

```cpp
#include <SFML/Audio/Music.hpp>
#include <SFML/System/Sleep.hpp>
#include <SFML/System/Time.hpp>
#include <iostream>
#include <fstream>
#include <memory>
#include <string>
#include <vector>

std::vector<char> readFile(std::string fileName)
{
        std::ifstream f(fileName);
        std::vector<char> data;
        f.seekg(0, std::ios::end);
        data.resize(f.tellg());
        f.seekg(0, std::ios::beg);
        f.read(data.data(), data.size());
        return data;
}

std::unique_ptr<sf::Music> play(const std::vector<char> & buffer, sf::Time offset)
{
        std::unique_ptr<sf::Music> music = std::make_unique<sf::Music>();
        music->openFromMemory(buffer.data(), buffer.size());

        music->setLoop(true);
        music->setVolume(20);
        music->setPitch(1);
        music->play();

        if (offset != sf::Time::Zero)
        {
                music->setPlayingOffset(offset);
                std::cout << "Playing at " << offset.asMicroseconds() << " us" << std::endl;
        }
        else
        {
                std::cout << "Playing from start" << std::endl;
        }

        return std::move(music);
}

int main()
{
        auto buffer = readFile("testsound.ogg");

        std::unique_ptr<sf::Music> music;

        music = play(buffer, sf::Time::Zero);       // Playing from the start: sound loops correctly
        sf::sleep(sf::seconds(5));
        music = play(buffer, sf::microseconds(20)); // Issue occurs here: sound does not loop
        sf::sleep(sf::seconds(5));
        music = play(buffer, sf::microseconds(25)); // No issue here, sound loops properly
        sf::sleep(sf::seconds(5));

        return 0;
}
```