### PR TITLE
Remove deprecated 'PrimitiveType::Quads'

### DIFF
--- a/include/SFML/Graphics/Drawable.hpp
+++ b/include/SFML/Graphics/Drawable.hpp
@@ -110,7 +110,7 @@ protected:
 ///         target.draw(m_vertices, states);
 ///
 ///         // ... or draw with OpenGL directly
-///         glBegin(GL_QUADS);
+///         glBegin(GL_TRIANGLES);
 ///         ...
 ///         glEnd();
 ///     }

--- a/include/SFML/Graphics/PrimitiveType.hpp
+++ b/include/SFML/Graphics/PrimitiveType.hpp
@@ -43,8 +43,7 @@ enum PrimitiveType
     LineStrip,     //!< List of connected lines, a point uses the previous point to form a line
     Triangles,     //!< List of individual triangles
     TriangleStrip, //!< List of connected triangles, a point uses the two previous points to form a triangle
-    TriangleFan,   //!< List of connected triangles, a point uses the common center and the previous point to form a triangle
-    Quads          //!< List of individual quads (deprecated, don't work with OpenGL ES)
+    TriangleFan    //!< List of connected triangles, a point uses the common center and the previous point to form a triangle
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -255,7 +255,7 @@ private:
 ///     window.popGLStates();
 ///
 ///     // Draw a 3D object using OpenGL
-///     glBegin(GL_QUADS);
+///     glBegin(GL_TRIANGLES);
 ///         glVertex3f(...);
 ///         ...
 ///     glEnd();

--- a/include/SFML/Graphics/Vertex.hpp
+++ b/include/SFML/Graphics/Vertex.hpp
@@ -115,7 +115,7 @@ public:
 ///
 /// The vertex is the building block of drawing. Everything which
 /// is visible on screen is made of vertices. They are grouped
-/// as 2D primitives (triangles, quads, ...), and these primitives
+/// as 2D primitives (lines, triangles, ...), and these primitives
 /// are grouped to create even more complex 2D entities such as
 /// sprites, texts, etc.
 ///
@@ -132,11 +132,13 @@ public:
 ///     sf::Vertex(sf::Vector2f(  0,   0), sf::Color::Red, sf::Vector2f( 0,  0)),
 ///     sf::Vertex(sf::Vector2f(  0, 100), sf::Color::Red, sf::Vector2f( 0, 10)),
 ///     sf::Vertex(sf::Vector2f(100, 100), sf::Color::Red, sf::Vector2f(10, 10)),
+///     sf::Vertex(sf::Vector2f(  0,   0), sf::Color::Red, sf::Vector2f( 0,  0)),
+///     sf::Vertex(sf::Vector2f(100, 100), sf::Color::Red, sf::Vector2f(10, 10)),
 ///     sf::Vertex(sf::Vector2f(100,   0), sf::Color::Red, sf::Vector2f(10,  0))
 /// };
 ///
 /// // draw it
-/// window.draw(vertices, 4, sf::Quads);
+/// window.draw(vertices, 6, sf::Triangles);
 /// \endcode
 ///
 /// Note: although texture coordinates are supposed to be an integer

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -144,7 +144,6 @@ public:
     /// \li As points
     /// \li As lines
     /// \li As triangles
-    /// \li As quads
     /// The default primitive type is sf::Points.
     ///
     /// \param type Type of primitive

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -42,14 +42,6 @@
 #include <unordered_map>
 
 
-// GL_QUADS is unavailable on OpenGL ES, thus we need to define GL_QUADS ourselves
-#ifndef GL_QUADS
-
-    #define GL_QUADS 0
-
-#endif // GL_QUADS
-
-
 namespace
 {
     // A nested named namespace is used here to allow unity builds of SFML.
@@ -277,15 +269,6 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount,
     if (!vertices || (vertexCount == 0))
         return;
 
-    // GL_QUADS is unavailable on OpenGL ES
-    #ifdef SFML_OPENGL_ES
-        if (type == Quads)
-        {
-            err() << "sf::Quads primitive type is not supported on OpenGL ES platforms, drawing skipped" << std::endl;
-            return;
-        }
-    #endif
-
     if (RenderTargetImpl::isActive(m_id) || setActive(true))
     {
         // Check if the vertex count is low enough so that we can pre-transform them
@@ -376,15 +359,6 @@ void RenderTarget::draw(const VertexBuffer& vertexBuffer, std::size_t firstVerte
     // Nothing to draw?
     if (!vertexCount || !vertexBuffer.getNativeHandle())
         return;
-
-    // GL_QUADS is unavailable on OpenGL ES
-    #ifdef SFML_OPENGL_ES
-        if (vertexBuffer.getPrimitiveType() == Quads)
-        {
-            err() << "sf::Quads primitive type is not supported on OpenGL ES platforms, drawing skipped" << std::endl;
-            return;
-        }
-    #endif
 
     if (RenderTargetImpl::isActive(m_id) || setActive(true))
     {
@@ -758,7 +732,7 @@ void RenderTarget::drawPrimitives(PrimitiveType type, std::size_t firstVertex, s
 {
     // Find the OpenGL primitive type
     static const GLenum modes[] = {GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_TRIANGLES,
-                                   GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN, GL_QUADS};
+                                   GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN};
     GLenum mode = modes[type];
 
     // Draw the primitives


### PR DESCRIPTION
## Description

This PR removes the deprecated `sf::PrimitiveType::Quads` enumerator and updates some usages and documentation. It is a breaking change IMHO very appropriate for SFML 3.x.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.