### PR TITLE
Fix potential crash when changing cursor - don't release the NSCursor object if it's already been released

### DIFF
--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -89,27 +89,23 @@ bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hot
 ////////////////////////////////////////////////////////////
 bool CursorImpl::loadFromSystem(Cursor::Type type)
 {
-    if (m_cursor)
-    {
-        [m_cursor release];
-        m_cursor = nil;
-    }
+    NSCursor* newCursor = nil;
 
     switch (type)
     {
         default: return false;
 
-        case Cursor::Arrow:           m_cursor = [NSCursor arrowCursor];               break;
-        case Cursor::Text:            m_cursor = [NSCursor IBeamCursor];               break;
-        case Cursor::Hand:            m_cursor = [NSCursor pointingHandCursor];        break;
-        case Cursor::SizeHorizontal:  m_cursor = [NSCursor resizeLeftRightCursor];     break;
-        case Cursor::SizeVertical:    m_cursor = [NSCursor resizeUpDownCursor];        break;
-        case Cursor::Cross:           m_cursor = [NSCursor crosshairCursor];           break;
-        case Cursor::NotAllowed:      m_cursor = [NSCursor operationNotAllowedCursor]; break;
-        case Cursor::SizeLeft:        m_cursor = [NSCursor resizeLeftRightCursor];     break;
-        case Cursor::SizeRight:       m_cursor = [NSCursor resizeLeftRightCursor];     break;
-        case Cursor::SizeTop:         m_cursor = [NSCursor resizeUpDownCursor];        break;
-        case Cursor::SizeBottom:      m_cursor = [NSCursor resizeUpDownCursor];        break;
+        case Cursor::Arrow:           newCursor = [NSCursor arrowCursor];               break;
+        case Cursor::Text:            newCursor = [NSCursor IBeamCursor];               break;
+        case Cursor::Hand:            newCursor = [NSCursor pointingHandCursor];        break;
+        case Cursor::SizeHorizontal:  newCursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::SizeVertical:    newCursor = [NSCursor resizeUpDownCursor];        break;
+        case Cursor::Cross:           newCursor = [NSCursor crosshairCursor];           break;
+        case Cursor::NotAllowed:      newCursor = [NSCursor operationNotAllowedCursor]; break;
+        case Cursor::SizeLeft:        newCursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::SizeRight:       newCursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::SizeTop:         newCursor = [NSCursor resizeUpDownCursor];        break;
+        case Cursor::SizeBottom:      newCursor = [NSCursor resizeUpDownCursor];        break;
             
         // These cursor types are undocumented, may not be available on some platforms
 #pragma clang diagnostic push
@@ -117,25 +113,29 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::SizeTopRight:
         case Cursor::SizeBottomLeft:
         case Cursor::SizeBottomLeftTopRight:
-            m_cursor = loadFromSelector(@selector(_windowResizeNorthEastSouthWestCursor));
+            newCursor = loadFromSelector(@selector(_windowResizeNorthEastSouthWestCursor));
             break;
 
         case Cursor::SizeTopLeft:
         case Cursor::SizeBottomRight:
         case Cursor::SizeTopLeftBottomRight:
-            m_cursor = loadFromSelector(@selector(_windowResizeNorthWestSouthEastCursor));
+            newCursor = loadFromSelector(@selector(_windowResizeNorthWestSouthEastCursor));
             break;
 
         case Cursor::Help:
-            m_cursor = loadFromSelector(@selector(_helpCursor));
+            newCursor = loadFromSelector(@selector(_helpCursor));
             break;
 #pragma clang diagnostic pop
     }
 
-    if (m_cursor)
+    if (newCursor)
+    {
+        [m_cursor release];
+        m_cursor = newCursor;
         [m_cursor retain];
+    }
 
-    return m_cursor != nil;
+    return newCursor != nil;
 }
 
 

--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -71,7 +71,11 @@ CursorImpl::~CursorImpl()
 ////////////////////////////////////////////////////////////
 bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hotspot)
 {
-    [m_cursor release];
+    if (m_cursor)
+    {
+        [m_cursor release];
+        m_cursor = nil;
+    }
 
     NSSize   nssize    = NSMakeSize(size.x, size.y);
     NSImage* image     = [NSImage imageWithRawData:pixels andSize:nssize];
@@ -85,7 +89,11 @@ bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hot
 ////////////////////////////////////////////////////////////
 bool CursorImpl::loadFromSystem(Cursor::Type type)
 {
-    [m_cursor release];
+    if (m_cursor)
+    {
+        [m_cursor release];
+        m_cursor = nil;
+    }
 
     switch (type)
     {


### PR DESCRIPTION
Follow up from #1721 which isn't suitable as it may try to retain a dangling reference. We solve this by setting our member reference to nil after we've released it.

 ## Tasks
 * [x]  Tested on macOS