### PR TITLE
Mark some non-'void' 'const'-qualified member functions as '[[nodiscard]]'

### DIFF
--- a/examples/shader/Effect.hpp
+++ b/examples/shader/Effect.hpp
@@ -25,7 +25,7 @@ public:
         s_font = &font;
     }
 
-    const std::string& getName() const
+    [[nodiscard]] const std::string& getName() const
     {
         return m_name;
     }

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -106,7 +106,7 @@ public:
     /// \return Number of samples
     ///
     ////////////////////////////////////////////////////////////
-    Uint64 getSampleCount() const;
+    [[nodiscard]] Uint64 getSampleCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of channels used by the sound
@@ -114,7 +114,7 @@ public:
     /// \return Number of channels (1 = mono, 2 = stereo)
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getChannelCount() const;
+    [[nodiscard]] unsigned int getChannelCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the sample rate of the sound
@@ -122,7 +122,7 @@ public:
     /// \return Sample rate, in samples per second
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getSampleRate() const;
+    [[nodiscard]] unsigned int getSampleRate() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total duration of the sound file
@@ -133,7 +133,7 @@ public:
     /// \return Duration of the sound file
     ///
     ////////////////////////////////////////////////////////////
-    Time getDuration() const;
+    [[nodiscard]] Time getDuration() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the read offset of the file in time
@@ -141,7 +141,7 @@ public:
     /// \return Time position
     ///
     ////////////////////////////////////////////////////////////
-    Time getTimeOffset() const;
+    [[nodiscard]] Time getTimeOffset() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the read offset of the file in samples
@@ -149,7 +149,7 @@ public:
     /// \return Sample position
     ///
     ////////////////////////////////////////////////////////////
-    Uint64 getSampleOffset() const;
+    [[nodiscard]] Uint64 getSampleOffset() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -161,7 +161,7 @@ public:
     /// \return Sound buffer attached to the sound (can be a null pointer)
     ///
     ////////////////////////////////////////////////////////////
-    const SoundBuffer* getBuffer() const;
+    [[nodiscard]] const SoundBuffer* getBuffer() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether or not the sound is in loop mode
@@ -171,7 +171,7 @@ public:
     /// \see setLoop
     ///
     ////////////////////////////////////////////////////////////
-    bool getLoop() const;
+    [[nodiscard]] bool getLoop() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current playing position of the sound
@@ -181,7 +181,7 @@ public:
     /// \see setPlayingOffset
     ///
     ////////////////////////////////////////////////////////////
-    Time getPlayingOffset() const;
+    [[nodiscard]] Time getPlayingOffset() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current status of the sound (stopped, paused, playing)
@@ -189,7 +189,7 @@ public:
     /// \return Current status of the sound
     ///
     ////////////////////////////////////////////////////////////
-    Status getStatus() const;
+    [[nodiscard]] Status getStatus() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator

--- a/include/SFML/Audio/SoundRecorder.hpp
+++ b/include/SFML/Audio/SoundRecorder.hpp
@@ -94,7 +94,7 @@ public:
     /// \return Sample rate, in samples per second
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getSampleRate() const;
+    [[nodiscard]] unsigned int getSampleRate() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a list of the names of all available audio capture devices
@@ -142,7 +142,7 @@ public:
     /// \return The name of the current audio capture device
     ///
     ////////////////////////////////////////////////////////////
-    const std::string& getDevice() const;
+    [[nodiscard]] const std::string& getDevice() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the channel count of the audio capture device
@@ -170,7 +170,7 @@ public:
     /// \see setChannelCount
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getChannelCount() const;
+    [[nodiscard]] unsigned int getChannelCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if the system supports audio capture

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -187,7 +187,7 @@ public:
     /// \see setPitch
     ///
     ////////////////////////////////////////////////////////////
-    float getPitch() const;
+    [[nodiscard]] float getPitch() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the volume of the sound
@@ -197,7 +197,7 @@ public:
     /// \see setVolume
     ///
     ////////////////////////////////////////////////////////////
-    float getVolume() const;
+    [[nodiscard]] float getVolume() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the 3D position of the sound in the audio scene
@@ -207,7 +207,7 @@ public:
     /// \see setPosition
     ///
     ////////////////////////////////////////////////////////////
-    Vector3f getPosition() const;
+    [[nodiscard]] Vector3f getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether the sound's position is relative to the
@@ -218,7 +218,7 @@ public:
     /// \see setRelativeToListener
     ///
     ////////////////////////////////////////////////////////////
-    bool isRelativeToListener() const;
+    [[nodiscard]] bool isRelativeToListener() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the minimum distance of the sound
@@ -228,7 +228,7 @@ public:
     /// \see setMinDistance, getAttenuation
     ///
     ////////////////////////////////////////////////////////////
-    float getMinDistance() const;
+    [[nodiscard]] float getMinDistance() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the attenuation factor of the sound
@@ -238,7 +238,7 @@ public:
     /// \see setAttenuation, getMinDistance
     ///
     ////////////////////////////////////////////////////////////
-    float getAttenuation() const;
+    [[nodiscard]] float getAttenuation() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
@@ -291,7 +291,7 @@ public:
     /// \return Current status of the sound
     ///
     ////////////////////////////////////////////////////////////
-    virtual Status getStatus() const;
+    [[nodiscard]] virtual Status getStatus() const;
 
 protected:
 

--- a/include/SFML/Graphics/Color.hpp
+++ b/include/SFML/Graphics/Color.hpp
@@ -75,7 +75,7 @@ public:
     /// \return Color represented as a 32-bit unsigned integer
     ///
     ////////////////////////////////////////////////////////////
-    Uint32 toInteger() const;
+    [[nodiscard]] Uint32 toInteger() const;
 
     ////////////////////////////////////////////////////////////
     // Static member data

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -153,7 +153,7 @@ public:
     /// \see create, loadFromFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    bool saveToFile(const std::string& filename) const;
+    [[nodiscard]] bool saveToFile(const std::string& filename) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the image to a buffer in memory
@@ -179,7 +179,7 @@ public:
     /// \return Size of the image, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const;
+    [[nodiscard]] Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a transparency mask from a specified color-key
@@ -247,7 +247,7 @@ public:
     /// \see setPixel
     ///
     ////////////////////////////////////////////////////////////
-    Color getPixel(unsigned int x, unsigned int y) const;
+    [[nodiscard]] Color getPixel(unsigned int x, unsigned int y) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only pointer to the array of pixels
@@ -262,7 +262,7 @@ public:
     /// \return Read-only pointer to the array of pixels
     ///
     ////////////////////////////////////////////////////////////
-    const Uint8* getPixelsPtr() const;
+    [[nodiscard]] const Uint8* getPixelsPtr() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Flip the image horizontally (left <-> right)

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -106,7 +106,7 @@ public:
     /// \see intersects
     ///
     ////////////////////////////////////////////////////////////
-    bool contains(T x, T y) const;
+    [[nodiscard]] bool contains(T x, T y) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if a point is inside the rectangle's area
@@ -121,7 +121,7 @@ public:
     /// \see intersects
     ///
     ////////////////////////////////////////////////////////////
-    bool contains(const Vector2<T>& point) const;
+    [[nodiscard]] bool contains(const Vector2<T>& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check the intersection between two rectangles
@@ -133,7 +133,7 @@ public:
     /// \see contains
     ///
     ////////////////////////////////////////////////////////////
-    bool intersects(const Rect<T>& rectangle) const;
+    [[nodiscard]] bool intersects(const Rect<T>& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check the intersection between two rectangles
@@ -159,7 +159,7 @@ public:
     /// \see getSize
     ///
     ////////////////////////////////////////////////////////////
-    sf::Vector2<T> getPosition() const;
+    [[nodiscard]] sf::Vector2<T> getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the rectangle
@@ -169,7 +169,7 @@ public:
     /// \see getPosition
     ///
     ////////////////////////////////////////////////////////////
-    sf::Vector2<T> getSize() const;
+    [[nodiscard]] sf::Vector2<T> getSize() const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -84,7 +84,7 @@ public:
     /// \return Pointer to a 4x4 matrix
     ///
     ////////////////////////////////////////////////////////////
-    const float* getMatrix() const;
+    [[nodiscard]] const float* getMatrix() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the inverse of the transform
@@ -95,7 +95,7 @@ public:
     /// \return A new transform which is the inverse of self
     ///
     ////////////////////////////////////////////////////////////
-    Transform getInverse() const;
+    [[nodiscard]] Transform getInverse() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Transform a 2D point
@@ -112,7 +112,7 @@ public:
     /// \return Transformed point
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f transformPoint(float x, float y) const;
+    [[nodiscard]] Vector2f transformPoint(float x, float y) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Transform a 2D point
@@ -128,7 +128,7 @@ public:
     /// \return Transformed point
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f transformPoint(const Vector2f& point) const;
+    [[nodiscard]] Vector2f transformPoint(const Vector2f& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Transform a rectangle
@@ -144,7 +144,7 @@ public:
     /// \return Transformed rectangle
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect transformRect(const FloatRect& rectangle) const;
+    [[nodiscard]] FloatRect transformRect(const FloatRect& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with another one

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -69,7 +69,7 @@ public:
     /// \return Number of vertices in the array
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getVertexCount() const;
+    [[nodiscard]] std::size_t getVertexCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-write access to a vertex by its index
@@ -158,7 +158,7 @@ public:
     /// \return Primitive type
     ///
     ////////////////////////////////////////////////////////////
-    PrimitiveType getPrimitiveType() const;
+    [[nodiscard]] PrimitiveType getPrimitiveType() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Compute the bounding rectangle of the vertex array
@@ -169,7 +169,7 @@ public:
     /// \return Bounding rectangle of the vertex array
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getBounds() const;
+    [[nodiscard]] FloatRect getBounds() const;
 
 private:
 

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -142,7 +142,7 @@ public:
     /// \return Number of vertices in the vertex buffer
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getVertexCount() const;
+    [[nodiscard]] std::size_t getVertexCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the whole buffer from an array of vertices
@@ -235,7 +235,7 @@ public:
     /// \return OpenGL handle of the vertex buffer or 0 if not yet created
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getNativeHandle() const;
+    [[nodiscard]] unsigned int getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the type of primitives to draw
@@ -256,7 +256,7 @@ public:
     /// \return Primitive type
     ///
     ////////////////////////////////////////////////////////////
-    PrimitiveType getPrimitiveType() const;
+    [[nodiscard]] PrimitiveType getPrimitiveType() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the usage specifier of this vertex buffer
@@ -281,7 +281,7 @@ public:
     /// \return Usage specifier
     ///
     ////////////////////////////////////////////////////////////
-    Usage getUsage() const;
+    [[nodiscard]] Usage getUsage() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind a vertex buffer for rendering

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -154,7 +154,7 @@ public:
         /// \return True if the status is a success, false if it is a failure
         ///
         ////////////////////////////////////////////////////////////
-        bool isOk() const;
+        [[nodiscard]] bool isOk() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the status code of the response
@@ -162,7 +162,7 @@ public:
         /// \return Status code
         ///
         ////////////////////////////////////////////////////////////
-        Status getStatus() const;
+        [[nodiscard]] Status getStatus() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the full message contained in the response
@@ -170,7 +170,7 @@ public:
         /// \return The response message
         ///
         ////////////////////////////////////////////////////////////
-        const std::string& getMessage() const;
+        [[nodiscard]] const std::string& getMessage() const;
 
     private:
 
@@ -203,7 +203,7 @@ public:
         /// \return Directory name
         ///
         ////////////////////////////////////////////////////////////
-        const std::string& getDirectory() const;
+        [[nodiscard]] const std::string& getDirectory() const;
 
     private:
 
@@ -237,7 +237,7 @@ public:
         /// \return Array containing the requested listing
         ///
         ////////////////////////////////////////////////////////////
-        const std::vector<std::string>& getListing() const;
+        [[nodiscard]] const std::vector<std::string>& getListing() const;
 
     private:
 

--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -156,7 +156,7 @@ public:
         /// \return String containing the request, ready to be sent
         ///
         ////////////////////////////////////////////////////////////
-        std::string prepare() const;
+        [[nodiscard]] std::string prepare() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Check if the request defines a field
@@ -168,7 +168,7 @@ public:
         /// \return True if the field exists, false otherwise
         ///
         ////////////////////////////////////////////////////////////
-        bool hasField(const std::string& field) const;
+        [[nodiscard]] bool hasField(const std::string& field) const;
 
         ////////////////////////////////////////////////////////////
         // Types
@@ -254,7 +254,7 @@ public:
         /// \return Value of the field, or empty string if not found
         ///
         ////////////////////////////////////////////////////////////
-        const std::string& getField(const std::string& field) const;
+        [[nodiscard]] const std::string& getField(const std::string& field) const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the response status code
@@ -267,7 +267,7 @@ public:
         /// \return Status code of the response
         ///
         ////////////////////////////////////////////////////////////
-        Status getStatus() const;
+        [[nodiscard]] Status getStatus() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the major HTTP version number of the response
@@ -277,7 +277,7 @@ public:
         /// \see getMinorHttpVersion
         ///
         ////////////////////////////////////////////////////////////
-        unsigned int getMajorHttpVersion() const;
+        [[nodiscard]] unsigned int getMajorHttpVersion() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the minor HTTP version number of the response
@@ -287,7 +287,7 @@ public:
         /// \see getMajorHttpVersion
         ///
         ////////////////////////////////////////////////////////////
-        unsigned int getMinorHttpVersion() const;
+        [[nodiscard]] unsigned int getMinorHttpVersion() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the body of the response
@@ -301,7 +301,7 @@ public:
         /// \return The response body
         ///
         ////////////////////////////////////////////////////////////
-        const std::string& getBody() const;
+        [[nodiscard]] const std::string& getBody() const;
 
     private:
 

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -120,7 +120,7 @@ public:
     /// \see toInteger
     ///
     ////////////////////////////////////////////////////////////
-    std::string toString() const;
+    [[nodiscard]] std::string toString() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get an integer representation of the address
@@ -136,7 +136,7 @@ public:
     /// \see toString
     ///
     ////////////////////////////////////////////////////////////
-    Uint32 toInteger() const;
+    [[nodiscard]] Uint32 toInteger() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the computer's local address

--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -87,7 +87,7 @@ public:
     /// \see append
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getReadPosition() const;
+    [[nodiscard]] std::size_t getReadPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear the packet
@@ -112,7 +112,7 @@ public:
     /// \see getDataSize
     ///
     ////////////////////////////////////////////////////////////
-    const void* getData() const;
+    [[nodiscard]] const void* getData() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the data contained in the packet
@@ -125,7 +125,7 @@ public:
     /// \see getData
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getDataSize() const;
+    [[nodiscard]] std::size_t getDataSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell if the reading position has reached the
@@ -139,7 +139,7 @@ public:
     /// \see operator bool
     ///
     ////////////////////////////////////////////////////////////
-    bool endOfPacket() const;
+    [[nodiscard]] bool endOfPacket() const;
 
 public:
 

--- a/include/SFML/Network/Socket.hpp
+++ b/include/SFML/Network/Socket.hpp
@@ -103,7 +103,7 @@ public:
     /// \see setBlocking
     ///
     ////////////////////////////////////////////////////////////
-    bool isBlocking() const;
+    [[nodiscard]] bool isBlocking() const;
 
 protected:
 
@@ -137,7 +137,7 @@ protected:
     /// \return The internal (OS-specific) handle of the socket
     ///
     ////////////////////////////////////////////////////////////
-    SocketHandle getHandle() const;
+    [[nodiscard]] SocketHandle getHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the internal representation of the socket

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -62,7 +62,7 @@ public:
     /// \see listen
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getLocalPort() const;
+    [[nodiscard]] unsigned short getLocalPort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Start listening for incoming connection attempts

--- a/include/SFML/Network/TcpSocket.hpp
+++ b/include/SFML/Network/TcpSocket.hpp
@@ -63,7 +63,7 @@ public:
     /// \see connect, getRemotePort
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getLocalPort() const;
+    [[nodiscard]] unsigned short getLocalPort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the address of the connected peer
@@ -76,7 +76,7 @@ public:
     /// \see getRemotePort
     ///
     ////////////////////////////////////////////////////////////
-    IpAddress getRemoteAddress() const;
+    [[nodiscard]] IpAddress getRemoteAddress() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the port of the connected peer to which
@@ -89,7 +89,7 @@ public:
     /// \see getRemoteAddress
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getRemotePort() const;
+    [[nodiscard]] unsigned short getRemotePort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Connect the socket to a remote peer

--- a/include/SFML/Network/UdpSocket.hpp
+++ b/include/SFML/Network/UdpSocket.hpp
@@ -71,7 +71,7 @@ public:
     /// \see bind
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getLocalPort() const;
+    [[nodiscard]] unsigned short getLocalPort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind the socket to a specific port

--- a/include/SFML/System/Clock.hpp
+++ b/include/SFML/System/Clock.hpp
@@ -60,7 +60,7 @@ public:
     /// \return Time elapsed
     ///
     ////////////////////////////////////////////////////////////
-    Time getElapsedTime() const;
+    [[nodiscard]] Time getElapsedTime() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Restart the clock

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -250,7 +250,7 @@ public:
     /// \see toWideString, operator std::string
     ///
     ////////////////////////////////////////////////////////////
-    std::string toAnsiString(const std::locale& locale = std::locale()) const;
+    [[nodiscard]] std::string toAnsiString(const std::locale& locale = std::locale()) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a wide string
@@ -263,7 +263,7 @@ public:
     /// \see toAnsiString, operator std::wstring
     ///
     ////////////////////////////////////////////////////////////
-    std::wstring toWideString() const;
+    [[nodiscard]] std::wstring toWideString() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-8 string
@@ -273,7 +273,7 @@ public:
     /// \see toUtf16, toUtf32
     ///
     ////////////////////////////////////////////////////////////
-    std::basic_string<Uint8> toUtf8() const;
+    [[nodiscard]] std::basic_string<Uint8> toUtf8() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-16 string
@@ -283,7 +283,7 @@ public:
     /// \see toUtf8, toUtf32
     ///
     ////////////////////////////////////////////////////////////
-    std::basic_string<Uint16> toUtf16() const;
+    [[nodiscard]] std::basic_string<Uint16> toUtf16() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-32 string
@@ -296,7 +296,7 @@ public:
     /// \see toUtf8, toUtf16
     ///
     ////////////////////////////////////////////////////////////
-    std::basic_string<Uint32> toUtf32() const;
+    [[nodiscard]] std::basic_string<Uint32> toUtf32() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
@@ -362,7 +362,7 @@ public:
     /// \see isEmpty
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getSize() const;
+    [[nodiscard]] std::size_t getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the string is empty or not
@@ -372,7 +372,7 @@ public:
     /// \see clear, getSize
     ///
     ////////////////////////////////////////////////////////////
-    bool isEmpty() const;
+    [[nodiscard]] bool isEmpty() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Erase one or more characters from the string
@@ -410,7 +410,7 @@ public:
     /// \return Position of \a str in the string, or String::InvalidPos if not found
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t find(const String& str, std::size_t start = 0) const;
+    [[nodiscard]] std::size_t find(const String& str, std::size_t start = 0) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Replace a substring with another string
@@ -453,7 +453,7 @@ public:
     /// \return String object containing a substring of this object
     ///
     ////////////////////////////////////////////////////////////
-    String substring(std::size_t position, std::size_t length = InvalidPos) const;
+    [[nodiscard]] String substring(std::size_t position, std::size_t length = InvalidPos) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a pointer to the C-style array of characters
@@ -466,7 +466,7 @@ public:
     /// \return Read-only pointer to the array of characters
     ///
     ////////////////////////////////////////////////////////////
-    const Uint32* getData() const;
+    [[nodiscard]] const Uint32* getData() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return an iterator to the beginning of the string
@@ -486,7 +486,7 @@ public:
     /// \see end
     ///
     ////////////////////////////////////////////////////////////
-    ConstIterator begin() const;
+    [[nodiscard]] ConstIterator begin() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return an iterator to the end of the string
@@ -514,7 +514,7 @@ public:
     /// \see begin
     ///
     ////////////////////////////////////////////////////////////
-    ConstIterator end() const;
+    [[nodiscard]] ConstIterator end() const;
 
 private:
 

--- a/include/SFML/System/ThreadLocal.hpp
+++ b/include/SFML/System/ThreadLocal.hpp
@@ -76,7 +76,7 @@ public:
     /// \return Value of the variable for the current thread
     ///
     ////////////////////////////////////////////////////////////
-    void* getValue() const;
+    [[nodiscard]] void* getValue() const;
 
 private:
 

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -57,7 +57,7 @@ public:
     /// \see asMilliseconds, asMicroseconds
     ///
     ////////////////////////////////////////////////////////////
-    float asSeconds() const;
+    [[nodiscard]] float asSeconds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the time value as a number of milliseconds
@@ -67,7 +67,7 @@ public:
     /// \see asSeconds, asMicroseconds
     ///
     ////////////////////////////////////////////////////////////
-    Int32 asMilliseconds() const;
+    [[nodiscard]] Int32 asMilliseconds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the time value as a number of microseconds
@@ -77,7 +77,7 @@ public:
     /// \see asSeconds, asMilliseconds
     ///
     ////////////////////////////////////////////////////////////
-    Int64 asMicroseconds() const;
+    [[nodiscard]] Int64 asMicroseconds() const;
 
     ////////////////////////////////////////////////////////////
     // Static member data

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -87,7 +87,7 @@ public:
     /// \return Structure containing the settings
     ///
     ////////////////////////////////////////////////////////////
-    const ContextSettings& getSettings() const;
+    [[nodiscard]] const ContextSettings& getSettings() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check whether a given OpenGL extension is available

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -191,7 +191,7 @@ private:
     /// \return a reference to the OS-specific implementation
     ///
     ////////////////////////////////////////////////////////////
-    const priv::CursorImpl& getImpl() const;
+    [[nodiscard]] const priv::CursorImpl& getImpl() const;
 
 private:
 

--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -94,7 +94,7 @@ public:
     /// \return True if the video mode is valid for fullscreen mode
     ///
     ////////////////////////////////////////////////////////////
-    bool isValid() const;
+    [[nodiscard]] bool isValid() const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -189,7 +189,7 @@ public:
     /// \return Structure containing the OpenGL context settings
     ///
     ////////////////////////////////////////////////////////////
-    const ContextSettings& getSettings() const;
+    [[nodiscard]] const ContextSettings& getSettings() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable vertical synchronization

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -142,7 +142,7 @@ public:
     /// \return True if the window is open, false if it has been closed
     ///
     ////////////////////////////////////////////////////////////
-    bool isOpen() const;
+    [[nodiscard]] bool isOpen() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Pop the event on top of the event queue, if any, and return it
@@ -204,7 +204,7 @@ public:
     /// \see setPosition
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const;
+    [[nodiscard]] Vector2i getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -231,7 +231,7 @@ public:
     /// \see setSize
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const;
+    [[nodiscard]] Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -378,7 +378,7 @@ public:
     /// \see requestFocus
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const;
+    [[nodiscard]] bool hasFocus() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the OS-specific handle of the window
@@ -392,7 +392,7 @@ public:
     /// \return System handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getSystemHandle() const;
+    [[nodiscard]] WindowHandle getSystemHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a Vulkan rendering surface

--- a/src/SFML/Graphics/RenderTextureImpl.hpp
+++ b/src/SFML/Graphics/RenderTextureImpl.hpp
@@ -84,7 +84,7 @@ public:
     /// \return True if the render-texture use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool isSrgb() const = 0;
+    [[nodiscard]] virtual bool isSrgb() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -100,7 +100,7 @@ private:
     /// \return True if the render-texture use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool isSrgb() const;
+    [[nodiscard]] virtual bool isSrgb() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture

--- a/src/SFML/System/Unix/ThreadLocalImpl.hpp
+++ b/src/SFML/System/Unix/ThreadLocalImpl.hpp
@@ -69,7 +69,7 @@ public:
     /// \return Value of the variable for this thread
     ///
     ////////////////////////////////////////////////////////////
-    void* getValue() const;
+    [[nodiscard]] void* getValue() const;
 
 private:
 

--- a/src/SFML/System/Win32/ThreadLocalImpl.hpp
+++ b/src/SFML/System/Win32/ThreadLocalImpl.hpp
@@ -69,7 +69,7 @@ public:
     /// \return Value of the variable for this thread
     ///
     ////////////////////////////////////////////////////////////
-    void* getValue() const;
+    [[nodiscard]] void* getValue() const;
 
 private:
 

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -192,7 +192,7 @@ public:
     /// \return Structure containing the settings
     ///
     ////////////////////////////////////////////////////////////
-    const ContextSettings& getSettings() const;
+    [[nodiscard]] const ContextSettings& getSettings() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the context as the current target for rendering

--- a/src/SFML/Window/JoystickManager.hpp
+++ b/src/SFML/Window/JoystickManager.hpp
@@ -61,7 +61,7 @@ public:
     /// \return Capabilities of the joystick
     ///
     ////////////////////////////////////////////////////////////
-    const JoystickCaps& getCapabilities(unsigned int joystick) const;
+    [[nodiscard]] const JoystickCaps& getCapabilities(unsigned int joystick) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current state of an open joystick
@@ -71,7 +71,7 @@ public:
     /// \return Current state of the joystick
     ///
     ////////////////////////////////////////////////////////////
-    const JoystickState& getState(unsigned int joystick) const;
+    [[nodiscard]] const JoystickState& getState(unsigned int joystick) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the identification for an open joystick
@@ -81,7 +81,7 @@ public:
     /// \return Identification for the joystick
     ///
     ////////////////////////////////////////////////////////////
-    const Joystick::Identification& getIdentification(unsigned int joystick) const;
+    [[nodiscard]] const Joystick::Identification& getIdentification(unsigned int joystick) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the state of all the joysticks

--- a/src/SFML/Window/SensorManager.hpp
+++ b/src/SFML/Window/SensorManager.hpp
@@ -80,7 +80,7 @@ public:
     /// \return True if the sensor is enabled, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool isEnabled(Sensor::Type sensor) const;
+    [[nodiscard]] bool isEnabled(Sensor::Type sensor) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current value of a sensor
@@ -90,7 +90,7 @@ public:
     /// \return Current value of the sensor
     ///
     ////////////////////////////////////////////////////////////
-    Vector3f getValue(Sensor::Type sensor) const;
+    [[nodiscard]] Vector3f getValue(Sensor::Type sensor) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the state of all the sensors

--- a/src/SFML/Window/Unix/JoystickImpl.hpp
+++ b/src/SFML/Window/Unix/JoystickImpl.hpp
@@ -94,7 +94,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -102,7 +102,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -80,7 +80,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    virtual WindowHandle getSystemHandle() const;
+    [[nodiscard]] virtual WindowHandle getSystemHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -88,7 +88,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2i getPosition() const;
+    [[nodiscard]] virtual Vector2i getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -104,7 +104,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2u getSize() const;
+    [[nodiscard]] virtual Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -185,7 +185,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool hasFocus() const;
+    [[nodiscard]] virtual bool hasFocus() const;
 
 protected:
 

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -114,7 +114,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -122,7 +122,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
@@ -182,7 +182,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilitiesDInput() const;
+    [[nodiscard]] JoystickCaps getCapabilitiesDInput() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state (DInput, Buffered)

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -77,7 +77,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    virtual WindowHandle getSystemHandle() const;
+    [[nodiscard]] virtual WindowHandle getSystemHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -85,7 +85,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2i getPosition() const;
+    [[nodiscard]] virtual Vector2i getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -101,7 +101,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2u getSize() const;
+    [[nodiscard]] virtual Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -182,7 +182,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool hasFocus() const;
+    [[nodiscard]] virtual bool hasFocus() const;
 
 protected:
 

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -120,7 +120,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    virtual WindowHandle getSystemHandle() const = 0;
+    [[nodiscard]] virtual WindowHandle getSystemHandle() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -128,7 +128,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2i getPosition() const = 0;
+    [[nodiscard]] virtual Vector2i getPosition() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -144,7 +144,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2u getSize() const = 0;
+    [[nodiscard]] virtual Vector2u getSize() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -225,7 +225,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool hasFocus() const = 0;
+    [[nodiscard]] virtual bool hasFocus() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a Vulkan rendering surface


### PR DESCRIPTION
## Description

Automatic run of `clang-tidy`'s `modernize-use-nodiscard` check with minor manual adjustments. This check is very conservative and marks only "obvious" `const`-qualified member functions that return something. There are more places where we could use `[[nodiscard]]`, but we can get there with multiple PRs. In other words, this is a very low-risk one to merge.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.