### PR TITLE
Fix improper cast inside packet operator

### DIFF
--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -430,7 +430,7 @@ Packet& Packet::operator <<(Uint16 data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator <<(Int32 data)
 {
-    Int32 toWrite = static_cast<Int16>(htonl(static_cast<uint32_t>(data)));
+    Int32 toWrite = static_cast<Int32>(htonl(static_cast<uint32_t>(data)));
     append(&toWrite, sizeof(toWrite));
     return *this;
 }


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Very tiny PR to fix a cast issue for one of the Packet operators.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Before the following code would return output as being 0.
Now it returns the correct value.

```cpp
sf::Packet newPacket;
sf::Int32 input = 1234;
sf::Int32 output;
newPacket << input;
newPacket >> output;
std::cout <<  "input: " << input << " output: " << output << "\n";
```