### PR TITLE
[sprite] don't set default rect before the user provided one

### DIFF
--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -55,7 +55,9 @@ Sprite::Sprite(const Texture& texture, const IntRect& rectangle) :
 m_texture    (NULL),
 m_textureRect()
 {
+    // Compute the texture area
     setTextureRect(rectangle);
+    // Assign texture
     setTexture(texture, false);
 }
 
@@ -65,7 +67,10 @@ void Sprite::setTexture(const Texture& texture, bool resetRect)
 {
     // Recompute the texture area if requested, or if there was no valid texture & rect before
     if (resetRect || (!m_texture && (m_textureRect == sf::IntRect())))
-        setTextureRect(IntRect(0, 0, texture.getSize().x, texture.getSize().y));
+    {
+        Vector2u size = texture.getSize();
+        setTextureRect(IntRect(0, 0, size.x, size.y));
+    }
 
     // Assign the new texture
     m_texture = &texture;

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -46,7 +46,7 @@ Sprite::Sprite(const Texture& texture) :
 m_texture    (NULL),
 m_textureRect()
 {
-    setTexture(texture);
+    setTexture(texture, true);
 }
 
 
@@ -55,8 +55,8 @@ Sprite::Sprite(const Texture& texture, const IntRect& rectangle) :
 m_texture    (NULL),
 m_textureRect()
 {
-    setTexture(texture);
     setTextureRect(rectangle);
+    setTexture(texture, false);
 }
 
 


### PR DESCRIPTION
Small Optimisation. Using second constructor with user provided rextureRect we first create the default one(by setTexture method) and then overwrite it with the user provided one. With this change we simply first set user provided textureRect and then set the texture which prevents unnecesary creating the default one.

Please review.

Cheers.