### PR TITLE
Remove 'SFML_DEPRECATED' and replace internal usages with '[[deprecated]]'

### DIFF
--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -2076,7 +2076,6 @@ PREDEFINED             = SFML_SYSTEM_API \
                          SFML_WINDOW_API \
                          SFML_AUDIO_API \
                          SFML_GRAPHICS_API \
-                         SFML_DEPRECATED \
                          SFML_DOXYGEN
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -169,44 +169,6 @@
 
 
 ////////////////////////////////////////////////////////////
-// Cross-platform warning for deprecated functions and classes
-//
-// Usage:
-// class SFML_DEPRECATED MyClass
-// {
-//     SFML_DEPRECATED void memberFunc();
-// };
-//
-// SFML_DEPRECATED void globalFunc();
-////////////////////////////////////////////////////////////
-#if defined(SFML_NO_DEPRECATED_WARNINGS)
-
-    // User explicitly requests to disable deprecation warnings
-    #define SFML_DEPRECATED
-
-#elif defined(_MSC_VER)
-
-    // Microsoft C++ compiler
-    // Note: On newer MSVC versions, using deprecated functions causes a compiler error. In order to
-    // trigger a warning instead of an error, the compiler flag /sdl- (instead of /sdl) must be specified.
-    #define SFML_DEPRECATED __declspec(deprecated)
-
-#elif defined(__GNUC__)
-
-    // g++ and Clang
-    #define SFML_DEPRECATED __attribute__ ((deprecated))
-
-#else
-
-    // Other compilers are not supported, leave class or function as-is.
-    // With a bit of luck, the #pragma directive works, otherwise users get a warning (no error!) for unrecognized #pragma.
-    #pragma message("SFML_DEPRECATED is not supported for your compiler, please contact the SFML team")
-    #define SFML_DEPRECATED
-
-#endif
-
-
-////////////////////////////////////////////////////////////
 // Define portable fixed-size types
 ////////////////////////////////////////////////////////////
 namespace sf

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -86,7 +86,7 @@ public:
     /// \deprecated Use create(unsigned int, unsigned int, const ContextSettings&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED bool create(unsigned int width, unsigned int height, bool depthBuffer);
+    [[deprecated]] bool create(unsigned int width, unsigned int height, bool depthBuffer);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the render-texture

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -166,7 +166,7 @@ public:
     /// \return Image containing the captured contents
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED Image capture() const;
+    [[deprecated]] Image capture() const;
 
 protected:
 

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -551,7 +551,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, float) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, float x);
+    [[deprecated]] void setParameter(const std::string& name, float x);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a 2-components vector parameter of the shader
@@ -559,7 +559,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Glsl::Vec2&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y);
+    [[deprecated]] void setParameter(const std::string& name, float x, float y);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a 3-components vector parameter of the shader
@@ -567,7 +567,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Glsl::Vec3&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y, float z);
+    [[deprecated]] void setParameter(const std::string& name, float x, float y, float z);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a 4-components vector parameter of the shader
@@ -575,7 +575,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Glsl::Vec4&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y, float z, float w);
+    [[deprecated]] void setParameter(const std::string& name, float x, float y, float z, float w);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a 2-components vector parameter of the shader
@@ -583,7 +583,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Glsl::Vec2&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, const Vector2f& vector);
+    [[deprecated]] void setParameter(const std::string& name, const Vector2f& vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a 3-components vector parameter of the shader
@@ -591,7 +591,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Glsl::Vec3&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, const Vector3f& vector);
+    [[deprecated]] void setParameter(const std::string& name, const Vector3f& vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a color parameter of the shader
@@ -599,7 +599,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Glsl::Vec4&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, const Color& color);
+    [[deprecated]] void setParameter(const std::string& name, const Color& color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a matrix parameter of the shader
@@ -607,7 +607,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Glsl::Mat4&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, const Transform& transform);
+    [[deprecated]] void setParameter(const std::string& name, const Transform& transform);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a texture parameter of the shader
@@ -615,7 +615,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, const Texture&) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, const Texture& texture);
+    [[deprecated]] void setParameter(const std::string& name, const Texture& texture);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change a texture parameter of the shader
@@ -623,7 +623,7 @@ public:
     /// \deprecated Use setUniform(const std::string&, CurrentTextureType) instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setParameter(const std::string& name, CurrentTextureType);
+    [[deprecated]] void setParameter(const std::string& name, CurrentTextureType);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the underlying OpenGL handle of the shader.

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -207,7 +207,7 @@ public:
     /// Use setFillColor() or setOutlineColor() instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED void setColor(const Color& color);
+    [[deprecated]] void setColor(const Color& color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the fill color of the text
@@ -335,7 +335,7 @@ public:
     /// Use getFillColor() or getOutlineColor() instead.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_DEPRECATED const Color& getColor() const;
+    [[deprecated]] const Color& getColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the fill color of the text


### PR DESCRIPTION
## Description

This PR removed `SFML_DEPRECATED` and changes all its internal usages to the C++14 standard `[[deprecated]]` attribute. This is technically an API-breaking changes as `SFML_DEPRECATED` was externally exposed, however:

- I've gone through around 50 pages of GitHub search results for `SFML_DEPRECATED`, and all of them were `SFML/Config.hpp` being copy-pasted into some project's repository. 

- If someone upgrades their project to use SFML 3.x, that implies that they have access to C++17. Therefore, all they have to do is literally a find-replace `s/SFML_DEPRECATED/[[deprecated]]/g`, which I think is a very reasonable amount of work for a breaking change.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI is enough.