### PR TITLE
Fix Vulkan example exceptions

### DIFF
--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -2479,7 +2479,8 @@ public:
                     swapchainOutOfDate = true;
             }
 
-            if (vulkanAvailable)
+            // Check that window was not closed before drawing to it
+            if (vulkanAvailable && window.isOpen())
             {
                 // Update the uniform buffer (matrices)
                 updateUniformBuffer(clock.getElapsedTime().asSeconds());

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -473,9 +473,9 @@ public:
         instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
         instanceCreateInfo.pApplicationInfo = &applicationInfo;
         instanceCreateInfo.enabledLayerCount = static_cast<sf::Uint32>(validationLayers.size());
-        instanceCreateInfo.ppEnabledLayerNames = &validationLayers[0];
+        instanceCreateInfo.ppEnabledLayerNames = validationLayers.data();
         instanceCreateInfo.enabledExtensionCount = static_cast<sf::Uint32>(requiredExtentions.size());
-        instanceCreateInfo.ppEnabledExtensionNames = &requiredExtentions[0];
+        instanceCreateInfo.ppEnabledExtensionNames = requiredExtentions.data();
 
         // Try to create a Vulkan instance with debug report enabled
         VkResult result = vkCreateInstance(&instanceCreateInfo, 0, &instance);


### PR DESCRIPTION
## Description

While testing another change I faced two exceptions in Vulkan example application.

First one was on application startup in `void setupInstance()` when trying to get `&validationLayers[0]`. On my PC `validationLayers.size()` is equals to zero.
To fix the issue I've changed the way the address of buffer is obtained to `validationLayers.data()`.

The second one was on application shutdown in call `void recreateSwapchain()` while trying to draw to closed window.
To fix that I've added a check that window is still open before trying drawing to it.

I was using Windows 10 21H1 build 19043.1348 and Visual Studio 2019 (16.11.7) with Windows SDK 10.0.22000.0 to debug and test this change.

## Tasks

* [NO] Tested on Linux
* [YES] Tested on Windows
* [NO] Tested on macOS
* [NO] Tested on iOS
* [NO] Tested on Android

## How to test this PR?

Compile SFML with examples and run Vulkan example.

If `validationLayers` is not empty on your environment, you may comment lines 451 and 455 to test my first change.
```cpp
//                validationLayers.push_back("VK_LAYER_LUNARG_standard_validation");
...
//                validationLayers.push_back("VK_LAYER_LUNARG_monitor");
```

To test the second change, run Vulkan example from Visual Studio with debugger attached. You should see no exceptions after window was closed.
