### PR TITLE
Enable and require C++17 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.8)
 
 # customize the compiler options CMake uses to initialize variables with
 set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerOptionsOverride.cmake")
@@ -343,6 +343,9 @@ else()
 
     # create SFML.framework
     add_library(SFML ${SFML_SOURCES})
+
+    # enable C++17 support
+    target_compile_features(SFML PUBLIC cxx_std_17)
 
     # set the target flags to use the appropriate C++ standard library
     sfml_set_stdlib(SFML)

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -66,6 +66,9 @@ macro(sfml_add_library target)
         add_library(${target} ${THIS_SOURCES})
     endif()
 
+    # enable C++17 support
+    target_compile_features(${target} PUBLIC cxx_std_17)
+
     set_file_warnings(${THIS_SOURCES})
 
     # define the export symbol of the module
@@ -265,6 +268,9 @@ macro(sfml_add_example target)
         add_executable(${target} ${target_input})
     endif()
 
+    # enable C++17 support
+    target_compile_features(${target} PUBLIC cxx_std_17)
+
     set_file_warnings(${target_input})
 
     # set the debug suffix
@@ -302,6 +308,9 @@ function(sfml_add_test target SOURCES DEPENDS)
     # create the target
     add_executable(${target} ${SOURCES})
 
+    # enable C++17 support
+    target_compile_features(${target} PUBLIC cxx_std_17)
+
     # set the target's folder (for IDEs that support it, e.g. Visual Studio)
     set_target_properties(${target} PROPERTIES FOLDER "Tests")
 
@@ -309,7 +318,7 @@ function(sfml_add_test target SOURCES DEPENDS)
     if(DEPENDS)
         target_link_libraries(${target} PRIVATE ${DEPENDS})
     endif()
-    
+
     # Add the test
     add_test(${target} ${target})
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This change enables (and requires) C++17 support in all library and executable targets generated by SFML's CMake build.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Compiling via CI and executing tests should be enough. There are no expected behavioral changes that might affect the correctness of the existing code.

I've also checked that `-std=c++17` is actually passed by using `CMAKE_EXPORT_COMPILE_COMMANDS`.