### PR TITLE
Update SFML version to 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,10 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake)
 include(GNUInstallDirs)
 
 # setup version numbers
-set(VERSION_MAJOR 2)
-set(VERSION_MINOR 5)
-set(VERSION_PATCH 1)
+set(VERSION_MAJOR 3)
+set(VERSION_MINOR 0)
+set(VERSION_PATCH 0)
+set(VERSION_IS_RELEASE OFF)
 
 # add an option for choosing the build type (shared or static)
 if(NOT (SFML_OS_IOS OR SFML_OS_ANDROID))

--- a/cmake/SFMLConfig.cmake.in
+++ b/cmake/SFMLConfig.cmake.in
@@ -13,8 +13,8 @@
 # If nothing is specified, the version won't be checked (i.e. any version will be accepted).
 # example:
 #   find_package(SFML COMPONENTS ...)     # no specific version required
-#   find_package(SFML 2 COMPONENTS ...)   # any 2.x version
-#   find_package(SFML 2.4 COMPONENTS ...) # version 2.4 or greater
+#   find_package(SFML 3 COMPONENTS ...)   # any 3.x version
+#   find_package(SFML 2.4 COMPONENTS ...) # version 2.4 or greater with the same major version
 #
 # By default, the dynamic libraries of SFML will be found. To find the static ones instead,
 # you must set the SFML_STATIC_LIBRARIES variable to TRUE before calling find_package(SFML ...).
@@ -22,7 +22,16 @@
 # they will all be configured automatically, even if you use SFML static libraries.
 # example:
 #   set(SFML_STATIC_LIBRARIES TRUE)
-#   find_package(SFML 2 COMPONENTS network system)
+#   find_package(SFML 3 COMPONENTS network system)
+#
+# When searching for SFML with find_package(), keep in mind that it will also find versions which are
+# in development (i.e. between two released versions), if you have them in your search path.
+# If you want to make sure that a found SFML package corresponds to an official release, check the
+# bool output variable SFML_VERSION_IS_RELEASE, which is true for official releases and false for development versions.
+#
+# If you want to use the latest features before a new SFML version is released, make sure to look for
+# the upcoming version number. For example, if you want to use latest SFML 3 features before 3.0.0 is officially released,
+# look for version 3 with find_package().
 #
 # On macOS by default CMake will search for frameworks. If you want to use static libraries and have installed
 # both SFML frameworks and SFML static libraries, your must set CMAKE_FIND_FRAMEWORK to "NEVER" or "LAST"
@@ -117,6 +126,8 @@ if (EXISTS "${targets_config_file}")
     include("${CMAKE_CURRENT_LIST_DIR}/SFMLConfigDependencies.cmake")
 
     if (SFML_FOUND)
+        set(SFML_VERSION_IS_RELEASE @VERSION_IS_RELEASE@)
+
         foreach (component ${SFML_FIND_COMPONENTS})
             string(TOUPPER "${component}" UPPER_COMPONENT)
             if (TARGET sfml-${component})

--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -29,9 +29,10 @@
 ////////////////////////////////////////////////////////////
 // Define the SFML version
 ////////////////////////////////////////////////////////////
-#define SFML_VERSION_MAJOR 2
-#define SFML_VERSION_MINOR 5
-#define SFML_VERSION_PATCH 1
+#define SFML_VERSION_MAJOR 3
+#define SFML_VERSION_MINOR 0
+#define SFML_VERSION_PATCH 0
+#define SFML_VERSION_IS_RELEASE false
 
 
 ////////////////////////////////////////////////////////////

--- a/readme.md
+++ b/readme.md
@@ -6,16 +6,17 @@ SFML is a simple, fast, cross-platform and object-oriented multimedia API. It pr
 
 ## Authors
 
-  - Laurent Gomila — main developer (laurent@sfml-dev.org)
-  - Marco Antognini — OS X developer (hiura@sfml-dev.org)
-  - Jonathan De Wachter — Android developer (dewachter.jonathan@gmail.com)
-  - Jan Haller (bromeon@sfml-dev.org)
-  - Stefan Schindler (tank@sfml-dev.org)
-  - Lukas Dürrenberger (eXpl0it3r@sfml-dev.org)
-  - binary1248 (binary1248@hotmail.com)
-  - Artur Moreira (artturmoreira@gmail.com)
-  - Mario Liebisch (mario@sfml-dev.org)
-  - And many other members of the SFML community
+-   Laurent Gomila (laurent@sfml-dev.org)
+-   Marco Antognini (hiura@sfml-dev.org)
+-   binary1248 (binary1248@hotmail.com)
+-   Lukas Dürrenberger (eXpl0it3r@sfml-dev.org)
+-   Jonathan De Wachter (dewachter.jonathan@gmail.com)
+-   Jan Haller (bromeon@sfml-dev.org)
+-   Mario Liebisch (mario@sfml-dev.org)
+-   Stefan Schindler (tank@sfml-dev.org)
+-   Artur Moreira (artturmoreira@gmail.com)
+-   Vittorio Romeo (vittorioromeo@sfml-dev.org)
+-   And many other members of the SFML community
 
 ## Download
 
@@ -29,10 +30,10 @@ Follow the instructions of the [tutorials](https://www.sfml-dev.org/tutorials/),
 
 There are several places to learn SFML:
 
-  * The [official tutorials](https://www.sfml-dev.org/tutorials/)
-  * The [online API documentation](https://www.sfml-dev.org/documentation/)
-  * The [community wiki](https://github.com/SFML/SFML/wiki/)
-  * The [community forum](https://en.sfml-dev.org/forums/) ([French](https://fr.sfml-dev.org/forums/))
+-   The [official tutorials](https://www.sfml-dev.org/tutorials/)
+-   The [online API documentation](https://www.sfml-dev.org/documentation/)
+-   The [community wiki](https://github.com/SFML/SFML/wiki/)
+-   The [community forum](https://en.sfml-dev.org/forums/) ([French](https://fr.sfml-dev.org/forums/))
 
 ## Contribute
 


### PR DESCRIPTION
## Description

Quite some while ago, there was an internal discussion and vote to bump release version numbers right after a release or in this case, when creating the "release branch".

Unlike with SFML 2.x and earlier the version numbers are updated as soon as work on the new release starts. This especially helps with version checks, which until now caused issues with in-development version matching the previous release.