### PR TITLE
X11: fix XIM input method support

### DIFF
--- a/src/SFML/Window/Unix/Display.hpp
+++ b/src/SFML/Window/Unix/Display.hpp
@@ -56,6 +56,27 @@ Display* OpenDisplay();
 void CloseDisplay(Display* display);
 
 ////////////////////////////////////////////////////////////
+/// \brief Get the shared XIM context for the Display
+///
+/// This function increments the reference count of the XIM context,
+/// it must be matched with a call to CloseXIM.
+///
+/// It must be called with a display already opened.
+///
+/// \return XIM handle (a pointer) of the context
+///
+////////////////////////////////////////////////////////////
+XIM OpenXIM();
+
+////////////////////////////////////////////////////////////
+/// \brief Release a reference to the shared XIM context
+///
+/// \param xim XIM context to release
+///
+////////////////////////////////////////////////////////////
+void CloseXIM(XIM xim);
+
+////////////////////////////////////////////////////////////
 /// \brief Get the atom with the specified name
 ///
 /// \param name         Name of the atom

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -101,7 +101,9 @@ namespace
         Bool checkEvent(::Display*, XEvent* event, XPointer userData)
         {
             // Just check if the event matches the window
-            return event->xany.window == reinterpret_cast< ::Window >(userData);
+            // The input method sometimes sends ClientMessages with a different window ID,
+            // our event loop has to process them for the IM to work
+            return (event->xany.window == reinterpret_cast< ::Window >(userData)) || (event->type == ClientMessage);
         }
 
         // Find the name of the current executable
@@ -803,7 +805,7 @@ WindowImplX11::~WindowImplX11()
 
     // Close the input method
     if (m_inputMethod)
-        XCloseIM(m_inputMethod);
+        CloseXIM(m_inputMethod);
 
     // Close the connection with the X server
     CloseDisplay(m_display);
@@ -1607,7 +1609,7 @@ void WindowImplX11::initialize()
     using namespace WindowsImplX11Impl;
 
     // Create the input context
-    m_inputMethod = XOpenIM(m_display, NULL, NULL, NULL);
+    m_inputMethod = OpenXIM();
 
     if (m_inputMethod)
     {
@@ -1845,27 +1847,31 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
         // Close event
         case ClientMessage:
         {
-            static Atom wmProtocols = getAtom("WM_PROTOCOLS");
-
-            // Handle window manager protocol messages we support
-            if (windowEvent.xclient.message_type == wmProtocols)
+            // Input methods might want random ClientMessage events
+            if (!XFilterEvent(&windowEvent, None))
             {
-                static Atom wmDeleteWindow = getAtom("WM_DELETE_WINDOW");
-                static Atom netWmPing = ewmhSupported() ? getAtom("_NET_WM_PING", true) : None;
+                static Atom wmProtocols = getAtom("WM_PROTOCOLS");
 
-                if ((windowEvent.xclient.format == 32) && (windowEvent.xclient.data.l[0]) == static_cast<long>(wmDeleteWindow))
+                // Handle window manager protocol messages we support
+                if (windowEvent.xclient.message_type == wmProtocols)
                 {
-                    // Handle the WM_DELETE_WINDOW message
-                    Event event;
-                    event.type = Event::Closed;
-                    pushEvent(event);
-                }
-                else if (netWmPing && (windowEvent.xclient.format == 32) && (windowEvent.xclient.data.l[0]) == static_cast<long>(netWmPing))
-                {
-                    // Handle the _NET_WM_PING message, send pong back to WM to show that we are responsive
-                    windowEvent.xclient.window = DefaultRootWindow(m_display);
+                    static Atom wmDeleteWindow = getAtom("WM_DELETE_WINDOW");
+                    static Atom netWmPing = ewmhSupported() ? getAtom("_NET_WM_PING", true) : None;
 
-                    XSendEvent(m_display, DefaultRootWindow(m_display), False, SubstructureNotifyMask | SubstructureRedirectMask, &windowEvent);
+                    if ((windowEvent.xclient.format == 32) && (windowEvent.xclient.data.l[0]) == static_cast<long>(wmDeleteWindow))
+                    {
+                        // Handle the WM_DELETE_WINDOW message
+                        Event event;
+                        event.type = Event::Closed;
+                        pushEvent(event);
+                    }
+                    else if (netWmPing && (windowEvent.xclient.format == 32) && (windowEvent.xclient.data.l[0]) == static_cast<long>(netWmPing))
+                    {
+                        // Handle the _NET_WM_PING message, send pong back to WM to show that we are responsive
+                        windowEvent.xclient.window = DefaultRootWindow(m_display);
+
+                        XSendEvent(m_display, DefaultRootWindow(m_display), False, SubstructureNotifyMask | SubstructureRedirectMask, &windowEvent);
+                    }
                 }
             }
             break;
@@ -1904,7 +1910,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 if (m_inputContext)
                 {
                     Status status;
-                    Uint8  keyBuffer[16];
+                    Uint8  keyBuffer[64];
 
                     int length = Xutf8LookupString(
                         m_inputContext,
@@ -1915,16 +1921,26 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                         &status
                     );
 
-                    if (length > 0)
+                    if (status == XBufferOverflow)
+                        err() << "A TextEntered event has more than 64 bytes of UTF-8 input, and "
+                                 "has been discarded\nThis means either you have typed a very long string "
+                                 "(more than 20 chars), or your input method is broken in obscure ways." << std::endl;
+                    else if (status == XLookupChars)
                     {
+                        // There might be more than 1 characters in this event,
+                        // so we must iterate it
                         Uint32 unicode = 0;
-                        Utf8::decode(keyBuffer, keyBuffer + length, unicode, 0);
-                        if (unicode != 0)
+                        Uint8* iter = keyBuffer;
+                        while (iter < keyBuffer + length)
                         {
-                            Event textEvent;
-                            textEvent.type         = Event::TextEntered;
-                            textEvent.text.unicode = unicode;
-                            pushEvent(textEvent);
+                            iter = Utf8::decode(iter, keyBuffer + length, unicode, 0);
+                            if (unicode != 0)
+                            {
+                                Event textEvent;
+                                textEvent.type         = Event::TextEntered;
+                                textEvent.text.unicode = unicode;
+                                pushEvent(textEvent);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION

## Description

This PR is a (good enough) fix to #1840.

It fixes the existing XIM code, supporting input methods (at least with Fcitx5).

### How to test

Dump all the KeyPressed/TextInput event from any window. If you don't have a input method, nothing should change. If you do have one, it should be working now.

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode(800, 600), "Window");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            switch (e.type) {
                case sf::Event::Closed:
                    win.close();
                    break;
                case sf::Event::KeyPressed:
                    printf("Key pressed: %d\n", (int)e.key.code);
                    break;
                case sf::Event::KeyReleased:
                    printf("Key released: %d\n", (int)e.key.code);
                    break;
                case sf::Event::TextEntered:
                    printf("Text entered: %d\n", (int)e.text.unicode);
                    break;
            }
        }

        window.clear();
        window.display();
    }
}
```