### PR TITLE
Add missing semicolon in doc example

### DIFF
--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -407,7 +407,7 @@ private:
 ///         // Change the current position in the stream source
 ///         ...
 ///     }
-/// }
+/// };
 ///
 /// // Usage
 /// CustomStream stream;


### PR DESCRIPTION
## Description

Fixes #1774 which reported a missing semicolon in the SoundSource example in the documentation.

## How to test this PR?

- Build the documentation
- Check the example code is correctly generated