### PR TITLE
Change GitHub Actions failure mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         platform:
         - { name: Windows VS2017, os: windows-2016   }
@@ -43,7 +44,7 @@ jobs:
         echo "y" | /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "cmake;3.10.2.4988404" --sdk_root=ANDROID_SDK_ROOT
         sudo ln -sf /usr/local/lib/android/sdk/cmake/3.10.2.4988404/bin/cmake /usr/bin/cmake
         wget -nv https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip -P $GITHUB_WORKSPACE
-        unzip -qq -d $GITHUB_WORKSPACE android-ndk-r18b-linux-x86_64.zip 
+        unzip -qq -d $GITHUB_WORKSPACE android-ndk-r18b-linux-x86_64.zip
 
 
     - name: Configure CMake


### PR DESCRIPTION
When a single GitHub Action build fails, the other builds should not be canceled, but instead should continue to build.
Since the matrix is setup on OS level, a failing build on one OS usually doesn't mean it's broken for all OS.

This was already successfully "tested" on the CSFML repo.

See also the [official documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)
