### PR TITLE
Fix OpenGL context on Android

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -102,6 +102,7 @@ static void initializeMain(ActivityStates* states)
      * input queue.
      */
     ALooper_acquire(states->looper);
+    ALooper_wake(states->looper);
 
     // Get the default configuration
     states->config = AConfiguration_new();


### PR DESCRIPTION
## Description

Fixes #1532 

> When waiting for an event, rather then polling, the android looper prevents the creation of an OpenGL context till ALooper receives an event rather then allowing creation at the appropriate time, and this is just one of a few issues caused by this

## How to test this PR?

I'm not a 100% certain, but I'd test this:

- Create Android build
- Use a waitEvent() instead of pollEvent() event loop
- Ensure that it's still drawing correctly