### PR TITLE
Enable support for unity builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS XCode,    os: macos-latest   }
         config:
-        - { name: Shared, flags: -DBUILD_SHARED_LIBS=TRUE }
-        - { name: Static, flags: -DBUILD_SHARED_LIBS=FALSE }
+        - { name: Shared,       flags: -DBUILD_SHARED_LIBS=TRUE }
+        - { name: Static,       flags: -DBUILD_SHARED_LIBS=FALSE }
 
         include:
+        - platform: { name: Windows VS2019, os: windows-latest }
+          config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
         - platform: { name: MacOS XCode, os: macos-latest }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }
         - platform: { name: MacOS XCode, os: macos-latest }

--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -7,8 +7,8 @@
 #include <iostream>
 
 
-const sf::Uint8 audioData   = 1;
-const sf::Uint8 endOfStream = 2;
+const sf::Uint8 clientAudioData   = 1;
+const sf::Uint8 clientEndOfStream = 2;
 
 
 ////////////////////////////////////////////////////////////
@@ -71,7 +71,7 @@ private:
     {
         // Pack the audio samples into a network packet
         sf::Packet packet;
-        packet << audioData;
+        packet << clientAudioData;
         packet.append(samples, sampleCount * sizeof(sf::Int16));
 
         // Send the audio packet to the server
@@ -86,7 +86,7 @@ private:
     {
         // Send a "end-of-stream" packet
         sf::Packet packet;
-        packet << endOfStream;
+        packet << clientEndOfStream;
         m_socket.send(packet);
 
         // Close the socket

--- a/examples/voip/Server.cpp
+++ b/examples/voip/Server.cpp
@@ -9,8 +9,8 @@
 #include <iterator>
 
 
-const sf::Uint8 audioData   = 1;
-const sf::Uint8 endOfStream = 2;
+const sf::Uint8 serverAudioData   = 1;
+const sf::Uint8 serverEndOfStream = 2;
 
 
 ////////////////////////////////////////////////////////////
@@ -123,7 +123,7 @@ private:
             sf::Uint8 id;
             packet >> id;
 
-            if (id == audioData)
+            if (id == serverAudioData)
             {
                 // Extract audio samples from the packet, and append it to our samples buffer
                 const sf::Int16* samples     = reinterpret_cast<const sf::Int16*>(static_cast<const char*>(packet.getData()) + 1);
@@ -136,7 +136,7 @@ private:
                     std::copy(samples, samples + sampleCount, std::back_inserter(m_samples));
                 }
             }
-            else if (id == endOfStream)
+            else if (id == serverEndOfStream)
             {
                 // End of stream reached: we stop receiving audio data
                 std::cout << "Audio data has been 100% received!" << std::endl;

--- a/src/SFML/Graphics/GLExtensions.cpp
+++ b/src/SFML/Graphics/GLExtensions.cpp
@@ -25,10 +25,17 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#define SF_GLAD_GL_IMPLEMENTATION
 #include <SFML/Graphics/GLExtensions.hpp>
 #include <SFML/Window/Context.hpp>
 #include <SFML/System/Err.hpp>
+
+// We check for this definition in order to avoid multiple definitions of GLAD
+// entities during unity builds of SFML.
+#ifndef SF_GLAD_GL_IMPLEMENTATION_INCLUDED
+#define SF_GLAD_GL_IMPLEMENTATION_INCLUDED
+#define SF_GLAD_GL_IMPLEMENTATION
+#include <glad/gl.h>
+#endif
 
 #if !defined(GL_MAJOR_VERSION)
     #define GL_MAJOR_VERSION 0x821B

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -40,18 +40,22 @@
 
 namespace
 {
-    sf::Mutex idMutex;
-    sf::Mutex maximumSizeMutex;
-
-    // Thread-safe unique identifier generator,
-    // is used for states cache (see RenderTarget)
-    sf::Uint64 getUniqueId()
+    // A nested named namespace is used here to allow unity builds of SFML.
+    namespace TextureImpl
     {
-        sf::Lock lock(idMutex);
+        sf::Mutex idMutex;
+        sf::Mutex maximumSizeMutex;
 
-        static sf::Uint64 id = 1; // start at 1, zero is "no texture"
+        // Thread-safe unique identifier generator,
+        // is used for states cache (see RenderTarget)
+        sf::Uint64 getUniqueId()
+        {
+            sf::Lock lock(idMutex);
 
-        return id++;
+            static sf::Uint64 id = 1; // start at 1, zero is "no texture"
+
+            return id++;
+        }
     }
 }
 
@@ -69,7 +73,7 @@ m_isRepeated   (false),
 m_pixelsFlipped(false),
 m_fboAttachment(false),
 m_hasMipmap    (false),
-m_cacheId      (getUniqueId())
+m_cacheId      (TextureImpl::getUniqueId())
 {
 }
 
@@ -85,7 +89,7 @@ m_isRepeated   (copy.m_isRepeated),
 m_pixelsFlipped(false),
 m_fboAttachment(false),
 m_hasMipmap    (false),
-m_cacheId      (getUniqueId())
+m_cacheId      (TextureImpl::getUniqueId())
 {
     if (copy.m_texture)
     {
@@ -206,7 +210,7 @@ bool Texture::create(unsigned int width, unsigned int height)
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, m_isRepeated ? GL_REPEAT : (textureEdgeClamp ? GLEXT_GL_CLAMP_TO_EDGE : GLEXT_GL_CLAMP)));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
-    m_cacheId = getUniqueId();
+    m_cacheId = TextureImpl::getUniqueId();
 
     m_hasMipmap = false;
 
@@ -422,7 +426,7 @@ void Texture::update(const Uint8* pixels, unsigned int width, unsigned int heigh
         glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
         m_hasMipmap = false;
         m_pixelsFlipped = false;
-        m_cacheId = getUniqueId();
+        m_cacheId = TextureImpl::getUniqueId();
 
         // Force an OpenGL flush, so that the texture data will appear updated
         // in all contexts immediately (solves problems in multi-threaded apps)
@@ -525,7 +529,7 @@ void Texture::update(const Texture& texture, unsigned int x, unsigned int y)
         glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
         m_hasMipmap = false;
         m_pixelsFlipped = false;
-        m_cacheId = getUniqueId();
+        m_cacheId = TextureImpl::getUniqueId();
 
         // Force an OpenGL flush, so that the texture data will appear updated
         // in all contexts immediately (solves problems in multi-threaded apps)
@@ -581,7 +585,7 @@ void Texture::update(const Window& window, unsigned int x, unsigned int y)
         glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
         m_hasMipmap = false;
         m_pixelsFlipped = true;
-        m_cacheId = getUniqueId();
+        m_cacheId = TextureImpl::getUniqueId();
 
         // Force an OpenGL flush, so that the texture will appear updated
         // in all contexts immediately (solves problems in multi-threaded apps)
@@ -790,7 +794,7 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
 ////////////////////////////////////////////////////////////
 unsigned int Texture::getMaximumSize()
 {
-    Lock lock(maximumSizeMutex);
+    Lock lock(TextureImpl::maximumSizeMutex);
 
     static bool checked = false;
     static GLint size = 0;
@@ -832,8 +836,8 @@ void Texture::swap(Texture& right)
     std::swap(m_fboAttachment, right.m_fboAttachment);
     std::swap(m_hasMipmap,     right.m_hasMipmap);
 
-    m_cacheId = getUniqueId();
-    right.m_cacheId = getUniqueId();
+    m_cacheId = TextureImpl::getUniqueId();
+    right.m_cacheId = TextureImpl::getUniqueId();
 }
 
 

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -36,15 +36,19 @@
 
 namespace
 {
-    sf::Mutex isAvailableMutex;
-
-    GLenum usageToGlEnum(sf::VertexBuffer::Usage usage)
+    // A nested named namespace is used here to allow unity builds of SFML.
+    namespace VertexBufferImpl
     {
-        switch (usage)
+        sf::Mutex isAvailableMutex;
+
+        GLenum usageToGlEnum(sf::VertexBuffer::Usage usage)
         {
-            case sf::VertexBuffer::Static:  return GLEXT_GL_STATIC_DRAW;
-            case sf::VertexBuffer::Dynamic: return GLEXT_GL_DYNAMIC_DRAW;
-            default:                        return GLEXT_GL_STREAM_DRAW;
+            switch (usage)
+            {
+                case sf::VertexBuffer::Static:  return GLEXT_GL_STATIC_DRAW;
+                case sf::VertexBuffer::Dynamic: return GLEXT_GL_DYNAMIC_DRAW;
+                default:                        return GLEXT_GL_STREAM_DRAW;
+            }
         }
     }
 }
@@ -143,7 +147,7 @@ bool VertexBuffer::create(std::size_t vertexCount)
     }
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
-    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, sizeof(Vertex) * vertexCount, 0, usageToGlEnum(m_usage)));
+    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, sizeof(Vertex) * vertexCount, 0, VertexBufferImpl::usageToGlEnum(m_usage)));
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, 0));
 
     m_size = vertexCount;
@@ -186,7 +190,7 @@ bool VertexBuffer::update(const Vertex* vertices, std::size_t vertexCount, unsig
     // Check if we need to resize or orphan the buffer
     if (vertexCount >= m_size)
     {
-        glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, sizeof(Vertex) * vertexCount, 0, usageToGlEnum(m_usage)));
+        glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, sizeof(Vertex) * vertexCount, 0, VertexBufferImpl::usageToGlEnum(m_usage)));
 
         m_size = vertexCount;
     }
@@ -230,7 +234,7 @@ bool VertexBuffer::update(const VertexBuffer& vertexBuffer)
     }
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
-    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, sizeof(Vertex) * vertexBuffer.m_size, 0, usageToGlEnum(m_usage)));
+    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, sizeof(Vertex) * vertexBuffer.m_size, 0, VertexBufferImpl::usageToGlEnum(m_usage)));
 
     void* destination = 0;
     glCheck(destination = GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_WRITE_ONLY));
@@ -332,7 +336,7 @@ VertexBuffer::Usage VertexBuffer::getUsage() const
 ////////////////////////////////////////////////////////////
 bool VertexBuffer::isAvailable()
 {
-    Lock lock(isAvailableMutex);
+    Lock lock(VertexBufferImpl::isAvailableMutex);
 
     static bool checked = false;
     static bool available = false;

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -32,8 +32,12 @@
 
 namespace
 {
-    // This per-thread variable holds the last activated sf::Context for each thread
-    sf::ThreadLocalPtr<sf::Context> currentContext(NULL);
+    // A nested named namespace is used here to allow unity builds of SFML.
+    namespace ContextImpl
+    {
+        // This per-thread variable holds the current context for each thread
+        sf::ThreadLocalPtr<sf::Context> currentContext(NULL);
+    }
 }
 
 namespace sf
@@ -60,7 +64,7 @@ bool Context::setActive(bool active)
     bool result = m_context->setActive(active);
 
     if (result)
-        currentContext = (active ? this : NULL);
+        ContextImpl::currentContext = (active ? this : NULL);
 
     return result;
 }
@@ -76,6 +80,8 @@ const ContextSettings& Context::getSettings() const
 ////////////////////////////////////////////////////////////
 const Context* Context::getActiveContext()
 {
+    using ContextImpl::currentContext;
+
     // We have to check that the last activated sf::Context is still active (a RenderTarget activation may have deactivated it)
     if (currentContext && currentContext->m_context == priv::GlContext::getActiveContext())
         return currentContext;

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -25,7 +25,6 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#define SF_GLAD_GLX_IMPLEMENTATION
 #include <SFML/Window/Unix/WindowImplX11.hpp> // important to be included first (conflict with None)
 #include <SFML/Window/Unix/GlxContext.hpp>
 #include <SFML/Window/Unix/Display.hpp>
@@ -33,6 +32,14 @@
 #include <SFML/System/Lock.hpp>
 #include <SFML/System/Err.hpp>
 #include <vector>
+
+// We check for this definition in order to avoid multiple definitions of GLAD
+// entities during unity builds of SFML.
+#ifndef SF_GLAD_GLX_IMPLEMENTATION_INCLUDED
+#define SF_GLAD_GLX_IMPLEMENTATION_INCLUDED
+#define SF_GLAD_GLX_IMPLEMENTATION
+#include <glad/glx.h>
+#endif
 
 #if !defined(GLX_DEBUGGING) && defined(SFML_DEBUG)
     // Enable this to print messages to err() everytime GLX produces errors
@@ -52,7 +59,7 @@ namespace
         if (!initialized)
         {
             initialized = true;
-    
+
             // We don't check the return value since the extension
             // flags are cleared even if loading fails
             gladLoaderLoadGLX(display, screen);

--- a/src/SFML/Window/Win32/VulkanImplWin32.cpp
+++ b/src/SFML/Window/Win32/VulkanImplWin32.cpp
@@ -26,7 +26,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Win32/VulkanImplWin32.hpp>
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #define VK_USE_PLATFORM_WIN32_KHR
 #define VK_NO_PROTOTYPES

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -31,6 +31,9 @@
 #ifdef _WIN32_WINNT
     #undef _WIN32_WINNT
 #endif
+#ifdef WINVER
+    #undef WINVER
+#endif
 #define _WIN32_WINDOWS 0x0501
 #define _WIN32_WINNT   0x0501
 #define WINVER         0x0501

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -33,7 +33,11 @@
 
 namespace
 {
-    const sf::WindowBase* fullscreenWindow = NULL;
+    // A nested named namespace is used here to allow unity builds of SFML.
+    namespace WindowsBaseImpl
+    {
+        const sf::WindowBase* fullscreenWindow = NULL;
+    }
 }
 
 
@@ -366,14 +370,14 @@ void WindowBase::initialize()
 ////////////////////////////////////////////////////////////
 const WindowBase* WindowBase::getFullscreenWindow()
 {
-    return fullscreenWindow;
+    return WindowsBaseImpl::fullscreenWindow;
 }
 
 
 ////////////////////////////////////////////////////////////
 void WindowBase::setFullscreenWindow(const WindowBase* window)
 {
-    fullscreenWindow = window;
+    WindowsBaseImpl::fullscreenWindow = window;
 }
 
 } // namespace sf


### PR DESCRIPTION
## Description

This PR renames objects with internal linkage defined in `.cpp` files in order to avoid name collisions when performing a *unity build* of SFML. You can read the benefits of *unity builds* [in this article](https://onqtam.com/programming/2019-12-20-pch-unity-cmake-3-16/). Here's an excerpt: 

> ## Unity builds
>
> The idea is to cram the .cpp files of a CMake target into a few .cpp files which include the original .cpp files
>
> - up to 7-8 times faster builds (usually x3 or x4)
>
> - example: a project of 200 .cpp files might be divided into 16 unity .cpp (or .cxx - whatever) files each including about 13 of the original .cpp files => 16 .cpp files to build in parallel and 16 .obj files to link
>
> - the reasons for the speedup are:
>     - common headers from the different .cpp files end up being included and parsed fewer times (this is beneficial even when using PCHs!)
>     - common template instantiations with the same types in separate .cpp files (vector<int>) end up being done in fewer places
>     - the linker has to stitch much fewer .obj files in the end - there are a lot less weak symbols to deduplicate (inline/template
>     - functions from headers end up in every .obj => linkers leave just 1)
>          - surprisingly incremental builds (changing a single .cpp) will probably also be faster instead of slower (even though you compile more .cpp files together) - precisely because of the reduced number of weak duplicated symbols!
>     - less compiler invocations and less .obj files are written to disk

This PR renames `static` objects defined in different `.cpp` files to avoid name collisions. It also fixes up some includes of `wgl.h` and `gl.h` to avoid redefinition errors. The renaming is necessary -- from the linked article:

> Initial problems when trying to compile a project as unity
>
> - there will be static globals (or in anonymous namespaces) in different .cpp files with identical names which would clash
>    - either rename them or put such globals into an additional namespace - perhaps with the name of the file: for GraphVisitor.cpp I would recommend GRAPH_VISITOR_CPP (putting static symbols inside of a named namespace in a .cpp keeps their linkage to internal , and the same is true with nesting anonymous namespaces into named ones)

And here are some benchmarks of a clean build on my machine, using MSYS2 + MinGW-w64:

```bash
# with `set(CMAKE_UNITY_BUILD ON)`
rm CMakeCache.txt; cmake .. -G"MinGW Makefiles"; make clean; time make -j8

real    0m11.285s
user    0m0.000s
sys     0m0.015s
```

```bash
# with `set(CMAKE_UNITY_BUILD OFF)`
rm CMakeCache.txt; cmake .. -G"MinGW Makefiles"; make clean; time make -j8

real    0m15.871s
user    0m0.000s
sys     0m0.000s
```

On average, I get a ~4s speedup in a full rebuild of SFML. 

Note that this PR does *not* enable unity builds. It merely makes them possible for users of SFML who are interested in them and build SFML from source.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

1. Compile the entirety of SFML as is
2. Clean the build
3. Compile the entirety of SFML passing `-DCMAKE_UNITY_BUILD=ON` to CMake