### PR TITLE
Use modern CMake property to handle static runtime linking with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,17 +207,6 @@ if(SFML_OS_WINDOWS)
     if(BUILD_SHARED_LIBS AND SFML_USE_STATIC_STD_LIBS)
         message(FATAL_ERROR "BUILD_SHARED_LIBS and SFML_USE_STATIC_STD_LIBS cannot be used together")
     endif()
-
-    # for VC++, we can apply it globally by modifying the compiler flags
-    if((SFML_COMPILER_MSVC OR (SFML_COMPILER_CLANG AND NOT MINGW)) AND SFML_USE_STATIC_STD_LIBS)
-        foreach(flag
-                CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-                CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if(${flag} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-            endif()
-        endforeach()
-    endif()
 endif()
 
 # setup Mac OS X stuff

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -115,20 +115,25 @@ macro(sfml_add_library module)
             )
             target_sources(${target} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${target}.rc")
             source_group("" FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}.rc")
+
+            if (SFML_COMPILER_GCC OR SFML_COMPILER_CLANG)
+                # on Windows + gcc/clang get rid of "lib" prefix for shared libraries,
+                # and transform the ".dll.a" suffix into ".a" for import libraries
+                set_target_properties(${target} PROPERTIES PREFIX "")
+                set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".a")
+            endif()
         else()
             set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)
-        endif()
-        if (SFML_OS_WINDOWS AND (SFML_COMPILER_GCC OR SFML_COMPILER_CLANG))
-            # on Windows + gcc/clang get rid of "lib" prefix for shared libraries,
-            # and transform the ".dll.a" suffix into ".a" for import libraries
-            set_target_properties(${target} PROPERTIES PREFIX "")
-            set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".a")
         endif()
     else()
         set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -s-d)
         set_target_properties(${target} PROPERTIES RELEASE_POSTFIX -s)
         set_target_properties(${target} PROPERTIES MINSIZEREL_POSTFIX -s)
         set_target_properties(${target} PROPERTIES RELWITHDEBINFO_POSTFIX -s)
+
+        if (SFML_USE_STATIC_STD_LIBS)
+            set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+        endif()
     endif()
 
     # set the version and soversion of the target (for compatible systems -- mostly Linuxes)
@@ -274,6 +279,10 @@ macro(sfml_add_example target)
         target_link_libraries(${target} PRIVATE SFML::Main)
     else()
         add_executable(${target} ${target_input})
+    endif()
+
+    if (SFML_USE_STATIC_STD_LIBS)
+        set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()
 
     set_target_warnings(${target})


### PR DESCRIPTION
## Description

In some cases /MD* flags aren't part of the CXX CMake flags and thus
won't be replaced with /MT, for example when adding SFML as
sub-directory to another CMake project.

This PR is related to the issue #1679

## Tasks

* [x] Tested on Windows

## How to test this PR?

Source Example

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    auto window = sf::RenderWindow{ sf::VideoMode{ { 1280, 720} }, "Example code" };
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        for (auto event = sf::Event{}; window.pollEvent(event);)
        {
            if (event.type == sf::Event::Closed)
            {
                window.close();
            }
        }

        window.clear();
        window.display();
    }
}
```

CMake Example

```cmake
cmake_minimum_required(VERSION 3.15)

project(Project VERSION 1.0 LANGUAGES CXX)

set(BUILD_SHARED_LIBS OFF)

add_executable(out main.cpp)

set_property(TARGET out PROPERTY
                MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

set(SFML_USE_STATIC_STD_LIBS ON CACHE BOOL "Use a static c++ runtime" FORCE)
add_subdirectory(SFML)
target_link_libraries(out PRIVATE sfml-graphics)
```