### PR TITLE
Support sRGB color space in RenderTexture

### DIFF
--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -277,6 +277,14 @@ public:
     virtual Vector2u getSize() const = 0;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Tell if the render target will use sRGB encoding when drawing on it
+    ///
+    /// \return True if the render target use sRGB encoding, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool isSrgb() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render target for rendering
     ///
     /// This function makes the render target's context current for

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -217,6 +217,18 @@ public:
     ////////////////////////////////////////////////////////////
     virtual Vector2u getSize() const;
 
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell if the render-texture will use sRGB encoding when drawing on it
+    ///
+    /// You can request sRGB encoding for a render-texture
+    /// by having the sRgbCapable flag set for the context parameter of create() method
+    ///
+    /// \return True if the render-texture use sRGB encoding, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool isSrgb() const;
+
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only reference to the target texture
     ///

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -112,6 +112,17 @@ public:
     ////////////////////////////////////////////////////////////
     virtual Vector2u getSize() const;
 
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell if the window will use sRGB encoding when drawing on it
+    ///
+    /// You can request sRGB encoding for a window by having the sRgbCapable flag set in the ContextSettings
+    ///
+    /// \return True if the window use sRGB encoding, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool isSrgb() const;
+
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the window as the current target
     ///        for OpenGL rendering

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -412,6 +412,14 @@ void RenderTarget::draw(const VertexBuffer& vertexBuffer, std::size_t firstVerte
 
 
 ////////////////////////////////////////////////////////////
+bool RenderTarget::isSrgb() const
+{
+    // By default sRGB encoding is not enabled for an arbitrary RenderTarget
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
 bool RenderTarget::setActive(bool active)
 {
     // Mark this RenderTarget as active or no longer active in the tracking map
@@ -680,6 +688,16 @@ void RenderTarget::applyShader(const Shader* shader)
 ////////////////////////////////////////////////////////////
 void RenderTarget::setupDraw(bool useVertexCache, const RenderStates& states)
 {
+    // Enable or disable sRGB encoding
+    // This is needed for drivers that do not check the format of the surface drawn to before applying sRGB conversion
+    if (!m_cache.enable)
+    {
+        if (isSrgb())
+            glCheck(glEnable(GL_FRAMEBUFFER_SRGB));
+        else
+            glCheck(glDisable(GL_FRAMEBUFFER_SRGB));
+    }
+
     // First set the persistent OpenGL states if it's the very first call
     if (!m_cache.glStatesSet)
         resetGLStates();

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -58,6 +58,9 @@ bool RenderTexture::create(unsigned int width, unsigned int height, bool depthBu
 ////////////////////////////////////////////////////////////
 bool RenderTexture::create(unsigned int width, unsigned int height, const ContextSettings& settings)
 {
+    // Set texture to be in sRGB scale if requested
+    m_texture.setSrgb(settings.sRgbCapable);
+
     // Create the texture
     if (!m_texture.create(width, height))
     {

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -181,6 +181,13 @@ Vector2u RenderTexture::getSize() const
 
 
 ////////////////////////////////////////////////////////////
+bool RenderTexture::isSrgb() const
+{
+    return m_impl->isSrgb();
+}
+
+
+////////////////////////////////////////////////////////////
 const Texture& RenderTexture::getTexture() const
 {
     return m_texture;

--- a/src/SFML/Graphics/RenderTextureImpl.hpp
+++ b/src/SFML/Graphics/RenderTextureImpl.hpp
@@ -76,6 +76,17 @@ public:
     virtual bool activate(bool active) = 0;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Tell if the render-texture will use sRGB encoding when drawing on it
+    ///
+    /// You can request sRGB encoding for a render-texture
+    /// by having the sRgbCapable flag set for the context parameter of create() method
+    ///
+    /// \return True if the render-texture use sRGB encoding, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool isSrgb() const = 0;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture
     ///
     /// \param textureId OpenGL identifier of the target texture

--- a/src/SFML/Graphics/RenderTextureImplDefault.cpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.cpp
@@ -86,6 +86,13 @@ bool RenderTextureImplDefault::activate(bool active)
 
 
 ////////////////////////////////////////////////////////////
+bool RenderTextureImplDefault::isSrgb() const
+{
+    return m_context->getSettings().sRgbCapable;
+}
+
+
+////////////////////////////////////////////////////////////
 void RenderTextureImplDefault::updateTexture(unsigned int textureId)
 {
     // Make sure that the current texture binding will be preserved

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -92,6 +92,17 @@ private:
     virtual bool activate(bool active);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Tell if the render-texture will use sRGB encoding when drawing on it
+    ///
+    /// You can request sRGB encoding for a render-texture
+    /// by having the sRgbCapable flag set for the context parameter of create() method
+    ///
+    /// \return True if the render-texture use sRGB encoding, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool isSrgb() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture
     ///
     /// \param textureId OpenGL identifier of the target texture

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -296,6 +296,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
 #ifndef SFML_OPENGL_ES
 
             // Create the multisample color buffer
+            bool srgb = settings.sRgbCapable && GLEXT_texture_sRGB;
             GLuint color = 0;
             glCheck(GLEXT_glGenRenderbuffers(1, &color));
             m_colorBuffer = static_cast<unsigned int>(color);
@@ -305,7 +306,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
                 return false;
             }
             glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_colorBuffer));
-            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, GL_RGBA, width, height));
+            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, srgb ? GL_SRGB8_ALPHA8_EXT : GL_RGBA, width, height));
 
             // Create the multisample depth/stencil buffer if requested
             if (settings.stencilBits)

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -120,7 +120,8 @@ m_height            (0),
 m_context           (NULL),
 m_textureId         (0),
 m_multisample       (false),
-m_stencil           (false)
+m_stencil           (false),
+m_sRgb              (false)
 {
     Lock lock(mutex);
 
@@ -228,6 +229,8 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
         if (settings.stencilBits && !GLEXT_packed_depth_stencil)
             return false;
 
+        m_sRgb = settings.sRgbCapable && GL_EXT_texture_sRGB;
+
 #ifndef SFML_OPENGL_ES
 
         // Check if the requested anti-aliasing level is supported
@@ -296,7 +299,6 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
 #ifndef SFML_OPENGL_ES
 
             // Create the multisample color buffer
-            bool srgb = settings.sRgbCapable && GLEXT_texture_sRGB;
             GLuint color = 0;
             glCheck(GLEXT_glGenRenderbuffers(1, &color));
             m_colorBuffer = static_cast<unsigned int>(color);
@@ -306,7 +308,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
                 return false;
             }
             glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_colorBuffer));
-            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, srgb ? GL_SRGB8_ALPHA8_EXT : GL_RGBA, width, height));
+            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, settings.antialiasingLevel, m_sRgb ? GL_SRGB8_ALPHA8_EXT : GL_RGBA, width, height));
 
             // Create the multisample depth/stencil buffer if requested
             if (settings.stencilBits)
@@ -565,6 +567,13 @@ bool RenderTextureImplFBO::activate(bool active)
     }
 
     return createFrameBuffer();
+}
+
+
+////////////////////////////////////////////////////////////
+bool RenderTextureImplFBO::isSrgb() const
+{
+    return m_sRgb;
 }
 
 

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -115,6 +115,17 @@ private:
     virtual bool activate(bool active);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Tell if the render-texture will use sRGB encoding when drawing on it
+    ///
+    /// You can request sRGB encoding for a render-texture
+    /// by having the sRgbCapable flag set for the context parameter of create() method
+    ///
+    /// \return True if the render-texture use sRGB encoding, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool isSrgb() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture
     ///
     /// \param textureId OpenGL identifier of the target texture
@@ -135,6 +146,7 @@ private:
     unsigned int                   m_textureId;               //!< The ID of the texture to attach to the FBO
     bool                           m_multisample;             //!< Whether we have to create a multisample frame buffer as well
     bool                           m_stencil;                 //!< Whether we have stencil attachment
+    bool                           m_sRgb;                    //!< Whether we need to encode drawn pixels into sRGB color space
 };
 
 } // namespace priv

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -74,6 +74,13 @@ Vector2u RenderWindow::getSize() const
 
 
 ////////////////////////////////////////////////////////////
+bool RenderWindow::isSrgb() const
+{
+    return getSettings().sRgbCapable;
+}
+
+
+////////////////////////////////////////////////////////////
 bool RenderWindow::setActive(bool active)
 {
     bool result = Window::setActive(active);


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [x] Does the fix fully solve the issue

----

## Description

This PR tries to fix #1092.

When the sf::ContextSettings asks for an sRGB capable buffer, set the rendered image to sRGB mode and convert pixels when drawing.

This is the choice of simplicity compared to actually support textures with more than 8 bit color depth: see my post in forum (https://en.sfml-dev.org/forums/index.php?topic=20358.msg175496#msg175496).

It differs from #1093 because now we try to both convert to sRGB space when writing to the texture and when decoding from the texture. This repairs the rendering on multisampled textures, and on non-FBO implementations.
It also repairs rendering for sRGB RenderTexture used along a non-sRGB window (or no window at all).

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

To test the PR, you should run the following code and check that it matches the [reference output](https://user-images.githubusercontent.com/7562593/115022631-ee5cd180-9ebd-11eb-9cee-b50d0dadba93.png) for all parameter combination.
You will need to following image: [Gradient.png](https://user-images.githubusercontent.com/7562593/115022505-c3727d80-9ebd-11eb-9054-b823007e1999.png)

GitHub's image compression makes it slightly hard to see, but it is normal if configurations `lS -> sT -> lW` and `sS -> lT -> sW` show color banding, the other configurations must not.
Enabling or disabling antialiasing should not change the output at all.

The code is adapted from the issue by @Fewes in the forum thread https://en.sfml-dev.org/forums/index.php?topic=20358.msg146448#msg146448.

```cpp
#include <SFML/Graphics.hpp>

void updateWindowTitle(sf::Window& window, bool bypass_texture, bool sRgbSprite, bool sRgbTexture, bool sRgbWindow, bool antialiasing)
{
    sf::String title;
    title += sRgbSprite ? "sS" : "lS";
    title += " -> ";
    if (!bypass_texture)
    {
        title += sRgbTexture ? "sT" : "lT";
        if (antialiasing)
            title += " (MSAA x2)";
        title += " -> ";
    }
    title += sRgbWindow ? "sW" : "lW";
    window.setTitle(title);
}

int main()
{
    bool bypass_texture = false;

    sf::RenderWindow window;
    sf::VideoMode videoMode;
    videoMode.width = 800;
    videoMode.height = 600;
    sf::ContextSettings windowContextSettings;
    windowContextSettings.sRgbCapable = true;

    window.create(videoMode, "sRGB testing", sf::Style::Default, windowContextSettings);

    sf::Texture spriteTexture;
    spriteTexture.setSrgb(true);
    spriteTexture.setSmooth(true);
    spriteTexture.loadFromFile("Gradient.png");

    sf::Sprite sprite;
    sprite.setTexture(spriteTexture);

    sf::RenderTexture renderTexture;
    renderTexture.setSmooth(true);
    sf::ContextSettings textureContextSettings;
    textureContextSettings.sRgbCapable = true;
    renderTexture.create(videoMode.width, videoMode.height, textureContextSettings);

    sf::Sprite renderTextureDrawable;
    renderTextureDrawable.setTexture(renderTexture.getTexture());

    updateWindowTitle(window, bypass_texture, spriteTexture.isSrgb(), textureContextSettings.sRgbCapable, windowContextSettings.sRgbCapable, textureContextSettings.antialiasingLevel);

    while (window.isOpen())
    {
        // Poll events
        sf::Event event;
        while (window.pollEvent(event))
        {
            // Window closed
            if (event.type == sf::Event::Closed || (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Key::Escape))
            {
                window.close();
            }
            else if (event.type == sf::Event::KeyPressed)
            {
                if (event.key.code == sf::Keyboard::Space)
                {
                    bypass_texture = !bypass_texture;
                }
                else if (event.key.code == sf::Keyboard::A)
                {
                    textureContextSettings.antialiasingLevel = textureContextSettings.antialiasingLevel ? 0 : 2;
                    renderTexture.create(videoMode.width, videoMode.height, textureContextSettings);
                }
                else if (event.key.code == sf::Keyboard::T)
                {
                    textureContextSettings.sRgbCapable = !textureContextSettings.sRgbCapable;
                    renderTexture.create(videoMode.width, videoMode.height, textureContextSettings);
                }
                else if (event.key.code == sf::Keyboard::S)
                {
                    spriteTexture.setSrgb(!spriteTexture.isSrgb());
                    spriteTexture.loadFromFile("Gradient.png");
                }
                else if (event.key.code == sf::Keyboard::W)
                {
                    windowContextSettings.sRgbCapable = !windowContextSettings.sRgbCapable;
                    window.create(videoMode, "sRGB testing", sf::Style::Default, windowContextSettings);
                }
                updateWindowTitle(window, bypass_texture, spriteTexture.isSrgb(), textureContextSettings.sRgbCapable, windowContextSettings.sRgbCapable, textureContextSettings.antialiasingLevel);
            }
        }

        // Clear render texture
        renderTexture.clear(sf::Color(0, 0, 0, 255));
        // Draw gradient sprite
        renderTexture.draw(sprite);
        // Finished drawing to render texture
        renderTexture.display();

        // Clear window
        window.clear(sf::Color(0, 0, 0, 255));
        if (bypass_texture)
        {
            window.draw(sprite);
        }
        else
        {
            // Draw render texture drawable
            window.draw(renderTextureDrawable);
        }

        // Finished drawing to the window
        window.display();
    }

    return 0;
}
```