### PR TITLE
Fixed joystick POV values not being set properly for devices that are…

### DIFF
--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -907,7 +907,7 @@ JoystickState JoystickImpl::updateDInputBuffered()
         {
             if (m_axes[j] == events[i].dwOfs)
             {
-                if (j == Joystick::PovX)
+                if ((j == Joystick::PovX) || (j == Joystick::PovY))
                 {
                     unsigned short value = LOWORD(events[i].dwData);
 
@@ -915,26 +915,13 @@ JoystickState JoystickImpl::updateDInputBuffered()
                     {
                         float angle = (static_cast<float>(value)) * 3.141592654f / DI_DEGREES / 180.f;
 
-                        m_state.axes[j] = std::sin(angle) * 100.f;
+                        m_state.axes[Joystick::PovX] = std::sin(angle) * 100.f;
+                        m_state.axes[Joystick::PovY] = std::cos(angle) * 100.f;
                     }
                     else
                     {
-                        m_state.axes[j] = 0;
-                    }
-                }
-                else if (j == Joystick::PovY)
-                {
-                    unsigned short value = LOWORD(events[i].dwData);
-
-                    if (value != 0xFFFF)
-                    {
-                        float angle = (static_cast<float>(value)) * 3.141592654f / DI_DEGREES / 180.f;
-
-                        m_state.axes[j] = std::cos(angle) * 100.f;
-                    }
-                    else
-                    {
-                        m_state.axes[j] = 0.f;
+                        m_state.axes[Joystick::PovX] = 0.f;
+                        m_state.axes[Joystick::PovY] = 0.f;
                     }
                 }
                 else
@@ -1009,7 +996,7 @@ JoystickState JoystickImpl::updateDInputPolled()
         {
             if (m_axes[i] != -1)
             {
-                if (i == Joystick::PovX)
+                if ((i == Joystick::PovX) || (i == Joystick::PovY))
                 {
                     unsigned short value = LOWORD(*reinterpret_cast<const DWORD*>(reinterpret_cast<const char*>(&joystate) + m_axes[i]));
 
@@ -1017,26 +1004,13 @@ JoystickState JoystickImpl::updateDInputPolled()
                     {
                         float angle = (static_cast<float>(value)) * 3.141592654f / DI_DEGREES / 180.f;
 
-                        state.axes[i] = std::sin(angle) * 100.f;
+                        state.axes[Joystick::PovX] = std::sin(angle) * 100.f;
+                        state.axes[Joystick::PovY] = std::cos(angle) * 100.f;
                     }
                     else
                     {
-                        state.axes[i] = 0;
-                    }
-                }
-                else if (i == Joystick::PovY)
-                {
-                    unsigned short value = LOWORD(*reinterpret_cast<const DWORD*>(reinterpret_cast<const char*>(&joystate) + m_axes[i]));
-
-                    if (value != 0xFFFF)
-                    {
-                        float angle = (static_cast<float>(value)) * 3.141592654f / DI_DEGREES / 180.f;
-
-                        state.axes[i] = std::cos(angle) * 100.f;
-                    }
-                    else
-                    {
-                        state.axes[i] = 0.f;
+                        state.axes[Joystick::PovX] = 0.f;
+                        state.axes[Joystick::PovY] = 0.f;
                     }
                 }
                 else


### PR DESCRIPTION
This fixes an issue where joystick/controller POV values were not set correctly for devices that are accessed via DirectInput.

See: https://github.com/SFML/SFML/pull/1634#issuecomment-667706226

DirectInput provides a combined value for both X and Y hat directions, this value has to be translated back to the separate X and Y values that SFML exposes through its API. Previously the implementation erroneously treated X and Y hat axes as separate objects which could only work if the device reported the same hat twice as distinct objects. This was the case with some devices but not all causing this bug to not always be reproducible.

This fix was tested with both a joystick and a controller (the same one mentioned in the linked comment).