### PR TITLE
Simplify management of `ActivityStates`

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -46,6 +46,7 @@
 #include <android/window.h>
 #include <android/native_activity.h>
 #include <cstring>
+#include <cassert>
 
 #define SF_GLAD_EGL_IMPLEMENTATION
 #include <glad/egl.h>
@@ -70,10 +71,10 @@ int getAndroidApiLevel(ANativeActivity* activity)
     jfieldID sdkIntFieldID = lJNIEnv->GetStaticFieldID(versionClass, "SDK_INT", "I");
     if (sdkIntFieldID == NULL)
         return 0;
-    
+
     jint sdkInt = 0;
     sdkInt = lJNIEnv->GetStaticIntField(versionClass, sdkIntFieldID);
-    
+
     return sdkInt;
 }
 
@@ -81,6 +82,8 @@ int getAndroidApiLevel(ANativeActivity* activity)
 ////////////////////////////////////////////////////////////
 ActivityStates* retrieveStates(ANativeActivity* activity)
 {
+    assert(activity != NULL);
+
     // Hide the ugly cast we find in each callback function
     return (ActivityStates*)activity->instance;
 }
@@ -97,8 +100,8 @@ static void initializeMain(ActivityStates* states)
     states->looper = looper;
 
     /**
-     * Acquire increments a reference counter on the looper. This keeps android 
-     * from collecting it before the activity thread has a chance to detach its 
+     * Acquire increments a reference counter on the looper. This keeps android
+     * from collecting it before the activity thread has a chance to detach its
      * input queue.
      */
     ALooper_acquire(states->looper);
@@ -175,7 +178,7 @@ void goToFullscreenMode(ANativeActivity* activity)
 
     // Default flags
     jint flags = 0;
-    
+
     // API Level 14
     if (apiLevel >= 14)
     {
@@ -327,7 +330,7 @@ static void onDestroy(ANativeActivity* activity)
     delete states;
 
     // Reset the activity pointer for all modules
-    sf::priv::getActivity(NULL, true);
+    sf::priv::resetActivity(NULL);
 
     // The application should now terminate
 }
@@ -509,7 +512,7 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
     states->terminated = false;
 
     // Share it across the SFML modules
-    sf::priv::getActivity(states, true);
+    sf::priv::resetActivity(states);
 
     // These functions will update the activity states and therefore, will allow
     // SFML to be kept in the know

--- a/src/SFML/System/Android/Activity.cpp
+++ b/src/SFML/System/Android/Activity.cpp
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Android/Activity.hpp>
 #include <android/log.h>
+#include <cassert>
 
 #define LOGE(...) ((void)__android_log_print(ANDROID_LOG_INFO, "sfml-error", __VA_ARGS__))
 
@@ -56,14 +57,24 @@ namespace sf
 {
 namespace priv
 {
-ActivityStates* getActivity(ActivityStates* initializedStates, bool reset)
+
+ActivityStates*& getActivityStatesPtr()
 {
     static ActivityStates* states = NULL;
-
-    if (!states || reset)
-        states = initializedStates;
-
     return states;
 }
+
+void resetActivity(ActivityStates* initializedStates)
+{
+    getActivityStatesPtr() = initializedStates;
+}
+
+ActivityStates& getActivity()
+{
+    ActivityStates* const states = getActivityStatesPtr();
+    assert(states != NULL);
+    return *states;
+}
+
 }
 }

--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -91,7 +91,9 @@ struct ActivityStates
     LogcatStream logcat;
 };
 
-SFML_SYSTEM_API ActivityStates* getActivity(ActivityStates* initializedStates=NULL, bool reset=false);
+SFML_SYSTEM_API ActivityStates*& getActivityStatesPtr();
+SFML_SYSTEM_API void resetActivity(ActivityStates* initializedStates);
+SFML_SYSTEM_API ActivityStates& getActivity();
 
 } // namespace priv
 } // namespace sf

--- a/src/SFML/System/Android/NativeActivity.cpp
+++ b/src/SFML/System/Android/NativeActivity.cpp
@@ -33,7 +33,7 @@ namespace sf
 ////////////////////////////////////////////////////////////
 ANativeActivity* getNativeActivity()
 {
-    return priv::getActivity()->activity;
+    return priv::getActivity().activity;
 }
 
 } // namespace sf

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -40,9 +40,9 @@ namespace priv
 ResourceStream::ResourceStream(const std::string& filename) :
 m_file (NULL)
 {
-    ActivityStates* states = getActivity(NULL);
-    Lock lock(states->mutex);
-    m_file = AAssetManager_open(states->activity->assetManager, filename.c_str(), AASSET_MODE_UNKNOWN);
+    ActivityStates& states = getActivity();
+    Lock lock(states.mutex);
+    m_file = AAssetManager_open(states.activity->assetManager, filename.c_str(), AASSET_MODE_UNKNOWN);
 }
 
 

--- a/src/SFML/Window/Android/InputImpl.cpp
+++ b/src/SFML/Window/Android/InputImpl.cpp
@@ -48,15 +48,15 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
 {
     // todo: Check if the window is active
 
-    ActivityStates* states = getActivity(NULL);
-    Lock lock(states->mutex);
+    ActivityStates& states = getActivity();
+    Lock lock(states.mutex);
 
     // Initializes JNI
     jint lResult;
     jint lFlags = 0;
 
-    JavaVM* lJavaVM = states->activity->vm;
-    JNIEnv* lJNIEnv = states->activity->env;
+    JavaVM* lJavaVM = states.activity->vm;
+    JNIEnv* lJNIEnv = states.activity->env;
 
     JavaVMAttachArgs lJavaVMAttachArgs;
     lJavaVMAttachArgs.version = JNI_VERSION_1_6;
@@ -69,7 +69,7 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
         err() << "Failed to initialize JNI, couldn't switch the keyboard visibility" << std::endl;
 
     // Retrieves NativeActivity
-    jobject lNativeActivity = states->activity->clazz;
+    jobject lNativeActivity = states.activity->clazz;
     jclass ClassNativeActivity = lJNIEnv->GetObjectClass(lNativeActivity);
 
     // Retrieves Context.INPUT_METHOD_SERVICE
@@ -138,10 +138,10 @@ bool InputImpl::isMouseButtonPressed(Mouse::Button button)
 {
     ALooper_pollAll(0, NULL, NULL, NULL);
 
-    priv::ActivityStates* states = priv::getActivity(NULL);
-    Lock lock(states->mutex);
+    priv::ActivityStates& states = priv::getActivity();
+    Lock lock(states.mutex);
 
-    return states->isButtonPressed[button];
+    return states.isButtonPressed[button];
 }
 
 
@@ -150,10 +150,10 @@ Vector2i InputImpl::getMousePosition()
 {
     ALooper_pollAll(0, NULL, NULL, NULL);
 
-    priv::ActivityStates* states = priv::getActivity(NULL);
-    Lock lock(states->mutex);
+    priv::ActivityStates& states = priv::getActivity();
+    Lock lock(states.mutex);
 
-    return states->mousePosition;
+    return states.mousePosition;
 }
 
 
@@ -183,10 +183,10 @@ bool InputImpl::isTouchDown(unsigned int finger)
 {
     ALooper_pollAll(0, NULL, NULL, NULL);
 
-    priv::ActivityStates* states = priv::getActivity(NULL);
-    Lock lock(states->mutex);
+    priv::ActivityStates& states = priv::getActivity();
+    Lock lock(states.mutex);
 
-    return states->touchEvents.find(finger) != states->touchEvents.end();
+    return states.touchEvents.find(finger) != states.touchEvents.end();
 }
 
 
@@ -195,10 +195,10 @@ Vector2i InputImpl::getTouchPosition(unsigned int finger)
 {
     ALooper_pollAll(0, NULL, NULL, NULL);
 
-    priv::ActivityStates* states = priv::getActivity(NULL);
-    Lock lock(states->mutex);
+    priv::ActivityStates& states = priv::getActivity();
+    Lock lock(states.mutex);
 
-    return states->touchEvents.find(finger)->second;
+    return states.touchEvents.find(finger)->second;
 }
 
 

--- a/src/SFML/Window/Android/VideoModeImpl.cpp
+++ b/src/SFML/Window/Android/VideoModeImpl.cpp
@@ -52,10 +52,10 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 VideoMode VideoModeImpl::getDesktopMode()
 {
     // Get the activity states
-    priv::ActivityStates* states = priv::getActivity(NULL);
-    Lock lock(states->mutex);
+    priv::ActivityStates& states = priv::getActivity();
+    Lock lock(states.mutex);
 
-    return VideoMode(states->screenSize.x, states->screenSize.y);
+    return VideoMode(states.screenSize.x, states.screenSize.y);
 }
 
 } // namespace priv

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -210,10 +210,10 @@ private:
     ////////////////////////////////////////////////////////////
     static int processEvent(int fd, int events, void* data);
 
-    static int processScrollEvent(AInputEvent* _event, ActivityStates* states);
-    static int processKeyEvent(AInputEvent* _event, ActivityStates* states);
-    static int processMotionEvent(AInputEvent* _event, ActivityStates* states);
-    static int processPointerEvent(bool isDown, AInputEvent* event, ActivityStates* states);
+    static int processScrollEvent(AInputEvent* _event, ActivityStates& states);
+    static int processKeyEvent(AInputEvent* _event, ActivityStates& states);
+    static int processMotionEvent(AInputEvent* _event, ActivityStates& states);
+    static int processPointerEvent(bool isDown, AInputEvent* event, ActivityStates& states);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a Android key to SFML key code

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -57,10 +57,10 @@ namespace
 #if defined(SFML_SYSTEM_ANDROID)
 
             // On Android, its native activity handles this for us
-            sf::priv::ActivityStates* states = sf::priv::getActivity(NULL);
-            sf::Lock lock(states->mutex);
+            sf::priv::ActivityStates& states = sf::priv::getActivity();
+            sf::Lock lock(states.mutex);
 
-            return states->display;
+            return states.display;
 
 #endif
 
@@ -143,10 +143,10 @@ m_config  (NULL)
 #ifdef SFML_SYSTEM_ANDROID
 
     // On Android, we must save the created context
-    ActivityStates* states = getActivity(NULL);
-    Lock lock(states->mutex);
+    ActivityStates& states = getActivity();
+    Lock lock(states.mutex);
 
-    states->context = this;
+    states.context = this;
 
 #endif
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?[^1]
* [x] Have you provided some example/test code for your changes?[^2]
* [x] If you have additional steps which need to be performed list them as tasks![^3]

[^1]: `ActivityStates` is used a dynamically-allocated object via `new`, but the changed code doesn't care about or manage its lifetime, so it is appropriate to use it as a reference there. The code that manages the lifetime of `ActivityStates` objects still uses raw pointers as specified by the coding guidelines.

[^2]: I have tested the existing test suite and compiled for Android.

[^3]: No additional tests required.

----

## Description

This is a refactoring PR that simplifies the way `ActivityStates` is managed, making it clear that the `NULL` state is almost always *not* a valid domain value. It was prompted by some improper use of SFML for an Android project, which resulted in some puzzling crashes due to `*states` being accessed without ever asserting `states != NULL`. 

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [x] Tested on Android

## How to test this PR?

This is a refactoring PR. The behavior of the code should not have changed. Any unlikely regression will be likely found by CI or testing suites.