### PR TITLE
Fix `sf::Context::getActiveContext` to stop returning inactive contexts

### DIFF
--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -32,7 +32,7 @@
 
 namespace
 {
-    // This per-thread variable holds the current context for each thread
+    // This per-thread variable holds the last activated sf::Context for each thread
     sf::ThreadLocalPtr<sf::Context> currentContext(NULL);
 }
 
@@ -76,7 +76,11 @@ const ContextSettings& Context::getSettings() const
 ////////////////////////////////////////////////////////////
 const Context* Context::getActiveContext()
 {
-    return currentContext;
+    // We have to check that the last activated sf::Context is still active (a RenderTarget activation may have deactivated it)
+    if (currentContext && currentContext->m_context == priv::GlContext::getActiveContext())
+        return currentContext;
+    else
+        return NULL;
 }
 
 

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -550,6 +550,13 @@ GlFunctionPointer GlContext::getFunction(const char* name)
 
 
 ////////////////////////////////////////////////////////////
+const GlContext* GlContext::getActiveContext()
+{
+    return currentContext;
+}
+
+
+////////////////////////////////////////////////////////////
 Uint64 GlContext::getActiveContextId()
 {
     return currentContext ? currentContext->m_id : 0;

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -158,6 +158,14 @@ public:
     static GlFunctionPointer getFunction(const char* name);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the currently active context
+    ///
+    /// \return The currently active context or NULL if none is active
+    ///
+    ////////////////////////////////////////////////////////////
+    static const GlContext* getActiveContext();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Get the currently active context's ID
     ///
     /// The context ID is used to identify contexts when


### PR DESCRIPTION
## Description

`sf::Context::getActiveContext` could return an inactive context if a
`RenderTarget`s activation occured since the last `sf::Context` activation.
This is not what its documentation suggest, and was clearly an
unexpected behaviour.

This fix make the function return `NULL` if the current active context is
not managed by `sf::Context` (e.g. because it is a `RenderTarget`).

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Here is a minimal example to test the change. In the last line of output, the printed address should be 0x0 and not the address for the created sf::Context.

```cpp
#include <SFML/Graphics.hpp>
#include <iostream>

int main()
{
    std::cout << "Create the sf::RenderWindow" << std::endl;
    sf::RenderWindow window(sf::VideoMode(1280, 720), "Test getActiveContext()");
    std::cout << "Active context: #" << std::dec << sf::Context::getActiveContextId()
              << " @ 0x" << std::hex << reinterpret_cast<size_t>(sf::Context::getActiveContext()) << std::endl;

    std::cout << "Create the sf::Context" << std::endl;
    sf::Context context(sf::ContextSettings(), 100, 100);
    std::cout << "Active context: #" << std::dec << sf::Context::getActiveContextId()
              << " @ 0x" << std::hex << reinterpret_cast<size_t>(sf::Context::getActiveContext()) << std::endl;

    std::cout << "Activate the window" << std::endl;
    window.setActive(true);
    std::cout << "Active context: #" << std::dec << sf::Context::getActiveContextId()
              << " @ 0x" << std::hex << reinterpret_cast<size_t>(sf::Context::getActiveContext()) << std::endl;

    return 0;
}
```