### PR TITLE
Use emplacement operations to avoid unnecessary copies/moves

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -364,7 +364,7 @@ const Glyph& Font::getGlyph(Uint32 codePoint, unsigned int characterSize, bool b
     {
         // Not found: we have to load it
         Glyph glyph = loadGlyph(codePoint, characterSize, bold, outlineThickness);
-        return glyphs.insert(std::make_pair(key, glyph)).first->second;
+        return glyphs.emplace(key, glyph).first->second;
     }
 }
 
@@ -785,7 +785,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
         }
 
         // We can now create the new row
-        page.rows.push_back(Row(page.nextRow, rowHeight));
+        page.rows.emplace_back(page.nextRow, rowHeight);
         page.nextRow += rowHeight;
         row = &page.rows.back();
     }

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -161,10 +161,10 @@ RenderTextureImplFBO::~RenderTextureImplFBO()
 
     // Move all frame buffer objects to stale set
     for (std::map<Uint64, unsigned int>::iterator iter = m_frameBuffers.begin(); iter != m_frameBuffers.end(); ++iter)
-        staleFrameBuffers.insert(std::make_pair(iter->first, iter->second));
+        staleFrameBuffers.emplace(iter->first, iter->second);
 
     for (std::map<Uint64, unsigned int>::iterator iter = m_multisampleFrameBuffers.begin(); iter != m_multisampleFrameBuffers.end(); ++iter)
-        staleFrameBuffers.insert(std::make_pair(iter->first, iter->second));
+        staleFrameBuffers.emplace(iter->first, iter->second);
 
     // Clean up FBOs
     destroyStaleFBOs();
@@ -446,7 +446,7 @@ bool RenderTextureImplFBO::createFrameBuffer()
         Lock lock(mutex);
 
         // Insert the FBO into our map
-        m_frameBuffers.insert(std::make_pair(Context::getActiveContextId(), frameBuffer));
+        m_frameBuffers.emplace(Context::getActiveContextId(), frameBuffer);
     }
 
 #ifndef SFML_OPENGL_ES
@@ -493,7 +493,7 @@ bool RenderTextureImplFBO::createFrameBuffer()
             Lock lock(mutex);
 
             // Insert the FBO into our map
-            m_multisampleFrameBuffers.insert(std::make_pair(Context::getActiveContextId(), multisampleFrameBuffer));
+            m_multisampleFrameBuffers.emplace(Context::getActiveContextId(), multisampleFrameBuffer);
         }
     }
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -999,7 +999,7 @@ int Shader::getUniformLocation(const std::string& name)
     {
         // Not in cache, request the location from OpenGL
         int location = GLEXT_glGetUniformLocation(castToGlHandle(m_shaderProgram), name.c_str());
-        m_uniforms.insert(std::make_pair(name, location));
+        m_uniforms.emplace(name, location);
 
         if (location == -1)
             err() << "Uniform \"" << name << "\" not found in shader" << std::endl;

--- a/src/SFML/Window/Android/VideoModeImpl.cpp
+++ b/src/SFML/Window/Android/VideoModeImpl.cpp
@@ -43,7 +43,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     // Return both portrait and landscape resolutions
     std::vector<VideoMode> modes;
     modes.push_back(desktop);
-    modes.push_back(VideoMode(desktop.height, desktop.width, desktop.bitsPerPixel));
+    modes.emplace_back(desktop.height, desktop.width, desktop.bitsPerPixel);
     return modes;
 }
 

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -264,7 +264,7 @@ namespace
                     while (*extensionString && (*extensionString != ' '))
                         extensionString++;
 
-                    extensions.push_back(std::string(extension, extensionString));
+                    extensions.emplace_back(extension, extensionString);
                 }
                 while (*extensionString++);
             }
@@ -381,7 +381,7 @@ void GlContext::cleanupResource()
 ////////////////////////////////////////////////////////////
 void GlContext::registerContextDestroyCallback(ContextDestroyCallback callback, void* arg)
 {
-    GlContextImpl::contextDestroyCallbacks.insert(std::make_pair(callback, arg));
+    GlContextImpl::contextDestroyCallbacks.emplace(callback, arg);
 }
 
 

--- a/src/SFML/Window/iOS/VideoModeImpl.mm
+++ b/src/SFML/Window/iOS/VideoModeImpl.mm
@@ -41,7 +41,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     // Return both portrait and landscape resolutions
     std::vector<VideoMode> modes;
     modes.push_back(desktop);
-    modes.push_back(VideoMode(desktop.height, desktop.width, desktop.bitsPerPixel));
+    modes.emplace_back(desktop.height, desktop.width, desktop.bitsPerPixel);
     return modes;
 }
 


### PR DESCRIPTION
## Description

This PR changes some calls to `insert` and `push_back` to the corresponding emplacement operations to avoid unnecessary copy-constructor/move-constructor calls when adding elements to certain containers. The behavior should be unchanged.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.