### PR TITLE
Retain cursor if an unsupported cursor is used

### DIFF
--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -89,7 +89,10 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
 
     switch (type)
     {
-        default: return false;
+        default:
+            if (m_cursor)
+                [m_cursor retain];
+            return false;
 
         case Cursor::Arrow:           m_cursor = [NSCursor arrowCursor];               break;
         case Cursor::Text:            m_cursor = [NSCursor IBeamCursor];               break;


### PR DESCRIPTION
## Description

While testing #1688, I ran into random crashes and after a while I realized that the switch-case construct didn't cover all cursor types - as documented - which then lead to random crashes when picking the unsupported cursors.

## Tasks

* [x] Tested on macOS

## How to test this PR?

You can use this example that counts through all the cursor types and will crash with `master` right now.

```cpp
#include <iostream>
#include <SFML/Graphics.hpp>

int main()
{
    auto window = sf::RenderWindow{{800, 600, 32}, "SFML Window"};
    window.setFramerateLimit(60);

    auto cursor = sf::Cursor{};

    auto start = sf::Cursor::Arrow;
    auto current = sf::Cursor::Arrow;
    auto end = sf::Cursor::NotAllowed;

    cursor.loadFromSystem(current);
    window.setMouseCursor(cursor);
    std::cout << "New cursor type: " << current << "\n";

    while (window.isOpen())
    {
        for (auto event = sf::Event{}; window.pollEvent(event);)
        {
            if (event.type == sf::Event::Closed)
            {
                window.close();
                return 0;
            }

            if ((event.type == sf::Event::KeyPressed))
            {
                switch (event.key.code)
                {
                    case sf::Keyboard::Escape:
                    {
                        window.close();
                        return 0;
                    }
                    case sf::Keyboard::Up:
                        if(current < end)
                        {
                            current = static_cast<sf::Cursor::Type>(current + 1);
                            cursor.loadFromSystem(current);
                            window.setMouseCursor(cursor);
                            std::cout << "New cursor type: " << current << "\n";
                        }
                        break;
                    case sf::Keyboard::Down:
                        if(current > start)
                        {
                            current = static_cast<sf::Cursor::Type>(current - 1);
                            cursor.loadFromSystem(current);
                            window.setMouseCursor(cursor);
                            std::cout << "New cursor type: " << current << "\n";
                        }
                        break;
                }
            }
        }


        window.clear();
        window.display();
    }
}```