### PR TITLE
Add Min and Max blend modes

### DIFF
--- a/include/SFML/Graphics/BlendMode.hpp
+++ b/include/SFML/Graphics/BlendMode.hpp
@@ -68,9 +68,11 @@ struct SFML_GRAPHICS_API BlendMode
     ////////////////////////////////////////////////////////
     enum Equation
     {
-        Add,            //!< Pixel = Src * SrcFactor + Dst * DstFactor
-        Subtract,       //!< Pixel = Src * SrcFactor - Dst * DstFactor
-        ReverseSubtract //!< Pixel = Dst * DstFactor - Src * SrcFactor
+        Add,             //!< Pixel = Src * SrcFactor + Dst * DstFactor
+        Subtract,        //!< Pixel = Src * SrcFactor - Dst * DstFactor
+        ReverseSubtract, //!< Pixel = Dst * DstFactor - Src * SrcFactor
+        Min,             //!< Pixel = min(Dst, Src)
+        Max              //!< Pixel = max(Dst, Src)
     };
 
     ////////////////////////////////////////////////////////////
@@ -150,6 +152,8 @@ SFML_GRAPHICS_API bool operator !=(const BlendMode& left, const BlendMode& right
 SFML_GRAPHICS_API extern const BlendMode BlendAlpha;    //!< Blend source and dest according to dest alpha
 SFML_GRAPHICS_API extern const BlendMode BlendAdd;      //!< Add source to dest
 SFML_GRAPHICS_API extern const BlendMode BlendMultiply; //!< Multiply source and dest
+SFML_GRAPHICS_API extern const BlendMode BlendMin;      //!< Take minimum between source and dest
+SFML_GRAPHICS_API extern const BlendMode BlendMax;      //!< Take maximum between source and dest
 SFML_GRAPHICS_API extern const BlendMode BlendNone;     //!< Overwrite dest with source
 
 } // namespace sf

--- a/src/SFML/Graphics/BlendMode.cpp
+++ b/src/SFML/Graphics/BlendMode.cpp
@@ -37,8 +37,10 @@ const BlendMode BlendAlpha(BlendMode::SrcAlpha, BlendMode::OneMinusSrcAlpha, Ble
                            BlendMode::One, BlendMode::OneMinusSrcAlpha, BlendMode::Add);
 const BlendMode BlendAdd(BlendMode::SrcAlpha, BlendMode::One, BlendMode::Add,
                          BlendMode::One, BlendMode::One, BlendMode::Add);
-const BlendMode BlendMultiply(BlendMode::DstColor, BlendMode::Zero);
-const BlendMode BlendNone(BlendMode::One, BlendMode::Zero);
+const BlendMode BlendMultiply(BlendMode::DstColor, BlendMode::Zero, BlendMode::Add);
+const BlendMode BlendMin(BlendMode::One, BlendMode::One, BlendMode::Min);
+const BlendMode BlendMax(BlendMode::One, BlendMode::One, BlendMode::Max);
+const BlendMode BlendNone(BlendMode::One, BlendMode::Zero, BlendMode::Add);
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -45,7 +45,6 @@
     #define GLEXT_multitexture                        true
     #define GLEXT_texture_edge_clamp                  true
     #define GLEXT_EXT_texture_edge_clamp              true
-    #define GLEXT_blend_minmax                        true
     #define GLEXT_glClientActiveTexture               glClientActiveTexture
     #define GLEXT_glActiveTexture                     glActiveTexture
     #define GLEXT_GL_TEXTURE0                         GL_TEXTURE0
@@ -140,6 +139,11 @@
     #define GLEXT_texture_sRGB                        false
     #define GLEXT_GL_SRGB8_ALPHA8                     0
 
+    // Core since 3.0 - EXT_blend_minmax
+    #define GLEXT_blend_minmax                        SF_GLAD_GL_EXT_blend_minmax
+    #define GLEXT_GL_MIN                              GL_MIN_EXT
+    #define GLEXT_GL_MAX                              GL_MAX_EXT
+
 #else
 
     // SFML requires at a bare minimum OpenGL 1.1 capability
@@ -164,6 +168,8 @@
     #define GLEXT_blend_minmax                        SF_GLAD_GL_EXT_blend_minmax
     #define GLEXT_glBlendEquation                     glBlendEquationEXT
     #define GLEXT_GL_FUNC_ADD                         GL_FUNC_ADD_EXT
+    #define GLEXT_GL_MIN                              GL_MIN_EXT
+    #define GLEXT_GL_MAX                              GL_MAX_EXT
 
     // Core since 1.2 - EXT_blend_subtract
     #define GLEXT_blend_subtract                      SF_GLAD_GL_EXT_blend_subtract


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

## Description

This PR adds two blend modes that are necessary for some effects, namely BlendMin and BlendMax.
Given the fact that constructing Min and Max from factors and equation might seem weird (because factors are ignored), I chose to provide constants.
It supports both OpenGL and OpenGL ES with the appropriate extension GL_EXT_blend_minmax.
It should also allow implementations with GL_EXT_blend_subtract but without GL_EXT_blend_minmax to use BlendMode::Subtract and BlendMode::ReverseSubtract.

This PR implements the suggestion #1710.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Here is a simple example to test the added blending modes. Place two images `1.png` and `2.png` in the working directory. Then press A to see them max blended, and Z to see them min blended.

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window;
    window.create(sf::VideoMode(128,128), "Min/Max blending test", sf::Style::Default);

    sf::Texture texture1;
    texture1.loadFromFile("1.png");
    texture1.setSmooth(true);
    sf::Sprite sprite1;
    sprite1.setTexture(texture1);

    sf::Texture texture2;
    texture2.loadFromFile("2.png");
    texture2.setSmooth(true);
    sf::Sprite sprite2;
    sprite2.setTexture(texture2);

    sf::Color clearColor = sf::Color::Black;
    sf::RenderStates states;
    states.blendMode = sf::BlendMax;

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed || (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Key::Escape))
            {
                window.close();
            }
            else if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Key::A)
            {
                states.blendMode = sf::BlendMax;
                clearColor = sf::Color::Black;
            }
            else if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Key::Z)
            {
                states.blendMode = sf::BlendMin;
                clearColor = sf::Color::White;
            }
        }

        window.clear(clearColor);
        window.draw(sprite1, states);
        window.draw(sprite2, states);
        window.display();
    }

    return 0;
}
```