### PR TITLE
Copy logo.png to Resources in Cocoa example

### DIFF
--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -41,6 +41,7 @@ compile_xib(INPUT "${SRCROOT}/MainMenu.xib" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/
 # all resource files
 set(RESOURCES ${SRCROOT}/resources/icon.icns
               ${SRCROOT}/resources/tuffy.ttf
+              ${SRCROOT}/resources/logo.png
               ${SRCROOT}/resources/blue.png
               ${SRCROOT}/resources/green.png
               ${SRCROOT}/resources/red.png


### PR DESCRIPTION
The logo will otherwise be missing from the Cocoa example. (Reproduce by opening `cocoa.app`. The logo should be missing on master, present in this PR).