### PR TITLE
Update of documentation in Vector implementation based in system module

### DIFF
--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -285,7 +285,7 @@ typedef Vector2<float>        Vector2f;
 ///
 /// Usage example:
 /// \code
-/// sf::Vector2f v1(16.5f, 24.f);
+/// sf::Vector2f v1 = { 16.2f, 2.0f}
 /// v1.x = 18.2f;
 /// float y = v1.y;
 ///


### PR DESCRIPTION
----

## Description

Hello guys!
I have been writing a simple game in SFML right now for my University Classes and I guess that I found a mistake in your documentation. When reading the example given in Vector2.hpp I tried to create a new Vector for my Player object and when I used notation 
``` C++
sf::Vector2f v1(1.2f, 3.4f)
```
It didn't work, so I tried to assign variables, like in normal vector, and finally, it compiled correctly.

``` C++
sf::Vector2f v1 = { 1.2f, 3.5f }
```

If It is my mistake, I'm really sorry for wasting your time, but still in the learning process (as everyone I guess)

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android