### PR TITLE
Use '[[fallthrough]]' attribute and enable relevant warning

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -65,7 +65,7 @@ function(set_file_warnings)
         -Wsign-conversion # warn on sign conversions
         -Wdouble-promotion # warn if float is implicit promoted to double
         -Wformat=2 # warn on security issues around functions that format output (ie printf)
-        # -Wimplicit-fallthrough # warn when a missing break causes control flow to continue at the next case in a switch statement (disabled until better compiler support for explicit fallthrough is available)
+        -Wimplicit-fallthrough # warn when a missing break causes control flow to continue at the next case in a switch statement
         ${NON_ANDROID_CLANG_AND_GCC_WARNINGS}
     )
 

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -62,11 +62,11 @@ In Utf<8>::decode(In begin, In end, Uint32& output, Uint32 replacement)
         output = 0;
         switch (trailingBytes)
         {
-            case 5: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
-            case 4: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
-            case 3: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
-            case 2: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
-            case 1: output += static_cast<Uint8>(*begin++); output <<= 6; // fallthrough
+            case 5: output += static_cast<Uint8>(*begin++); output <<= 6; [[fallthrough]];
+            case 4: output += static_cast<Uint8>(*begin++); output <<= 6; [[fallthrough]];
+            case 3: output += static_cast<Uint8>(*begin++); output <<= 6; [[fallthrough]];
+            case 2: output += static_cast<Uint8>(*begin++); output <<= 6; [[fallthrough]];
+            case 1: output += static_cast<Uint8>(*begin++); output <<= 6; [[fallthrough]];
             case 0: output += static_cast<Uint8>(*begin++);
         }
         output -= offsets[trailingBytes];
@@ -114,9 +114,9 @@ Out Utf<8>::encode(Uint32 input, Out output, Uint8 replacement)
         Uint8 bytes[4];
         switch (bytestoWrite)
         {
-            case 4: bytes[3] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; // fallthrough
-            case 3: bytes[2] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; // fallthrough
-            case 2: bytes[1] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; // fallthrough
+            case 4: bytes[3] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; [[fallthrough]];
+            case 3: bytes[2] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; [[fallthrough]];
+            case 2: bytes[1] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6; [[fallthrough]];
             case 1: bytes[0] = static_cast<Uint8> (input | firstBytes[bytestoWrite]);
         }
 


### PR DESCRIPTION
## Description

This PR changes "fallthrough" comments to the standard C++17 `[[fallthrough]]` attribute. It also enables the `-Wimplicit-fallthrough` attribute in the CMake warnings module.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.