### PR TITLE
Fix incorrect standard includes in 'InputSoundFile'

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -32,7 +32,7 @@
 #include <SFML/System/NonCopyable.hpp>
 #include <SFML/System/Time.hpp>
 #include <string>
-#include <algorithm>
+#include <cstddef>
 
 
 namespace sf

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -32,6 +32,8 @@
 #include <SFML/System/FileInputStream.hpp>
 #include <SFML/System/MemoryInputStream.hpp>
 #include <SFML/System/Err.hpp>
+#include <iostream>
+#include <algorithm>
 
 
 namespace sf

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -30,6 +30,7 @@
 #include <SFML/System/Lock.hpp>
 #include <SFML/System/Err.hpp>
 #include <fstream>
+#include <algorithm>
 
 
 namespace sf


### PR DESCRIPTION
## Description

`<algorithm>` is unused in the header -- it is only used in the `.cpp` file. `<cstddef>` was missing as `std::size_t` is exposed in the header.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Compile/run entirety of SFML + test suite.