### PR TITLE
Idea to improve high DPI handling on OS X

### DIFF
--- a/src/SFML/Window/OSX/SFOpenGLView.h
+++ b/src/SFML/Window/OSX/SFOpenGLView.h
@@ -78,6 +78,7 @@ namespace sf {
     BOOL                          m_cursorGrabbed;  ///< Is the mouse cursor trapped?
     CGFloat                       m_deltaXBuffer;   ///< See note about cursor grabbing above
     CGFloat                       m_deltaYBuffer;   ///< See note about cursor grabbing above
+    BOOL                          m_highDpi;        ///< Is high-DPI enabled?
 
     // Hidden text view used to convert key event to actual chars.
     // We use a silent responder to prevent sound alerts.
@@ -99,7 +100,7 @@ namespace sf {
 /// \return an initialized view
 ///
 ////////////////////////////////////////////////////////////
--(id)initWithFrame:(NSRect)frameRect fullscreen:(BOOL)isFullscreen;
+-(id)initWithFrame:(NSRect)frameRect fullscreen:(BOOL)isFullscreen highDpi:(BOOL)isHighDpi;
 
 ////////////////////////////////////////////////////////////
 /// \brief Finish the creation of the SFML OpenGL view

--- a/src/SFML/Window/OSX/SFWindowController.h
+++ b/src/SFML/Window/OSX/SFWindowController.h
@@ -62,6 +62,7 @@ namespace sf {
     sf::priv::WindowImplCocoa*  m_requester;        ///< Requester
     BOOL                        m_fullscreen;       ///< Indicate whether the window is fullscreen or not
     BOOL                        m_restoreResize;    ///< See note above
+    BOOL                        m_highDpi;          ///< Support high-DPI rendering or not
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -99,6 +99,7 @@
         m_requester = 0;
         m_fullscreen = NO; // assuming this is the case... too hard to handle anyway.
         m_restoreResize = NO;
+        m_highDpi = NO;
 
         // Retain the window for our own use.
         m_window = [window retain];
@@ -111,7 +112,8 @@
 
         // Create the view.
         m_oglView = [[SFOpenGLView alloc] initWithFrame:[[m_window contentView] frame]
-                                             fullscreen:NO];
+                                             fullscreen:NO
+                                                highDpi:NO];
 
         if (m_oglView == nil)
         {
@@ -153,6 +155,7 @@
         m_requester = 0;
         m_fullscreen = (style & sf::Style::Fullscreen);
         m_restoreResize = NO;
+        m_highDpi = NO;
 
         if (m_fullscreen)
             [self setupFullscreenViewWithMode:mode];
@@ -218,7 +221,8 @@
     NSRect oglRect = NSMakeRect(x, y, width, height);
 
     m_oglView = [[SFOpenGLView alloc] initWithFrame:oglRect
-                                         fullscreen:YES];
+                                         fullscreen:YES
+                                            highDpi:m_highDpi];
 
     if (m_oglView == nil)
     {
@@ -277,7 +281,8 @@
 
     // Create the view.
     m_oglView = [[SFOpenGLView alloc] initWithFrame:[[m_window contentView] frame]
-                                         fullscreen:NO];
+                                         fullscreen:NO
+                                            highDpi:m_highDpi];
 
     if (m_oglView == nil)
     {

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -130,9 +130,6 @@ m_showCursor(true)
     // Transform the app process.
     setUpProcess();
 
-    // Use backing size
-    scaleInWidthHeight(mode, nil);
-
     m_delegate = [[SFWindowController alloc] initWithMode:mode andStyle:style];
     [m_delegate changeTitle:sfStringToNSString(title)];
     [m_delegate setRequesterTo:this];
@@ -544,4 +541,3 @@ bool WindowImplCocoa::hasFocus() const
 } // namespace priv
 
 } // namespace sf
-


### PR DESCRIPTION
* [x] Forum posts: [1](https://en.sfml-dev.org/forums/index.php?topic=17092.0), [2](https://en.sfml-dev.org/forums/index.php?topic=18840.0), [3](https://en.sfml-dev.org/forums/index.php?topic=17354.0). Issues and PRs: #353, #388
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

### Problem Description

SFML doesn't really have complete support for DPI awareness (it is my understanding that this is planned for SFML version 3).

This can be an issue on MacBooks with retina displays (among other situations). There are two possible cases:

1. `NSHighResolutionCapable` is set to true, and all windows appear to be half the size in each dimension as expected.
2. `NSHighResolutionCapable` is set to false in the Info.plist file, and the whole app renders in low resolution.

Both of these cases are highly problematic.

In case 1, by default, all windows and graphics will be drawn far too small to be usable. In order to render at the correct size, the application developer must scale all of the window and graphics sizes by the correct scale. However, SFML does not expose an API to identify if the display is high DPI, and to return the correct scaling. This is a fairly invasive change to the application code, and will require platform-specific code to identify the display scaling.

In case 2, everything draws at the correct size, but the window decorations and fonts are blurry. Furthermore, if one uses a raw executable (rather than application bundle) then it is not possible to set this option using Info.plist.

| `NSHighResolutionCapable` true | `NSHighResolutionCapable` false |
| --- | --- |
| <img width="138" alt="high_dpi" src="https://user-images.githubusercontent.com/76420460/129491308-e6b35d57-6315-4ac9-ac94-9b1ebff819c0.png"> | <img width="136" alt="low_dpi" src="https://user-images.githubusercontent.com/76420460/129491312-8dee0afc-2646-4d92-af89-c9c21bcaef84.png"> |

---

### Proposed Solution

I believe that the **default** behavior should be as follows:

* The apparent window sizes should be the same on high DPI displays and low DPI displays
* Window decorations and fonts should be rendered in high resolution
* Graphics should be rendered at the same apparent size on high DPI and low DPI displays (without making SFML DPI-aware, which is a much bigger project, this means that graphics will be slightly pixelated on high DPI displays)

**If** the user wants to avoid the scaled rendering, and instead put in the extra effort to support high DPI rendering, then they can **opt-in** by setting a high DPI window style.

This PR accomplishes this by adding a new window style `HighDPI` (which has an effect only on Mac OS, but this could potentially be extended to other platforms). This style is not set by default. This will cause the window and graphics to render at the same apparent size on high DPI and low DPI displays, while retaining high-resolution window decorations and fonts. This is because if the style is not set, then `setWantsBestResolutionOpenGLSurface` is set to `NO` in the `SFOpenGLView`.

On the other hand, if the application developer wants to avoid possible pixelation from scaling the window, they can set the `HighDPI` window style, which will call `setWantsBestResolutionOpenGLSurface` to `YES`, and also enable scaling of window dimensions by the display factor. The developer will then need to manually scale all of the windows and graphics sizes in their rendering code to render everything at 2x.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::Uint32 style = sf::Style::Default;
    // Uncomment the next line to enable high DPI mode:
    // style |= sf::Style::HighDPI;
    const char *title = (style & sf::Style::HighDPI) ? "High DPI" : "Default";
    sf::RenderWindow window(sf::VideoMode(300, 300), title, style);
    window.setFramerateLimit(60);
    sf::CircleShape circle(150, 100);
    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }
        window.clear();
        window.draw(circle);
        window.display();
    }
}
```

| Default mode | High DPI mode | Low DPI mode (previous) |
| --- | --- | --- |
| <img width="300" alt="Screen Shot 2021-08-15 at 1 50 52 PM" src="https://user-images.githubusercontent.com/76420460/129492499-afc1a070-5b6b-47ec-94ac-f963381f85ba.png"> | <img width="150" alt="Screen Shot 2021-08-15 at 1 51 02 PM" src="https://user-images.githubusercontent.com/76420460/129492497-cd3719f6-eb63-4e9e-adc3-cae72ad649ea.png"> | <img width="300" alt="Screen Shot 2021-08-15 at 1 51 19 PM" src="https://user-images.githubusercontent.com/76420460/129492496-5e703c63-c320-43a7-ad5b-1a8a31467c14.png"> |

From the above screenshots, we can see that the "default mode" preserves the advantages of setting `NSHighResolutionCapable` to be false (everything renders at the correct size), while avoiding the blurry window decorations and fonts. Additionally, the application developer still retains the option to render everything in high resolution if desired.