### PR TITLE
Update to make compilation possible of 2.4.x on Arch.

### DIFF
--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -25,8 +25,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Window/Unix/WindowImplX11.hpp> // important to be included first (conflict with None)
 #include <SFML/Window/Unix/GlxContext.hpp>
-#include <SFML/Window/Unix/WindowImplX11.hpp>
 #include <SFML/Window/Unix/Display.hpp>
 #include <SFML/System/Mutex.hpp>
 #include <SFML/System/Lock.hpp>

--- a/src/SFML/Window/Unix/GlxExtensions.hpp
+++ b/src/SFML/Window/Unix/GlxExtensions.hpp
@@ -25,11 +25,12 @@
 #ifndef SF_POINTER_C_GENERATED_HEADER_GLXWIN_HPP
 #define SF_POINTER_C_GENERATED_HEADER_GLXWIN_HPP
 
-#ifdef __glxext_h_
+#if defined(__glxext_h_) || defined(__glx_glxext_h_)
 #error Attempt to include glx_exts after including glxext.h
 #endif
 
 #define __glxext_h_
+#define __glx_glxext_h_
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>


### PR DESCRIPTION
Hello, 

I could not compile SFML 2.4 on my linux (Arch Linux) due to OpenGL updates I guess. 

## Disclaimer: 

I did not check the forum, **I did not write code except copy more recent code and comment a line**. 

----

## Description

My answer to the problem was brute force, I just copied the version of the incriminated files from 2.5.x which compiled OK. 

Now it compiles and I made a PKGBUILD to create a package from it : 
https://gist.github.com/poqudrof/96eff1a0f143e0e2dd13d981944bc78f 

I may release it as an AUR package if it gets included in SFML sfml-2.4 just like Nakano did : https://aur.archlinux.org/packages/sfml2.3/ 

This PR is not related to an issue.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

**This affects only Linux.** 

## How to test this PR?

Check out the code and compile on Arch linux, or try the PKGBUILD linked above. 

Please let me know if I need to update anything, it would be great for Arch Linux users that need to maintain compatibility with previous versions. 

Regards, 

Jeremy.
