### PR TITLE
Minor modernization changes: 'nullptr', range-based 'for' loops, etc...

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -529,12 +529,12 @@ void threadFunction()
 
     std::vector<sf::Vertex> vertices(resolutionX * rowBlockSize * 6);
 
-    WorkItem workItem = {0, 0};
+    WorkItem workItem = {nullptr, 0};
 
     // Loop until the application exits
     for (;;)
     {
-        workItem.targetBuffer = 0;
+        workItem.targetBuffer = nullptr;
 
         // Check if there are new work items in the queue
         {

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -236,8 +236,8 @@ public:
         // Render the updated scene to the off-screen surface
         m_surface.clear(sf::Color::White);
         m_surface.draw(m_backgroundSprite);
-        for (std::size_t i = 0; i < m_entities.size(); ++i)
-            m_surface.draw(m_entities[i]);
+        for (const sf::Sprite& entity : m_entities)
+            m_surface.draw(entity);
         m_surface.display();
     }
 
@@ -366,8 +366,8 @@ int main()
     std::size_t current = 0;
 
     // Initialize them
-    for (std::size_t i = 0; i < effects.size(); ++i)
-        effects[i]->load();
+    for (Effect* effect : effects)
+        effect->load();
 
     // Create the messages background
     sf::Texture textBackgroundTexture;
@@ -457,8 +457,8 @@ int main()
     }
 
     // delete the effects
-    for (std::size_t i = 0; i < effects.size(); ++i)
-        delete effects[i];
+    for (Effect* effect : effects)
+        delete effect;
 
     return EXIT_SUCCESS;
 }

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -59,7 +59,7 @@ int main()
     windowClass.cbWndExtra    = 0;
     windowClass.hInstance     = instance;
     windowClass.hIcon         = nullptr;
-    windowClass.hCursor       = 0;
+    windowClass.hCursor       = nullptr;
     windowClass.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BACKGROUND);
     windowClass.lpszMenuName  = nullptr;
     windowClass.lpszClassName = TEXT("SFML App");

--- a/include/SFML/Window/Vulkan.hpp
+++ b/include/SFML/Window/Vulkan.hpp
@@ -31,7 +31,7 @@
 #include <SFML/Window/Export.hpp>
 #include <SFML/Window/WindowHandle.hpp>
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 
 
 using VkInstance = struct VkInstance_T*;

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -404,7 +404,7 @@ public:
     /// \return True if surface creation was successful, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool createVulkanSurface(const VkInstance& instance, VkSurfaceKHR& surface, const VkAllocationCallbacks* allocator = 0);
+    bool createVulkanSurface(const VkInstance& instance, VkSurfaceKHR& surface, const VkAllocationCallbacks* allocator = nullptr);
 
 protected:
 

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -153,7 +153,7 @@ std::vector<std::string> SoundRecorder::getAvailableDevices()
     {
         while (*deviceList)
         {
-            deviceNameList.push_back(deviceList);
+            deviceNameList.emplace_back(deviceList);
             deviceList += std::strlen(deviceList) + 1;
         }
     }

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -289,8 +289,8 @@ void SoundStream::streamData()
 
     // Create the buffers
     alCheck(alGenBuffers(BufferCount, m_buffers));
-    for (int i = 0; i < BufferCount; ++i)
-        m_bufferSeeks[i] = NoLoop;
+    for (Int64& bufferSeek : m_bufferSeeks)
+        bufferSeek = NoLoop;
 
     // Fill the queue
     requestStop = fillQueue();

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -294,7 +294,7 @@ bool Font::loadFromStream(InputStream& stream)
     FT_Open_Args args;
     args.flags  = FT_OPEN_STREAM;
     args.stream = rec;
-    args.driver = 0;
+    args.driver = nullptr;
 
     // Load the new font face from the specified stream
     FT_Face face;
@@ -616,7 +616,7 @@ Glyph Font::loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, f
     // Convert the glyph to a bitmap (i.e. rasterize it)
     // Warning! After this line, do not read any data from glyphDesc directly, use
     // bitmapGlyph.root to access the FT_Glyph data.
-    FT_Glyph_To_Bitmap(&glyphDesc, FT_RENDER_MODE_NORMAL, 0, 1);
+    FT_Glyph_To_Bitmap(&glyphDesc, FT_RENDER_MODE_NORMAL, nullptr, 1);
     auto bitmapGlyph = reinterpret_cast<FT_BitmapGlyph>(glyphDesc);
     FT_Bitmap& bitmap = bitmapGlyph->bitmap;
 

--- a/src/SFML/Graphics/RenderTextureImplDefault.cpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.cpp
@@ -37,7 +37,7 @@ namespace priv
 {
 ////////////////////////////////////////////////////////////
 RenderTextureImplDefault::RenderTextureImplDefault() :
-m_context(0),
+m_context(nullptr),
 m_width  (0),
 m_height (0)
 {

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -128,7 +128,7 @@ m_sRgb              (false)
     Lock lock(mutex);
 
     // Register the context destruction callback
-    registerContextDestroyCallback(contextDestroyCallback, 0);
+    registerContextDestroyCallback(contextDestroyCallback, nullptr);
 
     // Insert the new frame buffer mapping into the set of all active mappings
     frameBuffers.insert(&m_frameBuffers);

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -868,7 +868,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
         if (success == GL_FALSE)
         {
             char log[1024];
-            glCheck(GLEXT_glGetInfoLog(vertexShader, sizeof(log), 0, log));
+            glCheck(GLEXT_glGetInfoLog(vertexShader, sizeof(log), nullptr, log));
             err() << "Failed to compile vertex shader:" << std::endl
                   << log << std::endl;
             glCheck(GLEXT_glDeleteObject(vertexShader));
@@ -895,7 +895,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
         if (success == GL_FALSE)
         {
             char log[1024];
-            glCheck(GLEXT_glGetInfoLog(geometryShader, sizeof(log), 0, log));
+            glCheck(GLEXT_glGetInfoLog(geometryShader, sizeof(log), nullptr, log));
             err() << "Failed to compile geometry shader:" << std::endl
                   << log << std::endl;
             glCheck(GLEXT_glDeleteObject(geometryShader));
@@ -923,7 +923,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
         if (success == GL_FALSE)
         {
             char log[1024];
-            glCheck(GLEXT_glGetInfoLog(fragmentShader, sizeof(log), 0, log));
+            glCheck(GLEXT_glGetInfoLog(fragmentShader, sizeof(log), nullptr, log));
             err() << "Failed to compile fragment shader:" << std::endl
                   << log << std::endl;
             glCheck(GLEXT_glDeleteObject(fragmentShader));
@@ -945,7 +945,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
     if (success == GL_FALSE)
     {
         char log[1024];
-        glCheck(GLEXT_glGetInfoLog(shaderProgram, sizeof(log), 0, log));
+        glCheck(GLEXT_glGetInfoLog(shaderProgram, sizeof(log), nullptr, log));
         err() << "Failed to link shader:" << std::endl
               << log << std::endl;
         glCheck(GLEXT_glDeleteObject(shaderProgram));

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -147,7 +147,7 @@ bool VertexBuffer::create(std::size_t vertexCount)
     }
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
-    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexCount), 0, VertexBufferImpl::usageToGlEnum(m_usage)));
+    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexCount), nullptr, VertexBufferImpl::usageToGlEnum(m_usage)));
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, 0));
 
     m_size = vertexCount;
@@ -190,7 +190,7 @@ bool VertexBuffer::update(const Vertex* vertices, std::size_t vertexCount, unsig
     // Check if we need to resize or orphan the buffer
     if (vertexCount >= m_size)
     {
-        glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexCount), 0, VertexBufferImpl::usageToGlEnum(m_usage)));
+        glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexCount), nullptr, VertexBufferImpl::usageToGlEnum(m_usage)));
 
         m_size = vertexCount;
     }
@@ -234,14 +234,14 @@ bool VertexBuffer::update(const VertexBuffer& vertexBuffer)
     }
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
-    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexBuffer.m_size), 0, VertexBufferImpl::usageToGlEnum(m_usage)));
+    glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexBuffer.m_size), nullptr, VertexBufferImpl::usageToGlEnum(m_usage)));
 
-    void* destination = 0;
+    void* destination = nullptr;
     glCheck(destination = GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_WRITE_ONLY));
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, vertexBuffer.m_buffer));
 
-    void* source = 0;
+    void* source = nullptr;
     glCheck(source = GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_READ_ONLY));
 
     std::memcpy(destination, source, sizeof(Vertex) * vertexBuffer.m_size);

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -544,12 +544,12 @@ Ftp::Response Ftp::DataChannel::open(Ftp::TransferMode mode)
             Uint8 data[6] = {0, 0, 0, 0, 0, 0};
             std::string str = response.getMessage().substr(begin);
             std::size_t index = 0;
-            for (int i = 0; i < 6; ++i)
+            for (unsigned char& datum : data)
             {
                 // Extract the current number
                 while (isdigit(str[index]))
                 {
-                    data[i] = static_cast<Uint8>(static_cast<Uint8>(data[i] * 10) + static_cast<Uint8>(str[index] - '0'));
+                    datum = static_cast<Uint8>(static_cast<Uint8>(datum * 10) + static_cast<Uint8>(str[index] - '0'));
                     index++;
                 }
 

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -575,8 +575,8 @@ Packet& Packet::operator <<(const String& data)
     // Then insert characters
     if (length > 0)
     {
-        for (String::ConstIterator c = data.begin(); c != data.end(); ++c)
-            *this << *c;
+        for (unsigned int datum : data)
+            *this << datum;
     }
 
     return *this;

--- a/src/SFML/Network/Unix/SocketImpl.cpp
+++ b/src/SFML/Network/Unix/SocketImpl.cpp
@@ -27,9 +27,9 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Network/Unix/SocketImpl.hpp>
 #include <SFML/System/Err.hpp>
-#include <errno.h>
-#include <fcntl.h>
+#include <cerrno>
 #include <cstring>
+#include <fcntl.h>
 
 
 namespace sf

--- a/src/SFML/System/Unix/ClockImpl.cpp
+++ b/src/SFML/System/Unix/ClockImpl.cpp
@@ -29,7 +29,7 @@
 #if defined(SFML_SYSTEM_MACOS) || defined(SFML_SYSTEM_IOS)
     #include <mach/mach_time.h>
 #else
-    #include <time.h>
+    #include <ctime>
 #endif
 
 

--- a/src/SFML/System/Unix/SleepImpl.cpp
+++ b/src/SFML/System/Unix/SleepImpl.cpp
@@ -26,8 +26,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Unix/SleepImpl.hpp>
-#include <errno.h>
-#include <time.h>
+#include <cerrno>
+#include <ctime>
 
 
 namespace sf

--- a/src/SFML/Window/Cursor.cpp
+++ b/src/SFML/Window/Cursor.cpp
@@ -49,7 +49,7 @@ Cursor::~Cursor()
 ////////////////////////////////////////////////////////////
 bool Cursor::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hotspot)
 {
-    if ((pixels == 0) || (size.x == 0) || (size.y == 0))
+    if ((pixels == nullptr) || (size.x == 0) || (size.y == 0))
         return false;
     else
         return m_impl->loadFromPixels(pixels, size, hotspot);

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -189,8 +189,8 @@ namespace
             ////////////////////////////////////////////////////////////
             TransientContext() :
             referenceCount   (0),
-            context          (0),
-            sharedContextLock(0),
+            context          (nullptr),
+            sharedContextLock(nullptr),
             useSharedContext (false)
             {
                 if (resourceCount == 0)
@@ -279,8 +279,7 @@ namespace
                     for (unsigned int i = 0; i < static_cast<unsigned int>(numExtensions); ++i)
                     {
                         const char* extensionString = reinterpret_cast<const char*>(glGetStringiFunc(GL_EXTENSIONS, i));
-
-                        extensions.push_back(extensionString);
+                        extensions.emplace_back(extensionString);
                     }
                 }
             }

--- a/src/SFML/Window/JoystickManager.cpp
+++ b/src/SFML/Window/JoystickManager.cpp
@@ -109,10 +109,10 @@ JoystickManager::JoystickManager()
 ////////////////////////////////////////////////////////////
 JoystickManager::~JoystickManager()
 {
-    for (int i = 0; i < Joystick::Count; ++i)
+    for (Item& item : m_joysticks)
     {
-        if (m_joysticks[i].state.connected)
-            m_joysticks[i].joystick.close();
+        if (item.state.connected)
+            item.joystick.close();
     }
 
     JoystickImpl::cleanup();

--- a/src/SFML/Window/SensorManager.cpp
+++ b/src/SFML/Window/SensorManager.cpp
@@ -80,11 +80,11 @@ Vector3f SensorManager::getValue(Sensor::Type sensor) const
 ////////////////////////////////////////////////////////////
 void SensorManager::update()
 {
-    for (int i = 0; i < Sensor::Count; ++i)
+    for (Item& item : m_sensors)
     {
         // Only process available sensors
-        if (m_sensors[i].available)
-            m_sensors[i].value = m_sensors[i].sensor.update();
+        if (item.available)
+            item.value = item.sensor.update();
     }
 }
 
@@ -114,10 +114,10 @@ SensorManager::SensorManager()
 SensorManager::~SensorManager()
 {
     // Per sensor cleanup
-    for (int i = 0; i < Sensor::Count; ++i)
+    for (Item& item : m_sensors)
     {
-        if (m_sensors[i].available)
-            m_sensors[i].sensor.close();
+        if (item.available)
+            item.sensor.close();
     }
 
     // Global sensor cleanup

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -31,7 +31,7 @@
 #include <libudev.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <errno.h>
+#include <cerrno>
 #include <vector>
 #include <string>
 #include <cstring>

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -366,9 +366,9 @@ namespace
             if (!ewmhSupported())
                 return false;
 
-            for (size_t i = 0; i < (sizeof(wmAbsPosGood) / sizeof(wmAbsPosGood[0])); i++)
+            for (const sf::String& name : wmAbsPosGood)
             {
-                if (wmAbsPosGood[i] == windowManagerName)
+                if (name == windowManagerName)
                     return true;
             }
 

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -465,8 +465,8 @@ bool JoystickImpl::isConnectedDInput(unsigned int index)
 void JoystickImpl::updateConnectionsDInput()
 {
     // Clear plugged flags so we can determine which devices were added/removed
-    for (std::size_t i = 0; i < joystickList.size(); ++i)
-        joystickList[i].plugged = false;
+    for (JoystickRecord& record : joystickList)
+        record.plugged = false;
 
     // Enumerate devices
     HRESULT result = directInput->EnumDevices(DI8DEVCLASS_GAMECTRL, &JoystickImpl::deviceEnumerationCallback, nullptr, DIEDFL_ATTACHEDONLY);
@@ -511,11 +511,11 @@ bool JoystickImpl::openDInput(unsigned int index)
     // Initialize DirectInput members
     m_device = nullptr;
 
-    for (int i = 0; i < Joystick::AxisCount; ++i)
-        m_axes[i] = -1;
+    for (int& axis : m_axes)
+        axis = -1;
 
-    for (int i = 0; i < Joystick::ButtonCount; ++i)
-        m_buttons[i] = -1;
+    for (int& button : m_buttons)
+        button = -1;
 
     std::memset(&m_deviceCaps, 0, sizeof(DIDEVCAPS));
     m_deviceCaps.dwSize = sizeof(DIDEVCAPS);
@@ -706,9 +706,9 @@ bool JoystickImpl::openDInput(unsigned int index)
             }
 
             // Set device's axis mode to absolute if the device reports having at least one axis
-            for (int i = 0; i < Joystick::AxisCount; ++i)
+            for (int axis : m_axes)
             {
-                if (m_axes[i] != -1)
+                if (axis != -1)
                 {
                     std::memset(&property, 0, sizeof(property));
                     property.diph.dwSize = sizeof(property);
@@ -843,9 +843,9 @@ JoystickCaps JoystickImpl::getCapabilitiesDInput() const
     // Count how many buttons have valid offsets
     caps.buttonCount = 0;
 
-    for (int i = 0; i < Joystick::ButtonCount; ++i)
+    for (int button : m_buttons)
     {
-        if (m_buttons[i] != -1)
+        if (button != -1)
             ++caps.buttonCount;
     }
 
@@ -1047,11 +1047,11 @@ JoystickState JoystickImpl::updateDInputPolled()
 ////////////////////////////////////////////////////////////
 BOOL CALLBACK JoystickImpl::deviceEnumerationCallback(const DIDEVICEINSTANCE* deviceInstance, void*)
 {
-    for (std::size_t i = 0; i < joystickList.size(); ++i)
+    for (JoystickRecord& record : joystickList)
     {
-        if (joystickList[i].guid == deviceInstance->guidInstance)
+        if (record.guid == deviceInstance->guidInstance)
         {
-            joystickList[i].plugged = true;
+            record.plugged = true;
 
             return DIENUM_CONTINUE;
         }

--- a/src/SFML/Window/Win32/VulkanImplWin32.cpp
+++ b/src/SFML/Window/Win32/VulkanImplWin32.cpp
@@ -135,11 +135,11 @@ bool VulkanImplWin32::isAvailable(bool requireGraphics)
 
             uint32_t extensionCount = 0;
 
-            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, nullptr);
+            wrapper.vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
 
             extensionProperties.resize(extensionCount);
 
-            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, extensionProperties.data());
+            wrapper.vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, extensionProperties.data());
 
             // Check if the necessary extensions are available
             bool has_VK_KHR_surface = false;
@@ -173,7 +173,7 @@ bool VulkanImplWin32::isAvailable(bool requireGraphics)
 VulkanFunctionPointer VulkanImplWin32::getFunction(const char* name)
 {
     if (!isAvailable(false))
-        return 0;
+        return nullptr;
 
     return reinterpret_cast<VulkanFunctionPointer>(GetProcAddress(wrapper.library, name));
 }

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -211,7 +211,7 @@ GlFunctionPointer WglContext::getFunction(const char* name)
     if (module)
         return reinterpret_cast<GlFunctionPointer>(GetProcAddress(module, reinterpret_cast<LPCSTR>(name)));
 
-    return 0;
+    return nullptr;
 }
 
 

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -113,7 +113,7 @@ namespace
 
         if (user32Dll)
         {
-            using SetProcessDPIAwareFuncType = BOOL (*)();
+            using SetProcessDPIAwareFuncType = BOOL (WINAPI *)();
             auto SetProcessDPIAwareFunc = reinterpret_cast<SetProcessDPIAwareFuncType>(reinterpret_cast<void*>(GetProcAddress(user32Dll, "SetProcessDPIAware")));
 
             if (SetProcessDPIAwareFunc)
@@ -474,8 +474,8 @@ void WindowImplWin32::registerWindowClass()
     windowClass.cbWndExtra    = 0;
     windowClass.hInstance     = GetModuleHandleW(nullptr);
     windowClass.hIcon         = nullptr;
-    windowClass.hCursor       = 0;
-    windowClass.hbrBackground = 0;
+    windowClass.hCursor       = nullptr;
+    windowClass.hbrBackground = nullptr;
     windowClass.lpszMenuName  = nullptr;
     windowClass.lpszClassName = className;
     RegisterClassW(&windowClass);

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -308,7 +308,7 @@ bool WindowBase::hasFocus() const
 ////////////////////////////////////////////////////////////
 WindowHandle WindowBase::getSystemHandle() const
 {
-    return m_impl ? m_impl->getSystemHandle() : 0;
+    return m_impl ? m_impl->getSystemHandle() : WindowHandle{};
 }
 
 

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -104,8 +104,8 @@ m_joystickThreshold(0.1f)
     }
 
     // Get the initial sensor states
-    for (unsigned int i = 0; i < Sensor::Count; ++i)
-        m_sensorValue[i] = Vector3f(0, 0, 0);
+    for (sf::Vector3f& vec : m_sensorValue)
+        vec = Vector3f(0, 0, 0);
 }
 
 


### PR DESCRIPTION
## Description

This PR introduces various mixed modernization changes, mostly automated with `clang-tidy`. I used the following checks: 
```bash
run-clang-tidy -header-filter='.*' -checks="-*,modernize-use-bool-literals,modernize-shrink-to-fit, \
modernize-avoid-bind,modernize-deprecated-headers,modernize-loop-convert,\
modernize-raw-string-literal,modernize-redundant-void-arg,modernize-use-bool-literals,\
modernize-use-default,modernize-use-emplace,modernize-use-nullptr" -fix
```

I then manually went through every change and:
- Ensured nothing was broken. For example, `clang-tidy` uses `nullptr` as much as possible, but APIs like Vulkan do not guarantee that handles are always pointers (they can also be int64), so I reverted those to `0`.
- Rename things to make more sense. `clang-tidy` gives bogus names when converting a normal loop to a range-based one. 

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.