### PR TITLE
Fix wrong cast in sf::Packet

### DIFF
--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -178,7 +178,7 @@ Packet& Packet::operator >>(Int32& data)
     if (checkSize(sizeof(data)))
     {
         std::memcpy(&data, &m_data[m_readPos], sizeof(data));
-        data = static_cast<Int16>(ntohl(static_cast<uint32_t>(data)));
+        data = static_cast<Int32>(ntohl(static_cast<uint32_t>(data)));
         m_readPos += sizeof(data);
     }
 
@@ -430,7 +430,7 @@ Packet& Packet::operator <<(Uint16 data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator <<(Int32 data)
 {
-    Int32 toWrite = static_cast<Int16>(htonl(static_cast<uint32_t>(data)));
+    Int32 toWrite = static_cast<Int32>(htonl(static_cast<uint32_t>(data)));
     append(&toWrite, sizeof(toWrite));
     return *this;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,9 +33,17 @@ if(SFML_BUILD_GRAPHICS)
     sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" sfml-graphics)
 endif()
 
+if(SFML_BUILD_NETWORK)
+    SET(NETWORK_SRC
+        "${SRCROOT}/CatchMain.cpp"
+        "${SRCROOT}/Network/Packet.cpp"
+    )
+    sfml_add_test(test-sfml-network "${NETWORK_SRC}" sfml-network)
+endif()
+
 # Automatically run the tests at the end of the build
 add_custom_target(runtests ALL
-                  DEPENDS test-sfml-system test-sfml-window test-sfml-graphics
+                  DEPENDS test-sfml-system test-sfml-window test-sfml-graphics test-sfml-network
 )
 
 add_custom_command(TARGET runtests

--- a/test/src/Network/Packet.cpp
+++ b/test/src/Network/Packet.cpp
@@ -1,0 +1,52 @@
+#include <SFML/Network.hpp>
+
+#include <catch.hpp>
+#include <limits>
+
+template <typename IntegerType>
+static void testPacketStreamOperators(IntegerType expected)
+{
+    sf::Packet packet;
+    packet << expected;
+    IntegerType received;
+    packet >> received;
+    CHECK(expected == received);
+}
+
+TEST_CASE("sf::Packet class", "[network]")
+{
+    SECTION("Stream operators")
+    {
+        SECTION("Int8")
+        {
+            testPacketStreamOperators(sf::Int8(0));
+            testPacketStreamOperators(sf::Int8(1));
+            testPacketStreamOperators(std::numeric_limits<sf::Int8>::min());
+            testPacketStreamOperators(std::numeric_limits<sf::Int8>::max());
+        }
+
+        SECTION("Int16")
+        {
+            testPacketStreamOperators(sf::Int16(0));
+            testPacketStreamOperators(sf::Int16(1));
+            testPacketStreamOperators(std::numeric_limits<sf::Int16>::min());
+            testPacketStreamOperators(std::numeric_limits<sf::Int16>::max());
+        }
+
+        SECTION("Int32")
+        {
+            testPacketStreamOperators(sf::Int32(0));
+            testPacketStreamOperators(sf::Int32(1));
+            testPacketStreamOperators(std::numeric_limits<sf::Int32>::min());
+            testPacketStreamOperators(std::numeric_limits<sf::Int32>::max());
+        }
+
+        SECTION("Int64")
+        {
+            testPacketStreamOperators(sf::Int64(0));
+            testPacketStreamOperators(sf::Int64(1));
+            testPacketStreamOperators(std::numeric_limits<sf::Int64>::min());
+            testPacketStreamOperators(std::numeric_limits<sf::Int64>::max());
+        }
+    }
+}


### PR DESCRIPTION
A follow-up to #1867

Added unit tests as well which proved #1867 to be insufficient and a breaking change.

* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

## Description

`sf::Packet` does not work correctly for `sf::Int32` integer type due to a bug in casting.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
