### PR TITLE
MacOS: When initializing an openGL view with an existing window, call finishInit

### DIFF
--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -123,6 +123,8 @@
 
         // Set the view to the window as its content view.
         [m_window setContentView:m_oglView];
+        
+        [m_oglView finishInit];
     }
 
     return self;


### PR DESCRIPTION
See issue https://github.com/SFML/SFML/issues/1759 for a description of the problem.

For DPI-scaling reasons, I think it is the `sf::RenderWindow`'s "business" if the scaling factor changes, so my change signs it up to receive the same notifications on the window as it would if it had created the window.

* [x] Discussed in an issue
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

## Description

Please describe your pull request.

This PR is related to the issue #1759

## Tasks

* [x] Tested on macOS

## How to test this PR?

See below