### PR TITLE
macOS: allow CMAKE_OSX_ARCHITECTURES to be arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,10 +253,12 @@ if(SFML_OS_MACOSX)
         endif()
     endif()
 
-    # only the default architecture (i.e. 64-bit) is supported
-    if(NOT CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
-        message(FATAL_ERROR "Only 64-bit architecture is supported")
-    endif()
+    # only the default x86_64 or arm64 are supported
+    foreach (arch IN LISTS CMAKE_OSX_ARCHITECTURES)
+        if (NOT (arch STREQUAL "x86_64" OR arch STREQUAL "arm64"))
+            message(FATAL_ERROR "Invalid arch ${arch}")
+        endif()
+    endforeach()
 
     # configure Xcode templates
     set(XCODE_TEMPLATES_ARCH "\$(NATIVE_ARCH_ACTUAL)")


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Changed CMakeLists.txt to allow `CMAKE_OSX_ARCHITECTURES ` to be either x86_64, arm64, or both. This allows native builds on apple silicon.

This PR is related to the issue #1749 

## Tasks
* [x] Tested on macOS

## How to test this PR?

Pull the code on MacOS, enter some value into `CMAKE_OSX_ARCHITECTURES `, and configure.