### PR TITLE
Use std::vector.data() where appropriate

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -142,7 +142,7 @@ int main()
         terrainStagingBuffer.resize(resolutionX * resolutionY * 6);
 
         // Generate the initial terrain
-        generateTerrain(&terrainStagingBuffer[0]);
+        generateTerrain(terrainStagingBuffer.data());
 
         statusText.setString("Generating Terrain...");
     }
@@ -189,7 +189,7 @@ int main()
             {
                 switch (event.key.code)
                 {
-                    case sf::Keyboard::Return: generateTerrain(&terrainStagingBuffer[0]); break;
+                    case sf::Keyboard::Return: generateTerrain(terrainStagingBuffer.data()); break;
                     case sf::Keyboard::Down:   currentSetting = (currentSetting + 1) % settingCount; break;
                     case sf::Keyboard::Up:     currentSetting = (currentSetting + settingCount - 1) % settingCount; break;
                     case sf::Keyboard::Left:   *(settings[currentSetting].value) -= 0.1f; break;
@@ -215,7 +215,7 @@ int main()
                     // If there is new data pending to be uploaded to the VertexBuffer, do it now
                     if (bufferUploadPending)
                     {
-                        terrain.update(&terrainStagingBuffer[0]);
+                        terrain.update(terrainStagingBuffer.data());
                         bufferUploadPending = false;
                     }
 
@@ -513,7 +513,7 @@ void processWorkItem(std::vector<sf::Vertex>& vertices, const WorkItem& workItem
     }
 
     // Copy the resulting geometry from our thread-local buffer into the target buffer
-    std::memcpy(workItem.targetBuffer + (resolutionX * rowStart * 6), &vertices[0], sizeof(sf::Vertex) * resolutionX * rowCount * 6);
+    std::memcpy(workItem.targetBuffer + (resolutionX * rowStart * 6), vertices.data(), sizeof(sf::Vertex) * resolutionX * rowCount * 6);
 }
 
 

--- a/examples/voip/Server.cpp
+++ b/examples/voip/Server.cpp
@@ -89,7 +89,7 @@ private:
         }
 
         // Fill audio data to pass to the stream
-        data.samples     = &m_tempBuffer[0];
+        data.samples     = m_tempBuffer.data();
         data.sampleCount = m_tempBuffer.size();
 
         // Update the playing offset

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -192,8 +192,8 @@ bool Music::onGetData(SoundStream::Chunk& data)
         toFill = static_cast<std::size_t>(loopEnd - currentOffset);
 
     // Fill the chunk parameters
-    data.samples = &m_samples[0];
-    data.sampleCount = static_cast<std::size_t>(m_file.read(&m_samples[0], toFill));
+    data.samples = m_samples.data();
+    data.sampleCount = static_cast<std::size_t>(m_file.read(m_samples.data(), toFill));
     currentOffset += data.sampleCount;
 
     // Check if we have stopped obtaining samples or reached either the EOF or the loop end point

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -148,7 +148,7 @@ bool SoundBuffer::saveToFile(const std::string& filename) const
     if (file.openFromFile(filename, getSampleRate(), getChannelCount()))
     {
         // Write the samples to the opened file
-        file.write(&m_samples[0], m_samples.size());
+        file.write(m_samples.data(), m_samples.size());
 
         return true;
     }
@@ -162,7 +162,7 @@ bool SoundBuffer::saveToFile(const std::string& filename) const
 ////////////////////////////////////////////////////////////
 const Int16* SoundBuffer::getSamples() const
 {
-    return m_samples.empty() ? nullptr : &m_samples[0];
+    return m_samples.empty() ? nullptr : m_samples.data();
 }
 
 
@@ -224,7 +224,7 @@ bool SoundBuffer::initialize(InputSoundFile& file)
 
     // Read the samples from the provided file
     m_samples.resize(static_cast<std::size_t>(sampleCount));
-    if (file.read(&m_samples[0], sampleCount) == sampleCount)
+    if (file.read(m_samples.data(), sampleCount) == sampleCount)
     {
         // Update the internal buffer with the new samples
         return update(channelCount, sampleRate);
@@ -262,7 +262,7 @@ bool SoundBuffer::update(unsigned int channelCount, unsigned int sampleRate)
 
     // Fill the buffer
     ALsizei size = static_cast<ALsizei>(m_samples.size() * sizeof(Int16));
-    alCheck(alBufferData(m_buffer, format, &m_samples[0], size, static_cast<ALsizei>(sampleRate)));
+    alCheck(alBufferData(m_buffer, format, m_samples.data(), size, static_cast<ALsizei>(sampleRate)));
 
     // Compute the duration
     m_duration = seconds(static_cast<float>(m_samples.size()) / static_cast<float>(sampleRate) / static_cast<float>(channelCount));

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -63,7 +63,7 @@ bool SoundBufferRecorder::onProcessSamples(const Int16* samples, std::size_t sam
 void SoundBufferRecorder::onStop()
 {
     if (!m_samples.empty())
-        m_buffer.loadFromSamples(&m_samples[0], m_samples.size(), getChannelCount(), getSampleRate());
+        m_buffer.loadFromSamples(m_samples.data(), m_samples.size(), getChannelCount(), getSampleRate());
 }
 
 

--- a/src/SFML/Audio/SoundFileWriterFlac.cpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.cpp
@@ -113,7 +113,7 @@ void SoundFileWriterFlac::write(const Int16* samples, Uint64 count)
         m_samples32.assign(samples, samples + frames * m_channelCount);
 
         // Write them to the FLAC stream
-        FLAC__stream_encoder_process_interleaved(m_encoder, &m_samples32[0], frames);
+        FLAC__stream_encoder_process_interleaved(m_encoder, m_samples32.data(), frames);
 
         // Next chunk
         count -= m_samples32.size();

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -301,10 +301,10 @@ void SoundRecorder::processCapturedSamples()
     {
         // Get the recorded samples
         m_samples.resize(static_cast<unsigned int>(samplesAvailable) * getChannelCount());
-        alcCaptureSamples(captureDevice, &m_samples[0], samplesAvailable);
+        alcCaptureSamples(captureDevice, m_samples.data(), samplesAvailable);
 
         // Forward them to the derived class
-        if (!onProcessSamples(&m_samples[0], m_samples.size()))
+        if (!onProcessSamples(m_samples.data(), m_samples.size()))
         {
             // The user wants to stop the capture
             m_isCapturing = false;

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -672,7 +672,7 @@ Glyph Font::loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, f
         // Resize the pixel buffer to the new size and fill it with transparent white pixels
         m_pixelBuffer.resize(width * height * 4);
 
-        Uint8* current = &m_pixelBuffer[0];
+        Uint8* current = m_pixelBuffer.data();
         Uint8* end = current + width * height * 4;
 
         while (current != end)
@@ -719,7 +719,7 @@ Glyph Font::loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, f
         unsigned int y = static_cast<unsigned int>(glyph.textureRect.top) - padding;
         unsigned int w = static_cast<unsigned int>(glyph.textureRect.width) + 2 * padding;
         unsigned int h = static_cast<unsigned int>(glyph.textureRect.height) + 2 * padding;
-        page.texture.update(&m_pixelBuffer[0], w, h, x, y);
+        page.texture.update(m_pixelBuffer.data(), w, h, x, y);
     }
 
     // Delete the FT glyph

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -61,7 +61,7 @@ void Image::create(unsigned int width, unsigned int height, const Color& color)
         std::vector<Uint8> newPixels(width * height * 4);
 
         // Fill it with the specified color
-        Uint8* ptr = &newPixels[0];
+        Uint8* ptr = newPixels.data();
         Uint8* end = ptr + newPixels.size();
         while (ptr < end)
         {
@@ -174,7 +174,7 @@ void Image::createMaskFromColor(const Color& color, Uint8 alpha)
     if (!m_pixels.empty())
     {
         // Replace the alpha of the pixels that match the transparent color
-        Uint8* ptr = &m_pixels[0];
+        Uint8* ptr = m_pixels.data();
         Uint8* end = ptr + m_pixels.size();
         while (ptr < end)
         {
@@ -225,8 +225,8 @@ void Image::copy(const Image& source, unsigned int destX, unsigned int destY, co
     unsigned int rows      = height;
     int          srcStride = static_cast<int>(source.m_size.x) * 4;
     int          dstStride = static_cast<int>(m_size.x) * 4;
-    const Uint8* srcPixels = &source.m_pixels[0] + (static_cast<unsigned int>(srcRect.left) + static_cast<unsigned int>(srcRect.top) * source.m_size.x) * 4;
-    Uint8*       dstPixels = &m_pixels[0] + (destX + destY * m_size.x) * 4;
+    const Uint8* srcPixels = source.m_pixels.data() + (static_cast<unsigned int>(srcRect.left) + static_cast<unsigned int>(srcRect.top) * source.m_size.x) * 4;
+    Uint8*       dstPixels = m_pixels.data() + (destX + destY * m_size.x) * 4;
 
     // Copy the pixels
     if (applyAlpha)
@@ -289,7 +289,7 @@ const Uint8* Image::getPixelsPtr() const
 {
     if (!m_pixels.empty())
     {
-        return &m_pixels[0];
+        return m_pixels.data();
     }
     else
     {

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -123,7 +123,7 @@ bool ImageLoader::loadImageFromFile(const std::string& filename, std::vector<Uin
         {
             // Copy the loaded pixels to the pixel buffer
             pixels.resize(static_cast<std::size_t>(width * height * 4));
-            memcpy(&pixels[0], ptr, pixels.size());
+            memcpy(pixels.data(), ptr, pixels.size());
         }
 
         // Free the loaded pixels (they are now in our own pixel buffer)
@@ -167,7 +167,7 @@ bool ImageLoader::loadImageFromMemory(const void* data, std::size_t dataSize, st
             {
                 // Copy the loaded pixels to the pixel buffer
                 pixels.resize(static_cast<std::size_t>(width * height * 4));
-                memcpy(&pixels[0], ptr, pixels.size());
+                memcpy(pixels.data(), ptr, pixels.size());
             }
 
             // Free the loaded pixels (they are now in our own pixel buffer)
@@ -222,7 +222,7 @@ bool ImageLoader::loadImageFromStream(InputStream& stream, std::vector<Uint8>& p
         {
             // Copy the loaded pixels to the pixel buffer
             pixels.resize(static_cast<std::size_t>(width * height * 4));
-            memcpy(&pixels[0], ptr, pixels.size());
+            memcpy(pixels.data(), ptr, pixels.size());
         }
 
         // Free the loaded pixels (they are now in our own pixel buffer)
@@ -256,25 +256,25 @@ bool ImageLoader::saveImageToFile(const std::string& filename, const std::vector
         if (extension == "bmp")
         {
             // BMP format
-            if (stbi_write_bmp(filename.c_str(), convertedSize.x, convertedSize.y, 4, &pixels[0]))
+            if (stbi_write_bmp(filename.c_str(), convertedSize.x, convertedSize.y, 4, pixels.data()))
                 return true;
         }
         else if (extension == "tga")
         {
             // TGA format
-            if (stbi_write_tga(filename.c_str(), convertedSize.x, convertedSize.y, 4, &pixels[0]))
+            if (stbi_write_tga(filename.c_str(), convertedSize.x, convertedSize.y, 4, pixels.data()))
                 return true;
         }
         else if (extension == "png")
         {
             // PNG format
-            if (stbi_write_png(filename.c_str(), convertedSize.x, convertedSize.y, 4, &pixels[0], 0))
+            if (stbi_write_png(filename.c_str(), convertedSize.x, convertedSize.y, 4, pixels.data(), 0))
                 return true;
         }
         else if (extension == "jpg" || extension == "jpeg")
         {
             // JPG format
-            if (stbi_write_jpg(filename.c_str(), convertedSize.x, convertedSize.y, 4, &pixels[0], 90))
+            if (stbi_write_jpg(filename.c_str(), convertedSize.x, convertedSize.y, 4, pixels.data(), 90))
                 return true;
         }
     }
@@ -297,25 +297,25 @@ bool ImageLoader::saveImageToMemory(const std::string& format, std::vector<sf::U
         if (specified == "bmp")
         {
             // BMP format
-            if (stbi_write_bmp_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, &pixels[0]))
+            if (stbi_write_bmp_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, pixels.data()))
                 return true;
         }
         else if (specified == "tga")
         {
             // TGA format
-            if (stbi_write_tga_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, &pixels[0]))
+            if (stbi_write_tga_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, pixels.data()))
                 return true;
         }
         else if (specified == "png")
         {
             // PNG format
-            if (stbi_write_png_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, &pixels[0], 0))
+            if (stbi_write_png_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, pixels.data(), 0))
                 return true;
         }
         else if (specified == "jpg" || specified == "jpeg")
         {
             // JPG format
-            if (stbi_write_jpg_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, &pixels[0], 90))
+            if (stbi_write_jpg_to_func(&bufferFromCallback, &output, convertedSize.x, convertedSize.y, 4, pixels.data(), 90))
                 return true;
         }
     }

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -90,7 +90,7 @@ namespace
             {
                 file.seekg(0, std::ios_base::beg);
                 buffer.resize(static_cast<std::size_t>(size));
-                file.read(&buffer[0], static_cast<std::streamsize>(size));
+                file.read(buffer.data(), static_cast<std::streamsize>(size));
             }
             buffer.push_back('\0');
             return true;
@@ -110,7 +110,7 @@ namespace
         {
             buffer.resize(static_cast<std::size_t>(size));
             stream.seek(0);
-            sf::Int64 read = stream.read(&buffer[0], size);
+            sf::Int64 read = stream.read(buffer.data(), size);
             success = (read == size);
         }
         buffer.push_back('\0');
@@ -252,11 +252,11 @@ bool Shader::loadFromFile(const std::string& filename, Type type)
 
     // Compile the shader program
     if (type == Vertex)
-        return compile(&shader[0], nullptr, nullptr);
+        return compile(shader.data(), nullptr, nullptr);
     else if (type == Geometry)
-        return compile(nullptr, &shader[0], nullptr);
+        return compile(nullptr, shader.data(), nullptr);
     else
-        return compile(nullptr, nullptr, &shader[0]);
+        return compile(nullptr, nullptr, shader.data());
 }
 
 
@@ -280,7 +280,7 @@ bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::st
     }
 
     // Compile the shader program
-    return compile(&vertexShader[0], nullptr, &fragmentShader[0]);
+    return compile(vertexShader.data(), nullptr, fragmentShader.data());
 }
 
 
@@ -312,7 +312,7 @@ bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::st
     }
 
     // Compile the shader program
-    return compile(&vertexShader[0], &geometryShader[0], &fragmentShader[0]);
+    return compile(vertexShader.data(), geometryShader.data(), fragmentShader.data());
 }
 
 
@@ -358,11 +358,11 @@ bool Shader::loadFromStream(InputStream& stream, Type type)
 
     // Compile the shader program
     if (type == Vertex)
-        return compile(&shader[0], nullptr, nullptr);
+        return compile(shader.data(), nullptr, nullptr);
     else if (type == Geometry)
-        return compile(nullptr, &shader[0], nullptr);
+        return compile(nullptr, shader.data(), nullptr);
     else
-        return compile(nullptr, nullptr, &shader[0]);
+        return compile(nullptr, nullptr, shader.data());
 }
 
 
@@ -386,7 +386,7 @@ bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& fragme
     }
 
     // Compile the shader program
-    return compile(&vertexShader[0], nullptr, &fragmentShader[0]);
+    return compile(vertexShader.data(), nullptr, fragmentShader.data());
 }
 
 
@@ -418,7 +418,7 @@ bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& geomet
     }
 
     // Compile the shader program
-    return compile(&vertexShader[0], &geometryShader[0], &fragmentShader[0]);
+    return compile(vertexShader.data(), geometryShader.data(), fragmentShader.data());
 }
 
 
@@ -603,7 +603,7 @@ void Shader::setUniformArray(const std::string& name, const Glsl::Vec2* vectorAr
 
     UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniform2fv(binder.location, static_cast<GLsizei>(length), &contiguous[0]));
+        glCheck(GLEXT_glUniform2fv(binder.location, static_cast<GLsizei>(length), contiguous.data()));
 }
 
 
@@ -614,7 +614,7 @@ void Shader::setUniformArray(const std::string& name, const Glsl::Vec3* vectorAr
 
     UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniform3fv(binder.location, static_cast<GLsizei>(length), &contiguous[0]));
+        glCheck(GLEXT_glUniform3fv(binder.location, static_cast<GLsizei>(length), contiguous.data()));
 }
 
 
@@ -625,7 +625,7 @@ void Shader::setUniformArray(const std::string& name, const Glsl::Vec4* vectorAr
 
     UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniform4fv(binder.location, static_cast<GLsizei>(length), &contiguous[0]));
+        glCheck(GLEXT_glUniform4fv(binder.location, static_cast<GLsizei>(length), contiguous.data()));
 }
 
 
@@ -640,7 +640,7 @@ void Shader::setUniformArray(const std::string& name, const Glsl::Mat3* matrixAr
 
     UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniformMatrix3fv(binder.location, static_cast<GLsizei>(length), GL_FALSE, &contiguous[0]));
+        glCheck(GLEXT_glUniformMatrix3fv(binder.location, static_cast<GLsizei>(length), GL_FALSE, contiguous.data()));
 }
 
 
@@ -655,7 +655,7 @@ void Shader::setUniformArray(const std::string& name, const Glsl::Mat4* matrixAr
 
     UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniformMatrix4fv(binder.location, static_cast<GLsizei>(length), GL_FALSE, &contiguous[0]));
+        glCheck(GLEXT_glUniformMatrix4fv(binder.location, static_cast<GLsizei>(length), GL_FALSE, contiguous.data()));
 }
 
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -346,7 +346,7 @@ Image Texture::copyToImage() const
 
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, frameBuffer));
         glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0));
-        glCheck(glReadPixels(0, 0, m_size.x, m_size.y, GL_RGBA, GL_UNSIGNED_BYTE, &pixels[0]));
+        glCheck(glReadPixels(0, 0, m_size.x, m_size.y, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data()));
         glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
 
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, previousFrameBuffer));
@@ -358,7 +358,7 @@ Image Texture::copyToImage() const
     {
         // Texture is not padded nor flipped, we can use a direct copy
         glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
-        glCheck(glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, &pixels[0]));
+        glCheck(glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data()));
     }
     else
     {
@@ -367,11 +367,11 @@ Image Texture::copyToImage() const
         // All the pixels will first be copied to a temporary array
         std::vector<Uint8> allPixels(m_actualSize.x * m_actualSize.y * 4);
         glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
-        glCheck(glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, &allPixels[0]));
+        glCheck(glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, allPixels.data()));
 
         // Then we copy the useful pixels from the temporary array to the final one
-        const Uint8* src = &allPixels[0];
-        Uint8* dst = &pixels[0];
+        const Uint8* src = allPixels.data();
+        Uint8* dst = pixels.data();
         unsigned int srcPitch = m_actualSize.x * 4;
         unsigned int dstPitch = m_size.x * 4;
 
@@ -394,7 +394,7 @@ Image Texture::copyToImage() const
 
     // Create the image
     Image image;
-    image.create(m_size.x, m_size.y, &pixels[0]);
+    image.create(m_size.x, m_size.y, pixels.data());
 
     return image;
 }

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -144,7 +144,7 @@ FloatRect VertexArray::getBounds() const
 void VertexArray::draw(RenderTarget& target, RenderStates states) const
 {
     if (!m_vertices.empty())
-        target.draw(&m_vertices[0], m_vertices.size(), m_primitiveType, states);
+        target.draw(m_vertices.data(), m_vertices.size(), m_primitiveType, states);
 }
 
 } // namespace sf

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -82,7 +82,7 @@ void Packet::clear()
 ////////////////////////////////////////////////////////////
 const void* Packet::getData() const
 {
-    return !m_data.empty() ? &m_data[0] : nullptr;
+    return !m_data.empty() ? m_data.data() : nullptr;
 }
 
 

--- a/src/SFML/Network/UdpSocket.cpp
+++ b/src/SFML/Network/UdpSocket.cpp
@@ -192,12 +192,12 @@ Socket::Status UdpSocket::receive(Packet& packet, IpAddress& remoteAddress, unsi
 
     // Receive the datagram
     std::size_t received = 0;
-    Status status = receive(&m_buffer[0], m_buffer.size(), received, remoteAddress, remotePort);
+    Status status = receive(m_buffer.data(), m_buffer.size(), received, remoteAddress, remotePort);
 
     // If we received valid data, we can copy it to the user packet
     packet.clear();
     if ((status == Done) && (received > 0))
-        packet.onReceive(&m_buffer[0], received);
+        packet.onReceive(m_buffer.data(), received);
 
     return status;
 }

--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -292,7 +292,7 @@ Joystick::Identification JoystickImpl::getIdentification() const
 ////////////////////////////////////////////////////////////
 JoystickState JoystickImpl::JoystickImpl::update()
 {
-    while (read(m_file, &m_buffer[0], m_length) == m_length)
+    while (read(m_file, m_buffer.data(), m_length) == m_length)
     {
         hid_data_t data = hid_start_parse(m_desc, 1 << hid_input, m_id);
 
@@ -311,11 +311,11 @@ JoystickState JoystickImpl::JoystickImpl::update()
 
                 if (usage == HUP_BUTTON)
                 {
-                    m_state.buttons[buttonIndex++] = hid_get_data(&m_buffer[0], &item);
+                    m_state.buttons[buttonIndex++] = hid_get_data(m_buffer.data(), &item);
                 }
                 else if (usage == HUP_GENERIC_DESKTOP)
                 {
-                    int value = hid_get_data(&m_buffer[0], &item);
+                    int value = hid_get_data(m_buffer.data(), &item);
                     int axis = usageToAxis(usage);
 
                     if (usage == HUG_HAT_SWITCH)

--- a/src/SFML/Window/NetBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/NetBSD/JoystickImpl.cpp
@@ -297,7 +297,7 @@ Joystick::Identification JoystickImpl::getIdentification() const
 ////////////////////////////////////////////////////////////
 JoystickState JoystickImpl::JoystickImpl::update()
 {
-    while (read(m_file, &m_buffer[0], m_length) == m_length)
+    while (read(m_file, m_buffer.data(), m_length) == m_length)
     {
         hid_data_t data = hid_start_parse(m_desc, 1 << hid_input, m_id);
 
@@ -316,11 +316,11 @@ JoystickState JoystickImpl::JoystickImpl::update()
 
                 if (usage == HUP_BUTTON)
                 {
-                    m_state.buttons[buttonIndex++] = hid_get_data(&m_buffer[0], &item);
+                    m_state.buttons[buttonIndex++] = hid_get_data(m_buffer.data(), &item);
                 }
                 else if (usage == HUP_GENERIC_DESKTOP)
                 {
-                    int value = hid_get_data(&m_buffer[0], &item);
+                    int value = hid_get_data(m_buffer.data(), &item);
                     int axis = usageToAxis(usage);
 
                     if (usage == HUG_HAT_SWITCH)

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -46,8 +46,8 @@ namespace
         CFIndex length = CFStringGetLength(cfString);
         std::vector<char> str(length);
         CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
-        CFStringGetCString(cfString, &str[0], maxSize, kCFStringEncodingUTF8);
-        return &str[0];
+        CFStringGetCString(cfString, str.data(), maxSize, kCFStringEncodingUTF8);
+        return str.data();
     }
 
     // Get HID device property key as a string

--- a/src/SFML/Window/OSX/SFContext.mm
+++ b/src/SFML/Window/OSX/SFContext.mm
@@ -263,7 +263,7 @@ void SFContext::createContext(SFContext* shared,
     m_settings.sRgbCapable = true;
 
     // Create the pixel format.
-    NSOpenGLPixelFormat* pixFmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:&attrs[0]];
+    NSOpenGLPixelFormat* pixFmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:attrs.data()];
 
     if (pixFmt == nil)
     {

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -306,7 +306,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
                         XA_ATOM,
                         32,
                         PropModeReplace,
-                        reinterpret_cast<unsigned char*>(&targets[0]),
+                        reinterpret_cast<unsigned char*>(targets.data()),
                         static_cast<int>(targets.size())
                     );
 

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -131,9 +131,9 @@ bool CursorImpl::loadFromPixelsMonochrome(const Uint8* pixels, Vector2u size, Ve
     }
 
     Pixmap maskPixmap = XCreateBitmapFromData(m_display, XDefaultRootWindow(m_display),
-                                              reinterpret_cast<char*>(&mask[0]), size.x, size.y);
+                                              reinterpret_cast<char*>(mask.data()), size.x, size.y);
     Pixmap dataPixmap = XCreateBitmapFromData(m_display, XDefaultRootWindow(m_display),
-                                              reinterpret_cast<char*>(&data[0]), size.x, size.y);
+                                              reinterpret_cast<char*>(data.data()), size.x, size.y);
 
     // Define the foreground color as white and the background as black.
     XColor fg, bg;

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -726,7 +726,7 @@ void GlxContext::createContext(GlxContext* shared)
             }
 
             // Create the context
-            m_context = glXCreateContextAttribsARB(m_display, *config, toShare, true, &attributes[0]);
+            m_context = glXCreateContextAttribsARB(m_display, *config, toShare, true, attributes.data());
 
             if (!m_context)
             {

--- a/src/SFML/Window/Unix/VulkanImplX11.cpp
+++ b/src/SFML/Window/Unix/VulkanImplX11.cpp
@@ -137,7 +137,7 @@ bool VulkanImplX11::isAvailable(bool requireGraphics)
 
             extensionProperties.resize(extensionCount);
 
-            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, &extensionProperties[0]);
+            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, extensionProperties.data());
 
             // Check if the necessary extensions are available
             bool has_VK_KHR_surface = false;

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -131,7 +131,7 @@ namespace
                 buffer[offset] = 0;
 
                 // Remove the path to keep the executable name only
-                return basename(&buffer[0]);
+                return basename(buffer.data());
             }
 
             // Default fallback name
@@ -732,7 +732,7 @@ m_lastInputTime  (0)
     std::string executableName = findExecutableName();
     std::vector<char> windowInstance(executableName.size() + 1, 0);
     std::copy(executableName.begin(), executableName.end(), windowInstance.begin());
-    hint->res_name = &windowInstance[0];
+    hint->res_name = windowInstance.data();
 
     // The class name identifies a class of windows that
     // "are of the same type". We simply use the initial window name as
@@ -740,7 +740,7 @@ m_lastInputTime  (0)
     std::string ansiTitle = title.toAnsiString();
     std::vector<char> windowClass(ansiTitle.size() + 1, 0);
     std::copy(ansiTitle.begin(), ansiTitle.end(), windowClass.begin());
-    hint->res_class = &windowClass[0];
+    hint->res_class = windowClass.data();
 
     XSetClassHint(m_display, m_window, hint);
 
@@ -1051,7 +1051,7 @@ void WindowImplX11::setIcon(unsigned int width, unsigned int height, const Uint8
             }
         }
     }
-    m_iconMaskPixmap = XCreatePixmapFromBitmapData(m_display, m_window, reinterpret_cast<char*>(&maskPixels[0]), width, height, 1, 0, 1);
+    m_iconMaskPixmap = XCreatePixmapFromBitmapData(m_display, m_window, reinterpret_cast<char*>(maskPixels.data()), width, height, 1, 0, 1);
 
     // Send our new icon to the window through the WMHints
     XWMHints* hints = XAllocWMHints();
@@ -1064,7 +1064,7 @@ void WindowImplX11::setIcon(unsigned int width, unsigned int height, const Uint8
     // ICCCM wants BGRA pixels: swap red and blue channels
     // ICCCM also wants the first 2 unsigned 32-bit values to be width and height
     std::vector<unsigned long> icccmIconPixels(2 + width * height, 0);
-    unsigned long* ptr = &icccmIconPixels[0];
+    unsigned long* ptr = icccmIconPixels.data();
 
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wnull-dereference" // False positive.
@@ -1088,7 +1088,7 @@ void WindowImplX11::setIcon(unsigned int width, unsigned int height, const Uint8
                     XA_CARDINAL,
                     32,
                     PropModeReplace,
-                    reinterpret_cast<const unsigned char*>(&icccmIconPixels[0]),
+                    reinterpret_cast<const unsigned char*>(icccmIconPixels.data()),
                     static_cast<int>(2 + width * height));
 
     XFlush(m_display);
@@ -1591,7 +1591,7 @@ void WindowImplX11::setProtocols()
                         XA_ATOM,
                         32,
                         PropModeReplace,
-                        reinterpret_cast<const unsigned char*>(&atoms[0]),
+                        reinterpret_cast<const unsigned char*>(atoms.data()),
                         static_cast<int>(atoms.size()));
     }
     else

--- a/src/SFML/Window/Win32/VulkanImplWin32.cpp
+++ b/src/SFML/Window/Win32/VulkanImplWin32.cpp
@@ -139,7 +139,7 @@ bool VulkanImplWin32::isAvailable(bool requireGraphics)
 
             extensionProperties.resize(extensionCount);
 
-            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, &extensionProperties[0]);
+            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, extensionProperties.data());
 
             // Check if the necessary extensions are available
             bool has_VK_KHR_surface = false;

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -664,7 +664,7 @@ void WglContext::createContext(WglContext* shared)
             }
 
             // Create the context
-            m_context = wglCreateContextAttribsARB(m_deviceContext, sharedContext, &attributes[0]);
+            m_context = wglCreateContextAttribsARB(m_deviceContext, sharedContext, attributes.data());
         }
         else
         {

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -376,7 +376,7 @@ void WindowImplWin32::setIcon(unsigned int width, unsigned int height, const Uin
     }
 
     // Create the icon from the pixel array
-    m_icon = CreateIcon(GetModuleHandleW(nullptr), static_cast<int>(width), static_cast<int>(height), 1, 32, nullptr, &iconPixels[0]);
+    m_icon = CreateIcon(GetModuleHandleW(nullptr), static_cast<int>(width), static_cast<int>(height), 1, 32, nullptr, iconPixels.data());
 
     // Set it as both big and small icon of the window
     if (m_icon)


### PR DESCRIPTION
## Description

There were some places where an address of the first element of the `std::vector` was used as a pointer to array of vector's elements. These places were replaced with `std::vector.data()` that semantically better for that usage scenario.

This change was discussed in PR #1873

Two occurrences in file `examples/vulkan/Vulkan.cpp` was left untouched to avoid merge conflict with PR #1873.

Also in file `examples/vulkan/Vulkan.cpp` in `void setupRenderpass()` routine additional change to an array was made.
Array `VkAttachmentReference attachmentReferences[2];` was split into two separate variables for better readability and clearer variable usage.

I was using Windows 10 21H1 build 19043.1348 and Visual Studio 2019 (16.11.7) with Windows SDK 10.0.22000.0 to develop and test this change. 

Also I was using Ubuntu 20.04.3 with latest updates running under VirtualBox to build and test this change. Clang 10.0.0 was used for building.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

I've manually tested example applications to make sure that the change isn't breaking anything:
* on Windows: island, joystick, opengl, shader, sockets, sound, tennis, vulkan, win32 and window
* on Linux: island, joystick, opengl, shader, sockets, sound, tennis, window and x11

Sadly I was unable to test vulkan example on Linux. Seems that running Vulkan under VirtualBox involves some magic tricks that I'm not familiar with yet.

There are no visible changes or added features.
