### PR TITLE
Try more possible names for OpenGLES library.

### DIFF
--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -164,8 +164,19 @@ GlFunctionPointer EaglContext::getFunction(const char* name)
 {
     static void* module = 0;
 
-    if (!module)
-        module = dlopen("libGLESv1_CM.dylib", RTLD_LAZY | RTLD_LOCAL);
+    const int libCount = 3;
+    const char* libs[libCount] =
+    {
+        "libGLESv1_CM.dylib",
+        "/System/Library/Frameworks/OpenGLES.framework/OpenGLES",
+        "OpenGLES.framework/OpenGLES"
+    };
+    
+    for (int i = 0; i < libCount; ++i)
+    {
+        if (!module)
+            module = dlopen(libs[i], RTLD_LAZY | RTLD_LOCAL);
+    }
 
     if (module)
         return reinterpret_cast<GlFunctionPointer>(dlsym(module, name));


### PR DESCRIPTION
## Description

This PR fixes issue #1687.

While googling around for alternatives, I found the other names [here](https://github.com/kakashidinho/metalangle/blob/f3ab2c261fb9dcfa98a7294fe54bae814b817632/src/libANGLE/renderer/gl/eagl/DisplayEAGL.mm#L56).

Let me know if my formatting is off, it's been I while since I've used C++ or SFML.

## Tasks

* [ ] Tested on iOS

## How to test this PR?

According to the linked issue (and my own tests), all you need to do is run an app using the window module and make sure it doesn't crash with the error mentioned in #1687. I tested this on my iPhone 8 Plus, running iOS 14.4 (yes I need to update :P ).

![img](https://cdn.discordapp.com/attachments/477173543281491968/859241594560708668/image0.png)