### PR TITLE
Add missing comment

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -983,6 +983,8 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             pushEvent(event);
             break;
         }
+
+        // Hardware configuration change event
         case WM_DEVICECHANGE:
         {
             // Some sort of device change has happened, update joystick connections


### PR DESCRIPTION
I've noticed that there is a comment missing for exactly one (WM_DEVICECHANGE) event in Window implementation for Win32.

This change fixes that. 

Since only comment was added, there is no testing was done. 
