### PR TITLE
Use list-initialization to zero-initialize 'JoystickImpl.hpp' structures

### DIFF
--- a/src/SFML/Window/JoystickImpl.hpp
+++ b/src/SFML/Window/JoystickImpl.hpp
@@ -30,7 +30,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 #include <SFML/Window/Joystick.hpp>
-#include <algorithm>
 
 
 namespace sf
@@ -43,14 +42,8 @@ namespace priv
 ////////////////////////////////////////////////////////////
 struct JoystickCaps
 {
-    JoystickCaps()
-    {
-        buttonCount = 0;
-        std::fill(axes, axes + Joystick::AxisCount, false);
-    }
-
-    unsigned int buttonCount;               //!< Number of buttons supported by the joystick
-    bool         axes[Joystick::AxisCount]; //!< Support for each axis
+    unsigned int buttonCount{0};              //!< Number of buttons supported by the joystick
+    bool         axes[Joystick::AxisCount]{}; //!< Support for each axis
 };
 
 
@@ -60,16 +53,9 @@ struct JoystickCaps
 ////////////////////////////////////////////////////////////
 struct JoystickState
 {
-    JoystickState()
-    {
-        connected = false;
-        std::fill(axes, axes + Joystick::AxisCount, 0.f);
-        std::fill(buttons, buttons + Joystick::ButtonCount, false);
-    }
-
-    bool  connected;                      //!< Is the joystick currently connected?
-    float axes[Joystick::AxisCount];      //!< Position of each axis, in range [-100, 100]
-    bool  buttons[Joystick::ButtonCount]; //!< Status of each button (true = pressed)
+    bool  connected{false};                 //!< Is the joystick currently connected?
+    float axes[Joystick::AxisCount]{};      //!< Position of each axis, in range [-100, 100]
+    bool  buttons[Joystick::ButtonCount]{}; //!< Status of each button (true = pressed)
 };
 
 } // namespace priv


### PR DESCRIPTION
## Description

This PR introduces the first changes that actually require C++11 support to the codebase. It's a simple refactoring changes that removes a public dependency on `<algorithm>` and simplifies the initialization of some data members in `JoystickImpl.hpp`.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI and testing existing joystick examples would be enough.