### PR TITLE
Resolve two C++11 TODOs ('static' initialization synchronization and 'shrink_to_fit')

### DIFF
--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -56,7 +56,6 @@
 
 namespace
 {
-    sf::Mutex maxTextureUnitsMutex;
     sf::Mutex isAvailableMutex;
 
     GLint checkMaxTextureUnits()
@@ -70,11 +69,7 @@ namespace
     // Retrieve the maximum number of texture units available
     std::size_t getMaxTextureUnits()
     {
-        // TODO: Remove this lock when it becomes unnecessary in C++11
-        sf::Lock lock(maxTextureUnitsMutex);
-
         static GLint maxUnits = checkMaxTextureUnits();
-
         return static_cast<std::size_t>(maxUnits);
     }
 

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -772,9 +772,7 @@ bool JoystickImpl::openDInput(unsigned int index)
                             entry.productId = m_identification.productId;
 
                             joystickBlacklist.push_back(entry);
-
-                            // Pre-C++11 shrink_to_fit()
-                            JoystickBlacklist(joystickBlacklist.begin(), joystickBlacklist.end()).swap(joystickBlacklist);
+                            joystickBlacklist.shrink_to_fit();
                         }
 
                         m_device->Release();


### PR DESCRIPTION
Pretty self-explanatory:
1. `static` function variable initialization is guaranteed to be thread-safe in C++11 and above, so we don't need a mutex there.
2. `shrink_to_fit` is available as a `vector` member function in C++11 and above, so no need for `swap` tricks.

