### PR TITLE
Fix for issue #1733

### DIFF
--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -164,7 +164,7 @@ void RenderTexture::display()
     if (m_impl && (priv::RenderTextureImplFBO::isAvailable() || setActive(true)))
     {
         m_impl->updateTexture(m_texture.m_texture);
-        m_texture.m_pixelsFlipped = true;
+        m_texture.m_pixelsFlipped = false;
         m_texture.invalidateMipmap();
     }
 }


### PR DESCRIPTION
#### Description
Solves issue #1733, but needs checking from people, who possibly could explain why textures in RenderTexture::display() previously have set `m_texture.m_pixelsFlipped = true;`