### PR TITLE
Fix regression in copyToImage

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -372,14 +372,14 @@ Image Texture::copyToImage() const
         // Then we copy the useful pixels from the temporary array to the final one
         const Uint8* src = &allPixels[0];
         Uint8* dst = &pixels[0];
-        unsigned int srcPitch = m_actualSize.x * 4;
+        int srcPitch = static_cast<int>(m_actualSize.x * 4);
         unsigned int dstPitch = m_size.x * 4;
 
         // Handle the case where source pixels are flipped vertically
         if (m_pixelsFlipped)
         {
-            src += srcPitch * (m_size.y - 1);
-            srcPitch = UINT_MAX - srcPitch + 1;
+            src += static_cast<unsigned int>(srcPitch * static_cast<int>((m_size.y - 1)));
+            srcPitch = -srcPitch;
         }
 
         for (unsigned int i = 0; i < m_size.y; ++i)


### PR DESCRIPTION
## Description

When the source image is flipped, we want to read the source data backwards and thus need to keep subtracting the "iterator" on the source data.

Regression introduced with 01836ccea4f5655e16ad6d7cf4aac6f023234c53 as part of #1846 
Reported [here](https://github.com/SFML/SFML/pull/1846#issuecomment-986234097) by @texus 

## Tasks

* [x] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Testing wise it's a bit tricky, as the crash doesn't seem to happen with Visual Studio itself.
One source where the `m_pixelsFlipped` flag is set, would be when you copy the contents from a window, so I've created this example below.

```cpp
#include <SFML/Graphics.hpp>

int main()
{
	auto window = sf::RenderWindow{ { 1280u, 720u }, "Test" };
	window.setFramerateLimit(60);

	auto rectangle = sf::RectangleShape{ { 200.f, 200.f } };
	rectangle.setPosition({ 150.f, 150.f });
	rectangle.setFillColor(sf::Color::Green);

	auto texture = sf::Texture{};
	texture.create(window.getSize().x, window.getSize().y);
	auto sprite = sf::Sprite{ texture };
	sprite.setColor(sf::Color{ 200u, 200u, 200u, 200u });
	sprite.setPosition({ 10.f, 10.f });
	auto textureIsSet = false;

	while (window.isOpen())
	{
		for (auto event = sf::Event{}; window.pollEvent(event);)
		{
			if (event.type == sf::Event::Closed)
			{
				window.close();
			}
			else if (event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::Return)
			{
				texture.update(window);
				textureIsSet = true;
			}
		}

		window.clear();
		window.draw(rectangle);

		if (textureIsSet)
		{
			window.draw(sprite);
		}

		window.display();
	}
}
```