### PR TITLE
Add '.gitignore' file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build folders
+build/
+
+# Cache/IDE folders
+.cache/
+.vscode/
+


### PR DESCRIPTION
Taken from https://github.com/github/gitignore/blob/main/C++.gitignore, added a few extra entries for a `build` folder, `clangd` cache folder, and `.vscode` IDE folder.