### PR TITLE
Preserve the drop shadow for system cursors on Windows

### DIFF
--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -36,7 +36,8 @@ namespace priv
 
 ////////////////////////////////////////////////////////////
 CursorImpl::CursorImpl() :
-m_cursor(NULL)
+m_cursor(NULL),
+m_systemCursor(false)
 {
     // That's it.
 }
@@ -118,6 +119,7 @@ bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hot
 
     // Create the cursor
     m_cursor = reinterpret_cast<HCURSOR>(CreateIconIndirect(&cursorInfo));
+    m_systemCursor = false;
 
     // The data has been copied into the cursor, so get rid of these
     DeleteObject(color);
@@ -166,8 +168,9 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::NotAllowed:             shape = IDC_NO;          break;
     }
 
-    // Create a copy of the shared system cursor that we can destroy later
-    m_cursor = CopyCursor(LoadCursor(NULL, shape));
+    // Get the shared system cursor and make sure not to destroy it
+    m_cursor = LoadCursor(NULL, shape);
+    m_systemCursor = true;
 
     if (m_cursor)
     {
@@ -184,7 +187,7 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
 ////////////////////////////////////////////////////////////
 void CursorImpl::release()
 {
-    if (m_cursor) {
+    if (m_cursor && !m_systemCursor) {
         DestroyCursor(m_cursor);
         m_cursor = NULL;
     }

--- a/src/SFML/Window/Win32/CursorImpl.hpp
+++ b/src/SFML/Window/Win32/CursorImpl.hpp
@@ -93,6 +93,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     HCURSOR m_cursor;
+    bool m_systemCursor;
 };
 
 } // namespace priv


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

`CopyCursor` causes the cursor to lose the drop shadow effect. The only reason it was being used was so that it could keep an `HCURSOR` that could be destroyed later, for consistent usage in `release()`. I simply added a flag to indicate whether the cursor was loaded from a system cursor or a bitmap and a check on `release()` to only destroy the `HCURSOR` on the latter case.

## Tasks

* [x] Tested on Windows

(these changes do not affect any other OS)

## How to test this PR?

Run the code below and move the mouse over the window. It should change to a hand and honor the system-wide drop shadow setting.

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode(1280, 720), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);
        
    sf::Cursor cursor;
    cursor.loadFromSystem(sf::Cursor::Type::Hand);
    window.setMouseCursor(cursor);

    while (window.isOpen()) {
        sf::Event event;
        while (window.pollEvent(event)) {
            if (event.type == sf::Event::Closed) window.close();
        }

        window.clear(sf::Color::White);
        window.display();
    }
}
```