### PR TITLE
Add SO_REUSEADDR to socket.

### DIFF
--- a/src/SFML/Network/Socket.cpp
+++ b/src/SFML/Network/Socket.cpp
@@ -106,6 +106,9 @@ void Socket::create(SocketHandle handle)
         // Set the current blocking state
         setBlocking(m_isBlocking);
 
+		const int data = 1;
+		setsockopt(m_socket, SOL_SOCKET, SO_REUSEADDR, &data, sizeof(int));
+
         if (m_type == Tcp)
         {
             // Disable the Nagle algorithm (i.e. removes buffering of TCP packets)


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Now, you can kill your server and instantly restart it without an error message that the address is in use.

This PR is related to the issue #

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Build an EmptyEpsilon server with it.