### PR TITLE
Let CMake autodetect Apple arch on M1 processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,6 @@ if (NOT CMAKE_VERSION VERSION_LESS 3.9)
     cmake_policy(SET CMP0068 NEW)
 endif()
 
-# add some default value for some additional macOS variable
-# note that those variables are ignored on other systems
-if(NOT CMAKE_OSX_ARCHITECTURES)
-    set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "macOS architecture to build; 64-bit is expected" FORCE)
-endif()
 if(NOT CMAKE_OSX_SYSROOT)
     # query the path to the default SDK, will fail on non-macOS, but it's okay.
     execute_process(COMMAND xcodebuild -sdk macosx -version Path


### PR DESCRIPTION
## Description

With the introduction of Apple M1 processor the architecture for SFML build need not be imposed unless specified explicitly. It feels more intuitive to let CMake decide on what the default architecture should be for a specified Apple processor.

## Tasks

Changes affect only Apple systems

* [x] Tested on macOS
* [ ] Tested on iOS

## How to test this PR?

Simply assert that this finishes successfully on Apple M1:
```bash
# On Apple M1 processor natively
cmake -B build-native
cmake --build build-native -j12

# On Apple M1 processor with arch x86_64
cmake -B build-x86 -DCMAKE_OSX_ARCHITECTURES=x86_64
cmake --build build-x86 -j12

echo "Test results:"
[[ ! -z $(otool -hv build-native/lib/libsfml-system.dylib | grep -io arm64) ]] && echo "SUCCESS ARM64" || echo "FAILED ARM64"
[[ ! -z $(otool -hv build-x86/lib/libsfml-system.dylib | grep -io x86_64) ]] && echo "SUCCESS x86_64" || echo "FAILED x86_64"
```