### PR TITLE
Fixed regression introduced in 4fcef89 causing EXT_texture_edge_clamp support to not be considered

### DIFF
--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -308,6 +308,8 @@
     #define GLEXT_geometry_shader4                    SF_GLAD_GL_ARB_geometry_shader4
     #define GLEXT_GL_GEOMETRY_SHADER                  GL_GEOMETRY_SHADER_ARB
 
+#endif
+
     // OpenGL Versions
     #define GLEXT_GL_VERSION_1_0                      SF_GLAD_GL_VERSION_1_0
     #define GLEXT_GL_VERSION_1_1                      SF_GLAD_GL_VERSION_1_1
@@ -328,8 +330,6 @@
     #define GLEXT_GL_VERSION_4_4                      SF_GLAD_GL_VERSION_4_4
     #define GLEXT_GL_VERSION_4_5                      SF_GLAD_GL_VERSION_4_5
     #define GLEXT_GL_VERSION_4_6                      SF_GLAD_GL_VERSION_4_6
-
-#endif
 
 namespace sf
 {

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -162,7 +162,7 @@ bool Texture::create(unsigned int width, unsigned int height)
     // Make sure that the current texture binding will be preserved
     priv::TextureSaver save;
 
-    static bool textureEdgeClamp = GLEXT_texture_edge_clamp;
+    static bool textureEdgeClamp = GLEXT_texture_edge_clamp || GLEXT_GL_VERSION_1_2 || Context::isExtensionAvailable("GL_EXT_texture_edge_clamp");
 
     if (!m_isRepeated && !textureEdgeClamp)
     {

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -295,7 +295,7 @@ int WglContext::selectBestPixelFormat(HDC deviceContext, unsigned int bitsPerPix
 
         // Let's check how many formats are supporting our requirements
         int  formats[512];
-        UINT nbFormats;
+        UINT nbFormats = 0; // We must initialize to 0 otherwise broken drivers might fill with garbage in the following call
         bool isValid = wglChoosePixelFormatARB(deviceContext, intAttributes, NULL, 512, formats, &nbFormats) != FALSE;
 
         if (!isValid)


### PR DESCRIPTION
See title.

Fixes #1786.

Also added explicit initialization of `nbFormats` to 0 in WglContext.cpp in order to prevent broken graphics drivers from filling `nbFormats` with a garbage value. Continuing with the garbage value could sporadically cause subsequent `wglGetPixelFormatAttribivARB` calls to return `FALSE` and `GetLastError()` to return `ERROR_SUCCESS` which is nothing short of undefined behaviour somewhere in the driver code. The user would end up seeing the message "Failed to retrieve pixel format information: The operation completed successfully" in their console.