### PR TITLE
OpenAL Audio effects: reverb, chorus, delay

### DIFF
--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -118,7 +118,7 @@ int main()
     playMusic("ding.flac", reverbEffect);
 
     // Play music from a mp3 file
-    playMusic("ding.mp3");
+    playMusic("ding.mp3", reverbEffect);
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -26,17 +26,28 @@ void playSound()
 
     // Create a sound instance and play it
     sf::Sound sound(buffer);
-    sound.play();
+    sf::ReverbEffect effect;
 
-    // Loop while the sound is playing
-    while (sound.getStatus() == sf::Sound::Playing)
+    sound.setEffect(&effect);
+    effect.setDecayTime(20.f);
+    effect.setDensity(0.f);
+
+    for (auto i = 0; i < 2; ++i)
     {
-        // Leave some CPU time for other processes
-        sf::sleep(sf::milliseconds(100));
+        sound.play();
 
-        // Display the playing position
-        std::cout << "\rPlaying... " << sound.getPlayingOffset().asSeconds() << " sec        ";
-        std::cout << std::flush;
+
+        // Loop while the sound is playing
+        while (sound.getStatus() == sf::Sound::Playing)
+        {
+            // Leave some CPU time for other processes
+            sf::sleep(sf::milliseconds(100));
+
+            // Display the playing position
+            std::cout << "\rPlaying... " << sound.getPlayingOffset().asSeconds() << " sec        ";
+            std::cout << std::flush;
+        }
+        sound.setEffect(nullptr);
     }
     std::cout << std::endl << std::endl;
 }
@@ -72,6 +83,7 @@ void playMusic(const std::string& filename)
         std::cout << "\rPlaying... " << music.getPlayingOffset().asSeconds() << " sec        ";
         std::cout << std::flush;
     }
+
     std::cout << std::endl << std::endl;
 }
 

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -27,9 +27,9 @@ void playSound()
     sf::Sound sound(buffer);
 
     // Create a reverb effect to assign to the sound
-    sf::ReverbEffect effect;
+    sf::ChorusEffect effect;
 
-    for (auto i = 0; i < 2; ++i)
+    for (int i = 0; i < 2; ++i)
     {
         sound.play();
 
@@ -46,8 +46,12 @@ void playSound()
 
         //apply the reverb effect
         sound.setEffect(&effect);
-        effect.setDecayTime(20.f);
-        effect.setDensity(0.f);
+        effect.setPhase(80);
+        effect.setRate(5.f);
+        effect.setFeedback(-0.5f);
+        effect.setDelay(0.01f);
+       // effect.setDecayTime(20.f);
+        //effect.setDensity(0.f);
     }
     std::cout << std::endl << std::endl;
 }

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -42,7 +42,7 @@ void playSound(const sf::SoundEffect& effect)
         }
 
         // apply the effect
-        sound.setEffect(&effect);
+        sound.setEffect(effect);
     }
     std::cout << std::endl << std::endl;
 }
@@ -83,7 +83,7 @@ void playMusic(const std::string& filename, const sf::SoundEffect& effect)
         music.setPlayingOffset(sf::seconds(0.f));
 
         // Apply the effect the second time
-        music.setEffect(&effect);
+        music.setEffect(effect);
     }
 
     std::cout << std::endl << std::endl;

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -28,10 +28,6 @@ void playSound()
     sf::Sound sound(buffer);
     sf::ReverbEffect effect;
 
-    sound.setEffect(&effect);
-    effect.setDecayTime(20.f);
-    effect.setDensity(0.f);
-
     for (auto i = 0; i < 2; ++i)
     {
         sound.play();
@@ -47,7 +43,10 @@ void playSound()
             std::cout << "\rPlaying... " << sound.getPlayingOffset().asSeconds() << " sec        ";
             std::cout << std::flush;
         }
-        sound.setEffect(nullptr);
+
+        sound.setEffect(&effect);
+        effect.setDecayTime(20.f);
+        effect.setDensity(0.f);
     }
     std::cout << std::endl << std::endl;
 }

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <string>
 
-
 ////////////////////////////////////////////////////////////
 /// Play a sound
 ///
@@ -26,12 +25,13 @@ void playSound()
 
     // Create a sound instance and play it
     sf::Sound sound(buffer);
+
+    // Create a reverb effect to assign to the sound
     sf::ReverbEffect effect;
 
     for (auto i = 0; i < 2; ++i)
     {
         sound.play();
-
 
         // Loop while the sound is playing
         while (sound.getStatus() == sf::Sound::Playing)
@@ -44,6 +44,7 @@ void playSound()
             std::cout << std::flush;
         }
 
+        //apply the reverb effect
         sound.setEffect(&effect);
         effect.setDecayTime(20.f);
         effect.setDensity(0.f);

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -27,7 +27,7 @@ void playSound()
     sf::Sound sound(buffer);
 
     // Create a reverb effect to assign to the sound
-    sf::ChorusEffect effect;
+    sf::DelayEffect effect;
 
     for (int i = 0; i < 2; ++i)
     {
@@ -46,11 +46,7 @@ void playSound()
 
         //apply the reverb effect
         sound.setEffect(&effect);
-        effect.setPhase(80);
-        effect.setRate(5.f);
-        effect.setFeedback(-0.5f);
-        effect.setDelay(0.01f);
-       // effect.setDecayTime(20.f);
+        //effect.setDecayTime(20.f);
         //effect.setDensity(0.f);
     }
     std::cout << std::endl << std::endl;

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -114,7 +114,7 @@ int main()
 
     // Play music from a flac file
     reverbEffect.setDecayTime(5.f);
-    reverbEffect.setDensity(0.1f);
+    reverbEffect.setDiffusion(0.1f);
     playMusic("ding.flac", reverbEffect);
 
     // Play music from a mp3 file

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -10,7 +10,7 @@
 /// Play a sound
 ///
 ////////////////////////////////////////////////////////////
-void playSound()
+void playSound(sf::ReverbEffect& effect)
 {
     // Load a sound buffer from a wav file
     sf::SoundBuffer buffer;
@@ -25,9 +25,6 @@ void playSound()
 
     // Create a sound instance and play it
     sf::Sound sound(buffer);
-
-    // Create a reverb effect to assign to the sound
-    sf::DelayEffect effect;
 
     for (int i = 0; i < 2; ++i)
     {
@@ -44,10 +41,10 @@ void playSound()
             std::cout << std::flush;
         }
 
-        //apply the reverb effect
+        // apply the reverb effect
         sound.setEffect(&effect);
-        //effect.setDecayTime(20.f);
-        //effect.setDensity(0.f);
+        effect.setDecayTime(20.f);
+        effect.setDensity(0.f);
     }
     std::cout << std::endl << std::endl;
 }
@@ -96,8 +93,11 @@ void playMusic(const std::string& filename)
 ////////////////////////////////////////////////////////////
 int main()
 {
+    // Create a reverb effect to assign to the sound
+    sf::ReverbEffect effect;
+
     // Play a sound
-    playSound();
+    playSound(effect);
 
     // Play music from an ogg file
     playMusic("doodle_pop.ogg");

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -10,7 +10,7 @@
 /// Play a sound
 ///
 ////////////////////////////////////////////////////////////
-void playSound(sf::ReverbEffect& effect)
+void playSound(const sf::SoundEffect& effect)
 {
     // Load a sound buffer from a wav file
     sf::SoundBuffer buffer;
@@ -41,10 +41,8 @@ void playSound(sf::ReverbEffect& effect)
             std::cout << std::flush;
         }
 
-        // apply the reverb effect
+        // apply the effect
         sound.setEffect(&effect);
-        effect.setDecayTime(20.f);
-        effect.setDensity(0.f);
     }
     std::cout << std::endl << std::endl;
 }
@@ -54,7 +52,7 @@ void playSound(sf::ReverbEffect& effect)
 /// Play a music
 ///
 ////////////////////////////////////////////////////////////
-void playMusic(const std::string& filename)
+void playMusic(const std::string& filename, const sf::SoundEffect& effect)
 {
     // Load an ogg music file
     sf::Music music;
@@ -68,17 +66,24 @@ void playMusic(const std::string& filename)
     std::cout << " " << music.getChannelCount()         << " channels"      << std::endl;
 
     // Play it
-    music.play();
-
-    // Loop while the music is playing
-    while (music.getStatus() == sf::Music::Playing)
+    for (int i = 0; i < 2; ++i)
     {
-        // Leave some CPU time for other processes
-        sf::sleep(sf::milliseconds(100));
+        music.play();
 
-        // Display the playing position
-        std::cout << "\rPlaying... " << music.getPlayingOffset().asSeconds() << " sec        ";
-        std::cout << std::flush;
+        // Loop while the music is playing
+        while (music.getStatus() == sf::Music::Playing)
+        {
+            // Leave some CPU time for other processes
+            sf::sleep(sf::milliseconds(100));
+
+            // Display the playing position
+            std::cout << "\rPlaying... " << music.getPlayingOffset().asSeconds() << " sec        ";
+            std::cout << std::flush;
+        }
+        music.setPlayingOffset(sf::seconds(0.f));
+
+        // Apply the effect the second time
+        music.setEffect(&effect);
     }
 
     std::cout << std::endl << std::endl;
@@ -94,16 +99,23 @@ void playMusic(const std::string& filename)
 int main()
 {
     // Create a reverb effect to assign to the sound
-    sf::ReverbEffect effect;
+    sf::ReverbEffect reverbEffect;
+    reverbEffect.setDecayTime(20.f);
 
     // Play a sound
-    playSound(effect);
+    playSound(reverbEffect);
+
+    // Create a chorus effect
+    sf::ChorusEffect chorusEffect;
+    chorusEffect.setFeedback(-0.69f);
 
     // Play music from an ogg file
-    playMusic("doodle_pop.ogg");
+    playMusic("doodle_pop.ogg", chorusEffect);
 
     // Play music from a flac file
-    playMusic("ding.flac");
+    reverbEffect.setDecayTime(5.f);
+    reverbEffect.setDensity(0.1f);
+    playMusic("ding.flac", reverbEffect);
 
     // Play music from a mp3 file
     playMusic("ding.mp3");

--- a/include/SFML/Audio.hpp
+++ b/include/SFML/Audio.hpp
@@ -45,6 +45,7 @@
 #include <SFML/Audio/SoundStream.hpp>
 #include <SFML/Audio/ReverbEffect.hpp>
 #include <SFML/Audio/ChorusEffect.hpp>
+#include <SFML/Audio/DelayEffect.hpp>
 
 #endif // SFML_AUDIO_HPP
 

--- a/include/SFML/Audio.hpp
+++ b/include/SFML/Audio.hpp
@@ -30,10 +30,13 @@
 ////////////////////////////////////////////////////////////
 
 #include <SFML/System.hpp>
+#include <SFML/Audio/ChorusEffect.hpp>
+#include <SFML/Audio/DelayEffect.hpp>
 #include <SFML/Audio/InputSoundFile.hpp>
 #include <SFML/Audio/Listener.hpp>
 #include <SFML/Audio/Music.hpp>
 #include <SFML/Audio/OutputSoundFile.hpp>
+#include <SFML/Audio/ReverbEffect.hpp>
 #include <SFML/Audio/Sound.hpp>
 #include <SFML/Audio/SoundBuffer.hpp>
 #include <SFML/Audio/SoundBufferRecorder.hpp>
@@ -43,9 +46,6 @@
 #include <SFML/Audio/SoundRecorder.hpp>
 #include <SFML/Audio/SoundSource.hpp>
 #include <SFML/Audio/SoundStream.hpp>
-#include <SFML/Audio/ReverbEffect.hpp>
-#include <SFML/Audio/ChorusEffect.hpp>
-#include <SFML/Audio/DelayEffect.hpp>
 
 #endif // SFML_AUDIO_HPP
 

--- a/include/SFML/Audio.hpp
+++ b/include/SFML/Audio.hpp
@@ -44,6 +44,7 @@
 #include <SFML/Audio/SoundSource.hpp>
 #include <SFML/Audio/SoundStream.hpp>
 #include <SFML/Audio/ReverbEffect.hpp>
+#include <SFML/Audio/ChorusEffect.hpp>
 
 #endif // SFML_AUDIO_HPP
 

--- a/include/SFML/Audio.hpp
+++ b/include/SFML/Audio.hpp
@@ -43,7 +43,7 @@
 #include <SFML/Audio/SoundRecorder.hpp>
 #include <SFML/Audio/SoundSource.hpp>
 #include <SFML/Audio/SoundStream.hpp>
-
+#include <SFML/Audio/ReverbEffect.hpp>
 
 #endif // SFML_AUDIO_HPP
 

--- a/include/SFML/Audio/ChorusEffect.hpp
+++ b/include/SFML/Audio/ChorusEffect.hpp
@@ -169,6 +169,16 @@ public:
     ////////////////////////////////////////////////////////////
     float getDelay() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    ChorusEffect& operator =(const ChorusEffect& right);
+
 private:
 
     Waveform m_waveform;

--- a/include/SFML/Audio/ChorusEffect.hpp
+++ b/include/SFML/Audio/ChorusEffect.hpp
@@ -210,6 +210,9 @@ private:
 /// This class implements a chorus effect which is used to create
 /// 'thicker' sounds by doubling the input via a small delay.
 ///
+/// Default parameter values and parameter limits are taken from
+/// the OpenAL specification: https://openal.org/documentation/
+/// 
 /// Usage example:
 /// \code
 /// //create an effect

--- a/include/SFML/Audio/ChorusEffect.hpp
+++ b/include/SFML/Audio/ChorusEffect.hpp
@@ -187,9 +187,6 @@ private:
     float m_depth;
     float m_feedback;
     float m_delay;
-
-    //handle to OpenAL effect returned by setType();
-    sf::Uint32 m_effect;
 };
 }
 

--- a/include/SFML/Audio/ChorusEffect.hpp
+++ b/include/SFML/Audio/ChorusEffect.hpp
@@ -1,0 +1,225 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2020 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#ifndef SFML_CHORUS_EFFECT_HPP
+#define SFML_CHORUS_EFFECT_HPP
+
+#include <SFML/Audio/SoundEffect.hpp>
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Implements a chorus sound effect
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API ChorusEffect : public SoundEffect
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ChorusEffect();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    ChorusEffect(const ChorusEffect& copy);
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Waveform enum
+    ///
+    /// \see setWaveform()
+    ////////////////////////////////////////////////////////////
+    enum Waveform
+    {
+        Sine,
+        Triangle
+    };
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current waveform value
+    ///
+    /// This property sets the waveform shape of the LFO that controls
+    /// the delay time of the delayed signals.
+    /// 
+    /// \param waveform new Waveform to set. Defaults to Waveform::Triangle
+    ////////////////////////////////////////////////////////////
+    void setWaveform(Waveform waveform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current phase value
+    ///
+    /// This property controls the phase difference between the left and
+    /// right LFOs. At zero degrees the two LFOs are synchronized. Use
+    /// this parameter to create the illusion of an expanded stereo field
+    /// of the output signal.
+    /// 
+    /// \param angle The angle of phase to set, between -180 to 180. Defaults to 90
+    ////////////////////////////////////////////////////////////
+    void setPhase(sf::Int32 angle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current rate value
+    ///
+    /// This property sets the modulation rate of the LFO that controls
+    /// the delay time of the delayed signals.
+    /// 
+    /// \param rate new rate to set in hz, between 0.f and 10.f. Defaults to 1.1f
+    ////////////////////////////////////////////////////////////
+    void setRate(float rate);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current depth value
+    ///
+    /// This property controls the amount by which the delay time is modulated by the LFO
+    /// 
+    /// \param depth new depth to set, between 0.f and 1.f. Defaults to 0.1f
+    ////////////////////////////////////////////////////////////
+    void setDepth(float depth);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current feedback value
+    ///
+    /// This property controls the amount of processed signal that is fed back to the
+    /// input of the chorus effect. Negative values will reverse the phase of the feedback
+    /// signal. At full magnitude the identical sample will repeat endlessly. At lower
+    /// magnitudes the sample will repeat and fade out over time. Use this parameter to
+    /// create a "cascading" chorus effect.
+    /// 
+    /// \param amount new feedback amount to set, between -1.f and 1.f. Defaults to 0.25f
+    ////////////////////////////////////////////////////////////
+    void setFeedback(float amount);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current delay value
+    ///
+    /// This property controls the average amount of time the sample is delayed before
+    /// it is played back, and with feedback, the amount of time between iterations of
+    /// the sample.Larger values lower the pitch. Smaller values make the chorus sound
+    /// like a flanger, but with different frequency characteristics.
+    /// 
+    /// \param delay new delay to set in second, between 0.f and 0.016f. Defaults to 0.016f
+    ////////////////////////////////////////////////////////////
+    void setDelay(float delay);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current waveform value
+    /// \see setWaveform()
+    ////////////////////////////////////////////////////////////
+    Waveform getWaveform() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current phase value
+    /// \see setPhase()
+    ////////////////////////////////////////////////////////////
+    sf::Int32 getPhase() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current rate value
+    /// \see setRate()
+    ////////////////////////////////////////////////////////////
+    float getRate() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current depth value
+    /// \see setDepth()
+    ////////////////////////////////////////////////////////////
+    float getDepth() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current feedback value
+    /// \see setFeedback()
+    ////////////////////////////////////////////////////////////
+    float getFeedback() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current delay value
+    /// \see setDelay()
+    ////////////////////////////////////////////////////////////
+    float getDelay() const;
+
+private:
+
+    Waveform m_waveform;
+    sf::Int32 m_phase;
+    float m_rate;
+    float m_depth;
+    float m_feedback;
+    float m_delay;
+
+    //handle to OpenAL effect returned by setType();
+    std::uint32_t m_effect;
+};
+}
+
+#endif //SFML_CHORUS_EFFECT_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::ChorusEffect
+/// \ingroup audio
+///
+/// Sound effect objects are applied to any SoundSource by
+/// creating an instance of that effect and then using
+/// sf::SoundSource::setEffect() to attach it. An effect
+/// may be applied to multiple SourceSources at the same time
+/// and to different types such as sf::Sound or sf::Music.
+/// However a SoundSource may be only attached to a single effect
+/// at any one time.
+/// Much like an sf::SoundBuffer which supplies audio data to
+/// an sf::Sound, an effect must be kept alive for at least as
+/// long as the SoundSource using it.
+///
+/// This class implements a chorus effect which is used to create
+/// 'thicker' sounds by doubling the input via a small delay.
+///
+/// Usage example:
+/// \code
+/// //create an effect
+/// sf::ChorusEffect chorus;
+/// chorus.setPhase(120);
+/// chorus.setFeedback(0.2f);
+///
+/// //load some music
+/// sf::Music music;
+/// if(music.loadFromFile("sound.ogg"))
+/// {
+///     //apply the effect to the music
+///     music.setEffect(&chorus);
+///     music.play();
+/// }
+/// \endcode
+/// 
+/// \see sf::SoundSource, sf::SoundEffect
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/ChorusEffect.hpp
+++ b/include/SFML/Audio/ChorusEffect.hpp
@@ -189,7 +189,7 @@ private:
     float m_delay;
 
     //handle to OpenAL effect returned by setType();
-    std::uint32_t m_effect;
+    sf::Uint32 m_effect;
 };
 }
 

--- a/include/SFML/Audio/DelayEffect.hpp
+++ b/include/SFML/Audio/DelayEffect.hpp
@@ -188,6 +188,9 @@ private:
 /// feedback is controllable. The delay is 'two tap' – you can control
 /// the interaction between two separate instances of echoes.
 ///
+/// Default parameter values and parameter limits are taken from
+/// the OpenAL specification: https://openal.org/documentation/
+/// 
 /// Usage example:
 /// \code
 /// //create an effect

--- a/include/SFML/Audio/DelayEffect.hpp
+++ b/include/SFML/Audio/DelayEffect.hpp
@@ -109,7 +109,7 @@ public:
     /// This property controls how hard panned the individual echoes are.
     /// With a value of 1.0, the first 'tap' will be panned hard left, and
     /// the second tap hard right. A value of –1.0 gives the opposite result.
-    /// Settings nearer to 0.0 result in less emphasized panning.
+    /// Settings nearer to 0.0 result in less emphasised panning.
     /// 
     /// \param spread The spread value to set, between -1.f and 1.f, Defaults to -1.0
     ////////////////////////////////////////////////////////////
@@ -145,6 +145,16 @@ public:
     /// \see setSpread()
     ////////////////////////////////////////////////////////////
     float getSpread() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    DelayEffect& operator =(const DelayEffect& right);
 
 private:
 

--- a/include/SFML/Audio/DelayEffect.hpp
+++ b/include/SFML/Audio/DelayEffect.hpp
@@ -165,7 +165,7 @@ private:
     float m_spread;
 
     //OpenAL handle returned by setType()
-    std::uint32_t m_effect;
+    sf::Uint32 m_effect;
 };
 }
 

--- a/include/SFML/Audio/DelayEffect.hpp
+++ b/include/SFML/Audio/DelayEffect.hpp
@@ -163,9 +163,6 @@ private:
     float m_damping;
     float m_feedback;
     float m_spread;
-
-    //OpenAL handle returned by setType()
-    sf::Uint32 m_effect;
 };
 }
 

--- a/include/SFML/Audio/DelayEffect.hpp
+++ b/include/SFML/Audio/DelayEffect.hpp
@@ -25,18 +25,19 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#ifndef SFML_CHORUS_EFFECT_HPP
-#define SFML_CHORUS_EFFECT_HPP
+
+#ifndef SFML_DELAY_EFFECT_HPP
+#define SFML_DELAY_EFFECT_HPP
 
 #include <SFML/Audio/SoundEffect.hpp>
 
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-/// \brief Implements a chorus sound effect
+/// \brief Implements a delay sound effect
 ///
 ////////////////////////////////////////////////////////////
-class SFML_AUDIO_API ChorusEffect : public SoundEffect
+class SFML_AUDIO_API DelayEffect : public SoundEffect
 {
 public:
 
@@ -44,7 +45,7 @@ public:
     /// \brief Default constructor
     ///
     ////////////////////////////////////////////////////////////
-    ChorusEffect();
+    DelayEffect();
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
@@ -52,110 +53,86 @@ public:
     /// \param copy Instance to copy
     ///
     ////////////////////////////////////////////////////////////
-    ChorusEffect(const ChorusEffect& copy);
-
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Waveform enum
-    ///
-    /// \see setWaveform()
-    ////////////////////////////////////////////////////////////
-    enum Waveform
-    {
-        Sine,
-        Triangle
-    };
-
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the current waveform value
-    ///
-    /// This property sets the waveform shape of the LFO that controls
-    /// the delay time of the delayed signals.
-    /// 
-    /// \param waveform new Waveform to set. Defaults to Waveform::Triangle
-    ////////////////////////////////////////////////////////////
-    void setWaveform(Waveform waveform);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the current phase value
-    ///
-    /// This property controls the phase difference between the left and
-    /// right LFOs. At zero degrees the two LFOs are synchronized. Use
-    /// this parameter to create the illusion of an expanded stereo field
-    /// of the output signal.
-    /// 
-    /// \param angle The angle of phase to set, between -180 and 180. Defaults to 90
-    ////////////////////////////////////////////////////////////
-    void setPhase(sf::Int32 angle);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the current rate value
-    ///
-    /// This property sets the modulation rate of the LFO that controls
-    /// the delay time of the delayed signals.
-    /// 
-    /// \param rate new rate to set in hz, between 0.f and 10.f. Defaults to 1.1f
-    ////////////////////////////////////////////////////////////
-    void setRate(float rate);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the current depth value
-    ///
-    /// This property controls the amount by which the delay time is modulated by the LFO
-    /// 
-    /// \param depth new depth to set, between 0.f and 1.f. Defaults to 0.1f
-    ////////////////////////////////////////////////////////////
-    void setDepth(float depth);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the current feedback value
-    ///
-    /// This property controls the amount of processed signal that is fed back to the
-    /// input of the chorus effect. Negative values will reverse the phase of the feedback
-    /// signal. At full magnitude the identical sample will repeat endlessly. At lower
-    /// magnitudes the sample will repeat and fade out over time. Use this parameter to
-    /// create a "cascading" chorus effect.
-    /// 
-    /// \param amount new feedback amount to set, between -1.f and 1.f. Defaults to 0.25f
-    ////////////////////////////////////////////////////////////
-    void setFeedback(float amount);
+    DelayEffect(const DelayEffect& copy);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the current delay value
     ///
-    /// This property controls the average amount of time the sample is delayed before
-    /// it is played back, and with feedback, the amount of time between iterations of
-    /// the sample.Larger values lower the pitch. Smaller values make the chorus sound
-    /// like a flanger, but with different frequency characteristics.
+    /// This property controls the delay between the original sound
+    /// and the first 'tap', or echo instance. Subsequently, the
+    /// value for Delay is used to determine the time delay
+    /// between each 'second tap' and the next 'first tap'.
     /// 
-    /// \param delay new delay to set in second, between 0.f and 0.016f. Defaults to 0.016f
+    /// \param delay The delay in seconds to set, between 0.f and 0.207f, Defaults to 0.1
     ////////////////////////////////////////////////////////////
     void setDelay(float delay);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Returns the current waveform value
-    /// \see setWaveform()
+    /// \brief Set the current LR delay value
+    ///
+    /// This property controls the delay between the first 'tap' and
+    /// the second 'tap'. Subsequently, the value for Echo LR Delay
+    /// is used to determine the time delay between each 'first tap'
+    /// and the next 'second tap'.
+    /// 
+    /// \param delay The LR delay in seconds to set, between 0.f and 0.404f, Defaults to 0.1
     ////////////////////////////////////////////////////////////
-    Waveform getWaveform() const;
+    void setLRDelay(float delay);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Returns the current phase value
-    /// \see setPhase()
+    /// \brief Set the current damping value
+    ///
+    /// This property controls the amount of high frequency damping
+    /// applied to each echo. As the sound is subsequently fed back
+    /// for further echoes, damping results in an echo which progressively
+    /// gets softer in tone as well as intensity.
+    /// 
+    /// \param damping The damping value to set, between 0.f and 0.99f, Defaults to 0.5
     ////////////////////////////////////////////////////////////
-    sf::Int32 getPhase() const;
+    void setDamping(float damping);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Returns the current rate value
-    /// \see setRate()
+    /// \brief Set the current feedback value
+    ///
+    /// This property controls the amount of feedback the output signal
+    /// fed back into the input. Use this parameter to create "cascading"
+    /// echoes. At full magnitude, the identical sample will repeat endlessly.
+    /// Below full magnitude, the sample will repeat and fade.
+    /// 
+    /// \param feedback The feedback value to set, between 0.f and 1.f, Defaults to 0.5
     ////////////////////////////////////////////////////////////
-    float getRate() const;
+    void setFeedback(float feedback);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Returns the current depth value
-    /// \see setDepth()
+    /// \brief Set the current spread value
+    ///
+    /// This property controls how hard panned the individual echoes are.
+    /// With a value of 1.0, the first 'tap' will be panned hard left, and
+    /// the second tap hard right. A value of –1.0 gives the opposite result.
+    /// Settings nearer to 0.0 result in less emphasized panning.
+    /// 
+    /// \param spread The spread value to set, between -1.f and 1.f, Defaults to -1.0
     ////////////////////////////////////////////////////////////
-    float getDepth() const;
+    void setSpread(float spread);
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current delay value
+    /// \see setDelay()
+    ////////////////////////////////////////////////////////////
+    float getDelay() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current LRDelay value
+    /// \see setLRDelay()
+    ////////////////////////////////////////////////////////////
+    float getLRDelay() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current damping value
+    /// \see setDamping()
+    ////////////////////////////////////////////////////////////
+    float getDamping() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Returns the current feedback value
@@ -164,29 +141,28 @@ public:
     float getFeedback() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Returns the current delay value
-    /// \see setDelay()
+    /// \brief Returns the current spread value
+    /// \see setSpread()
     ////////////////////////////////////////////////////////////
-    float getDelay() const;
+    float getSpread() const;
 
 private:
 
-    Waveform m_waveform;
-    sf::Int32 m_phase;
-    float m_rate;
-    float m_depth;
-    float m_feedback;
     float m_delay;
+    float m_LRDelay;
+    float m_damping;
+    float m_feedback;
+    float m_spread;
 
-    //handle to OpenAL effect returned by setType();
+    //OpenAL handle returned by setType()
     std::uint32_t m_effect;
 };
 }
 
-#endif //SFML_CHORUS_EFFECT_HPP
+#endif //SFML_DELAY_EFFECT_HPP
 
 ////////////////////////////////////////////////////////////
-/// \class sf::ChorusEffect
+/// \class sf::DelayEffect
 /// \ingroup audio
 ///
 /// Sound effect objects are applied to any SoundSource by
@@ -200,22 +176,24 @@ private:
 /// an sf::Sound, an effect must be kept alive for at least as
 /// long as the SoundSource using it.
 ///
-/// This class implements a chorus effect which is used to create
-/// 'thicker' sounds by doubling the input via a small delay.
+/// This class implements a delay effect which generates discrete,
+/// delayed instances of the input signal. The amount of delay and
+/// feedback is controllable. The delay is 'two tap' – you can control
+/// the interaction between two separate instances of echoes.
 ///
 /// Usage example:
 /// \code
 /// //create an effect
-/// sf::ChorusEffect chorus;
-/// chorus.setPhase(120);
-/// chorus.setFeedback(0.2f);
+/// sf::DelayEffect delay;
+/// delay.setDelay(0.2f);
+/// delay.setFeedback(0.2f);
 ///
 /// //load some music
 /// sf::Music music;
 /// if(music.loadFromFile("sound.ogg"))
 /// {
 ///     //apply the effect to the music
-///     music.setEffect(&chorus);
+///     music.setEffect(&delay);
 ///     music.play();
 /// }
 /// \endcode

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -247,6 +247,16 @@ public:
     ////////////////////////////////////////////////////////////
     float getRoomRolloff() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    ReverbEffect& operator =(const ReverbEffect& right);
+
 private:
     float m_density;
     float m_diffusion;

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -1,69 +1,313 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2020 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
 #ifndef SFML_REVERB_EFFECT_HPP
 #define SFML_REVERB_EFFECT_HPP
 
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
 #include <SFML/Audio/SoundEffect.hpp>
 
 namespace sf
 {
-    class SFML_AUDIO_API ReverbEffect final : public SoundEffect
-    {
-    public:
-        ReverbEffect();
-        ReverbEffect(const ReverbEffect& copy);
 
-        //0-1
-        void setDensity(float density);
+////////////////////////////////////////////////////////////
+/// \brief Implements a reverb sound effect
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API ReverbEffect final : public SoundEffect
+{
+public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ReverbEffect();
 
-        //0-1
-        void setDiffusion(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    ReverbEffect(const ReverbEffect& copy);
 
-        //0-1
-        void setGain(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current density value
+    ///
+    /// Reverb Modal Density controls the coloration of the late reverb.
+    /// Lowering the value adds more coloration to the late reverb.
+    /// 
+    /// \param density new value to set between 0.f and 1.f. Defaults to 1.f
+    ////////////////////////////////////////////////////////////
+    void setDensity(float density);
 
-        //0.1 - 20 (seconds)
-        void setDecayTime(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current diffusion value
+    ///
+    /// The Reverb Diffusion property controls the echo density in
+    /// the reverberation decay. It's set by default to 1.0, which
+    /// provides the highest density.Reducing diffusion gives the
+    /// reverberation a more 'grainy' character that is especially
+    /// noticeable with percussive sound sources. If you set a
+    /// diffusion value of 0.0, the later reverberation sounds like
+    /// a succession of distinct echoes.
+    /// 
+    /// \param diffusion new value to set between 0.f and 1.f. Defaults to 1.f
+    ////////////////////////////////////////////////////////////
+    void setDiffusion(float diffusion);
 
-        //0-1
-        void setReflectionGain(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current gain value
+    ///
+    /// The Reverb Gain property is the master volume control for
+    /// the reflected sound (both early reflections and reverberation)
+    /// that the reverb effect adds to all sound sources. It sets the
+    /// maximum amount of reflections and reverberation added to the
+    /// final sound mix. The value of the Reverb Gain property ranges
+    /// from 1.0 (0db) (the maximum amount) to 0.0 (-100db)
+    /// (no reflected sound at all).
+    /// 
+    /// \param gain new value to set between 0.f and 1.f. Defaults to 0.32f
+    ////////////////////////////////////////////////////////////
+    void setGain(float gain);
 
-        //0-0.3
-        void setReflectionDelay(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current decay value
+    ///
+    /// The Decay Time property sets the reverberation decay time.
+    /// It ranges from 0.1 (typically a small room with very dead
+    /// surfaces) to 20.0 (typically a large room with very live surfaces).
+    /// 
+    /// \param decay new value to set between 0.1f and 20.f seconds. Defaults to 1.49f
+    ////////////////////////////////////////////////////////////
+    void setDecayTime(float decay);
 
-        //0-1
-        void setLateReverbGain(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current reflection gain value
+    ///
+    /// The Reflections Gain property controls the overall amount
+    /// of initial reflections relative to the Gain property.
+    /// (The Gain property sets the overall amount of reflected
+    /// sound : both initial reflections and later reverberation.)
+    /// The value of Reflections Gain ranges from a maximum of
+    /// 3.16 (+10 dB) to a minimum of 0.0 (-100 dB) (no initial
+    /// reflections at all), and is corrected by the value of the
+    /// Gain property.The Reflections Gain property does not affect
+    /// the subsequent reverberation decay.
+    ///
+    /// You can increase the amount of initial reflections to simulate
+    /// a more narrow space or closer walls, especially effective if
+    /// you associate the initial reflections increase with a reduction
+    /// in reflections delays by lowering the value of the Reflection
+    /// Delay property.To simulate open or semi - open environments,
+    /// you can maintain the amount of early reflections while reducing
+    /// the value of the Late Reverb Gain property, which controls later
+    /// reflections.
+    /// 
+    /// \param gain new value to set between 0.f and 1.f. Defaults to 0.05f
+    ////////////////////////////////////////////////////////////
+    void setReflectionGain(float gain);
 
-        //0-0.1
-        void setLateReverbDelay(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current reflection delay value
+    ///
+    /// The Reflections Delay property is the amount of delay
+    /// between the arrival time of the direct path from the source
+    /// to the first reflection from the source.It ranges from 0 to
+    /// 300 milliseconds.You can reduce or increase Reflections Delay
+    /// to simulate closer or more distant reflective surfaces — and
+    /// therefore control the perceived size of the room.
+    /// 
+    /// \param delay new value to set between 0.f and 0.3f. Defaults to 0.007f
+    ////////////////////////////////////////////////////////////
+    void setReflectionDelay(float delay);
 
-        //0-10
-        void setRoomRolloff(float);
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current late reverb delay value
+    ///
+    /// The Late Reverb Gain property controls the overall amount
+    /// of later reverberation relative to the Gain property.
+    /// (The Gain property sets the overall amount of both initial
+    /// reflectionsand later reverberation.) The value of Late Reverb
+    /// Gain ranges from a maximum of 10.0 (+20 dB) to a minimum of
+    /// 0.0 (-100 dB) (no late reverberation at all). Note that Late
+    /// Reverb Gain and Decay Time are independent properties :
+    /// If you adjust Decay Time without changing Late Reverb Gain,
+    /// the total intensity(the averaged square of the amplitude)
+    /// of the late reverberation remains constant.
+    /// 
+    /// \param delay new value to set between 0.f and 10.f. Defaults to 1.26f
+    ////////////////////////////////////////////////////////////
+    void setLateReverbGain(float delay);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current late reverb delay value
+    ///
+    /// The Late Reverb Delay property defines the begin time of the
+    /// late reverberation relative to the time of the initial
+    /// reflection(the first of the early reflections).It ranges from
+    /// 0 to 100 milliseconds. Reducing or increasing Late Reverb Delay
+    /// is useful for simulating a smaller or larger room.
+    /// 
+    /// \param delay new value to set between 0.f and 0.1f. Defaults to 0.011f
+    ////////////////////////////////////////////////////////////
+    void setLateReverbDelay(float delay);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current room rolloff value
+    ///
+    /// The Room Rolloff Factor property is one of two methods available
+    /// to attenuate the reflected sound (containing both reflections and
+    /// reverberation) according to source - listener distance. It's defined
+    /// the same way as sf::SoundSource's Attenuation Factor, but operates
+    /// on reverb sound instead of direct - path sound. Setting the Room
+    /// Rolloff Factor value to 1.0 specifies that the reflected sound will
+    /// decay by 6 dB every time the distance doubles. Any value other than
+    /// 1.0 is equivalent to a scaling factor.
+    /// 
+    /// \param rolloff new value to set between 0.f and 10.f. Defaults to 0.f
+    ////////////////////////////////////////////////////////////
+    void setRoomRolloff(float rolloff);
 
 
-        float getDensity() const;
-        float getDiffusion() const;
-        float getGain() const;
-        float getDecayTime() const;
-        float getReflectionGain() const;
-        float getReflectionDelay() const;
-        float getLateReverbGain() const;
-        float getLateReverbDelay() const;
-        float getRoomRolloff() const;
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current density value
+    /// \see setDensity()
+    ////////////////////////////////////////////////////////////
+    float getDensity() const;
 
-    private:
-        float m_density;
-        float m_diffusion;
-        float m_gain;
-        float m_decayTime;
-        float m_reflectionGain;
-        float m_reflectionDelay;
-        float m_lateReverbGain;
-        float m_lateReverbDelay;
-        float m_roomRolloff;
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current diffusion value
+    /// \see setDiffusion()
+    ////////////////////////////////////////////////////////////
+    float getDiffusion() const;
 
-        //OpenAL handle if setType() is successful
-        std::uint32_t m_effect; 
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current gain value
+    /// \see setGain()
+    ////////////////////////////////////////////////////////////
+    float getGain() const;
 
-        void applyParameterNames();
-    };
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current decay time value
+    /// \see setDecayTime()
+    ////////////////////////////////////////////////////////////
+    float getDecayTime() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current reflection gain value
+    /// \see setReflectionGain()
+    ////////////////////////////////////////////////////////////
+    float getReflectionGain() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current reflection delay value
+    /// \see setReflectionDelay()
+    ////////////////////////////////////////////////////////////
+    float getReflectionDelay() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current late reverb gain value
+    /// \see setLateReverbGain()
+    ////////////////////////////////////////////////////////////
+    float getLateReverbGain() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current late reverb delay value
+    /// \see setLateReverbDelay()
+    ////////////////////////////////////////////////////////////
+    float getLateReverbDelay() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current room rolloff value
+    /// \see setRoomRolloff()
+    ////////////////////////////////////////////////////////////
+    float getRoomRolloff() const;
+
+private:
+    float m_density;
+    float m_diffusion;
+    float m_gain;
+    float m_decayTime;
+    float m_reflectionGain;
+    float m_reflectionDelay;
+    float m_lateReverbGain;
+    float m_lateReverbDelay;
+    float m_roomRolloff;
+
+    //OpenAL handle if setType() is successful
+    std::uint32_t m_effect; 
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Used to apply the correct paramter names depending
+    /// on whether the currnt system supports EAX or regular reverb
+    ////////////////////////////////////////////////////////////
+    void applyParameterNames();
+};
 }
 #endif //SFML_REVERB_EFFECT_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::ReverbEffect
+/// \ingroup audio
+///
+/// Sound effect objects are applied to any SoundSource by
+/// creating an instance of that effect and then using
+/// sf::SoundSource::setEffect() to attach it. An effect
+/// may be applied to multiple SourceSources at the same time
+/// and of different types such as sf::Sound or sf::Music.
+/// However a SoundSource may be only attached to a single effect
+/// at any one time.
+/// Much like an sf::SoundBuffer which supplies audio data to
+/// an sf::Sound, an effect must be kept alived for at least as
+/// long as the SoundSource using it. Potentially reverb (and
+/// other delay effects) will need to be kept alive longer
+/// else the trailing audio effect (the audible 'echo') will be
+/// cut short once an effect object is destroyed.
+///
+/// This class implements a reverb effect which is used to create
+/// echo-like sounds such as being in a cave, cathedral or, more
+/// subtly, in a small dense room.
+///
+/// Usage example:
+/// \code
+/// //create an effect
+/// sf::ReverbEffect reverb;
+/// reverb.setDecayTime(12.f);
+/// reverb.setDensity(0.2f);
+///
+/// //load some music
+/// sf::Music music;
+/// if(music.loadFromFile("sound.ogg"))
+/// {
+///     //apply the effect to the music
+///     music.setEffect(&reverb);
+///     music.play();
+/// }
+/// 
+/// \see sf::SoundSource, sf::SoundEffect
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -295,10 +295,14 @@ private:
 /// other delay type effects) will need to be kept alive longer
 /// else the trailing audio effect (the audible 'echo') will be
 /// cut short once an effect object is destroyed.
-///
+/// 
 /// This class implements a reverb effect which is used to create
 /// echo-like sounds such as being in a cave, cathedral or, more
-/// subtly, in a small dense room.
+/// subtly, in a small dense room.///
+///
+/// Default parameter values and parameter limits are taken from
+/// the OpenAL specification: https://openal.org/documentation/
+/// 
 ///
 /// Usage example:
 /// \code

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -272,8 +272,8 @@ private:
     std::uint32_t m_effect; 
 
     ////////////////////////////////////////////////////////////
-    /// \brief Used to apply the correct paramter names depending
-    /// on whether the currnt system supports EAX or regular reverb
+    /// \brief Used to apply the correct parameter names depending
+    /// on whether the current system supports EAX or regular reverb
     ////////////////////////////////////////////////////////////
     void applyParameterNames();
 };

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -37,7 +37,7 @@ namespace sf
 /// \brief Implements a reverb sound effect
 ///
 ////////////////////////////////////////////////////////////
-class SFML_AUDIO_API ReverbEffect final : public SoundEffect
+class SFML_AUDIO_API ReverbEffect : public SoundEffect
 {
 public:
     ////////////////////////////////////////////////////////////
@@ -278,13 +278,13 @@ private:
 /// creating an instance of that effect and then using
 /// sf::SoundSource::setEffect() to attach it. An effect
 /// may be applied to multiple SourceSources at the same time
-/// and of different types such as sf::Sound or sf::Music.
+/// and to different types such as sf::Sound or sf::Music.
 /// However a SoundSource may be only attached to a single effect
 /// at any one time.
 /// Much like an sf::SoundBuffer which supplies audio data to
-/// an sf::Sound, an effect must be kept alived for at least as
+/// an sf::Sound, an effect must be kept alive for at least as
 /// long as the SoundSource using it. Potentially reverb (and
-/// other delay effects) will need to be kept alive longer
+/// other delay type effects) will need to be kept alive longer
 /// else the trailing audio effect (the audible 'echo') will be
 /// cut short once an effect object is destroyed.
 ///
@@ -307,6 +307,8 @@ private:
 ///     music.setEffect(&reverb);
 ///     music.play();
 /// }
+///
+/// \endcode
 /// 
 /// \see sf::SoundSource, sf::SoundEffect
 ///

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -269,7 +269,7 @@ private:
     float m_roomRolloff;
 
     //OpenAL handle if setType() is successful
-    std::uint32_t m_effect; 
+    sf::Uint32 m_effect; 
 
     ////////////////////////////////////////////////////////////
     /// \brief Used to apply the correct parameter names depending

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <SFML/Audio/SoundEffect.hpp>
+
+namespace sf
+{
+    class SFML_AUDIO_API ReverbEffect final : public SoundEffect
+    {
+    public:
+        ReverbEffect();
+        ReverbEffect(const ReverbEffect& copy);
+
+        //0-1
+        void setDensity(float density);
+
+        //0-1
+        void setDiffusion(float);
+
+        //0-1
+        void setGain(float);
+
+        //0.1 - 20 (seconds)
+        void setDecayTime(float);
+
+        //0-1
+        void setReflectionGain(float);
+
+        //0-0.3
+        void setReflectionDelay(float);
+
+        //0-1
+        void setLateReverbGain(float);
+
+        //0-0.1
+        void setLateReverbDelay(float);
+
+        //0-10
+        void setRoomRolloff(float);
+
+
+        float getDensity() const;
+        float getDiffusion() const;
+        float getGain() const;
+        float getDecayTime() const;
+        float getReflectionGain() const;
+        float getReflectionDelay() const;
+        float getLateReverbGain() const;
+        float getLateReverbDelay() const;
+        float getRoomRolloff() const;
+
+    private:
+        float m_density;
+        float m_diffusion;
+        float m_gain;
+        float m_decayTime;
+        float m_reflectionGain;
+        float m_reflectionDelay;
+        float m_lateReverbGain;
+        float m_lateReverbDelay;
+        float m_roomRolloff;
+
+        //OpenAL handle if setType() is successful
+        std::uint32_t m_effect; 
+
+        void applyParameterNames();
+    };
+}

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -268,8 +268,6 @@ private:
     float m_lateReverbDelay;
     float m_roomRolloff;
 
-    //OpenAL handle if setType() is successful
-    sf::Uint32 m_effect; 
 
     ////////////////////////////////////////////////////////////
     /// \brief Used to apply the correct parameter names depending

--- a/include/SFML/Audio/ReverbEffect.hpp
+++ b/include/SFML/Audio/ReverbEffect.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef SFML_REVERB_EFFECT_HPP
+#define SFML_REVERB_EFFECT_HPP
 
 #include <SFML/Audio/SoundEffect.hpp>
 
@@ -65,3 +66,4 @@ namespace sf
         void applyParameterNames();
     };
 }
+#endif //SFML_REVERB_EFFECT_HPP

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -137,6 +137,16 @@ protected:
     ////////////////////////////////////////////////////////////
     virtual ~SoundEffect();
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundEffect& operator =(const SoundEffect& right);
+
 private:
     friend class SoundSource;
 

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -51,27 +51,6 @@ public:
     static bool isAvailable();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Used to determine which type of effect has been implemented
-    ///
-    /// Generally not useful for classes outside of those which implement
-    /// a specific type of effect.
-    /// 
-    ////////////////////////////////////////////////////////////
-    enum Type
-    {
-        Null,
-        Reverb,
-        Chorus,
-        Delay
-    };
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Returns the type of effect implemented
-    ///
-    ////////////////////////////////////////////////////////////
-    Type getType() const;
-
-    ////////////////////////////////////////////////////////////
     /// \brief Sets the volume for this effect
     ///
     /// The volume is in the range 0 - 1, multiplying the output volume
@@ -92,34 +71,15 @@ public:
 protected:
 
     ////////////////////////////////////////////////////////////
-    /// \brief Sets the type of effect this will be
-    ///
-    /// When implementing a specific effect type this sould be called on effect
-    /// creation so that the underlying effects object is properly configured
-    ///
-    /// \returns A handle to the OpenAL effects object. This can be used by
-    /// effects classes to modify specific effects properties.
-    ///
-    ////////////////////////////////////////////////////////////
-    sf::Uint32 setType(Type type);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Reapplies any effects parameters.
-    ///
-    /// When a derived class updates any effects parameters this must be called
-    /// so that the new paramter values take effect.
-    ///
-    ////////////////////////////////////////////////////////////
-    void applyEffect();
-
-
-    ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
     /// Protected so that it may only be called by derived classes
     ///
+    /// \param alEffectType AL_EFFECT_X enum type to declare which effect
+    /// should be used.
+    ///
     ////////////////////////////////////////////////////////////
-    SoundEffect();
+    explicit SoundEffect(int alEffectType);
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
@@ -136,6 +96,28 @@ protected:
     ///
     ////////////////////////////////////////////////////////////
     virtual ~SoundEffect();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets an effect parameter
+    ///
+    /// \param parameter AL_EFFECTNAME_PARAM enum declaraing
+    /// parameter name to be set
+    ///
+    /// \param value Value to set the parameter to
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(int parameter, float value);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets an effect parameter
+    ///
+    /// \param parameter AL_EFFECTNAME_PARAM enum declaraing
+    /// parameter name to be set
+    ///
+    /// \param value Value to set the parameter to
+    ///
+    ////////////////////////////////////////////////////////////
+    void setParameter(int parameter, int value);
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
@@ -168,12 +150,12 @@ private:
 
     sf::Uint32 m_effectSlot;    //!< OpenAL Effects slot handle
     sf::Uint32 m_effect;        //!< OpenAL Effect handle assigned to this slot
+    int m_type;                 //!< OpenAL Effect type used to track reference counting
 
-    Type m_type;                //!< Type of effect assigned to this slot
     float m_volume;             //!< Current volume of this slot
 
     mutable std::set<SoundSource*> m_soundlist; //!< List of SoundSources using this effect
-    void ensureEffect(Type);    //!< Used to ensure that there is only one instance of OpenAL effect object for each type
+    void ensureEffect(int);    //!< Used to ensure that there is only one instance of OpenAL effect object for each type
 };
 }
 
@@ -185,17 +167,10 @@ private:
 ///
 /// Base class for creating OpenAL sound effects. This class is
 /// used to wrap an OpenAL EffectsSlot and assign an Effect object
-/// to it. It is up to derived classes to implemented specific
-/// effect types, the interface for adjusting paramters for that
-/// effect, and making sure that this class knows which effect is
-/// being implemented.
+/// to it. It is up to derived classes to implemented the interface
+/// for adjusting parameters a specific effect type.
 ///
-/// This is done by the derived class calling setType() with a
-/// given type defined in the SoundEffect::Type enumeration. This
-/// class will then return a handle to an effect object of that type
-/// if it is successful, else 0 if the type requested was invalid
-/// or could not be created for some reason.
 /// 
-/// \see sf::ReverbEffect
+/// \see sf::ReverbEffect, sf::ChorusEffect, sf::DelayEffect
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -148,14 +148,14 @@ private:
     ////////////////////////////////////////////////////////////
     void detachSoundSource(SoundSource* source) const;
 
-    sf::Uint32 m_effectSlot;    //!< OpenAL Effects slot handle
-    sf::Uint32 m_effect;        //!< OpenAL Effect handle assigned to this slot
-    int m_type;                 //!< OpenAL Effect type used to track reference counting
+    sf::Uint32 m_effectSlot;                    //!< OpenAL Effects slot handle
+    sf::Uint32 m_effect;                        //!< OpenAL Effect handle assigned to this slot
+    int m_type;                                 //!< OpenAL Effect type used to track reference counting
 
-    float m_volume;             //!< Current volume of this slot
+    float m_volume;                             //!< Current volume of this slot
 
     mutable std::set<SoundSource*> m_soundlist; //!< List of SoundSources using this effect
-    void ensureEffect(int);    //!< Used to ensure that there is only one instance of OpenAL effect object for each type
+    void ensureEffect(int type);                //!< Used to ensure that there is only one instance of OpenAL effect object for each type
 };
 }
 

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/AlResource.hpp>
+
+#include <set>
+
+namespace sf
+{
+    class SoundSource;
+
+    class SFML_AUDIO_API SoundEffect : AlResource
+    {
+    public:
+
+        //returns true if effects are available on this platform
+        static bool isAvailable();
+
+        enum Type
+        {
+            Null,
+            Reverb,
+            Chorus
+        };
+
+        Type getType() const;
+
+        //range 0 - 1
+        void setVolume(float volume);
+
+        float getVolume() const;
+
+    protected:
+        //used by concrete types to define what type of effect this
+        //will be. Those types are responsible for exposing effect
+        //specific interfaces for updating properties. Returns the effect handle
+        std::uint32_t setType(Type type);
+
+        //reapplies the effect on this slot after the paramters were changed
+        void applyEffect();
+
+        SoundEffect();
+        SoundEffect(const SoundEffect& copy);
+
+        virtual ~SoundEffect();
+
+    private:
+        friend class SoundSource;
+
+        //allows tracking of sound sources using this effect
+        void attachSoundSource(SoundSource* source) const;
+        void detachSoundSource(SoundSource* source) const;
+
+        std::uint32_t m_effectSlot;
+        std::uint32_t m_effect;
+
+        Type m_type;
+        float m_volume;
+
+        mutable std::set<SoundSource*> m_soundlist;
+    };
+}

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -1,67 +1,191 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2020 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
 #ifndef SFML_SOUNDEFFECT_HPP
 #define SFML_SOUNDEFFECT_HPP
 
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
 #include <SFML/Audio/Export.hpp>
 #include <SFML/Audio/AlResource.hpp>
-
 #include <set>
 #include <cstdint>
 
 namespace sf
 {
-    class SoundSource;
+class SoundSource;
 
-    class SFML_AUDIO_API SoundEffect : AlResource
+////////////////////////////////////////////////////////////
+/// \brief Base class for implementing audio effects
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundEffect : AlResource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns true if audio effects are available on the current platform
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isAvailable();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Used to determine which type of effect has been implemented
+    ///
+    /// Generally not useful for classes outside of those which implement
+    /// a specific type of effect.
+    /// 
+    ////////////////////////////////////////////////////////////
+    enum Type
     {
-    public:
-
-        //returns true if effects are available on this platform
-        static bool isAvailable();
-
-        enum Type
-        {
-            Null,
-            Reverb,
-            Chorus
-        };
-
-        Type getType() const;
-
-        //range 0 - 1
-        void setVolume(float volume);
-
-        float getVolume() const;
-
-    protected:
-        //used by concrete types to define what type of effect this
-        //will be. Those types are responsible for exposing effect
-        //specific interfaces for updating properties. Returns the effect handle
-        std::uint32_t setType(Type type);
-
-        //reapplies the effect on this slot after the parameters were changed
-        void applyEffect();
-
-        SoundEffect();
-        SoundEffect(const SoundEffect& copy);
-
-        virtual ~SoundEffect();
-
-    private:
-        friend class SoundSource;
-
-        //allows tracking of sound sources using this effect
-        void attachSoundSource(SoundSource* source) const;
-        void detachSoundSource(SoundSource* source) const;
-
-        std::uint32_t m_effectSlot;
-        std::uint32_t m_effect;
-
-        Type m_type;
-        float m_volume;
-
-        mutable std::set<SoundSource*> m_soundlist;
-        void ensureEffect(Type);
+        Null,
+        Reverb,
+        Chorus
     };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the type of effect implemented
+    ///
+    ////////////////////////////////////////////////////////////
+    Type getType() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets the volume for this effect
+    ///
+    /// The volume is in the range 0 - 1, multiplying the output volume
+    /// of any SoundSource which uses this effect. A value of 0 will
+    /// effectively mute all sounds that have this effect applied
+    ///
+    /// \param volume Floating point value automatically clamped between 0 and 1
+    ///
+    ////////////////////////////////////////////////////////////
+    void setVolume(float volume);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns the current volume of this effect
+    ///
+    ////////////////////////////////////////////////////////////
+    float getVolume() const;
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets the type of effect this will be
+    ///
+    /// When implemwnting a specific effect type this sould be called on effect
+    /// creation so that the underlying effects object is properly configured
+    ///
+    /// \returns A handle to the OpenAL effects object. This can be used by
+    /// effects classes to modify specific effects properties.
+    ///
+    ////////////////////////////////////////////////////////////
+    std::uint32_t setType(Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Reapplies any effects parameters.
+    ///
+    /// When a derived class updates any effects parameters this must be called
+    /// so that the new paramter values take effect.
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyEffect();
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Protected so that it may only be called by derived classes
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundEffect();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// Protected so that it may only be called by derived classes
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundEffect(const SoundEffect& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~SoundEffect();
+
+private:
+    friend class SoundSource;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Add a sound to the list of sounds that use this effect
+    ///
+    /// \param sound SoundSource instance to attach
+    ///
+    ////////////////////////////////////////////////////////////
+    void attachSoundSource(SoundSource* source) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Remove a sound from the list of sounds that use this effect
+    ///
+    /// \param sound SoundSource instance to detach
+    ///
+    ////////////////////////////////////////////////////////////
+    void detachSoundSource(SoundSource* source) const;
+
+    std::uint32_t m_effectSlot; //!< OpenAL Effects slot handle
+    std::uint32_t m_effect;     //!< OpenAL Effect handle assigned to this slot
+
+    Type m_type;                //!< Type of effect assigned to this slot
+    float m_volume;             //!< Current volume of this slot
+
+    mutable std::set<SoundSource*> m_soundlist; //!< List of SoundSources using this effect
+    void ensureEffect(Type);    //!< Used to ensure that there is only one instance of OpenAL effect object for each type
+};
 }
 
 #endif // SFML_SOUNDEFFECT_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundEffect
+/// \ingroup audio
+///
+/// Base class for creating OpenAL sound effects. This class is
+/// used to wrap an OpenAL EffectsSlot and assign an Effect object
+/// to it. It is up to derived classes to implemented specific
+/// effect types, the interface for adjusting paramters for that
+/// effect, and making sure that this class knows which effect is
+/// being implemented.
+///
+/// This is done by the derived class calling setType() with a
+/// given type defined in the SoundEffect::Type enumeration. This
+/// class will then return a handle to an effect object of that type
+/// if it is successful, else 0 if the type requested was invalid
+/// or could not be created for some reason.
+/// 
+/// \see sf::ReverbEffect
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -31,7 +31,6 @@
 #include <SFML/Audio/Export.hpp>
 #include <SFML/Audio/AlResource.hpp>
 #include <set>
-#include <cstdint>
 
 namespace sf
 {
@@ -102,7 +101,7 @@ protected:
     /// effects classes to modify specific effects properties.
     ///
     ////////////////////////////////////////////////////////////
-    std::uint32_t setType(Type type);
+    sf::Uint32 setType(Type type);
 
     ////////////////////////////////////////////////////////////
     /// \brief Reapplies any effects parameters.
@@ -157,8 +156,8 @@ private:
     ////////////////////////////////////////////////////////////
     void detachSoundSource(SoundSource* source) const;
 
-    std::uint32_t m_effectSlot; //!< OpenAL Effects slot handle
-    std::uint32_t m_effect;     //!< OpenAL Effect handle assigned to this slot
+    sf::Uint32 m_effectSlot;    //!< OpenAL Effects slot handle
+    sf::Uint32 m_effect;        //!< OpenAL Effect handle assigned to this slot
 
     Type m_type;                //!< Type of effect assigned to this slot
     float m_volume;             //!< Current volume of this slot

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -5,6 +5,7 @@
 #include <SFML/Audio/AlResource.hpp>
 
 #include <set>
+#include <cstdint>
 
 namespace sf
 {

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -62,7 +62,8 @@ public:
     {
         Null,
         Reverb,
-        Chorus
+        Chorus,
+        Delay
     };
 
     ////////////////////////////////////////////////////////////
@@ -94,7 +95,7 @@ protected:
     ////////////////////////////////////////////////////////////
     /// \brief Sets the type of effect this will be
     ///
-    /// When implemwnting a specific effect type this sould be called on effect
+    /// When implementing a specific effect type this sould be called on effect
     /// creation so that the underlying effects object is properly configured
     ///
     /// \returns A handle to the OpenAL effects object. This can be used by

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -28,8 +28,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Audio/Export.hpp>
 #include <SFML/Audio/AlResource.hpp>
+#include <SFML/Audio/Export.hpp>
 #include <set>
 
 namespace sf
@@ -51,22 +51,23 @@ public:
     static bool isAvailable();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Sets the volume for this effect
+    /// \brief Sets the volume multiplier for this effect
     ///
-    /// The volume is in the range 0 - 1, multiplying the output volume
+    /// The value is in the range 0 - 1, multiplying the output volume
     /// of any SoundSource which uses this effect. A value of 0 will
-    /// effectively mute all sounds that have this effect applied
+    /// effectively mute all sounds that have this effect applied,
+    /// and 1 will set the output volume to that of the SoundSource
     ///
-    /// \param volume Floating point value automatically clamped between 0 and 1
+    /// \param value Floating point value automatically clamped between 0 and 1
     ///
     ////////////////////////////////////////////////////////////
-    void setVolume(float volume);
+    void setVolumeMultiplier(float value);
 
     ////////////////////////////////////////////////////////////
     /// \brief Returns the current volume of this effect
     ///
     ////////////////////////////////////////////////////////////
-    float getVolume() const;
+    float getVolumeMultiplier() const;
 
 protected:
 
@@ -152,7 +153,7 @@ private:
     sf::Uint32 m_effect;                        //!< OpenAL Effect handle assigned to this slot
     int m_type;                                 //!< OpenAL Effect type used to track reference counting
 
-    float m_volume;                             //!< Current volume of this slot
+    float m_volumeMultiplier;                   //!< Current volume multiplier of this slot
 
     mutable std::set<SoundSource*> m_soundlist; //!< List of SoundSources using this effect
     void ensureEffect(int type);                //!< Used to ensure that there is only one instance of OpenAL effect object for each type

--- a/include/SFML/Audio/SoundEffect.hpp
+++ b/include/SFML/Audio/SoundEffect.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef SFML_SOUNDEFFECT_HPP
+#define SFML_SOUNDEFFECT_HPP
 
 #include <SFML/Audio/Export.hpp>
 #include <SFML/Audio/AlResource.hpp>
@@ -36,7 +37,7 @@ namespace sf
         //specific interfaces for updating properties. Returns the effect handle
         std::uint32_t setType(Type type);
 
-        //reapplies the effect on this slot after the paramters were changed
+        //reapplies the effect on this slot after the parameters were changed
         void applyEffect();
 
         SoundEffect();
@@ -58,5 +59,8 @@ namespace sf
         float m_volume;
 
         mutable std::set<SoundSource*> m_soundlist;
+        void ensureEffect(Type);
     };
 }
+
+#endif // SFML_SOUNDEFFECT_HPP

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -282,31 +282,31 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set an effect to be applied to the sound source
     ///
-    /// \param effect Pointer to a SoundEffect object, or nullptr.
-    /// Setting this to nullptr will remove any currently assigned effects.
+    /// Any existing effect will first be removed. To remove
+    /// an effect completely use removeEffect()
+    /// \param effect Reference to a SoundEffect object to assign.
     /// \see SoundEffect
     ///
     ////////////////////////////////////////////////////////////
-    void setEffect(const SoundEffect* effect);
+    void setEffect(const SoundEffect& effect);
 
     ////////////////////////////////////////////////////////////
     /// \brief Returns a pointer to the active SoundEffect.
     ///
     /// \return If a SoundEffect object has been assigned to this SoundSource
-    /// then a pointer to that object is returned, else returns nullptr
+    /// then a pointer to that object is returned, else returns NULL
     ////////////////////////////////////////////////////////////
     const SoundEffect* getEffect() const;
+
 
     ////////////////////////////////////////////////////////////
     /// \brief Reset the internal effect of the sound
     ///
-    /// This function is for internal use only, you don't have
-    /// to use it. It is called by the sf::SoundEffect that
-    /// this sound uses, when it is destroyed in order to prevent
-    /// the sound from using a dead effect.
-    ///
+    /// Removes any effect set on the SoundSource. Note that
+    /// this will also stop the SoundSource if it is playing
+    /// even if there is not effect assigned.
     ////////////////////////////////////////////////////////////
-    void resetEffect();
+    void removeEffect();
 
 protected:
 

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -35,6 +35,8 @@
 
 namespace sf
 {
+class SoundEffect;
+
 ////////////////////////////////////////////////////////////
 /// \brief Base class defining a sound's properties
 ///
@@ -277,6 +279,21 @@ public:
     ////////////////////////////////////////////////////////////
     virtual Status getStatus() const;
 
+    void setEffect(const SoundEffect* effect);
+
+    const SoundEffect* getEffect() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Reset the internal effect of the sound
+    ///
+    /// This function is for internal use only, you don't have
+    /// to use it. It is called by the sf::SoundEffect that
+    /// this sound uses, when it is destroyed in order to prevent
+    /// the sound from using a dead effect.
+    ///
+    ////////////////////////////////////////////////////////////
+    void resetEffect();
+
 protected:
 
     ////////////////////////////////////////////////////////////
@@ -291,6 +308,8 @@ protected:
     // Member data
     ////////////////////////////////////////////////////////////
     unsigned int m_source; //!< OpenAL source identifier
+
+    SoundEffect* m_effect;
 };
 
 } // namespace sf

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -283,6 +283,7 @@ public:
     /// \brief Set an effect to be applied to the sound source
     ///
     /// \param effect Pointer to a SoundEffect object, or nullptr.
+    /// Setting this to nullptr will remove any currently assigned effects.
     /// \see SoundEffect
     ///
     ////////////////////////////////////////////////////////////
@@ -322,7 +323,7 @@ protected:
     ////////////////////////////////////////////////////////////
     unsigned int m_source; //!< OpenAL source identifier
 
-    SoundEffect* m_effect;
+    const SoundEffect* m_effect;
 };
 
 } // namespace sf

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -279,8 +279,21 @@ public:
     ////////////////////////////////////////////////////////////
     virtual Status getStatus() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Set an effect to be applied to the sound source
+    ///
+    /// \param effect Pointer to a SoundEffect object, or nullptr.
+    /// \see SoundEffect
+    ///
+    ////////////////////////////////////////////////////////////
     void setEffect(const SoundEffect* effect);
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns a pointer to the active SoundEffect.
+    ///
+    /// \return If a SoundEffect object has been assigned to this SoundSource
+    /// then a pointer to that object is returned, else returns nullptr
+    ////////////////////////////////////////////////////////////
     const SoundEffect* getEffect() const;
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -31,6 +31,10 @@ set(SRC
     ${INCROOT}/SoundSource.hpp
     ${SRCROOT}/SoundStream.cpp
     ${INCROOT}/SoundStream.hpp
+    ${SRCROOT}/SoundEffect.cpp
+    ${INCROOT}/SoundEffect.hpp
+    ${SRCROOT}/ReverbEffect.cpp
+    ${INCROOT}/ReverbEffect.hpp
 )
 source_group("" FILES ${SRC})
 

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -35,6 +35,8 @@ set(SRC
     ${INCROOT}/SoundEffect.hpp
     ${SRCROOT}/ReverbEffect.cpp
     ${INCROOT}/ReverbEffect.hpp
+    ${SRCROOT}/ChorusEffect.cpp
+    ${INCROOT}/ChorusEffect.hpp
 )
 source_group("" FILES ${SRC})
 

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -37,6 +37,8 @@ set(SRC
     ${INCROOT}/ReverbEffect.hpp
     ${SRCROOT}/ChorusEffect.cpp
     ${INCROOT}/ChorusEffect.hpp
+    ${SRCROOT}/DelayEffect.cpp
+    ${INCROOT}/DelayEffect.hpp
 )
 source_group("" FILES ${SRC})
 

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -293,7 +293,7 @@ float ChorusEffect::getDelay() const
 
 
 ////////////////////////////////////////////////////////////
-ChorusEffect& ChorusEffect::operator= (const ChorusEffect& right)
+ChorusEffect& ChorusEffect::operator= (const ChorusEffect&)
 {
     return *this;
 }

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -27,8 +27,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/ChorusEffect.hpp>
 
-#include "ALCheck.hpp"
-
 #define AL_ALEXT_PROTOTYPES
 #include <AL/efx.h>
 #include <AL/alext.h>
@@ -41,16 +39,15 @@ namespace sf
 //defaults are set as p67 of the effect extension guide
 ////////////////////////////////////////////////////////////
 ChorusEffect::ChorusEffect()
-    : SoundEffect   (),
+    : SoundEffect   (AL_EFFECT_CHORUS),
     m_waveform      (Triangle),
     m_phase         (90),
     m_rate          (1.1f),
     m_depth         (0.1f),
     m_feedback      (0.25f),
-    m_delay         (0.016f),
-    m_effect        (0)
+    m_delay         (0.016f)
 {
-    m_effect = setType(Chorus);
+
 }
 
 
@@ -62,11 +59,8 @@ ChorusEffect::ChorusEffect(const ChorusEffect& copy)
     m_rate          (1.1f),
     m_depth         (0.1f),
     m_feedback      (0.25f),
-    m_delay         (0.016f),
-    m_effect        (0)
+    m_delay         (0.016f)
 {
-    m_effect = setType(Chorus);
-
     setWaveform(copy.getWaveform());
     setPhase(copy.getPhase());
     setRate(copy.getRate());
@@ -79,72 +73,48 @@ ChorusEffect::ChorusEffect(const ChorusEffect& copy)
 ////////////////////////////////////////////////////////////
 void ChorusEffect::setWaveform(Waveform waveform)
 {
-    assert(m_effect != 0);
-
     m_waveform = waveform;
-    alCheck(alEffecti(m_effect, AL_CHORUS_WAVEFORM, waveform == Triangle ? AL_CHORUS_WAVEFORM_TRIANGLE : AL_CHORUS_WAVEFORM_SINUSOID));
-
-    applyEffect();
+    setParameter(AL_CHORUS_WAVEFORM, waveform == Triangle ? AL_CHORUS_WAVEFORM_TRIANGLE : AL_CHORUS_WAVEFORM_SINUSOID);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ChorusEffect::setPhase(sf::Int32 phase)
 {
-    assert(m_effect != 0);
-
     m_phase = std::min(180, std::max(-180, phase));
-    alCheck(alEffecti(m_effect, AL_CHORUS_PHASE, m_phase));
-
-    applyEffect();
+    setParameter(AL_CHORUS_PHASE, m_phase);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ChorusEffect::setRate(float rate)
 {
-    assert(m_effect != 0);
-
     m_rate = std::min(10.f, std::max(0.f, rate));
-    alCheck(alEffectf(m_effect, AL_CHORUS_RATE, m_rate));
-
-    applyEffect();
+    setParameter(AL_CHORUS_RATE, m_rate);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ChorusEffect::setDepth(float depth)
 {
-    assert(m_effect != 0);
-
     m_depth = std::min(1.f, std::max(0.f, depth));
-    alCheck(alEffectf(m_effect, AL_CHORUS_DEPTH, m_depth));
-
-    applyEffect();
+    setParameter(AL_CHORUS_DEPTH, m_depth);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ChorusEffect::setFeedback(float feedback)
 {
-    assert(m_effect != 0);
-
     m_feedback = std::min(1.f, std::max(-1.f, feedback));
-    alCheck(alEffectf(m_effect, AL_CHORUS_FEEDBACK, m_feedback));
-
-    applyEffect();
+    setParameter(AL_CHORUS_FEEDBACK, m_feedback);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ChorusEffect::setDelay(float delay)
 {
-    assert(m_effect != 0);
-
     m_delay = std::min(0.016f, std::max(0.f, delay));
-    alCheck(alEffectf(m_effect, AL_CHORUS_DELAY, m_delay));
-
-    applyEffect();
+    setParameter(AL_CHORUS_DELAY, m_delay);
 }
 
 

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -1,0 +1,181 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2020 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/ChorusEffect.hpp>
+
+#include "ALCheck.hpp"
+
+#define AL_ALEXT_PROTOTYPES
+#include <AL/efx.h>
+#include <AL/alext.h>
+
+#include <cassert>
+
+namespace sf
+{
+//defaults are set as p67 of the effect extension guide
+////////////////////////////////////////////////////////////
+ChorusEffect::ChorusEffect()
+    : SoundEffect   (),
+    m_waveform      (Triangle),
+    m_phase         (90),
+    m_rate          (1.1f),
+    m_depth         (0.1f),
+    m_feedback      (0.25f),
+    m_delay         (0.016f),
+    m_effect        (0)
+{
+    m_effect = setType(Chorus);
+}
+
+
+////////////////////////////////////////////////////////////
+ChorusEffect::ChorusEffect(const ChorusEffect& copy)
+    : SoundEffect   (copy),
+    m_waveform      (Triangle),
+    m_phase         (90),
+    m_rate          (1.1f),
+    m_depth         (0.1f),
+    m_feedback      (0.25f),
+    m_delay         (0.016f),
+    m_effect        (0)
+{
+    m_effect = setType(Chorus);
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setWaveform(Waveform waveform)
+{
+    assert(m_effect != 0);
+
+    m_waveform = waveform;
+    alCheck(alEffecti(m_effect, AL_CHORUS_WAVEFORM, waveform == Triangle ? AL_CHORUS_WAVEFORM_TRIANGLE : AL_CHORUS_WAVEFORM_SINUSOID));
+
+    applyEffect();
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setPhase(sf::Int32 phase)
+{
+    assert(m_effect != 0);
+
+    m_phase = std::min(180, std::max(-180, phase));
+    alCheck(alEffecti(m_effect, AL_CHORUS_PHASE, m_phase));
+
+    applyEffect();
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setRate(float rate)
+{
+    assert(m_effect != 0);
+
+    m_rate = std::min(10.f, std::max(0.f, rate));
+    alCheck(alEffectf(m_effect, AL_CHORUS_RATE, m_rate));
+
+    applyEffect();
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setDepth(float depth)
+{
+    assert(m_effect != 0);
+
+    m_depth = std::min(1.f, std::max(0.f, depth));
+    alCheck(alEffectf(m_effect, AL_CHORUS_DEPTH, m_depth));
+
+    applyEffect();
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setFeedback(float feedback)
+{
+    assert(m_effect != 0);
+
+    m_feedback = std::min(1.f, std::max(-1.f, feedback));
+    alCheck(alEffectf(m_effect, AL_CHORUS_FEEDBACK, m_feedback));
+
+    applyEffect();
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setDelay(float delay)
+{
+    assert(m_effect != 0);
+
+    m_delay = std::min(0.016f, std::max(0.f, delay));
+    alCheck(alEffectf(m_effect, AL_CHORUS_DELAY, m_delay));
+
+    applyEffect();
+}
+
+
+////////////////////////////////////////////////////////////
+ChorusEffect::Waveform ChorusEffect::getWaveform() const
+{
+    return m_waveform;
+}
+
+
+////////////////////////////////////////////////////////////
+sf::Int32 ChorusEffect::getPhase() const
+{
+    return m_phase;
+}
+
+float ChorusEffect::getRate() const
+{
+    return m_rate;
+}
+
+
+////////////////////////////////////////////////////////////
+float ChorusEffect::getDepth() const
+{
+    return m_depth;
+}
+
+
+////////////////////////////////////////////////////////////
+float ChorusEffect::getFeedback() const
+{
+    return m_feedback;
+}
+
+
+////////////////////////////////////////////////////////////
+float ChorusEffect::getDelay() const
+{
+    return m_delay;
+}
+}

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/ChorusEffect.hpp>
 
+#ifndef SFML_SYSTEM_IOS
+
 #define AL_ALEXT_PROTOTYPES
 #include <AL/efx.h>
 #include <AL/alext.h>
@@ -173,3 +175,128 @@ ChorusEffect& ChorusEffect::operator= (const ChorusEffect& right)
     return *this;
 }
 } // namespace sf
+
+#else
+
+//empty implementation for IOS
+namespace sf
+{
+//defaults are set as p67 of the effect extension guide
+////////////////////////////////////////////////////////////
+ChorusEffect::ChorusEffect()
+    : SoundEffect   (0),
+    m_waveform      (Triangle),
+    m_phase         (90),
+    m_rate          (1.1f),
+    m_depth         (0.1f),
+    m_feedback      (0.25f),
+    m_delay         (0.016f)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+ChorusEffect::ChorusEffect(const ChorusEffect& copy)
+    : SoundEffect   (copy),
+    m_waveform      (Triangle),
+    m_phase         (90),
+    m_rate          (1.1f),
+    m_depth         (0.1f),
+    m_feedback      (0.25f),
+    m_delay         (0.016f)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setWaveform(Waveform)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setPhase(sf::Int32)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setRate(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setDepth(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setFeedback(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ChorusEffect::setDelay(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+ChorusEffect::Waveform ChorusEffect::getWaveform() const
+{
+    return m_waveform;
+}
+
+
+////////////////////////////////////////////////////////////
+sf::Int32 ChorusEffect::getPhase() const
+{
+    return m_phase;
+}
+
+float ChorusEffect::getRate() const
+{
+    return m_rate;
+}
+
+
+////////////////////////////////////////////////////////////
+float ChorusEffect::getDepth() const
+{
+    return m_depth;
+}
+
+
+////////////////////////////////////////////////////////////
+float ChorusEffect::getFeedback() const
+{
+    return m_feedback;
+}
+
+
+////////////////////////////////////////////////////////////
+float ChorusEffect::getDelay() const
+{
+    return m_delay;
+}
+
+
+////////////////////////////////////////////////////////////
+ChorusEffect& ChorusEffect::operator= (const ChorusEffect& right)
+{
+    return *this;
+}
+} // namespace sf
+
+#endif //SFML_SYSTEM_IOS

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -199,4 +199,4 @@ ChorusEffect& ChorusEffect::operator= (const ChorusEffect& right)
 
     return *this;
 }
-} //namespace sf
+} // namespace sf

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -191,6 +191,8 @@ float ChorusEffect::getDelay() const
 ////////////////////////////////////////////////////////////
 ChorusEffect& ChorusEffect::operator= (const ChorusEffect& right)
 {
+    SoundEffect::operator=(right);
+
     setWaveform(right.getWaveform());
     setPhase(right.getPhase());
     setRate(right.getRate());

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -34,6 +34,7 @@
 #include <AL/alext.h>
 
 #include <cassert>
+#include <algorithm>
 
 namespace sf
 {

--- a/src/SFML/Audio/ChorusEffect.cpp
+++ b/src/SFML/Audio/ChorusEffect.cpp
@@ -185,4 +185,18 @@ float ChorusEffect::getDelay() const
 {
     return m_delay;
 }
+
+
+////////////////////////////////////////////////////////////
+ChorusEffect& ChorusEffect::operator= (const ChorusEffect& right)
+{
+    setWaveform(right.getWaveform());
+    setPhase(right.getPhase());
+    setRate(right.getRate());
+    setDepth(right.getDepth());
+    setFeedback(right.getFeedback());
+    setDelay(right.getDelay());
+
+    return *this;
 }
+} //namespace sf

--- a/src/SFML/Audio/DelayEffect.cpp
+++ b/src/SFML/Audio/DelayEffect.cpp
@@ -170,6 +170,8 @@ float DelayEffect::getSpread() const
 ////////////////////////////////////////////////////////////
 DelayEffect& DelayEffect::operator= (const DelayEffect& right)
 {
+    SoundEffect::operator=(right);
+
     setDelay(right.getDelay());
     setLRDelay(right.getLRDelay());
     setDamping(right.getDamping());

--- a/src/SFML/Audio/DelayEffect.cpp
+++ b/src/SFML/Audio/DelayEffect.cpp
@@ -27,8 +27,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/DelayEffect.hpp>
 
-#include "ALCheck.hpp"
-
 #define AL_ALEXT_PROTOTYPES
 #include <AL/efx.h>
 #include <AL/alext.h>
@@ -41,15 +39,14 @@ namespace sf
 //default values as p108 of OpenAL extensions guide
 ////////////////////////////////////////////////////////////
 DelayEffect::DelayEffect()
-    : SoundEffect   (),
+    : SoundEffect   (AL_EFFECT_ECHO),
     m_delay         (0.1f),
     m_LRDelay       (0.1f),
     m_damping       (0.5f),
     m_feedback      (0.5f),
-    m_spread        (-1.f),
-    m_effect        (0)
+    m_spread        (-1.f)
 {
-    m_effect = setType(Delay);
+
 }
 
 
@@ -60,11 +57,8 @@ DelayEffect::DelayEffect(const DelayEffect& copy)
     m_LRDelay       (0.1f),
     m_damping       (0.5f),
     m_feedback      (0.5f),
-    m_spread        (-1.f),
-    m_effect        (0)
+    m_spread        (-1.f)
 {
-    m_effect = setType(Delay);
-
     setDelay(copy.getDelay());
     setLRDelay(copy.getLRDelay());
     setDamping(copy.getDamping());
@@ -76,60 +70,40 @@ DelayEffect::DelayEffect(const DelayEffect& copy)
 ////////////////////////////////////////////////////////////
 void DelayEffect::setDelay(float delay)
 {
-    assert(m_effect != 0);
-
     m_delay = std::min(0.27f, std::max(0.f, delay));
-    alCheck(alEffectf(m_effect, AL_ECHO_DELAY, m_delay));
-
-    applyEffect();
+    setParameter(AL_ECHO_DELAY, m_delay);
 }
 
 
 ////////////////////////////////////////////////////////////
 void DelayEffect::setLRDelay(float delay)
 {
-    assert(m_effect != 0);
-
     m_LRDelay = std::min(0.404f, std::max(0.f, delay));
-    alCheck(alEffectf(m_effect, AL_ECHO_LRDELAY, m_LRDelay));
-
-    applyEffect();
+    setParameter(AL_ECHO_LRDELAY, m_LRDelay);
 }
 
 
 ////////////////////////////////////////////////////////////
 void DelayEffect::setDamping(float damping)
 {
-    assert(m_effect != 0);
-
     m_damping = std::min(0.99f, std::max(0.f, damping));
-    alCheck(alEffectf(m_effect, AL_ECHO_DAMPING, m_damping));
-
-    applyEffect();
+    setParameter(AL_ECHO_DAMPING, m_damping);
 }
 
 
 ////////////////////////////////////////////////////////////
 void DelayEffect::setFeedback(float feedback)
 {
-    assert(m_effect != 0);
-
     m_feedback = std::min(1.f, std::max(0.f, feedback));
-    alCheck(alEffectf(m_effect, AL_ECHO_FEEDBACK, m_feedback));
-
-    applyEffect();
+    setParameter(AL_ECHO_FEEDBACK, m_feedback);
 }
 
 
 ////////////////////////////////////////////////////////////
 void DelayEffect::setSpread(float spread)
 {
-    assert(m_effect != 0);
-
     m_spread = std::min(1.f, std::max(-1.f, spread));
-    alCheck(alEffectf(m_effect, AL_ECHO_SPREAD, m_spread));
-
-    applyEffect();
+    setParameter(AL_ECHO_SPREAD, m_spread);
 }
 
 

--- a/src/SFML/Audio/DelayEffect.cpp
+++ b/src/SFML/Audio/DelayEffect.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/DelayEffect.hpp>
 
+#ifndef SFML_SYSTEM_IOS
+
 #define AL_ALEXT_PROTOTYPES
 #include <AL/efx.h>
 #include <AL/alext.h>
@@ -155,4 +157,117 @@ DelayEffect& DelayEffect::operator= (const DelayEffect& right)
     return *this;
 }
 
-} //naemspace sf
+} //namespace sf
+
+
+#else
+
+//empty implementation for IOS
+
+namespace sf
+{
+//default values as p108 of OpenAL extensions guide
+////////////////////////////////////////////////////////////
+DelayEffect::DelayEffect()
+    : SoundEffect   (0),
+    m_delay         (0.1f),
+    m_LRDelay       (0.1f),
+    m_damping       (0.5f),
+    m_feedback      (0.5f),
+    m_spread        (-1.f)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+DelayEffect::DelayEffect(const DelayEffect& copy)
+    : SoundEffect   (copy),
+    m_delay         (0.1f),
+    m_LRDelay       (0.1f),
+    m_damping       (0.5f),
+    m_feedback      (0.5f),
+    m_spread        (-1.f)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void DelayEffect::setDelay(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void DelayEffect::setLRDelay(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void DelayEffect::setDamping(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void DelayEffect::setFeedback(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void DelayEffect::setSpread(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+float DelayEffect::getDelay() const
+{
+    return m_delay;
+}
+
+
+////////////////////////////////////////////////////////////
+float DelayEffect::getLRDelay() const
+{
+    return m_LRDelay;
+}
+
+
+////////////////////////////////////////////////////////////
+float DelayEffect::getDamping() const
+{
+    return m_damping;
+}
+
+
+////////////////////////////////////////////////////////////
+float DelayEffect::getFeedback() const
+{
+    return m_feedback;
+}
+
+////////////////////////////////////////////////////////////
+float DelayEffect::getSpread() const
+{
+    return m_spread;
+}
+
+
+////////////////////////////////////////////////////////////
+DelayEffect& DelayEffect::operator= (const DelayEffect& right)
+{
+    return *this;
+}
+
+} //namespace sf
+
+#endif //SFML_SYSTEM_IOS

--- a/src/SFML/Audio/DelayEffect.cpp
+++ b/src/SFML/Audio/DelayEffect.cpp
@@ -164,4 +164,18 @@ float DelayEffect::getSpread() const
 {
     return m_spread;
 }
+
+
+////////////////////////////////////////////////////////////
+DelayEffect& DelayEffect::operator= (const DelayEffect& right)
+{
+    setDelay(right.getDelay());
+    setLRDelay(right.getLRDelay());
+    setDamping(right.getDamping());
+    setFeedback(right.getFeedback());
+    setSpread(right.getSpread());
+
+    return *this;
 }
+
+} //naemspace sf

--- a/src/SFML/Audio/DelayEffect.cpp
+++ b/src/SFML/Audio/DelayEffect.cpp
@@ -34,6 +34,7 @@
 #include <AL/alext.h>
 
 #include <cassert>
+#include <algorithm>
 
 namespace sf
 {

--- a/src/SFML/Audio/DelayEffect.cpp
+++ b/src/SFML/Audio/DelayEffect.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Audio/ChorusEffect.hpp>
+#include <SFML/Audio/DelayEffect.hpp>
 
 #include "ALCheck.hpp"
 
@@ -37,152 +37,131 @@
 
 namespace sf
 {
-//defaults are set as p67 of the effect extension guide
+//default values as p108 of OpenAL extensions guide
 ////////////////////////////////////////////////////////////
-ChorusEffect::ChorusEffect()
+DelayEffect::DelayEffect()
     : SoundEffect   (),
-    m_waveform      (Triangle),
-    m_phase         (90),
-    m_rate          (1.1f),
-    m_depth         (0.1f),
-    m_feedback      (0.25f),
-    m_delay         (0.016f),
+    m_delay         (0.1f),
+    m_LRDelay       (0.1f),
+    m_damping       (0.5f),
+    m_feedback      (0.5f),
+    m_spread        (-1.f),
     m_effect        (0)
 {
-    m_effect = setType(Chorus);
+    m_effect = setType(Delay);
 }
 
 
 ////////////////////////////////////////////////////////////
-ChorusEffect::ChorusEffect(const ChorusEffect& copy)
+DelayEffect::DelayEffect(const DelayEffect& copy)
     : SoundEffect   (copy),
-    m_waveform      (Triangle),
-    m_phase         (90),
-    m_rate          (1.1f),
-    m_depth         (0.1f),
-    m_feedback      (0.25f),
-    m_delay         (0.016f),
+    m_delay         (0.1f),
+    m_LRDelay       (0.1f),
+    m_damping       (0.5f),
+    m_feedback      (0.5f),
+    m_spread        (-1.f),
     m_effect        (0)
 {
-    m_effect = setType(Chorus);
+    m_effect = setType(Delay);
 
-    setWaveform(copy.getWaveform());
-    setPhase(copy.getPhase());
-    setRate(copy.getRate());
-    setDepth(copy.getDepth());
-    setFeedback(copy.getFeedback());
     setDelay(copy.getDelay());
+    setLRDelay(copy.getLRDelay());
+    setDamping(copy.getDamping());
+    setFeedback(copy.getFeedback());
+    setSpread(copy.getSpread());
 }
 
 
 ////////////////////////////////////////////////////////////
-void ChorusEffect::setWaveform(Waveform waveform)
+void DelayEffect::setDelay(float delay)
 {
     assert(m_effect != 0);
 
-    m_waveform = waveform;
-    alCheck(alEffecti(m_effect, AL_CHORUS_WAVEFORM, waveform == Triangle ? AL_CHORUS_WAVEFORM_TRIANGLE : AL_CHORUS_WAVEFORM_SINUSOID));
+    m_delay = std::min(0.27f, std::max(0.f, delay));
+    alCheck(alEffectf(m_effect, AL_ECHO_DELAY, m_delay));
 
     applyEffect();
 }
 
 
 ////////////////////////////////////////////////////////////
-void ChorusEffect::setPhase(sf::Int32 phase)
+void DelayEffect::setLRDelay(float delay)
 {
     assert(m_effect != 0);
 
-    m_phase = std::min(180, std::max(-180, phase));
-    alCheck(alEffecti(m_effect, AL_CHORUS_PHASE, m_phase));
+    m_LRDelay = std::min(0.404f, std::max(0.f, delay));
+    alCheck(alEffectf(m_effect, AL_ECHO_LRDELAY, m_LRDelay));
 
     applyEffect();
 }
 
 
 ////////////////////////////////////////////////////////////
-void ChorusEffect::setRate(float rate)
+void DelayEffect::setDamping(float damping)
 {
     assert(m_effect != 0);
 
-    m_rate = std::min(10.f, std::max(0.f, rate));
-    alCheck(alEffectf(m_effect, AL_CHORUS_RATE, m_rate));
+    m_damping = std::min(0.99f, std::max(0.f, damping));
+    alCheck(alEffectf(m_effect, AL_ECHO_DAMPING, m_damping));
 
     applyEffect();
 }
 
 
 ////////////////////////////////////////////////////////////
-void ChorusEffect::setDepth(float depth)
+void DelayEffect::setFeedback(float feedback)
 {
     assert(m_effect != 0);
 
-    m_depth = std::min(1.f, std::max(0.f, depth));
-    alCheck(alEffectf(m_effect, AL_CHORUS_DEPTH, m_depth));
+    m_feedback = std::min(1.f, std::max(0.f, feedback));
+    alCheck(alEffectf(m_effect, AL_ECHO_FEEDBACK, m_feedback));
 
     applyEffect();
 }
 
 
 ////////////////////////////////////////////////////////////
-void ChorusEffect::setFeedback(float feedback)
+void DelayEffect::setSpread(float spread)
 {
     assert(m_effect != 0);
 
-    m_feedback = std::min(1.f, std::max(-1.f, feedback));
-    alCheck(alEffectf(m_effect, AL_CHORUS_FEEDBACK, m_feedback));
+    m_spread = std::min(1.f, std::max(-1.f, spread));
+    alCheck(alEffectf(m_effect, AL_ECHO_SPREAD, m_spread));
 
     applyEffect();
 }
 
 
 ////////////////////////////////////////////////////////////
-void ChorusEffect::setDelay(float delay)
+float DelayEffect::getDelay() const
 {
-    assert(m_effect != 0);
-
-    m_delay = std::min(0.016f, std::max(0.f, delay));
-    alCheck(alEffectf(m_effect, AL_CHORUS_DELAY, m_delay));
-
-    applyEffect();
+    return m_delay;
 }
 
 
 ////////////////////////////////////////////////////////////
-ChorusEffect::Waveform ChorusEffect::getWaveform() const
+float DelayEffect::getLRDelay() const
 {
-    return m_waveform;
+    return m_LRDelay;
 }
 
 
 ////////////////////////////////////////////////////////////
-sf::Int32 ChorusEffect::getPhase() const
+float DelayEffect::getDamping() const
 {
-    return m_phase;
-}
-
-float ChorusEffect::getRate() const
-{
-    return m_rate;
+    return m_damping;
 }
 
 
 ////////////////////////////////////////////////////////////
-float ChorusEffect::getDepth() const
-{
-    return m_depth;
-}
-
-
-////////////////////////////////////////////////////////////
-float ChorusEffect::getFeedback() const
+float DelayEffect::getFeedback() const
 {
     return m_feedback;
 }
 
-
 ////////////////////////////////////////////////////////////
-float ChorusEffect::getDelay() const
+float DelayEffect::getSpread() const
 {
-    return m_delay;
+    return m_spread;
 }
 }

--- a/src/SFML/Audio/DelayEffect.cpp
+++ b/src/SFML/Audio/DelayEffect.cpp
@@ -263,7 +263,7 @@ float DelayEffect::getSpread() const
 
 
 ////////////////////////////////////////////////////////////
-DelayEffect& DelayEffect::operator= (const DelayEffect& right)
+DelayEffect& DelayEffect::operator= (const DelayEffect&)
 {
     return *this;
 }

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -34,6 +34,7 @@
 #include <AL/alext.h>
 
 #include <cassert>
+#include <algorithm>
 
 namespace
 {

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -451,7 +451,7 @@ float ReverbEffect::getRoomRolloff() const
 
 
 ////////////////////////////////////////////////////////////
-ReverbEffect& ReverbEffect::operator= (const ReverbEffect& right)
+ReverbEffect& ReverbEffect::operator= (const ReverbEffect&)
 {
     return *this;
 }

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -276,6 +276,8 @@ float ReverbEffect::getRoomRolloff() const
 ////////////////////////////////////////////////////////////
 ReverbEffect& ReverbEffect::operator= (const ReverbEffect& right)
 {
+    SoundEffect::operator=(right);
+
     setDensity(right.getDensity());
     setDiffusion(right.getDiffusion());
     setGain(right.getGain());

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/ReverbEffect.hpp>
 
+#ifndef SFML_SYSTEM_IOS
+
 #define AL_ALEXT_PROTOTYPES
 #include <AL/efx.h>
 #include <AL/alext.h>
@@ -108,7 +110,7 @@ void ReverbEffect::setDensity(float density)
 void ReverbEffect::setDiffusion(float diffusion)
 {
     m_diffusion = std::min(1.f, std::max(0.f, diffusion));
-    setParameter(REVERB_DIFFUSION, m_density);
+    setParameter(REVERB_DIFFUSION, m_diffusion);
 }
 
 
@@ -281,3 +283,185 @@ void ReverbEffect::applyParameterNames()
     }
 }
 } // namespace sf
+
+#else
+
+//empty implementation for IOS
+namespace sf
+{
+//values are initialised according to OpenAL extension guide p.66
+////////////////////////////////////////////////////////////
+ReverbEffect::ReverbEffect()
+    : SoundEffect       (0),
+    m_density           (1.f),
+    m_diffusion         (1.f),
+    m_gain              (0.32f),
+    m_decayTime         (1.4f),
+    m_reflectionGain    (0.05f),
+    m_reflectionDelay   (0.007f),
+    m_lateReverbGain    (1.26f),
+    m_lateReverbDelay   (0.011f),
+    m_roomRolloff       (0.f)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+ReverbEffect::ReverbEffect(const ReverbEffect& copy)
+    : SoundEffect       (copy),
+    m_density           (1.f),
+    m_diffusion         (1.f),
+    m_gain              (0.32f),
+    m_decayTime         (1.4f),
+    m_reflectionGain    (0.05f),
+    m_reflectionDelay   (0.007f),
+    m_lateReverbGain    (1.26f),
+    m_lateReverbDelay   (0.011f),
+    m_roomRolloff       (0.f)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setDensity(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setDiffusion(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setGain(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setDecayTime(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setReflectionGain(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setReflectionDelay(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setLateReverbGain(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setLateReverbDelay(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::setRoomRolloff(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getDensity() const
+{
+    return m_density;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getDiffusion() const
+{
+    return m_diffusion;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getGain() const
+{
+    return m_gain;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getDecayTime() const
+{
+    return m_decayTime;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getReflectionGain() const
+{
+    return m_reflectionGain;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getReflectionDelay() const
+{
+    return m_reflectionDelay;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getLateReverbGain() const
+{
+    return m_lateReverbGain;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getLateReverbDelay() const
+{
+    return m_lateReverbDelay;
+}
+
+
+////////////////////////////////////////////////////////////
+float ReverbEffect::getRoomRolloff() const
+{
+    return m_roomRolloff;
+}
+
+
+////////////////////////////////////////////////////////////
+ReverbEffect& ReverbEffect::operator= (const ReverbEffect& right)
+{
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+void ReverbEffect::applyParameterNames()
+{
+
+}
+} // namespace sf
+
+#endif //SFML_SYSTEM_IOS

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -27,8 +27,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/ReverbEffect.hpp>
 
-#include "ALCheck.hpp"
-
 #define AL_ALEXT_PROTOTYPES
 #include <AL/efx.h>
 #include <AL/alext.h>
@@ -56,7 +54,7 @@ namespace sf
 //values are initialised according to OpenAL extension guide p.66
 ////////////////////////////////////////////////////////////
 ReverbEffect::ReverbEffect()
-    : SoundEffect       (),
+    : SoundEffect       (alGetEnumValue("AL_EFFECT_EAXREVERB") == 0 ? AL_EFFECT_REVERB : AL_EFFECT_EAXREVERB),
     m_density           (1.f),
     m_diffusion         (1.f),
     m_gain              (0.32f),
@@ -65,10 +63,8 @@ ReverbEffect::ReverbEffect()
     m_reflectionDelay   (0.007f),
     m_lateReverbGain    (1.26f),
     m_lateReverbDelay   (0.011f),
-    m_roomRolloff       (0.f),
-    m_effect            (0)
+    m_roomRolloff       (0.f)
 {
-    m_effect = setType(SoundEffect::Reverb);
     applyParameterNames();
 }
 
@@ -84,10 +80,8 @@ ReverbEffect::ReverbEffect(const ReverbEffect& copy)
     m_reflectionDelay   (0.007f),
     m_lateReverbGain    (1.26f),
     m_lateReverbDelay   (0.011f),
-    m_roomRolloff       (0.f),
-    m_effect            (0)
+    m_roomRolloff       (0.f)
 {
-    m_effect = setType(SoundEffect::Reverb);
     applyParameterNames();
 
     setDensity(copy.getDensity());
@@ -105,108 +99,72 @@ ReverbEffect::ReverbEffect(const ReverbEffect& copy)
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setDensity(float density)
 {
-    assert(m_effect != 0);
-
     m_density = std::min(1.f, std::max(0.f, density));
-    alCheck(alEffectf(m_effect, REVERB_DENSITY, m_density));
-
-    applyEffect();
+    setParameter(REVERB_DENSITY, m_density);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setDiffusion(float diffusion)
 {
-    assert(m_effect != 0);
-
     m_diffusion = std::min(1.f, std::max(0.f, diffusion));
-    alCheck(alEffectf(m_effect, REVERB_DIFFUSION, m_density));
-
-    applyEffect();
+    setParameter(REVERB_DIFFUSION, m_density);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setGain(float gain)
 {
-    assert(m_effect != 0);
-
     m_gain = std::min(1.f, std::max(0.f, gain));
-    alCheck(alEffectf(m_effect, REVERB_GAIN, m_gain));
-
-    applyEffect();
+    setParameter(REVERB_GAIN, m_gain);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setDecayTime(float decayTime)
 {
-    assert(m_effect != 0);
-
     m_decayTime = std::min(20.f, std::max(0.1f, decayTime));
-    alCheck(alEffectf(m_effect, REVERB_DECAY_TIME, m_decayTime));
-
-    applyEffect();
+    setParameter(REVERB_DECAY_TIME, m_decayTime);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setReflectionGain(float gain)
 {
-    assert(m_effect != 0);
-
     m_reflectionGain = std::min(1.f, std::max(0.f, gain));
-    alCheck(alEffectf(m_effect, REVERB_REFLECTIONS_GAIN, m_reflectionGain));
-
-    applyEffect();
+    setParameter(REVERB_REFLECTIONS_GAIN, m_reflectionGain);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setReflectionDelay(float delay)
 {
-    assert(m_effect != 0);
-
     m_reflectionDelay = std::min(0.3f, std::max(0.f, delay));
-    alCheck(alEffectf(m_effect, REVERB_REFLECTIONS_DELAY, m_reflectionDelay));
-
-    applyEffect();
+    setParameter(REVERB_REFLECTIONS_DELAY, m_reflectionDelay);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setLateReverbGain(float gain)
 {
-    assert(m_effect != 0);
-
     m_lateReverbGain = std::min(10.f, std::max(0.f, gain));
-    alCheck(alEffectf(m_effect, REVERB_LATE_REVERB_GAIN, m_lateReverbGain));
-
-    applyEffect();
+    setParameter(REVERB_LATE_REVERB_GAIN, m_lateReverbGain);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setLateReverbDelay(float delay)
 {
-    assert(m_effect != 0);
-
     m_lateReverbDelay = std::min(0.1f, std::max(0.f, delay));
-    alCheck(alEffectf(m_effect, REVERB_LATE_REVERB_DELAY, m_lateReverbDelay));
-
-    applyEffect();
+    setParameter(REVERB_LATE_REVERB_DELAY, m_lateReverbDelay);
 }
 
 
 ////////////////////////////////////////////////////////////
 void ReverbEffect::setRoomRolloff(float rolloff)
 {
-    assert(m_effect != 0);
-
     m_roomRolloff = std::min(10.f, std::max(0.f, rolloff));
-    alCheck(alEffectf(m_effect, REVERB_ROOM_ROLLOFF_FACTOR, m_roomRolloff));
-
-    applyEffect();
+    setParameter(REVERB_ROOM_ROLLOFF_FACTOR, m_roomRolloff);
 }
 
 

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -40,15 +40,15 @@ namespace
 {
     //these are defined so that they can be shared between EAX/non-EAX
     //versions of the reverb effect. See applyParameterNames()
-    sf::Uint32 REVERB_DENSITY              = 0;
-    sf::Uint32 REVERB_DIFFUSION            = 0;
-    sf::Uint32 REVERB_GAIN                 = 0;
-    sf::Uint32 REVERB_DECAY_TIME           = 0;
-    sf::Uint32 REVERB_REFLECTIONS_GAIN     = 0;
-    sf::Uint32 REVERB_REFLECTIONS_DELAY    = 0;
-    sf::Uint32 REVERB_LATE_REVERB_GAIN     = 0;
-    sf::Uint32 REVERB_LATE_REVERB_DELAY    = 0;
-    sf::Uint32 REVERB_ROOM_ROLLOFF_FACTOR  = 0;
+    sf::Int32 REVERB_DENSITY              = 0;
+    sf::Int32 REVERB_DIFFUSION            = 0;
+    sf::Int32 REVERB_GAIN                 = 0;
+    sf::Int32 REVERB_DECAY_TIME           = 0;
+    sf::Int32 REVERB_REFLECTIONS_GAIN     = 0;
+    sf::Int32 REVERB_REFLECTIONS_DELAY    = 0;
+    sf::Int32 REVERB_LATE_REVERB_GAIN     = 0;
+    sf::Int32 REVERB_LATE_REVERB_DELAY    = 0;
+    sf::Int32 REVERB_ROOM_ROLLOFF_FACTOR  = 0;
 }
 
 namespace sf

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -273,6 +273,23 @@ float ReverbEffect::getRoomRolloff() const
 
 
 ////////////////////////////////////////////////////////////
+ReverbEffect& ReverbEffect::operator= (const ReverbEffect& right)
+{
+    setDensity(right.getDensity());
+    setDiffusion(right.getDiffusion());
+    setGain(right.getGain());
+    setDecayTime(right.getDecayTime());
+    setReflectionGain(right.getReflectionGain());
+    setReflectionDelay(right.getReflectionDelay());
+    setLateReverbGain(right.getLateReverbGain());
+    setLateReverbDelay(right.getLateReverbDelay());
+    setRoomRolloff(right.getRoomRolloff());
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::applyParameterNames()
 {
     //sets the correct values depending on if this

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -1,17 +1,17 @@
 #include <SFML/Audio/ReverbEffect.hpp>
 
+#include "ALCheck.hpp"
+
 #define AL_ALEXT_PROTOTYPES
 #include <AL/efx.h>
 #include <AL/alext.h>
 
-#include "ALCheck.hpp"
-
 #include <cassert>
-
-using namespace sf;
 
 namespace
 {
+    //these are defined so that they can be shared between EAX/non-EAX
+    //versions of the reverb effect. See applyParamterNames()
     std::uint32_t REVERB_DENSITY              = 0;
     std::uint32_t REVERB_DIFFUSION            = 0;
     std::uint32_t REVERB_GAIN                 = 0;
@@ -23,9 +23,11 @@ namespace
     std::uint32_t REVERB_ROOM_ROLLOFF_FACTOR  = 0;
 }
 
+namespace sf
+{
 //values are initialised according to OpenAL extension guide p.66
 ReverbEffect::ReverbEffect()
-    : SoundEffect       (),
+    : SoundEffect        (),
     m_density           (1.f),
     m_diffusion         (1.f),
     m_gain              (0.32f),
@@ -211,26 +213,27 @@ void ReverbEffect::applyParameterNames()
     //is an EAX reverb or not
     if (alGetEnumValue("AL_EFFECT_EAXREVERB") != 0)
     {
-        REVERB_DENSITY             = AL_EAXREVERB_DENSITY;
-        REVERB_DIFFUSION           = AL_EAXREVERB_DIFFUSION;
-        REVERB_GAIN                = AL_EAXREVERB_GAIN;
-        REVERB_DECAY_TIME          = AL_EAXREVERB_DECAY_TIME;
-        REVERB_REFLECTIONS_GAIN    = AL_EAXREVERB_REFLECTIONS_GAIN;
-        REVERB_REFLECTIONS_DELAY   = AL_EAXREVERB_REFLECTIONS_DELAY;
-        REVERB_LATE_REVERB_GAIN    = AL_EAXREVERB_LATE_REVERB_GAIN;
-        REVERB_LATE_REVERB_DELAY   = AL_EAXREVERB_LATE_REVERB_DELAY;
+        REVERB_DENSITY = AL_EAXREVERB_DENSITY;
+        REVERB_DIFFUSION = AL_EAXREVERB_DIFFUSION;
+        REVERB_GAIN = AL_EAXREVERB_GAIN;
+        REVERB_DECAY_TIME = AL_EAXREVERB_DECAY_TIME;
+        REVERB_REFLECTIONS_GAIN = AL_EAXREVERB_REFLECTIONS_GAIN;
+        REVERB_REFLECTIONS_DELAY = AL_EAXREVERB_REFLECTIONS_DELAY;
+        REVERB_LATE_REVERB_GAIN = AL_EAXREVERB_LATE_REVERB_GAIN;
+        REVERB_LATE_REVERB_DELAY = AL_EAXREVERB_LATE_REVERB_DELAY;
         REVERB_ROOM_ROLLOFF_FACTOR = AL_EAXREVERB_ROOM_ROLLOFF_FACTOR;
     }
     else
     {
-        REVERB_DENSITY             = AL_REVERB_DENSITY;
-        REVERB_DIFFUSION           = AL_REVERB_DIFFUSION;
-        REVERB_GAIN                = AL_REVERB_GAIN;
-        REVERB_DECAY_TIME          = AL_REVERB_DECAY_TIME;
-        REVERB_REFLECTIONS_GAIN    = AL_REVERB_REFLECTIONS_GAIN;
-        REVERB_REFLECTIONS_DELAY   = AL_REVERB_REFLECTIONS_DELAY;
-        REVERB_LATE_REVERB_GAIN    = AL_REVERB_LATE_REVERB_GAIN;
-        REVERB_LATE_REVERB_DELAY   = AL_REVERB_LATE_REVERB_DELAY;
+        REVERB_DENSITY = AL_REVERB_DENSITY;
+        REVERB_DIFFUSION = AL_REVERB_DIFFUSION;
+        REVERB_GAIN = AL_REVERB_GAIN;
+        REVERB_DECAY_TIME = AL_REVERB_DECAY_TIME;
+        REVERB_REFLECTIONS_GAIN = AL_REVERB_REFLECTIONS_GAIN;
+        REVERB_REFLECTIONS_DELAY = AL_REVERB_REFLECTIONS_DELAY;
+        REVERB_LATE_REVERB_GAIN = AL_REVERB_LATE_REVERB_GAIN;
+        REVERB_LATE_REVERB_DELAY = AL_REVERB_LATE_REVERB_DELAY;
         REVERB_ROOM_ROLLOFF_FACTOR = AL_REVERB_ROOM_ROLLOFF_FACTOR;
     }
 }
+} // namespace sf

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -1,0 +1,236 @@
+#include <SFML/Audio/ReverbEffect.hpp>
+
+#define AL_ALEXT_PROTOTYPES
+#include <AL/efx.h>
+#include <AL/alext.h>
+
+#include "ALCheck.hpp"
+
+#include <cassert>
+
+using namespace sf;
+
+namespace
+{
+    std::uint32_t REVERB_DENSITY              = 0;
+    std::uint32_t REVERB_DIFFUSION            = 0;
+    std::uint32_t REVERB_GAIN                 = 0;
+    std::uint32_t REVERB_DECAY_TIME           = 0;
+    std::uint32_t REVERB_REFLECTIONS_GAIN     = 0;
+    std::uint32_t REVERB_REFLECTIONS_DELAY    = 0;
+    std::uint32_t REVERB_LATE_REVERB_GAIN     = 0;
+    std::uint32_t REVERB_LATE_REVERB_DELAY    = 0;
+    std::uint32_t REVERB_ROOM_ROLLOFF_FACTOR  = 0;
+}
+
+//values are initialised according to OpenAL extension guide p.66
+ReverbEffect::ReverbEffect()
+    : SoundEffect       (),
+    m_density           (1.f),
+    m_diffusion         (1.f),
+    m_gain              (0.32f),
+    m_decayTime         (1.4f),
+    m_reflectionGain    (0.05f),
+    m_reflectionDelay   (0.007f),
+    m_lateReverbGain    (1.26f),
+    m_lateReverbDelay   (0.011f),
+    m_roomRolloff       (0.f),
+    m_effect            (0)
+{
+    m_effect = setType(SoundEffect::Reverb);
+    applyParameterNames();
+}
+
+ReverbEffect::ReverbEffect(const ReverbEffect& copy)
+    : SoundEffect       (copy),
+    m_density           (1.f),
+    m_diffusion         (1.f),
+    m_gain              (0.32f),
+    m_decayTime         (1.4f),
+    m_reflectionGain    (0.05f),
+    m_reflectionDelay   (0.007f),
+    m_lateReverbGain    (1.26f),
+    m_lateReverbDelay   (0.011f),
+    m_roomRolloff       (0.f),
+    m_effect            (0)
+{
+    m_effect = setType(SoundEffect::Reverb);
+    applyParameterNames();
+
+    setDensity(copy.getDensity());
+    setDiffusion(copy.getDiffusion());
+    setGain(copy.getGain());
+    setDecayTime(copy.getDecayTime());
+    setReflectionGain(copy.getReflectionGain());
+    setReflectionDelay(copy.getReflectionDelay());
+    setLateReverbGain(copy.getLateReverbGain());
+    setLateReverbDelay(copy.getLateReverbDelay());
+    setRoomRolloff(copy.getRoomRolloff());
+}
+
+//public
+void ReverbEffect::setDensity(float density)
+{
+    assert(m_effect != 0);
+
+    m_density = std::min(1.f, std::max(0.f, density));
+    alCheck(alEffectf(m_effect, REVERB_DENSITY, m_density));
+
+    applyEffect();
+}
+
+void ReverbEffect::setDiffusion(float diffusion)
+{
+    assert(m_effect != 0);
+
+    m_diffusion = std::min(1.f, std::max(0.f, diffusion));
+    alCheck(alEffectf(m_effect, REVERB_DIFFUSION, m_density));
+
+    applyEffect();
+}
+
+void ReverbEffect::setGain(float gain)
+{
+    assert(m_effect != 0);
+
+    m_gain = std::min(1.f, std::max(0.f, gain));
+    alCheck(alEffectf(m_effect, REVERB_GAIN, m_gain));
+
+    applyEffect();
+}
+
+void ReverbEffect::setDecayTime(float decayTime)
+{
+    assert(m_effect != 0);
+
+    m_decayTime = std::min(20.f, std::max(0.1f, decayTime));
+    alCheck(alEffectf(m_effect, REVERB_DECAY_TIME, m_decayTime));
+
+    applyEffect();
+}
+
+void ReverbEffect::setReflectionGain(float gain)
+{
+    assert(m_effect != 0);
+
+    m_reflectionGain = std::min(1.f, std::max(0.f, gain));
+    alCheck(alEffectf(m_effect, REVERB_REFLECTIONS_GAIN, m_reflectionGain));
+
+    applyEffect();
+}
+
+void ReverbEffect::setReflectionDelay(float delay)
+{
+    assert(m_effect != 0);
+
+    m_reflectionDelay = std::min(0.3f, std::max(0.f, delay));
+    alCheck(alEffectf(m_effect, REVERB_REFLECTIONS_DELAY, m_reflectionDelay));
+
+    applyEffect();
+}
+
+void ReverbEffect::setLateReverbGain(float gain)
+{
+    assert(m_effect != 0);
+
+    m_lateReverbGain = std::min(1.f, std::max(0.f, gain));
+    alCheck(alEffectf(m_effect, REVERB_LATE_REVERB_GAIN, m_lateReverbGain));
+
+    applyEffect();
+}
+
+void ReverbEffect::setLateReverbDelay(float delay)
+{
+    assert(m_effect != 0);
+
+    m_lateReverbDelay = std::min(0.1f, std::max(0.f, delay));
+    alCheck(alEffectf(m_effect, REVERB_LATE_REVERB_DELAY, m_lateReverbDelay));
+
+    applyEffect();
+}
+
+void ReverbEffect::setRoomRolloff(float rolloff)
+{
+    assert(m_effect != 0);
+
+    m_roomRolloff = std::min(10.f, std::max(0.f, rolloff));
+    alCheck(alEffectf(m_effect, REVERB_ROOM_ROLLOFF_FACTOR, m_roomRolloff));
+
+    applyEffect();
+}
+
+float ReverbEffect::getDensity() const
+{
+    return m_density;
+}
+
+float ReverbEffect::getDiffusion() const
+{
+    return m_diffusion;
+}
+
+float ReverbEffect::getGain() const
+{
+    return m_gain;
+}
+
+float ReverbEffect::getDecayTime() const
+{
+    return m_decayTime;
+}
+
+float ReverbEffect::getReflectionGain() const
+{
+    return m_reflectionGain;
+}
+
+float ReverbEffect::getReflectionDelay() const
+{
+    return m_reflectionDelay;
+}
+
+float ReverbEffect::getLateReverbGain() const
+{
+    return m_lateReverbGain;
+}
+
+float ReverbEffect::getLateReverbDelay() const
+{
+    return m_lateReverbDelay;
+}
+
+float ReverbEffect::getRoomRolloff() const
+{
+    return m_roomRolloff;
+}
+
+//private
+void ReverbEffect::applyParameterNames()
+{
+    //sets the correct values depending on if this
+    //is an EAX reverb or not
+    if (alGetEnumValue("AL_EFFECT_EAXREVERB") != 0)
+    {
+        REVERB_DENSITY             = AL_EAXREVERB_DENSITY;
+        REVERB_DIFFUSION           = AL_EAXREVERB_DIFFUSION;
+        REVERB_GAIN                = AL_EAXREVERB_GAIN;
+        REVERB_DECAY_TIME          = AL_EAXREVERB_DECAY_TIME;
+        REVERB_REFLECTIONS_GAIN    = AL_EAXREVERB_REFLECTIONS_GAIN;
+        REVERB_REFLECTIONS_DELAY   = AL_EAXREVERB_REFLECTIONS_DELAY;
+        REVERB_LATE_REVERB_GAIN    = AL_EAXREVERB_LATE_REVERB_GAIN;
+        REVERB_LATE_REVERB_DELAY   = AL_EAXREVERB_LATE_REVERB_DELAY;
+        REVERB_ROOM_ROLLOFF_FACTOR = AL_EAXREVERB_ROOM_ROLLOFF_FACTOR;
+    }
+    else
+    {
+        REVERB_DENSITY             = AL_REVERB_DENSITY;
+        REVERB_DIFFUSION           = AL_REVERB_DIFFUSION;
+        REVERB_GAIN                = AL_REVERB_GAIN;
+        REVERB_DECAY_TIME          = AL_REVERB_DECAY_TIME;
+        REVERB_REFLECTIONS_GAIN    = AL_REVERB_REFLECTIONS_GAIN;
+        REVERB_REFLECTIONS_DELAY   = AL_REVERB_REFLECTIONS_DELAY;
+        REVERB_LATE_REVERB_GAIN    = AL_REVERB_LATE_REVERB_GAIN;
+        REVERB_LATE_REVERB_DELAY   = AL_REVERB_LATE_REVERB_DELAY;
+        REVERB_ROOM_ROLLOFF_FACTOR = AL_REVERB_ROOM_ROLLOFF_FACTOR;
+    }
+}

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -1,3 +1,30 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2020 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
 #include <SFML/Audio/ReverbEffect.hpp>
 
 #include "ALCheck.hpp"
@@ -11,7 +38,7 @@
 namespace
 {
     //these are defined so that they can be shared between EAX/non-EAX
-    //versions of the reverb effect. See applyParamterNames()
+    //versions of the reverb effect. See applyParameterNames()
     std::uint32_t REVERB_DENSITY              = 0;
     std::uint32_t REVERB_DIFFUSION            = 0;
     std::uint32_t REVERB_GAIN                 = 0;
@@ -26,6 +53,7 @@ namespace
 namespace sf
 {
 //values are initialised according to OpenAL extension guide p.66
+////////////////////////////////////////////////////////////
 ReverbEffect::ReverbEffect()
     : SoundEffect        (),
     m_density           (1.f),
@@ -43,6 +71,8 @@ ReverbEffect::ReverbEffect()
     applyParameterNames();
 }
 
+
+////////////////////////////////////////////////////////////
 ReverbEffect::ReverbEffect(const ReverbEffect& copy)
     : SoundEffect       (copy),
     m_density           (1.f),
@@ -70,7 +100,8 @@ ReverbEffect::ReverbEffect(const ReverbEffect& copy)
     setRoomRolloff(copy.getRoomRolloff());
 }
 
-//public
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setDensity(float density)
 {
     assert(m_effect != 0);
@@ -81,6 +112,8 @@ void ReverbEffect::setDensity(float density)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setDiffusion(float diffusion)
 {
     assert(m_effect != 0);
@@ -91,6 +124,8 @@ void ReverbEffect::setDiffusion(float diffusion)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setGain(float gain)
 {
     assert(m_effect != 0);
@@ -101,6 +136,8 @@ void ReverbEffect::setGain(float gain)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setDecayTime(float decayTime)
 {
     assert(m_effect != 0);
@@ -111,6 +148,8 @@ void ReverbEffect::setDecayTime(float decayTime)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setReflectionGain(float gain)
 {
     assert(m_effect != 0);
@@ -121,6 +160,8 @@ void ReverbEffect::setReflectionGain(float gain)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setReflectionDelay(float delay)
 {
     assert(m_effect != 0);
@@ -131,16 +172,20 @@ void ReverbEffect::setReflectionDelay(float delay)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setLateReverbGain(float gain)
 {
     assert(m_effect != 0);
 
-    m_lateReverbGain = std::min(1.f, std::max(0.f, gain));
+    m_lateReverbGain = std::min(10.f, std::max(0.f, gain));
     alCheck(alEffectf(m_effect, REVERB_LATE_REVERB_GAIN, m_lateReverbGain));
 
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setLateReverbDelay(float delay)
 {
     assert(m_effect != 0);
@@ -151,6 +196,8 @@ void ReverbEffect::setLateReverbDelay(float delay)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::setRoomRolloff(float rolloff)
 {
     assert(m_effect != 0);
@@ -161,52 +208,71 @@ void ReverbEffect::setRoomRolloff(float rolloff)
     applyEffect();
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getDensity() const
 {
     return m_density;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getDiffusion() const
 {
     return m_diffusion;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getGain() const
 {
     return m_gain;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getDecayTime() const
 {
     return m_decayTime;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getReflectionGain() const
 {
     return m_reflectionGain;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getReflectionDelay() const
 {
     return m_reflectionDelay;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getLateReverbGain() const
 {
     return m_lateReverbGain;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getLateReverbDelay() const
 {
     return m_lateReverbDelay;
 }
 
+
+////////////////////////////////////////////////////////////
 float ReverbEffect::getRoomRolloff() const
 {
     return m_roomRolloff;
 }
 
-//private
+
+////////////////////////////////////////////////////////////
 void ReverbEffect::applyParameterNames()
 {
     //sets the correct values depending on if this

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -39,15 +39,15 @@ namespace
 {
     //these are defined so that they can be shared between EAX/non-EAX
     //versions of the reverb effect. See applyParameterNames()
-    std::uint32_t REVERB_DENSITY              = 0;
-    std::uint32_t REVERB_DIFFUSION            = 0;
-    std::uint32_t REVERB_GAIN                 = 0;
-    std::uint32_t REVERB_DECAY_TIME           = 0;
-    std::uint32_t REVERB_REFLECTIONS_GAIN     = 0;
-    std::uint32_t REVERB_REFLECTIONS_DELAY    = 0;
-    std::uint32_t REVERB_LATE_REVERB_GAIN     = 0;
-    std::uint32_t REVERB_LATE_REVERB_DELAY    = 0;
-    std::uint32_t REVERB_ROOM_ROLLOFF_FACTOR  = 0;
+    sf::Uint32 REVERB_DENSITY              = 0;
+    sf::Uint32 REVERB_DIFFUSION            = 0;
+    sf::Uint32 REVERB_GAIN                 = 0;
+    sf::Uint32 REVERB_DECAY_TIME           = 0;
+    sf::Uint32 REVERB_REFLECTIONS_GAIN     = 0;
+    sf::Uint32 REVERB_REFLECTIONS_DELAY    = 0;
+    sf::Uint32 REVERB_LATE_REVERB_GAIN     = 0;
+    sf::Uint32 REVERB_LATE_REVERB_DELAY    = 0;
+    sf::Uint32 REVERB_ROOM_ROLLOFF_FACTOR  = 0;
 }
 
 namespace sf

--- a/src/SFML/Audio/ReverbEffect.cpp
+++ b/src/SFML/Audio/ReverbEffect.cpp
@@ -55,7 +55,7 @@ namespace sf
 //values are initialised according to OpenAL extension guide p.66
 ////////////////////////////////////////////////////////////
 ReverbEffect::ReverbEffect()
-    : SoundEffect        (),
+    : SoundEffect       (),
     m_density           (1.f),
     m_diffusion         (1.f),
     m_gain              (0.32f),

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -261,7 +261,7 @@ void SoundEffect::setVolumeMultiplier(float)
 ////////////////////////////////////////////////////////////
 float SoundEffect::getVolumeMultiplier() const
 {
-    return m_volume;
+    return m_volumeMultiplier;
 }
 
 

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -1,3 +1,31 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2020 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
 #include <SFML/Audio/AudioDevice.hpp>
 #include <SFML/Audio/SoundEffect.hpp>
 #include <SFML/Audio/SoundSource.hpp>
@@ -26,6 +54,7 @@ namespace
 
 namespace sf
 {
+////////////////////////////////////////////////////////////
 SoundEffect::SoundEffect()
     : m_effectSlot  (0),
     m_effect        (0),
@@ -35,6 +64,8 @@ SoundEffect::SoundEffect()
     alCheck(alGenAuxiliaryEffectSlots(1, &m_effectSlot));
 }
 
+
+////////////////////////////////////////////////////////////
 SoundEffect::SoundEffect(const SoundEffect& copy)
     : m_effectSlot  (0),
     m_effect        (0),
@@ -47,6 +78,8 @@ SoundEffect::SoundEffect(const SoundEffect& copy)
     setVolume(copy.getVolume());
 }
 
+
+////////////////////////////////////////////////////////////
 SoundEffect::~SoundEffect()
 {
     std::set<SoundSource*> sounds;
@@ -70,17 +103,22 @@ SoundEffect::~SoundEffect()
     }
 }
 
-//public
+
+////////////////////////////////////////////////////////////
 bool SoundEffect::isAvailable()
 {
     return priv::AudioDevice::isExtensionSupported("ALC_EXT_EFX");
 }
 
+
+////////////////////////////////////////////////////////////
 SoundEffect::Type SoundEffect::getType() const
 {
     return m_type;
 }
 
+
+////////////////////////////////////////////////////////////
 void SoundEffect::setVolume(float vol)
 {
     m_volume = std::min(1.f, std::max(0.f, vol));
@@ -88,12 +126,15 @@ void SoundEffect::setVolume(float vol)
     alCheck(alAuxiliaryEffectSlotf(m_effectSlot, AL_EFFECTSLOT_GAIN, m_volume));
 }
 
+
+////////////////////////////////////////////////////////////
 float SoundEffect::getVolume() const
 {
     return m_volume;
 }
 
-//protected
+
+////////////////////////////////////////////////////////////
 std::uint32_t SoundEffect::setType(SoundEffect::Type type)
 {
     switch (type)
@@ -125,22 +166,29 @@ std::uint32_t SoundEffect::setType(SoundEffect::Type type)
     return m_effect;
 }
 
+
+////////////////////////////////////////////////////////////
 void SoundEffect::applyEffect()
 {
     alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
 }
 
-//private
+
+////////////////////////////////////////////////////////////
 void SoundEffect::attachSoundSource(SoundSource* sound) const
 {
     m_soundlist.insert(sound);
 }
 
+
+////////////////////////////////////////////////////////////
 void SoundEffect::detachSoundSource(SoundSource* sound) const
 {
     m_soundlist.erase(sound);
 }
 
+
+////////////////////////////////////////////////////////////
 void SoundEffect::ensureEffect(Type type)
 {
     if (effects.count(type) == 0)

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -145,7 +145,7 @@ float SoundEffect::getVolumeMultiplier() const
 void SoundEffect::setParameter(int parameter, float value)
 {
     alCheck(alEffectf(m_effect, parameter, value));
-    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
+    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, static_cast<ALint>(m_effect)));
 }
 
 

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -62,10 +62,10 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 SoundEffect::SoundEffect(int effectType)
-    : m_effectSlot  (0),
-    m_effect        (0),
-    m_type          (effectType),
-    m_volume        (1.f)
+    : m_effectSlot      (0),
+    m_effect            (0),
+    m_type              (effectType),
+    m_volumeMultiplier  (1.f)
 {
     alCheck(alGenAuxiliaryEffectSlots(1, &m_effectSlot));
 
@@ -77,10 +77,10 @@ SoundEffect::SoundEffect(int effectType)
 
 ////////////////////////////////////////////////////////////
 SoundEffect::SoundEffect(const SoundEffect& copy)
-    : m_effectSlot  (0),
-    m_effect        (0),
-    m_type          (copy.m_type),
-    m_volume        (1.f)
+    : m_effectSlot      (0),
+    m_effect            (0),
+    m_type              (copy.m_type),
+    m_volumeMultiplier  (1.f)
 {
     alCheck(alGenAuxiliaryEffectSlots(1, &m_effectSlot));
 
@@ -89,7 +89,7 @@ SoundEffect::SoundEffect(const SoundEffect& copy)
     alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
 
     //copy properties from copy
-    setVolume(copy.getVolume());
+    setVolumeMultiplier(copy.getVolumeMultiplier());
 }
 
 
@@ -126,18 +126,18 @@ return priv::AudioDevice::isExtensionSupported("ALC_EXT_EFX");
 
 
 ////////////////////////////////////////////////////////////
-void SoundEffect::setVolume(float vol)
+void SoundEffect::setVolumeMultiplier(float value)
 {
-    m_volume = std::min(1.f, std::max(0.f, vol));
+    m_volumeMultiplier = std::min(1.f, std::max(0.f, value));
 
-    alCheck(alAuxiliaryEffectSlotf(m_effectSlot, AL_EFFECTSLOT_GAIN, m_volume));
+    alCheck(alAuxiliaryEffectSlotf(m_effectSlot, AL_EFFECTSLOT_GAIN, m_volumeMultiplier));
 }
 
 
 ////////////////////////////////////////////////////////////
-float SoundEffect::getVolume() const
+float SoundEffect::getVolumeMultiplier() const
 {
-    return m_volume;
+    return m_volumeMultiplier;
 }
 
 
@@ -213,10 +213,10 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 SoundEffect::SoundEffect(int effectType)
-    : m_effectSlot  (0),
-    m_effect        (0),
-    m_type          (effectType),
-    m_volume        (1.f)
+    : m_effectSlot      (0),
+    m_effect            (0),
+    m_type              (effectType),
+    m_volumeMultiplier  (1.f)
 {
     if (!hasWarned)
     {
@@ -228,10 +228,10 @@ SoundEffect::SoundEffect(int effectType)
 
 ////////////////////////////////////////////////////////////
 SoundEffect::SoundEffect(const SoundEffect& copy)
-    : m_effectSlot  (0),
-    m_effect        (0),
-    m_type          (copy.m_type),
-    m_volume        (1.f)
+    : m_effectSlot      (0),
+    m_effect            (0),
+    m_type              (copy.m_type),
+    m_volumeMultiplier  (1.f)
 {
 
 }
@@ -252,14 +252,14 @@ bool SoundEffect::isAvailable()
 
 
 ////////////////////////////////////////////////////////////
-void SoundEffect::setVolume(float)
+void SoundEffect::setVolumeMultiplier(float)
 {
 
 }
 
 
 ////////////////////////////////////////////////////////////
-float SoundEffect::getVolume() const
+float SoundEffect::getVolumeMultiplier() const
 {
     return m_volume;
 }

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -1,0 +1,123 @@
+#include <SFML/Audio/AudioDevice.hpp>
+#include <SFML/Audio/SoundEffect.hpp>
+#include <SFML/Audio/SoundSource.hpp>
+#include <SFML/System/Err.hpp>
+
+#define AL_ALEXT_PROTOTYPES
+#include <AL/efx.h>
+#include <AL/alext.h>
+
+#include "ALCheck.hpp"
+
+using namespace sf;
+
+namespace
+{
+
+}
+
+SoundEffect::SoundEffect()
+    : m_effectSlot  (0),
+    m_effect        (0),
+    m_type          (Null),
+    m_volume        (1.f)
+{
+    alCheck(alGenAuxiliaryEffectSlots(1, &m_effectSlot));
+    alCheck(alGenEffects(1, &m_effect));
+}
+
+SoundEffect::SoundEffect(const SoundEffect& copy)
+    : m_effectSlot  (0),
+    m_effect        (0),
+    m_type          (Null),
+    m_volume        (1.f)
+{
+    alCheck(alGenAuxiliaryEffectSlots(1, &m_effectSlot));
+    alCheck(alGenEffects(1, &m_effect));
+
+    //copy properties from copy
+    setVolume(copy.getVolume());
+}
+
+SoundEffect::~SoundEffect()
+{
+    std::set<SoundSource*> sounds;
+    m_soundlist.swap(sounds);
+
+    for (auto* sound : sounds)
+    {
+        sound->resetEffect();
+    }
+
+    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, AL_EFFECT_NULL));
+    alCheck(alDeleteAuxiliaryEffectSlots(1, &m_effectSlot));
+    alCheck(alDeleteEffects(1, &m_effect));
+}
+
+//public
+bool SoundEffect::isAvailable()
+{
+    return priv::AudioDevice::isExtensionSupported("ALC_EXT_EFX");
+}
+
+SoundEffect::Type SoundEffect::getType() const
+{
+    return m_type;
+}
+
+void SoundEffect::setVolume(float vol)
+{
+    m_volume = std::min(1.f, std::max(0.f, vol));
+
+    alCheck(alAuxiliaryEffectSlotf(m_effectSlot, AL_EFFECTSLOT_GAIN, m_volume));
+}
+
+float SoundEffect::getVolume() const
+{
+    return m_volume;
+}
+
+//protected
+std::uint32_t SoundEffect::setType(SoundEffect::Type type)
+{
+    switch (type)
+    {
+    default:
+        err() << type << ": not a known effect type." << std::endl;
+        return 0;
+    case Reverb:
+        //check if EAX reverb is  available
+        if (alGetEnumValue("AL_EFFECT_EAXREVERB") != 0)
+        {
+            alCheck(alEffecti(m_effect, AL_EFFECT_TYPE, AL_EFFECT_EAXREVERB));
+        }
+        else
+        {
+            alCheck(alEffecti(m_effect, AL_EFFECT_TYPE, AL_EFFECT_REVERB));
+        }
+        break;
+    case Chorus:
+        alCheck(alEffecti(m_effect, AL_EFFECT_TYPE, AL_EFFECT_CHORUS));
+        break;
+    }
+
+    m_type = type;
+    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
+    return m_effect;
+}
+
+void SoundEffect::applyEffect()
+{
+    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
+}
+
+//private
+void SoundEffect::attachSoundSource(SoundSource* sound) const
+{
+    m_soundlist.insert(sound);
+}
+
+void SoundEffect::detachSoundSource(SoundSource* sound) const
+{
+    m_soundlist.erase(sound);
+}

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -39,6 +39,7 @@
 
 #include <map>
 #include <algorithm>
+#include <memory>
 
 namespace
 {
@@ -134,6 +135,16 @@ void SoundEffect::setVolume(float vol)
 float SoundEffect::getVolume() const
 {
     return m_volume;
+}
+
+
+////////////////////////////////////////////////////////////
+SoundEffect& SoundEffect::operator=(const SoundEffect& right)
+{
+    SoundEffect temp(right);
+    std::swap(m_soundlist, temp.m_soundlist);
+
+    return *this;
 }
 
 

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -26,12 +26,12 @@
 // Headers
 ////////////////////////////////////////////////////////////
 
+#include <SFML/Audio/SoundEffect.hpp>
+
 #ifndef SFML_SYSTEM_IOS
 
 #include <SFML/Audio/AudioDevice.hpp>
-#include <SFML/Audio/SoundEffect.hpp>
 #include <SFML/Audio/SoundSource.hpp>
-#include <SFML/System/Err.hpp>
 
 #include "ALCheck.hpp"
 
@@ -202,7 +202,6 @@ void SoundEffect::ensureEffect(int type)
 #else
 
 //empty implementation for IOS
-#include <SFML/Audio/SoundEffect.hpp>
 #include <SFML/System/Err.hpp>
 
 namespace

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -71,7 +71,7 @@ SoundEffect::SoundEffect(int effectType)
 
     ensureEffect(effectType);
     alCheck(alEffecti(m_effect, AL_EFFECT_TYPE, effectType));
-    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
+    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, static_cast<ALint>(m_effect)));
 }
 
 
@@ -86,7 +86,7 @@ SoundEffect::SoundEffect(const SoundEffect& copy)
 
     //make sure we properly reference count our handle
     ensureEffect(m_type);
-    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
+    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, static_cast<ALint>(m_effect)));
 
     //copy properties from copy
     setVolumeMultiplier(copy.getVolumeMultiplier());

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -9,7 +9,7 @@
 #include <AL/efx.h>
 #include <AL/alext.h>
 
-#include <unordered_map>
+#include <map>
 
 namespace
 {
@@ -20,7 +20,7 @@ namespace
         std::uint32_t handle = 0;
         std::uint32_t count = 0;
     };
-    std::unordered_map<sf::SoundEffect::Type, CountedEffect> effects;
+    std::map<sf::SoundEffect::Type, CountedEffect> effects;
 }
 
 namespace sf

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -26,6 +26,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 
+#ifndef SFML_SYSTEM_IOS
+
 #include <SFML/Audio/AudioDevice.hpp>
 #include <SFML/Audio/SoundEffect.hpp>
 #include <SFML/Audio/SoundSource.hpp>
@@ -119,7 +121,7 @@ SoundEffect::~SoundEffect()
 ////////////////////////////////////////////////////////////
 bool SoundEffect::isAvailable()
 {
-    return priv::AudioDevice::isExtensionSupported("ALC_EXT_EFX");
+return priv::AudioDevice::isExtensionSupported("ALC_EXT_EFX");
 }
 
 
@@ -195,3 +197,114 @@ void SoundEffect::ensureEffect(int type)
     m_effect = effect.handle;
 }
 } // namespace sf
+
+
+#else
+
+//empty implementation for IOS
+#include <SFML/Audio/SoundEffect.hpp>
+#include <SFML/System/Err.hpp>
+
+namespace
+{
+    bool hasWarned = false;
+}
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+SoundEffect::SoundEffect(int effectType)
+    : m_effectSlot  (0),
+    m_effect        (0),
+    m_type          (effectType),
+    m_volume        (1.f)
+{
+    if (!hasWarned)
+    {
+        sf::err() << "Sound effects are unavailable on IOS\n";
+        hasWarned = true;
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+SoundEffect::SoundEffect(const SoundEffect& copy)
+    : m_effectSlot  (0),
+    m_effect        (0),
+    m_type          (copy.m_type),
+    m_volume        (1.f)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+SoundEffect::~SoundEffect()
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+bool SoundEffect::isAvailable()
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+void SoundEffect::setVolume(float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+float SoundEffect::getVolume() const
+{
+    return m_volume;
+}
+
+
+////////////////////////////////////////////////////////////
+void SoundEffect::setParameter(int, float)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void SoundEffect::setParameter(int, int)
+{
+
+}
+
+////////////////////////////////////////////////////////////
+SoundEffect& SoundEffect::operator=(const SoundEffect&)
+{
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+void SoundEffect::attachSoundSource(SoundSource*) const
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void SoundEffect::detachSoundSource(SoundSource*) const
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+void SoundEffect::ensureEffect(int)
+{
+
+}
+} // namespace sf
+
+#endif //SFML_SYSTEM_IOS

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -38,6 +38,7 @@
 #include <AL/alext.h>
 
 #include <map>
+#include <algorithm>
 
 namespace
 {

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -101,7 +101,7 @@ SoundEffect::~SoundEffect()
 
     for (std::set<SoundSource*>::const_iterator it = sounds.begin(); it != sounds.end(); ++it)
     {
-        (*it)->resetEffect();
+        (*it)->removeEffect();
     }
 
     alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, AL_EFFECT_NULL));

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -46,8 +46,10 @@ namespace
     //see ensureEffect()
     struct CountedEffect
     {
-        std::uint32_t handle = 0;
-        std::uint32_t count = 0;
+        CountedEffect() : handle(0), count(0) {}
+
+        std::uint32_t handle;
+        std::uint32_t count;
     };
     std::map<sf::SoundEffect::Type, CountedEffect> effects;
 }

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -159,6 +159,10 @@ std::uint32_t SoundEffect::setType(SoundEffect::Type type)
         ensureEffect(type);
         alCheck(alEffecti(m_effect, AL_EFFECT_TYPE, AL_EFFECT_CHORUS));
         break;
+    case Delay:
+        ensureEffect(type);
+        alCheck(alEffecti(m_effect, AL_EFFECT_TYPE, AL_EFFECT_ECHO));
+        break;
     }
 
     m_type = type;

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -46,7 +46,7 @@
 namespace
 {
     //reference counted effects object handle.
-    //this is to enables sharing of objects between effects slots
+    //this is to enable sharing of objects between effects slots
     //see ensureEffect()
     struct CountedEffect
     {
@@ -153,7 +153,7 @@ void SoundEffect::setParameter(int parameter, float value)
 void SoundEffect::setParameter(int parameter, int value)
 {
     alCheck(alEffecti(m_effect, parameter, value));
-    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, m_effect));
+    alCheck(alAuxiliaryEffectSloti(m_effectSlot, AL_EFFECTSLOT_EFFECT, static_cast<ALint>(m_effect)));
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Audio/SoundEffect.cpp
+++ b/src/SFML/Audio/SoundEffect.cpp
@@ -48,8 +48,8 @@ namespace
     {
         CountedEffect() : handle(0), count(0) {}
 
-        std::uint32_t handle;
-        std::uint32_t count;
+        sf::Uint32 handle;
+        sf::Uint32 count;
     };
     std::map<sf::SoundEffect::Type, CountedEffect> effects;
 }
@@ -137,7 +137,7 @@ float SoundEffect::getVolume() const
 
 
 ////////////////////////////////////////////////////////////
-std::uint32_t SoundEffect::setType(SoundEffect::Type type)
+sf::Uint32 SoundEffect::setType(SoundEffect::Type type)
 {
     switch (type)
     {

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -234,7 +234,7 @@ void SoundSource::setEffect(const SoundEffect* effect)
     }
 
     // Assign and use the new effect
-    m_effect = const_cast<SoundEffect*>(effect);
+    m_effect = effect;
     if (m_effect)
     {
         m_effect->attachSoundSource(this);

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -68,7 +68,7 @@ SoundSource::SoundSource(const SoundSource& copy)
 
     if (copy.m_effect)
     {
-        setEffect(copy.m_effect);
+        setEffect(*copy.m_effect);
     }
 }
 
@@ -201,7 +201,7 @@ SoundSource& SoundSource::operator =(const SoundSource& right)
     setRelativeToListener(right.isRelativeToListener());
     setMinDistance(right.getMinDistance());
     setAttenuation(right.getAttenuation());
-    setEffect(right.getEffect());
+    setEffect(*right.getEffect());
 
     return *this;
 }
@@ -224,7 +224,9 @@ SoundSource::Status SoundSource::getStatus() const
     return Stopped;
 }
 
-void SoundSource::setEffect(const SoundEffect* effect)
+
+////////////////////////////////////////////////////////////
+void SoundSource::setEffect(const SoundEffect& effect)
 {
     // First detach from the previous effect
     if (m_effect)
@@ -234,24 +236,23 @@ void SoundSource::setEffect(const SoundEffect* effect)
     }
 
     // Assign and use the new effect
-    m_effect = effect;
-    if (m_effect)
-    {
-        m_effect->attachSoundSource(this);
-        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, static_cast<ALint>(m_effect->m_effectSlot), 0, 0));
-    }
-    else
-    {
-        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, 0));
-    }
+    m_effect = &effect;
+
+    m_effect->attachSoundSource(this);
+    alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, static_cast<ALint>(m_effect->m_effectSlot), 0, 0));
+
 }
 
+
+////////////////////////////////////////////////////////////
 const SoundEffect* SoundSource::getEffect() const
 {
     return m_effect;
 }
 
-void SoundSource::resetEffect()
+
+////////////////////////////////////////////////////////////
+void SoundSource::removeEffect()
 {
     // First stop the sound in case it is playing
     stop();

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -45,7 +45,7 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 SoundSource::SoundSource()
-    : m_effect(nullptr)
+    : m_effect(NULL)
 {
     alCheck(alGenSources(1, &m_source));
     alCheck(alSourcei(m_source, AL_BUFFER, 0));
@@ -54,7 +54,7 @@ SoundSource::SoundSource()
 
 ////////////////////////////////////////////////////////////
 SoundSource::SoundSource(const SoundSource& copy)
-    : m_effect(nullptr)
+    : m_effect(NULL)
 {
     alCheck(alGenSources(1, &m_source));
     alCheck(alSourcei(m_source, AL_BUFFER, 0));

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -201,7 +201,17 @@ SoundSource& SoundSource::operator =(const SoundSource& right)
     setRelativeToListener(right.isRelativeToListener());
     setMinDistance(right.getMinDistance());
     setAttenuation(right.getAttenuation());
-    setEffect(*right.getEffect());
+
+
+    if (m_effect)
+    {
+        m_effect->detachSoundSource(this);
+    }
+
+    if (right.m_effect)
+    {
+        setEffect(*right.getEffect());
+    }
 
     return *this;
 }

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -27,6 +27,11 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/SoundSource.hpp>
 #include <SFML/Audio/ALCheck.hpp>
+#include <SFML/Audio/SoundEffect.hpp>
+
+#define AL_ALEXT_PROTOTYPES
+#include <AL/efx.h>
+#include <AL/alext.h>
 
 #if defined(__APPLE__)
     #if defined(__clang__)
@@ -40,6 +45,7 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 SoundSource::SoundSource()
+    : m_effect(nullptr)
 {
     alCheck(alGenSources(1, &m_source));
     alCheck(alSourcei(m_source, AL_BUFFER, 0));
@@ -48,6 +54,7 @@ SoundSource::SoundSource()
 
 ////////////////////////////////////////////////////////////
 SoundSource::SoundSource(const SoundSource& copy)
+    : m_effect(nullptr)
 {
     alCheck(alGenSources(1, &m_source));
     alCheck(alSourcei(m_source, AL_BUFFER, 0));
@@ -58,6 +65,11 @@ SoundSource::SoundSource(const SoundSource& copy)
     setRelativeToListener(copy.isRelativeToListener());
     setMinDistance(copy.getMinDistance());
     setAttenuation(copy.getAttenuation());
+
+    if (copy.m_effect)
+    {
+        setEffect(copy.m_effect);
+    }
 }
 
 
@@ -66,6 +78,11 @@ SoundSource::~SoundSource()
 {
     alCheck(alSourcei(m_source, AL_BUFFER, 0));
     alCheck(alDeleteSources(1, &m_source));
+
+    if (m_effect)
+    {
+        m_effect->detachSoundSource(this);
+    }
 }
 
 
@@ -184,6 +201,7 @@ SoundSource& SoundSource::operator =(const SoundSource& right)
     setRelativeToListener(right.isRelativeToListener());
     setMinDistance(right.getMinDistance());
     setAttenuation(right.getAttenuation());
+    setEffect(right.getEffect());
 
     return *this;
 }
@@ -204,6 +222,47 @@ SoundSource::Status SoundSource::getStatus() const
     }
 
     return Stopped;
+}
+
+void SoundSource::setEffect(const SoundEffect* effect)
+{
+    // First detach from the previous effect
+    if (m_effect)
+    {
+        stop();
+        m_effect->detachSoundSource(this);
+    }
+
+    // Assign and use the new effect
+    m_effect = const_cast<SoundEffect*>(effect);
+    if (m_effect)
+    {
+        m_effect->attachSoundSource(this);
+        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, m_effect->m_effectSlot, 0, NULL));
+    }
+    else
+    {
+        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, NULL));
+    }
+}
+
+const SoundEffect* SoundSource::getEffect() const
+{
+    return m_effect;
+}
+
+void SoundSource::resetEffect()
+{
+    // First stop the sound in case it is playing
+    stop();
+
+    // Detach the effect
+    if (m_effect)
+    {
+        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, NULL));
+        m_effect->detachSoundSource(this);
+        m_effect = NULL;
+    }
 }
 
 } // namespace sf

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -238,7 +238,7 @@ void SoundSource::setEffect(const SoundEffect* effect)
     if (m_effect)
     {
         m_effect->attachSoundSource(this);
-        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, m_effect->m_effectSlot, 0, 0));
+        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, static_cast<ALint>(m_effect->m_effectSlot), 0, 0));
     }
     else
     {

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -264,5 +264,4 @@ void SoundSource::resetEffect()
         m_effect = NULL;
     }
 }
-
 } // namespace sf

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -238,11 +238,11 @@ void SoundSource::setEffect(const SoundEffect* effect)
     if (m_effect)
     {
         m_effect->attachSoundSource(this);
-        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, m_effect->m_effectSlot, 0, NULL));
+        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, m_effect->m_effectSlot, 0, 0));
     }
     else
     {
-        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, NULL));
+        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, 0));
     }
 }
 
@@ -259,7 +259,7 @@ void SoundSource::resetEffect()
     // Detach the effect
     if (m_effect)
     {
-        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, NULL));
+        alCheck(alSource3i(m_source, AL_AUXILIARY_SEND_FILTER, AL_EFFECTSLOT_NULL, 0, 0));
         m_effect->detachSoundSource(this);
         m_effect = NULL;
     }


### PR DESCRIPTION
## Description

Implements OpenAL sound effects for reverb, chorus and delay. Can be easily extended to more types supported by OpenAL.
This was discussed some time (10 years!) ago here: https://en.sfml-dev.org/forums/index.php?topic=2245.0 the conclusion being that available OpenAL implementations were not capable. Thankfully things have changed somewhat in the last decade. I've tested this on platforms using openal-soft (windows and ubuntu) and on macOS using Apple's OpenAL library. I was pleasantly surprised to find that the effects are supported by the Apple library, although they are audibly rendered differently - particularly the delay which sounds much softer. However it seems openal-soft is supported on macOS and building SFML against that makes the effects sound consistent across tested platforms. I'm unable to test on mobile platforms.

I'm submitting this mostly because I find the effects useful, and it would be preferable not to have to maintain my own fork of SFML. I'd also like to gauge interest to potentially develop further with features such as low/high pass filters for example.

## Tasks

* [X] Tested on Linux - xubuntu 20.04
* [X] Tested on Windows 10 - 2004
* [X] Tested on macOS - 10.14
* [ ] Tested on iOS
* [ ] Tested on Android

## API Overview

- `sf::SoundSource` - Base class of e.g. `sf::Music` or `sf::Sound`
  - `void setEffect(const SoundEffect* effect);` - Set or remove (with `NULL`) effects to anything implementing SoundSource
  - `const SoundEffect* getEffect() const;` - Get the currently set effect or `NULL` if none is set
  - `void resetEffect();` - Internal use to reset the effect when the `sf::SoundEffect` instance is destroyed

- `sf::SoundEffect` - Sound effect base class
  - `static bool isAvailable();` - Not all platforms support effects (e.g. iOS)
  - `void setVolume(float volume);` - Volume of the effect in the range or 0 to 1
  - `float getVolume() const;` - Retrieve set volume

- `sf::ChorusEffect`
  - `void setWaveform(Waveform waveform);` - Set the LFO waveform shape, either Sine or Triangle
  - `void setPhase(sf::Int32 angle);` - Set the LFO phase
  - `void setRate(float rate);` - Set the LFO modulation rate
  - `void setDepth(float depth);` - Set the amount by which the delay time is modulated
  - `void setFeedback(float amount);` - Set the amount of processed signal that is fed back to the input
  - `void setDelay(float delay);` - Set the average amount of time the sample is delayed
  - `Waveform getWaveform() const;`
  - `sf::Int32 getPhase() const;`
  - `float getRate() const;`
  - `float getDepth() const;`
  - `float getFeedback() const;`
  - `float getDelay() const;`

- `sf::DelayEffect`
  - `void setDelay(float delay);` - Set the delay between the original sound and the first 'tap', or echo instance
  - `void setLRDelay(float delay);` - Set the delay between the first 'tap' and the second 'tap'
  - `void setDamping(float damping);` - Set the amount of high frequency damping applied to each echo
  - `void setFeedback(float feedback);` - Set the amount of feedback the output signal fed back into the input
  - `void setSpread(float spread);` - Set how hard panned the individual echoes are
  - `float getDelay() const;`
  - `float getLRDelay() const;`
  - `float getDamping() const;`
  - `float getFeedback() const;`
  - `float getSpread() const;`

- `sf::ReverbEffect`
  - `void setDensity(float density);` - Set the coloration of the late reverb
  - `void setDiffusion(float diffusion);` - Set the echo density in the reverberation decay
  - `void setGain(float gain);` - Sets the max amount of reflections and reverberation added to the final sound mix
  - `void setDecayTime(float decay);` - Set the reverberation decay time
  - `void setReflectionGain(float gain);` - Set  the overall amount of initial reflections relative to the Gain property
  - `void setReflectionDelay(float delay);` - Set the amount of delay between the arrival time of the direct path from the source to the first reflection from the source
  - `void setLateReverbGain(float delay);` - Set the overall amount of later reverberation relative to the Gain property
  - `void setLateReverbDelay(float delay);` - Set the begin time of the late reverberation relative to the time of the initial reflection
  - `void setRoomRolloff(float rolloff);` - Set the attenuation of the reflected sound
  - `float getDensity() const;`
  - `float getDiffusion() const;`
  - `float getGain() const;`
  - `float getDecayTime() const;`
  - `float getReflectionGain() const;`
  - `float getReflectionDelay() const;`
  - `float getLateReverbGain() const;`
  - `float getLateReverbDelay() const;`
  - `float getRoomRolloff() const;`

## How to test this PR?

I've updated the 'sound' example in the included examples directory to demonstrate the use of effects. The syntax is similar to that of `sf::SoundBuffer` to `sf::Sound`:

    sf::ReverbEffect effect;
    effect.setDecayTime(2.f);

    sf::Music music;
    music.loadFromFile("music.wav");
    music.setEffect(&effect);
    music.play();