### PR TITLE
Fix warning: control may reach end of non-void function [-Wreturn-type]

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -664,7 +664,8 @@ Keyboard::Key WindowImplAndroid::androidKeyToSF(int32_t key)
         case AKEYCODE_BUTTON_THUMBR:
         case AKEYCODE_BUTTON_START:
         case AKEYCODE_BUTTON_SELECT:
-        case AKEYCODE_BUTTON_MODE:        return Keyboard::Unknown;
+        case AKEYCODE_BUTTON_MODE:
+        default:                          return Keyboard::Unknown;
     }
 }
 


### PR DESCRIPTION
Fix warning and/or bug in androidKeyToSF() adding a default label for all keys _Keyboard::Unknown_