### PR TITLE
Fix useless temporary `sf::Lock`

### DIFF
--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -41,7 +41,7 @@ ResourceStream::ResourceStream(const std::string& filename) :
 m_file (NULL)
 {
     ActivityStates* states = getActivity(NULL);
-    Lock(states->mutex);
+    Lock lock(states->mutex);
     m_file = AAssetManager_open(states->activity->assetManager, filename.c_str(), AASSET_MODE_UNKNOWN);
 }
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Prior to this PR, a temporary `sf::Lock` object was being created and immediately destroyed. I believe this is a bug.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Run the tests under Android and try an SFML Android project, I guess.