### PR TITLE
Fix overflow when using sf::Clock for long time

### DIFF
--- a/src/SFML/System/Win32/ClockImpl.cpp
+++ b/src/SFML/System/Win32/ClockImpl.cpp
@@ -54,9 +54,9 @@ namespace priv
 ////////////////////////////////////////////////////////////
 Time ClockImpl::getCurrentTime()
 {
-    // Get the frequency of the performance counter
-    // (it is constant across the program lifetime)
-    static LARGE_INTEGER frequency = getFrequency();
+    // Calculate inverse of frequency multiplied by 1000000 to prevent overflow in final calculation
+    // Frequency is constant across the program lifetime
+    static double inverse = 1000000.0 / getFrequency().QuadPart;
 
     // Detect if we are on Windows XP or older
     static bool oldWindows = isWindowsXpOrOlder();
@@ -80,7 +80,7 @@ Time ClockImpl::getCurrentTime()
     }
 
     // Return the current time as microseconds
-    return sf::microseconds(1000000 * time.QuadPart / frequency.QuadPart);
+    return sf::microseconds(static_cast<sf::Int64>(time.QuadPart * inverse));
 }
 
 } // namespace priv


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before? It was an issue.
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This PR is related to the issue #1765

When using sf::Clock class, method restart() may return negative value in continious work because of overflow when calculating current time in microseconds. This pull request is trying to fix that.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

See description in issue #1765