### PR TITLE
Remove standard '<algorithm>' depedency in common headers

### DIFF
--- a/include/SFML/Graphics/Glsl.hpp
+++ b/include/SFML/Graphics/Glsl.hpp
@@ -32,7 +32,7 @@
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <SFML/System/Vector3.hpp>
-
+#include <cstddef>
 
 namespace sf
 {

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -29,7 +29,6 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Vector2.hpp>
-#include <algorithm>
 
 
 namespace sf
@@ -178,6 +177,33 @@ public:
     T top;    //!< Top coordinate of the rectangle
     T width;  //!< Width of the rectangle
     T height; //!< Height of the rectangle
+
+private:
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the minimum between two values
+    ///
+    /// This function is implemented here to avoid a dependency
+    /// on the <algorithm> C++ Standard header, unnecessarily
+    /// expensive to compile for the task of computing min/max.
+    ///
+    /// \param a First value
+    /// \param b Second value
+    ///
+    ////////////////////////////////////////////////////////////
+    static T getMin(T a, T b);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the maximum between two values
+    ///
+    /// This function is implemented here to avoid a dependency
+    /// on the <algorithm> C++ Standard header, unnecessarily
+    /// expensive to compile for the task of computing min/max.
+    ///
+    /// \param a First value
+    /// \param b Second value
+    ///
+    ////////////////////////////////////////////////////////////
+    static T getMax(T a, T b);
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -78,10 +78,10 @@ bool Rect<T>::contains(T x, T y) const
     // Rectangles with negative dimensions are allowed, so we must handle them correctly
 
     // Compute the real min and max of the rectangle on both axes
-    T minX = std::min(left, static_cast<T>(left + width));
-    T maxX = std::max(left, static_cast<T>(left + width));
-    T minY = std::min(top, static_cast<T>(top + height));
-    T maxY = std::max(top, static_cast<T>(top + height));
+    T minX = getMin(left, static_cast<T>(left + width));
+    T maxX = getMax(left, static_cast<T>(left + width));
+    T minY = getMin(top, static_cast<T>(top + height));
+    T maxY = getMax(top, static_cast<T>(top + height));
 
     return (x >= minX) && (x < maxX) && (y >= minY) && (y < maxY);
 }
@@ -111,22 +111,22 @@ bool Rect<T>::intersects(const Rect<T>& rectangle, Rect<T>& intersection) const
     // Rectangles with negative dimensions are allowed, so we must handle them correctly
 
     // Compute the min and max of the first rectangle on both axes
-    T r1MinX = std::min(left, static_cast<T>(left + width));
-    T r1MaxX = std::max(left, static_cast<T>(left + width));
-    T r1MinY = std::min(top, static_cast<T>(top + height));
-    T r1MaxY = std::max(top, static_cast<T>(top + height));
+    T r1MinX = getMin(left, static_cast<T>(left + width));
+    T r1MaxX = getMax(left, static_cast<T>(left + width));
+    T r1MinY = getMin(top, static_cast<T>(top + height));
+    T r1MaxY = getMax(top, static_cast<T>(top + height));
 
     // Compute the min and max of the second rectangle on both axes
-    T r2MinX = std::min(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
-    T r2MaxX = std::max(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
-    T r2MinY = std::min(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
-    T r2MaxY = std::max(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
+    T r2MinX = getMin(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
+    T r2MaxX = getMax(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
+    T r2MinY = getMin(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
+    T r2MaxY = getMax(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
 
     // Compute the intersection boundaries
-    T interLeft   = std::max(r1MinX, r2MinX);
-    T interTop    = std::max(r1MinY, r2MinY);
-    T interRight  = std::min(r1MaxX, r2MaxX);
-    T interBottom = std::min(r1MaxY, r2MaxY);
+    T interLeft   = getMax(r1MinX, r2MinX);
+    T interTop    = getMax(r1MinY, r2MinY);
+    T interRight  = getMin(r1MaxX, r2MaxX);
+    T interBottom = getMin(r1MaxY, r2MaxY);
 
     // If the intersection is valid (positive non zero area), then there is an intersection
     if ((interLeft < interRight) && (interTop < interBottom))
@@ -153,6 +153,17 @@ sf::Vector2<T> Rect<T>::getSize() const
     return sf::Vector2<T>(width, height);
 }
 
+template <typename T>
+T Rect<T>::getMin(T a, T b)
+{
+    return (a < b) ? a : b;
+}
+
+template <typename T>
+T Rect<T>::getMax(T a, T b)
+{
+    return (a < b) ? b : a;
+}
 
 ////////////////////////////////////////////////////////////
 template <typename T>

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -38,6 +38,7 @@
 #include <SFML/Graphics/PrimitiveType.hpp>
 #include <SFML/Graphics/Vertex.hpp>
 #include <SFML/System/NonCopyable.hpp>
+#include <cstddef>
 
 
 namespace sf

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -32,6 +32,7 @@
 #include <SFML/Graphics/PrimitiveType.hpp>
 #include <SFML/Graphics/Drawable.hpp>
 #include <SFML/Window/GlResource.hpp>
+#include <cstddef>
 
 
 namespace sf

--- a/src/SFML/Window/JoystickImpl.hpp
+++ b/src/SFML/Window/JoystickImpl.hpp
@@ -31,7 +31,6 @@
 #include <SFML/Config.hpp>
 #include <SFML/Window/Joystick.hpp>
 #include <SFML/System/String.hpp>
-#include <algorithm>
 
 
 namespace sf
@@ -47,7 +46,11 @@ struct JoystickCaps
     JoystickCaps()
     {
         buttonCount = 0;
-        std::fill(axes, axes + Joystick::AxisCount, false);
+
+        for(int i = 0; i < Joystick::AxisCount; ++i)
+        {
+            axes[i] = false;
+        }
     }
 
     unsigned int buttonCount;               //!< Number of buttons supported by the joystick
@@ -64,8 +67,16 @@ struct JoystickState
     JoystickState()
     {
         connected = false;
-        std::fill(axes, axes + Joystick::AxisCount, 0.f);
-        std::fill(buttons, buttons + Joystick::ButtonCount, false);
+
+        for(int i = 0; i < Joystick::AxisCount; ++i)
+        {
+            axes[i] = 0.f;
+        }
+
+        for(int i = 0; i < Joystick::ButtonCount; ++i)
+        {
+            buttons[i] = false;
+        }
     }
 
     bool  connected;                      //!< Is the joystick currently connected?


### PR DESCRIPTION
## Description

The standard `<algorithm>` header is expensive to compile in comparison to other standard headers. I have benchmarked this myself using `clang++ -ftime-trace` on a [large SFML-powered codebase](https://github.com/SuperV1234/SSVOpenHexagon/) and it has also been [experienced and verified by others in the past](https://blog.magnum.graphics/backstage/reducing-cpp-compilation-time-in-magnum-code-optimizations/).

When benchmarking, I've noticed that many of my object files were taking an unexpected extra 800-900ms to compile due to `<algorithm>` being brought in by `Rect.hpp`. Upon investigation, I noticed that `Rect.hpp` only needs `std::min` and `std::max` -- including `<algorithm>` is overkill for that functionality.

Furthermore, `Rect.hpp`'s usage of `std::min` and `std::max` is only on primitive types, which can generate suboptimal codegen when taken by reference in functions. 

I removed the `<algorithm>` dependency in `Rect.hpp` by implementing two `private` static functions (`getMin` and `getMax`). I have also removed another `<algorithm>` depedency in `JoystickImpl.hpp` by using some simple loops. 

Some other SFML files relied on transitive `<algorithm>` inclusion of `std::size_t` (which is pretty bad), so I fixed those by explicitly including `<cstddef>`.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Compile/run entirety of SFML + test suite.