### PR TITLE
Fixed text underline and strike-through missing outline

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -34,17 +34,17 @@
 namespace
 {
     // Add an underline or strikethrough line to the vertex array
-    void addLine(sf::VertexArray& vertices, float lineLength, float lineTop, const sf::Color& color, float offset, float thickness)
+    void addLine(sf::VertexArray& vertices, float lineLength, float lineTop, const sf::Color& color, float offset, float thickness, float outlineThickness = 0)
     {
         float top = std::floor(lineTop + offset - (thickness / 2) + 0.5f);
         float bottom = top + std::floor(thickness + 0.5f);
 
-        vertices.append(sf::Vertex(sf::Vector2f(0,          top),    color, sf::Vector2f(1, 1)));
-        vertices.append(sf::Vertex(sf::Vector2f(lineLength, top),    color, sf::Vector2f(1, 1)));
-        vertices.append(sf::Vertex(sf::Vector2f(0,          bottom), color, sf::Vector2f(1, 1)));
-        vertices.append(sf::Vertex(sf::Vector2f(0,          bottom), color, sf::Vector2f(1, 1)));
-        vertices.append(sf::Vertex(sf::Vector2f(lineLength, top),    color, sf::Vector2f(1, 1)));
-        vertices.append(sf::Vertex(sf::Vector2f(lineLength, bottom), color, sf::Vector2f(1, 1)));
+        vertices.append(sf::Vertex(sf::Vector2f(-outlineThickness,             top    - outlineThickness), color, sf::Vector2f(1, 1)));
+        vertices.append(sf::Vertex(sf::Vector2f(lineLength + outlineThickness, top    - outlineThickness), color, sf::Vector2f(1, 1)));
+        vertices.append(sf::Vertex(sf::Vector2f(-outlineThickness,             bottom + outlineThickness), color, sf::Vector2f(1, 1)));
+        vertices.append(sf::Vertex(sf::Vector2f(-outlineThickness,             bottom + outlineThickness), color, sf::Vector2f(1, 1)));
+        vertices.append(sf::Vertex(sf::Vector2f(lineLength + outlineThickness, top    - outlineThickness), color, sf::Vector2f(1, 1)));
+        vertices.append(sf::Vertex(sf::Vector2f(lineLength + outlineThickness, bottom + outlineThickness), color, sf::Vector2f(1, 1)));
     }
 
     // Add a glyph quad to the vertex array
@@ -459,7 +459,7 @@ void Text::ensureGeometryUpdate() const
             addLine(m_vertices, x, y, m_fillColor, underlineOffset, underlineThickness);
 
             if (m_outlineThickness != 0)
-                addLine(m_outlineVertices, x, y, m_outlineColor, underlineOffset, underlineThickness);
+                addLine(m_outlineVertices, x, y, m_outlineColor, underlineOffset, underlineThickness, m_outlineThickness);
         }
 
         // If we're using the strike through style and there's a new line, draw a line across all characters
@@ -468,7 +468,7 @@ void Text::ensureGeometryUpdate() const
             addLine(m_vertices, x, y, m_fillColor, strikeThroughOffset, underlineThickness);
 
             if (m_outlineThickness != 0)
-                addLine(m_outlineVertices, x, y, m_outlineColor, strikeThroughOffset, underlineThickness);
+                addLine(m_outlineVertices, x, y, m_outlineColor, strikeThroughOffset, underlineThickness, m_outlineThickness);
         }
 
         prevChar = curChar;
@@ -545,7 +545,7 @@ void Text::ensureGeometryUpdate() const
         addLine(m_vertices, x, y, m_fillColor, underlineOffset, underlineThickness);
 
         if (m_outlineThickness != 0)
-            addLine(m_outlineVertices, x, y, m_outlineColor, underlineOffset, underlineThickness);
+            addLine(m_outlineVertices, x, y, m_outlineColor, underlineOffset, underlineThickness, m_outlineThickness);
     }
 
     // If we're using the strike through style, add the last line across all characters
@@ -554,7 +554,7 @@ void Text::ensureGeometryUpdate() const
         addLine(m_vertices, x, y, m_fillColor, strikeThroughOffset, underlineThickness);
 
         if (m_outlineThickness != 0)
-            addLine(m_outlineVertices, x, y, m_outlineColor, strikeThroughOffset, underlineThickness);
+            addLine(m_outlineVertices, x, y, m_outlineColor, strikeThroughOffset, underlineThickness, m_outlineThickness);
     }
 
     // Update the bounding rectangle


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [x] If you have additional steps which need to be performed list them as tasks!

----

## Description

This reverts some of the change from https://github.com/SFML/SFML/pull/1827, made to the `addLine()` function. The changes had made underline and strike-through missing their outline when drawing text. This is now reverted and outlines are drawn correctly.

![Screenshot from 2021-10-20 08-17-28](https://user-images.githubusercontent.com/2236577/138046734-7dde0909-f325-4060-b43b-610ee94aeb1c.png)

Note, however, how the strike-through (also affects underline) disappears for very small font sizes. This is because FreeType returns the line thickness as a fractional value, which is then `std::floor(thickness + 0.5f)` in the `addLine()` function. If `thickness` is less than 0.5, the line will have zero thickness and will not render. Maybe there should be a `std::min(1, ...)` added there? Or would this be bad for hi-DPI displays? Maybe this is one for another issue/PR.

This PR is related to the PR https://github.com/SFML/SFML/pull/1827

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

```cpp
#include <SFML/Graphics.hpp>
#include <cmath>

int main() {
    sf::RenderWindow window(sf::VideoMode(768, 512), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    sf::Font fnt;
    fnt.loadFromFile("noto.ttf");

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }

        window.clear(sf::Color(128, 128, 128));

        float y = 0.0;
        for (std::size_t i = 5; i < 20; ++i) {
            sf::Text txt("Language: C++", fnt, i);
            txt.setStyle(sf::Text::StrikeThrough);
            txt.setFillColor(sf::Color::White);
            txt.setOutlineColor(sf::Color::Black);
            txt.setOutlineThickness(2.0f);
            txt.setPosition(0.0, std::round(y));
            window.draw(txt);

            y += 1.5f*i;
        }

        y = 0.0;
        for (std::size_t i = 5; i < 20; ++i) {
            sf::Text txt("Language: C++", fnt, i);
            txt.setFillColor(sf::Color::White);
            txt.setStyle(sf::Text::Bold | sf::Text::StrikeThrough);
            txt.setOutlineColor(sf::Color::Black);
            txt.setOutlineThickness(2.0f);
            txt.setPosition(256.0, std::round(y));
            window.draw(txt);

            y += 1.5f*i;
        }

        y = 0.0;
        for (std::size_t i = 5; i < 20; ++i) {
            sf::Text txt("Language: C++", fnt, i);
            txt.setFillColor(sf::Color::White);
            txt.setStyle(sf::Text::Italic | sf::Text::StrikeThrough);
            txt.setOutlineColor(sf::Color::Black);
            txt.setOutlineThickness(2.0f);
            txt.setPosition(512.0, std::round(y));
            window.draw(txt);

            y += 1.5f*i;
        }

        window.display();
    }
}
```