### PR TITLE
Replace 'BoolType' with 'explicit operator bool'

### DIFF
--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -46,9 +46,6 @@ class UdpSocket;
 ////////////////////////////////////////////////////////////
 class SFML_NETWORK_API Packet
 {
-    // A bool-like type that cannot be converted to integer or pointer types
-    using BoolType = bool (Packet::*)(std::size_t);
-
 public:
 
     ////////////////////////////////////////////////////////////
@@ -181,7 +178,7 @@ public:
     /// \see endOfPacket
     ///
     ////////////////////////////////////////////////////////////
-    operator BoolType() const;
+    explicit operator bool() const;
 
     ////////////////////////////////////////////////////////////
     /// Overload of operator >> to read data from the packet

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -101,9 +101,9 @@ bool Packet::endOfPacket() const
 
 
 ////////////////////////////////////////////////////////////
-Packet::operator BoolType() const
+Packet::operator bool() const
 {
-    return m_isValid ? &Packet::checkSize : nullptr;
+    return m_isValid;
 }
 
 


### PR DESCRIPTION
## Description

Replace the obsolete "safe bool idiom" with `explicit operator bool`, which safely does the same thing in C++11. See https://www.ibm.com/docs/en/zos/2.2.0?topic=only-explicit-conversion-operators-c11 for some examples.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.