### PR TITLE
Add support for SFML unity builds

### DIFF
--- a/src/SFML/Audio/AlResource.cpp
+++ b/src/SFML/Audio/AlResource.cpp
@@ -34,13 +34,13 @@
 namespace
 {
     // OpenAL resources counter and its mutex
-    unsigned int count = 0;
-    sf::Mutex mutex;
+    unsigned int sfmlAlResourceCount = 0;
+    sf::Mutex sfmlAlResourceMutex;
 
     // The audio device is instantiated on demand rather than at global startup,
     // which solves a lot of weird crashes and errors.
     // It is destroyed when it is no longer needed.
-    sf::priv::AudioDevice* globalDevice;
+    sf::priv::AudioDevice* sfmlAlGlobalDevice;
 }
 
 
@@ -50,14 +50,14 @@ namespace sf
 AlResource::AlResource()
 {
     // Protect from concurrent access
-    Lock lock(mutex);
+    Lock lock(sfmlAlResourceMutex);
 
     // If this is the very first resource, trigger the global device initialization
-    if (count == 0)
-        globalDevice = new priv::AudioDevice;
+    if (sfmlAlResourceCount == 0)
+        sfmlAlGlobalDevice = new priv::AudioDevice;
 
     // Increment the resources counter
-    count++;
+    sfmlAlResourceCount++;
 }
 
 
@@ -65,14 +65,14 @@ AlResource::AlResource()
 AlResource::~AlResource()
 {
     // Protect from concurrent access
-    Lock lock(mutex);
+    Lock lock(sfmlAlResourceMutex);
 
     // Decrement the resources counter
-    count--;
+    sfmlAlResourceCount--;
 
     // If there's no more resource alive, we can destroy the device
-    if (count == 0)
-        delete globalDevice;
+    if (sfmlAlResourceCount == 0)
+        delete sfmlAlGlobalDevice;
 }
 
 } // namespace sf

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -40,7 +40,7 @@
 
 namespace
 {
-    ALCdevice* captureDevice = NULL;
+    ALCdevice* sfmlALCDeviceCaptureDevice = NULL;
 }
 
 namespace sf
@@ -81,7 +81,7 @@ bool SoundRecorder::start(unsigned int sampleRate)
     }
 
     // Check that another capture is not already running
-    if (captureDevice)
+    if (sfmlALCDeviceCaptureDevice)
     {
         err() << "Trying to start audio capture, but another capture is already running" << std::endl;
         return false;
@@ -91,8 +91,8 @@ bool SoundRecorder::start(unsigned int sampleRate)
     ALCenum format = (m_channelCount == 1) ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
 
     // Open the capture device for capturing 16 bits samples
-    captureDevice = alcCaptureOpenDevice(m_deviceName.c_str(), sampleRate, format, sampleRate);
-    if (!captureDevice)
+    sfmlALCDeviceCaptureDevice = alcCaptureOpenDevice(m_deviceName.c_str(), sampleRate, format, sampleRate);
+    if (!sfmlALCDeviceCaptureDevice)
     {
         err() << "Failed to open the audio capture device with the name: " << m_deviceName << std::endl;
         return false;
@@ -108,7 +108,7 @@ bool SoundRecorder::start(unsigned int sampleRate)
     if (onStart())
     {
         // Start the capture
-        alcCaptureStart(captureDevice);
+        alcCaptureStart(sfmlALCDeviceCaptureDevice);
 
         // Start the capture in a new thread, to avoid blocking the main thread
         m_isCapturing = true;
@@ -188,8 +188,8 @@ bool SoundRecorder::setDevice(const std::string& name)
         ALCenum format = (m_channelCount == 1) ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
 
         // Open the requested capture device for capturing 16 bits samples
-        captureDevice = alcCaptureOpenDevice(m_deviceName.c_str(), m_sampleRate, format, m_sampleRate);
-        if (!captureDevice)
+        sfmlALCDeviceCaptureDevice = alcCaptureOpenDevice(m_deviceName.c_str(), m_sampleRate, format, m_sampleRate);
+        if (!sfmlALCDeviceCaptureDevice)
         {
             // Notify derived class
             onStop();
@@ -199,7 +199,7 @@ bool SoundRecorder::setDevice(const std::string& name)
         }
 
         // Start the capture
-        alcCaptureStart(captureDevice);
+        alcCaptureStart(sfmlALCDeviceCaptureDevice);
 
         // Start the capture in a new thread, to avoid blocking the main thread
         m_isCapturing = true;
@@ -295,13 +295,13 @@ void SoundRecorder::processCapturedSamples()
 {
     // Get the number of samples available
     ALCint samplesAvailable;
-    alcGetIntegerv(captureDevice, ALC_CAPTURE_SAMPLES, 1, &samplesAvailable);
+    alcGetIntegerv(sfmlALCDeviceCaptureDevice, ALC_CAPTURE_SAMPLES, 1, &samplesAvailable);
 
     if (samplesAvailable > 0)
     {
         // Get the recorded samples
         m_samples.resize(samplesAvailable * getChannelCount());
-        alcCaptureSamples(captureDevice, &m_samples[0], samplesAvailable);
+        alcCaptureSamples(sfmlALCDeviceCaptureDevice, &m_samples[0], samplesAvailable);
 
         // Forward them to the derived class
         if (!onProcessSamples(&m_samples[0], m_samples.size()))
@@ -317,14 +317,14 @@ void SoundRecorder::processCapturedSamples()
 void SoundRecorder::cleanup()
 {
     // Stop the capture
-    alcCaptureStop(captureDevice);
+    alcCaptureStop(sfmlALCDeviceCaptureDevice);
 
     // Get the samples left in the buffer
     processCapturedSamples();
 
     // Close the device
-    alcCaptureCloseDevice(captureDevice);
-    captureDevice = NULL;
+    alcCaptureCloseDevice(sfmlALCDeviceCaptureDevice);
+    sfmlALCDeviceCaptureDevice = NULL;
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/GLExtensions.cpp
+++ b/src/SFML/Graphics/GLExtensions.cpp
@@ -25,10 +25,11 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#define SF_GLAD_GL_IMPLEMENTATION
 #include <SFML/Graphics/GLExtensions.hpp>
 #include <SFML/Window/Context.hpp>
 #include <SFML/System/Err.hpp>
+#define SF_GLAD_GL_IMPLEMENTATION
+#include <glad/gl.h>
 
 #if !defined(GL_MAJOR_VERSION)
     #define GL_MAJOR_VERSION 0x821B

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -53,13 +53,13 @@
 namespace
 {
     // Mutex to protect ID generation and our context-RenderTarget-map
-    sf::Mutex mutex;
+    sf::Mutex sfmlRenderTargetMutex;
 
     // Unique identifier, used for identifying RenderTargets when
     // tracking the currently active RenderTarget within a given context
-    sf::Uint64 getUniqueId()
+    sf::Uint64 sfmlRenderTargetGetUniqueId()
     {
-        sf::Lock lock(mutex);
+        sf::Lock lock(sfmlRenderTargetMutex);
 
         static sf::Uint64 id = 1; // start at 1, zero is "no RenderTarget"
 
@@ -416,7 +416,7 @@ bool RenderTarget::setActive(bool active)
 {
     // Mark this RenderTarget as active or no longer active in the tracking map
     {
-        sf::Lock lock(mutex);
+        sf::Lock lock(sfmlRenderTargetMutex);
 
         Uint64 contextId = Context::getActiveContextId();
 
@@ -574,7 +574,7 @@ void RenderTarget::initialize()
 
     // Generate a unique ID for this RenderTarget to track
     // whether it is active within a specific context
-    m_id = getUniqueId();
+    m_id = sfmlRenderTargetGetUniqueId();
 }
 
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -56,8 +56,8 @@
 
 namespace
 {
-    sf::Mutex maxTextureUnitsMutex;
-    sf::Mutex isAvailableMutex;
+    sf::Mutex sfmlShaderMaxTextureUnitsMutex;
+    sf::Mutex sfmlShaderIsAvailableMutex;
 
     GLint checkMaxTextureUnits()
     {
@@ -71,7 +71,7 @@ namespace
     GLint getMaxTextureUnits()
     {
         // TODO: Remove this lock when it becomes unnecessary in C++11
-        sf::Lock lock(maxTextureUnitsMutex);
+        sf::Lock lock(sfmlShaderMaxTextureUnitsMutex);
 
         static GLint maxUnits = checkMaxTextureUnits();
 
@@ -773,7 +773,7 @@ void Shader::bind(const Shader* shader)
 ////////////////////////////////////////////////////////////
 bool Shader::isAvailable()
 {
-    Lock lock(isAvailableMutex);
+    Lock lock(sfmlShaderIsAvailableMutex);
 
     static bool checked = false;
     static bool available = false;
@@ -801,7 +801,7 @@ bool Shader::isAvailable()
 ////////////////////////////////////////////////////////////
 bool Shader::isGeometryAvailable()
 {
-    Lock lock(isAvailableMutex);
+    Lock lock(sfmlShaderIsAvailableMutex);
 
     static bool checked = false;
     static bool available = false;

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -40,14 +40,14 @@
 
 namespace
 {
-    sf::Mutex idMutex;
-    sf::Mutex maximumSizeMutex;
+    sf::Mutex sfmlTextureIdMutex;
+    sf::Mutex sfmlTextureMaximumSizeMutex;
 
     // Thread-safe unique identifier generator,
     // is used for states cache (see RenderTarget)
-    sf::Uint64 getUniqueId()
+    sf::Uint64 sfmlTextureGetUniqueId()
     {
-        sf::Lock lock(idMutex);
+        sf::Lock lock(sfmlTextureIdMutex);
 
         static sf::Uint64 id = 1; // start at 1, zero is "no texture"
 
@@ -69,7 +69,7 @@ m_isRepeated   (false),
 m_pixelsFlipped(false),
 m_fboAttachment(false),
 m_hasMipmap    (false),
-m_cacheId      (getUniqueId())
+m_cacheId      (sfmlTextureGetUniqueId())
 {
 }
 
@@ -85,7 +85,7 @@ m_isRepeated   (copy.m_isRepeated),
 m_pixelsFlipped(false),
 m_fboAttachment(false),
 m_hasMipmap    (false),
-m_cacheId      (getUniqueId())
+m_cacheId      (sfmlTextureGetUniqueId())
 {
     if (copy.m_texture)
     {
@@ -206,7 +206,7 @@ bool Texture::create(unsigned int width, unsigned int height)
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, m_isRepeated ? GL_REPEAT : (textureEdgeClamp ? GLEXT_GL_CLAMP_TO_EDGE : GLEXT_GL_CLAMP)));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
-    m_cacheId = getUniqueId();
+    m_cacheId = sfmlTextureGetUniqueId();
 
     m_hasMipmap = false;
 
@@ -422,7 +422,7 @@ void Texture::update(const Uint8* pixels, unsigned int width, unsigned int heigh
         glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
         m_hasMipmap = false;
         m_pixelsFlipped = false;
-        m_cacheId = getUniqueId();
+        m_cacheId = sfmlTextureGetUniqueId();
 
         // Force an OpenGL flush, so that the texture data will appear updated
         // in all contexts immediately (solves problems in multi-threaded apps)
@@ -525,7 +525,7 @@ void Texture::update(const Texture& texture, unsigned int x, unsigned int y)
         glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
         m_hasMipmap = false;
         m_pixelsFlipped = false;
-        m_cacheId = getUniqueId();
+        m_cacheId = sfmlTextureGetUniqueId();
 
         // Force an OpenGL flush, so that the texture data will appear updated
         // in all contexts immediately (solves problems in multi-threaded apps)
@@ -581,7 +581,7 @@ void Texture::update(const Window& window, unsigned int x, unsigned int y)
         glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
         m_hasMipmap = false;
         m_pixelsFlipped = true;
-        m_cacheId = getUniqueId();
+        m_cacheId = sfmlTextureGetUniqueId();
 
         // Force an OpenGL flush, so that the texture will appear updated
         // in all contexts immediately (solves problems in multi-threaded apps)
@@ -790,7 +790,7 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
 ////////////////////////////////////////////////////////////
 unsigned int Texture::getMaximumSize()
 {
-    Lock lock(maximumSizeMutex);
+    Lock lock(sfmlTextureMaximumSizeMutex);
 
     static bool checked = false;
     static GLint size = 0;
@@ -832,8 +832,8 @@ void Texture::swap(Texture& right)
     std::swap(m_fboAttachment, right.m_fboAttachment);
     std::swap(m_hasMipmap,     right.m_hasMipmap);
 
-    m_cacheId = getUniqueId();
-    right.m_cacheId = getUniqueId();
+    m_cacheId = sfmlTextureGetUniqueId();
+    right.m_cacheId = sfmlTextureGetUniqueId();
 }
 
 

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -36,7 +36,7 @@
 
 namespace
 {
-    sf::Mutex isAvailableMutex;
+    sf::Mutex sfmlVertexBufferIsAvailableMutex;
 
     GLenum usageToGlEnum(sf::VertexBuffer::Usage usage)
     {
@@ -332,7 +332,7 @@ VertexBuffer::Usage VertexBuffer::getUsage() const
 ////////////////////////////////////////////////////////////
 bool VertexBuffer::isAvailable()
 {
-    Lock lock(isAvailableMutex);
+    Lock lock(sfmlVertexBufferIsAvailableMutex);
 
     static bool checked = false;
     static bool available = false;

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -42,9 +42,9 @@ namespace
 {
     // Define the low-level send/receive flags, which depend on the OS
     #ifdef SFML_SYSTEM_LINUX
-        const int flags = MSG_NOSIGNAL;
+        const int sfmlSocketflags = MSG_NOSIGNAL;
     #else
-        const int flags = 0;
+        const int sfmlSocketflags = 0;
     #endif
 }
 
@@ -246,7 +246,7 @@ Socket::Status TcpSocket::send(const void* data, std::size_t size, std::size_t& 
     for (sent = 0; sent < size; sent += result)
     {
         // Send a chunk of data
-        result = ::send(getHandle(), static_cast<const char*>(data) + sent, static_cast<int>(size - sent), flags);
+        result = ::send(getHandle(), static_cast<const char*>(data) + sent, static_cast<int>(size - sent), sfmlSocketflags);
 
         // Check for errors
         if (result < 0)
@@ -278,7 +278,7 @@ Socket::Status TcpSocket::receive(void* data, std::size_t size, std::size_t& rec
     }
 
     // Receive a chunk of bytes
-    int sizeReceived = recv(getHandle(), static_cast<char*>(data), static_cast<int>(size), flags);
+    int sizeReceived = recv(getHandle(), static_cast<char*>(data), static_cast<int>(size), sfmlSocketflags);
 
     // Check the number of bytes received
     if (sizeReceived > 0)

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -33,7 +33,7 @@
 namespace
 {
     // This per-thread variable holds the current context for each thread
-    sf::ThreadLocalPtr<sf::Context> currentContext(NULL);
+    sf::ThreadLocalPtr<sf::Context> sfmlGenericCurrentContext(NULL);
 }
 
 namespace sf
@@ -60,7 +60,7 @@ bool Context::setActive(bool active)
     bool result = m_context->setActive(active);
 
     if (result)
-        currentContext = (active ? this : NULL);
+        sfmlGenericCurrentContext = (active ? this : NULL);
 
     return result;
 }
@@ -76,7 +76,7 @@ const ContextSettings& Context::getSettings() const
 ////////////////////////////////////////////////////////////
 const Context* Context::getActiveContext()
 {
-    return currentContext;
+    return sfmlGenericCurrentContext;
 }
 
 

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -69,7 +69,7 @@ namespace
 
 
     ////////////////////////////////////////////////////////////
-    void ensureInit()
+    void sfmlEglContextEnsureInit()
     {
         static bool initialized = false;
         if (!initialized)
@@ -98,7 +98,7 @@ m_context (EGL_NO_CONTEXT),
 m_surface (EGL_NO_SURFACE),
 m_config  (NULL)
 {
-    ensureInit();
+    sfmlEglContextEnsureInit();
 
     // Get the initialized EGL display
     m_display = getInitializedDisplay();
@@ -129,7 +129,7 @@ m_context (EGL_NO_CONTEXT),
 m_surface (EGL_NO_SURFACE),
 m_config  (NULL)
 {
-    ensureInit();
+    sfmlEglContextEnsureInit();
 
 #ifdef SFML_SYSTEM_ANDROID
 
@@ -166,7 +166,7 @@ m_context (EGL_NO_CONTEXT),
 m_surface (EGL_NO_SURFACE),
 m_config  (NULL)
 {
-    ensureInit();
+    sfmlEglContextEnsureInit();
 }
 
 
@@ -202,7 +202,7 @@ EglContext::~EglContext()
 ////////////////////////////////////////////////////////////
 GlFunctionPointer EglContext::getFunction(const char* name)
 {
-    ensureInit();
+    sfmlEglContextEnsureInit();
 
     return reinterpret_cast<GlFunctionPointer>(eglGetProcAddress(name));
 }
@@ -288,7 +288,7 @@ void EglContext::destroySurface()
 ////////////////////////////////////////////////////////////
 EGLConfig EglContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixel, const ContextSettings& settings)
 {
-    ensureInit();
+    sfmlEglContextEnsureInit();
 
     // Set our video settings constraint
     const EGLint attributes[] = {
@@ -352,7 +352,7 @@ void EglContext::updateSettings()
 ////////////////////////////////////////////////////////////
 XVisualInfo EglContext::selectBestVisual(::Display* XDisplay, unsigned int bitsPerPixel, const ContextSettings& settings)
 {
-    ensureInit();
+    sfmlEglContextEnsureInit();
 
     // Get the initialized EGL display
     EGLDisplay display = getInitializedDisplay();

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -41,18 +41,18 @@
 
 namespace
 {
-    sf::Mutex glxErrorMutex;
-    bool glxErrorOccurred = false;
+    sf::Mutex sfmlGlxContextErrorMutex;
+    bool sfmlGlxErrorOccurred = false;
 
 
     ////////////////////////////////////////////////////////////
-    void ensureExtensionsInit(::Display* display, int screen)
+    void sfmlGlxContetEnsureExtensionsInit(::Display* display, int screen)
     {
         static bool initialized = false;
         if (!initialized)
         {
             initialized = true;
-    
+
             // We don't check the return value since the extension
             // flags are cleared even if loading fails
             gladLoaderLoadGLX(display, screen);
@@ -64,7 +64,7 @@ namespace
 
     int HandleXError(::Display*, XErrorEvent*)
     {
-        glxErrorOccurred = true;
+        sfmlGlxErrorOccurred = true;
         return 0;
     }
 
@@ -74,10 +74,10 @@ namespace
     public:
 
         GlxErrorHandler(::Display* display) :
-        m_lock   (glxErrorMutex),
+        m_lock   (sfmlGlxContextErrorMutex),
         m_display(display)
         {
-            glxErrorOccurred = false;
+            sfmlGlxErrorOccurred = false;
             m_previousHandler = XSetErrorHandler(HandleXError);
         }
 
@@ -114,7 +114,7 @@ m_ownsWindow(false)
     m_display = OpenDisplay();
 
     // Make sure that extensions are initialized
-    ensureExtensionsInit(m_display, DefaultScreen(m_display));
+    sfmlGlxContetEnsureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface (window or pbuffer if supported)
     createSurface(shared, 1, 1, VideoMode::getDesktopMode().bitsPerPixel);
@@ -139,7 +139,7 @@ m_ownsWindow(false)
     m_display = OpenDisplay();
 
     // Make sure that extensions are initialized
-    ensureExtensionsInit(m_display, DefaultScreen(m_display));
+    sfmlGlxContetEnsureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface from the owner window
     createSurface(static_cast< ::Window>(owner->getSystemHandle()));
@@ -164,7 +164,7 @@ m_ownsWindow(false)
     m_display = OpenDisplay();
 
     // Make sure that extensions are initialized
-    ensureExtensionsInit(m_display, DefaultScreen(m_display));
+    sfmlGlxContetEnsureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface (window or pbuffer if supported)
     createSurface(shared, width, height, VideoMode::getDesktopMode().bitsPerPixel);
@@ -192,7 +192,7 @@ GlxContext::~GlxContext()
         glXDestroyContext(m_display, m_context);
 
 #if defined(GLX_DEBUGGING)
-        if (glxErrorOccurred)
+        if (sfmlGlxErrorOccurred)
             err() << "GLX error in GlxContext::~GlxContext()" << std::endl;
 #endif
     }
@@ -250,7 +250,7 @@ bool GlxContext::makeCurrent(bool current)
     }
 
 #if defined(GLX_DEBUGGING)
-    if (glxErrorOccurred)
+    if (sfmlGlxErrorOccurred)
         err() << "GLX error in GlxContext::makeCurrent()" << std::endl;
 #endif
 
@@ -271,7 +271,7 @@ void GlxContext::display()
         glXSwapBuffers(m_display, m_window);
 
 #if defined(GLX_DEBUGGING)
-    if (glxErrorOccurred)
+    if (sfmlGlxErrorOccurred)
         err() << "GLX error in GlxContext::display()" << std::endl;
 #endif
 }
@@ -319,7 +319,7 @@ void GlxContext::setVerticalSyncEnabled(bool enabled)
 XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPerPixel, const ContextSettings& settings)
 {
     // Make sure that extensions are initialized
-    ensureExtensionsInit(display, DefaultScreen(display));
+    sfmlGlxContetEnsureExtensionsInit(display, DefaultScreen(display));
 
     const int screen = DefaultScreen(display);
 
@@ -774,7 +774,7 @@ void GlxContext::createContext(GlxContext* shared)
         m_context = glXCreateContext(m_display, visualInfo, toShare, true);
 
 #if defined(GLX_DEBUGGING)
-    if (glxErrorOccurred)
+    if (sfmlGlxErrorOccurred)
         err() << "GLX error in GlxContext::createContext()" << std::endl;
 #endif
     }

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -62,7 +62,7 @@
 ////////////////////////////////////////////////////////////
 namespace
 {
-    sf::priv::WindowImplX11*              fullscreenWindow = NULL;
+    sf::priv::WindowImplX11*              sfmlWindowImplX11FullscreenWindow = NULL;
     std::vector<sf::priv::WindowImplX11*> allWindows;
     sf::Mutex                             allWindowsMutex;
     sf::String                            windowManagerName;
@@ -745,7 +745,7 @@ m_lastInputTime  (0)
         sizeHints->flags &= ~(PMinSize | PMaxSize);
         XSetWMNormalHints(m_display, m_window, sizeHints);
         XFree(sizeHints);
- 
+
         setVideoMode(mode);
         switchToFullscreen();
     }
@@ -1368,7 +1368,7 @@ void WindowImplX11::setVideoMode(const VideoMode& mode)
                      1);
 
     // Set "this" as the current fullscreen window
-    fullscreenWindow = this;
+    sfmlWindowImplX11FullscreenWindow = this;
 
     XRRFreeScreenResources(res);
     XRRFreeOutputInfo(outputInfo);
@@ -1379,7 +1379,7 @@ void WindowImplX11::setVideoMode(const VideoMode& mode)
 ////////////////////////////////////////////////////////////
 void WindowImplX11::resetVideoMode()
 {
-    if (fullscreenWindow == this)
+    if (sfmlWindowImplX11FullscreenWindow == this)
     {
         // Try to set old configuration
         // Check if the XRandR extension
@@ -1433,7 +1433,7 @@ void WindowImplX11::resetVideoMode()
         }
 
         // Reset the fullscreen window
-        fullscreenWindow = NULL;
+        sfmlWindowImplX11FullscreenWindow = NULL;
     }
 }
 

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -64,7 +64,7 @@ namespace
     unsigned int               windowCount      = 0; // Windows owned by SFML
     unsigned int               handleCount      = 0; // All window handles
     const wchar_t*             className        = L"SFML_Window";
-    sf::priv::WindowImplWin32* fullscreenWindow = NULL;
+    sf::priv::WindowImplWin32* sfmlWindowImplWin32FullscreenWindow = NULL;
 
     const GUID GUID_DEVINTERFACE_HID = {0x4d1e55b2, 0xf16f, 0x11cf, {0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30}};
 
@@ -505,7 +505,7 @@ void WindowImplWin32::switchToFullscreen(const VideoMode& mode)
     ShowWindow(m_handle, SW_SHOW);
 
     // Set "this" as the current fullscreen window
-    fullscreenWindow = this;
+    sfmlWindowImplWin32FullscreenWindow = this;
 }
 
 
@@ -513,10 +513,10 @@ void WindowImplWin32::switchToFullscreen(const VideoMode& mode)
 void WindowImplWin32::cleanup()
 {
     // Restore the previous video mode (in case we were running in fullscreen)
-    if (fullscreenWindow == this)
+    if (sfmlWindowImplWin32FullscreenWindow == this)
     {
         ChangeDisplaySettingsW(NULL, 0);
-        fullscreenWindow = NULL;
+        sfmlWindowImplWin32FullscreenWindow = NULL;
     }
 
     // Unhide the mouse cursor (in case it was hidden)

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -33,7 +33,7 @@
 
 namespace
 {
-    const sf::WindowBase* fullscreenWindow = NULL;
+    const sf::WindowBase* sfmlWindowBaseFullscreenWindow = NULL;
 }
 
 
@@ -366,14 +366,14 @@ void WindowBase::initialize()
 ////////////////////////////////////////////////////////////
 const WindowBase* WindowBase::getFullscreenWindow()
 {
-    return fullscreenWindow;
+    return sfmlWindowBaseFullscreenWindow;
 }
 
 
 ////////////////////////////////////////////////////////////
 void WindowBase::setFullscreenWindow(const WindowBase* window)
 {
-    fullscreenWindow = window;
+    sfmlWindowBaseFullscreenWindow = window;
 }
 
 } // namespace sf

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -34,6 +34,8 @@
 #include <OpenGLES/EAGLDrawable.h>
 #include <QuartzCore/CAEAGLLayer.h>
 #include <dlfcn.h>
+#define SF_GLAD_GL_IMPLEMENTATION
+#include <glad/gl.h>
 
 
 namespace
@@ -50,7 +52,7 @@ namespace
     PFNGLRENDERBUFFERSTORAGEOESPROC        glRenderbufferStorageOESFunc        = 0;
 
 
-    void ensureInit()
+    void sfmlEaglContextEnsureInit()
     {
         static bool initialized = false;
         if (!initialized)
@@ -85,7 +87,7 @@ m_depthbuffer (0),
 m_vsyncEnabled(false),
 m_clock       ()
 {
-    ensureInit();
+    sfmlEaglContextEnsureInit();
 
     // Create the context
     if (shared)
@@ -105,7 +107,7 @@ m_depthbuffer (0),
 m_vsyncEnabled(false),
 m_clock       ()
 {
-    ensureInit();
+    sfmlEaglContextEnsureInit();
 
     const WindowImplUIKit* window = static_cast<const WindowImplUIKit*>(owner);
 
@@ -123,7 +125,7 @@ m_depthbuffer (0),
 m_vsyncEnabled(false),
 m_clock       ()
 {
-    ensureInit();
+    sfmlEaglContextEnsureInit();
 
     // This constructor should never be used by implementation
     err() << "Calling bad EaglContext constructor, please contact your developer :)" << std::endl;


### PR DESCRIPTION
## Description

This PR renames objects with internal linkage defined in `.cpp` files in order to avoid name collisions when performing a *unity build* of SFML. You can read the benefits of *unity builds* [in this article](https://onqtam.com/programming/2019-12-20-pch-unity-cmake-3-16/). Here's an excerpt: 

> ## Unity builds
>
> The idea is to cram the .cpp files of a CMake target into a few .cpp files which include the original .cpp files
>
> - up to 7-8 times faster builds (usually x3 or x4)
>
> - example: a project of 200 .cpp files might be divided into 16 unity .cpp (or .cxx - whatever) files each including about 13 of the original .cpp files => 16 .cpp files to build in parallel and 16 .obj files to link
>
> - the reasons for the speedup are:
>     - common headers from the different .cpp files end up being included and parsed fewer times (this is beneficial even when using PCHs!)
>     - common template instantiations with the same types in separate .cpp files (vector<int>) end up being done in fewer places
>     - the linker has to stitch much fewer .obj files in the end - there are a lot less weak symbols to deduplicate (inline/template
>     - functions from headers end up in every .obj => linkers leave just 1)
>          - surprisingly incremental builds (changing a single .cpp) will probably also be faster instead of slower (even though you compile more .cpp files together) - precisely because of the reduced number of weak duplicated symbols!
>     - less compiler invocations and less .obj files are written to disk

This PR renames `static` objects defined in different `.cpp` files to avoid name collisions. It also fixes up some includes of `wgl.h` and `gl.h` to avoid redefinition errors. The renaming is necessary -- from the linked article:

> Initial problems when trying to compile a project as unity
>
> - there will be static globals (or in anonymous namespaces) in different .cpp files with identical names which would clash
>    - either rename them or put such globals into an additional namespace - perhaps with the name of the file: for GraphVisitor.cpp I would recommend GRAPH_VISITOR_CPP (putting static symbols inside of a named namespace in a .cpp keeps their linkage to internal , and the same is true with nesting anonymous namespaces into named ones)

And here are some benchmarks of a clean build on my machine, using MSYS2 + MinGW-w64:

```bash
# with `set(CMAKE_UNITY_BUILD ON)`
rm CMakeCache.txt; cmake .. -G"MinGW Makefiles"; make clean; time make -j8

real    0m11.285s
user    0m0.000s
sys     0m0.015s
```

```bash
# with `set(CMAKE_UNITY_BUILD OFF)`
rm CMakeCache.txt; cmake .. -G"MinGW Makefiles"; make clean; time make -j8

real    0m15.871s
user    0m0.000s
sys     0m0.000s
```

On average, I get a ~4s speedup in a full rebuild of SFML. 

Note that this PR does *not* enable unity builds. It merely makes them possible for users of SFML who are interested in them and build SFML from source.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

1. Compile the entirety of SFML as is
2. Clean the build
3. Compile the entirety of SFML passing `-DCMAKE_UNITY_BUILD=ON` to CMake
