### PR TITLE
Fix '-Wimplicit-fallthrough' warnings by adding a fallthrough comment

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -62,11 +62,11 @@ In Utf<8>::decode(In begin, In end, Uint32& output, Uint32 replacement)
         output = 0;
         switch (trailingBytes)
         {
-            case 5: output += static_cast<Uint8>(*begin++); output <<= 6;
-            case 4: output += static_cast<Uint8>(*begin++); output <<= 6;
-            case 3: output += static_cast<Uint8>(*begin++); output <<= 6;
-            case 2: output += static_cast<Uint8>(*begin++); output <<= 6;
-            case 1: output += static_cast<Uint8>(*begin++); output <<= 6;
+            case 5: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
+            case 4: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
+            case 3: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
+            case 2: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
+            case 1: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
             case 0: output += static_cast<Uint8>(*begin++);
         }
         output -= offsets[trailingBytes];
@@ -114,9 +114,9 @@ Out Utf<8>::encode(Uint32 input, Out output, Uint8 replacement)
         Uint8 bytes[4];
         switch (bytestoWrite)
         {
-            case 4: bytes[3] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6;
-            case 3: bytes[2] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6;
-            case 2: bytes[1] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6;
+            case 4: bytes[3] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; // fallthrough
+            case 3: bytes[2] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; // fallthrough
+            case 2: bytes[1] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; // fallthrough
             case 1: bytes[0] = static_cast<Uint8> (input | firstBytes[bytestoWrite]);
         }
 


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

When compiling with a modern version of GCC or Clang, the `-Wimplicit-fallthrough` warning will be produced for switch cases that do not have an explicit "fallthrough" comment (or attribute) in the code. This PR fixes all occurrences of such warning in SFML.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Just compile. The PR doesn't change any code, it only adds comments. Modern compilers will recognize the comment and suppress warning production. See <https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html>.