### PR TITLE
Fixed copy assign operator in sf::Sound so it checks for self-assignment

### DIFF
--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -160,6 +160,10 @@ Sound& Sound::operator =(const Sound& right)
     // the list of sound instances contained in the buffers and unnecessarily
     // destroy/create OpenAL sound sources
 
+    // Handle self-assignment here, as no copy-and-swap idiom is being used
+    if (this == &right)
+        return *this;
+
     // Delegate to base class, which copies all the sound attributes
     SoundSource::operator=(right);
 


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Please describe your pull request.

The copy-assign operator in sf::Sound doesn't use the copy-and-swap idiom. It's also modifying the member variable m_buffer. For those two reasons, it is necessary to check for self-assignment.

If we don't check for self-assignment, and we're assigning an object to itself, look what happens in this snippet:

```cpp
if (m_buffer)
{
    stop();
    m_buffer->detachSound(this);
    m_buffer = NULL;
}
```

If `this == &right`, we are basically setting `right.m_buffer` to `NULL` too, which is undesirable in this situation.

## Tasks

* [X] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Just create a sf::Sound and try to assign it to itself. It shouldn't modify itself.