### PR TITLE
Update CMake minimum version to 3.7.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,4 @@
-# CMake's built-in Android support requires 3.7.0
-if(CMAKE_SYSTEM_NAME MATCHES "Android")
-    cmake_minimum_required(VERSION 3.7.2)
-else()
-    cmake_minimum_required(VERSION 3.0.2)
-endif()
+cmake_minimum_required(VERSION 3.7.2)
 
 # define a macro that helps defining an option
 macro(sfml_set_option var default type docstring)


### PR DESCRIPTION
## Description

The CMake version is currently constraint to 3.0.2 mostly because Debian Jessie only shipped with said version. Jessie has since been superseded by Stretch (2017-06-17), which itself has been superseded by Buster (2019-07-06).

According to [Repology](https://repology.org/project/cmake/versions) most distros do support CMake 3.7.2 or higher.

I chose 3.7.2 as it's the minimum version required for Android and it's the minimum version supported by Debian Buster.

This PR enables the implementation of other features, such as #1419

## How to test this PR?

Build SFML on your platform of choice