### PR TITLE
Silence deprecation warnings on Mac OS X

### DIFF
--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -55,6 +55,7 @@ sfml_add_example(cocoa
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
                  DEPENDS sfml-system sfml-window sfml-graphics)
+target_compile_options(cocoa PRIVATE -Wno-deprecated-declarations)
 set_target_properties(cocoa PROPERTIES
                       MACOSX_BUNDLE TRUE
                       MACOSX_BUNDLE_INFO_PLIST ${SRCROOT}/resources/Cocoa-Info.plist)

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -85,6 +85,10 @@ if(SFML_OS_ANDROID)
     target_link_libraries(sfml-audio PRIVATE android OpenSLES)
 endif()
 
+if(SFML_OS_MACOSX)
+    target_compile_options(sfml-audio PRIVATE -Wno-deprecated-declarations)
+endif()
+
 target_link_libraries(sfml-audio
                       PUBLIC sfml-system
                       PRIVATE VORBIS FLAC)

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -285,6 +285,10 @@ if(SFML_OS_WINDOWS AND NOT SFML_COMPILER_MSVC)
     endif()
 endif()
 
+if(SFML_OS_MACOSX)
+    target_compile_options(sfml-window PRIVATE -Wno-deprecated-declarations)
+endif()
+
 if(SFML_OS_LINUX)
     sfml_find_package(UDev INCLUDE "UDEV_INCLUDE_DIR" LINK "UDEV_LIBRARIES")
     target_link_libraries(sfml-window PRIVATE UDev dl)


### PR DESCRIPTION
Building SFML on Mac OS X results in ~170 compiler warnings (all of which are deprecation warnings), mostly because OpenAL and OpenGL are deprecated on Mac.

Given that SFML's use of OpenAL and OpenGL is pretty hard-coded (at least for the foreseeable future) it probably makes sense to silence these warnings.