### PR TITLE
Strategic use of '[[nodiscard]]' in 'Audio' module

### DIFF
--- a/examples/sound_capture/SoundCapture.cpp
+++ b/examples/sound_capture/SoundCapture.cpp
@@ -4,6 +4,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio.hpp>
 #include <iostream>
+#include <cstdlib>
 
 
 ////////////////////////////////////////////////////////////
@@ -35,7 +36,12 @@ int main()
     sf::SoundBufferRecorder recorder;
 
     // Audio capture is done in a separate thread, so we can block the main thread while it is capturing
-    recorder.start(sampleRate);
+    if (!recorder.start(sampleRate))
+    {
+        std::cerr << "Failed to start recorder" << std::endl;
+        return EXIT_FAILURE;
+    }
+
     std::cout << "Recording... press enter to stop";
     std::cin.ignore(10000, '\n');
     recorder.stop();
@@ -63,7 +69,8 @@ int main()
         std::getline(std::cin, filename);
 
         // Save the buffer
-        buffer.saveToFile(filename);
+        if (!buffer.saveToFile(filename))
+            std::cerr << "Could not save sound buffer to file" << std::endl;
     }
     else
     {

--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -138,7 +138,12 @@ void doClient(unsigned short port)
     std::cin.ignore(10000, '\n');
 
     // Start capturing audio data
-    recorder.start(44100);
+    if (!recorder.start(44100))
+    {
+        std::cerr << "Failed to start recorder" << std::endl;
+        return;
+    }
+
     std::cout << "Recording... press enter to stop";
     std::cin.ignore(10000, '\n');
     recorder.stop();

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -76,7 +76,7 @@ public:
     /// \return True if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    bool openFromFile(const std::string& filename);
+    [[nodiscard]] bool openFromFile(const std::string& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a sound file in memory for reading
@@ -90,7 +90,7 @@ public:
     /// \return True if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    bool openFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] bool openFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a sound file from a custom stream for reading
@@ -103,7 +103,7 @@ public:
     /// \return True if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    bool openFromStream(InputStream& stream);
+    [[nodiscard]] bool openFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total number of audio samples in the file
@@ -198,7 +198,7 @@ public:
     /// \return Number of samples actually read (may be less than \a maxCount)
     ///
     ////////////////////////////////////////////////////////////
-    Uint64 read(Int16* samples, Uint64 maxCount);
+    [[nodiscard]] Uint64 read(Int16* samples, Uint64 maxCount);
 
     ////////////////////////////////////////////////////////////
     /// \brief Close the current file

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -116,7 +116,7 @@ public:
     /// \see openFromMemory, openFromStream
     ///
     ////////////////////////////////////////////////////////////
-    bool openFromFile(const std::string& filename);
+    [[nodiscard]] bool openFromFile(const std::string& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a music from an audio file in memory
@@ -139,7 +139,7 @@ public:
     /// \see openFromFile, openFromStream
     ///
     ////////////////////////////////////////////////////////////
-    bool openFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] bool openFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a music from an audio file in a custom stream
@@ -160,7 +160,7 @@ public:
     /// \see openFromFile, openFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    bool openFromStream(InputStream& stream);
+    [[nodiscard]] bool openFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total duration of the music
@@ -222,7 +222,7 @@ protected:
     /// \return True to continue playback, false to stop
     ///
     ////////////////////////////////////////////////////////////
-    bool onGetData(Chunk& data) override;
+    [[nodiscard]] bool onGetData(Chunk& data) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current playing position in the stream source

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -71,7 +71,7 @@ public:
     /// \return True if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    bool openFromFile(const std::string& filename, unsigned int sampleRate, unsigned int channelCount);
+    [[nodiscard]] bool openFromFile(const std::string& filename, unsigned int sampleRate, unsigned int channelCount);
 
     ////////////////////////////////////////////////////////////
     /// \brief Write audio samples to the file

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -252,7 +252,10 @@ private:
 /// Usage example:
 /// \code
 /// sf::SoundBuffer buffer;
-/// buffer.loadFromFile("sound.wav");
+/// if (!buffer.loadFromFile("sound.wav"))
+/// {
+///     // Handle error...
+/// }
 ///
 /// sf::Sound sound;
 /// sound.setBuffer(buffer);

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -83,7 +83,7 @@ public:
     /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    bool loadFromFile(const std::string& filename);
+    [[nodiscard]] bool loadFromFile(const std::string& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from a file in memory
@@ -99,7 +99,7 @@ public:
     /// \see loadFromFile, loadFromStream, loadFromSamples
     ///
     ////////////////////////////////////////////////////////////
-    bool loadFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from a custom stream
@@ -114,7 +114,7 @@ public:
     /// \see loadFromFile, loadFromMemory, loadFromSamples
     ///
     ////////////////////////////////////////////////////////////
-    bool loadFromStream(InputStream& stream);
+    [[nodiscard]] bool loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from an array of audio samples
@@ -132,7 +132,7 @@ public:
     /// \see loadFromFile, loadFromMemory, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    bool loadFromSamples(const Int16* samples, Uint64 sampleCount, unsigned int channelCount, unsigned int sampleRate);
+    [[nodiscard]] bool loadFromSamples(const Int16* samples, Uint64 sampleCount, unsigned int channelCount, unsigned int sampleRate);
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the sound buffer to an audio file
@@ -147,7 +147,7 @@ public:
     /// \see loadFromFile, loadFromMemory, loadFromSamples
     ///
     ////////////////////////////////////////////////////////////
-    bool saveToFile(const std::string& filename) const;
+    [[nodiscard]] bool saveToFile(const std::string& filename) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the array of audio samples stored in the buffer
@@ -235,7 +235,7 @@ private:
     /// \return True on successful initialization, false on failure
     ///
     ////////////////////////////////////////////////////////////
-    bool initialize(InputSoundFile& file);
+    [[nodiscard]] bool initialize(InputSoundFile& file);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the internal buffer with the cached audio samples
@@ -246,7 +246,7 @@ private:
     /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    bool update(unsigned int channelCount, unsigned int sampleRate);
+    [[nodiscard]] bool update(unsigned int channelCount, unsigned int sampleRate);
 
     ////////////////////////////////////////////////////////////
     /// \brief Add a sound to the list of sounds that use this buffer

--- a/include/SFML/Audio/SoundBufferRecorder.hpp
+++ b/include/SFML/Audio/SoundBufferRecorder.hpp
@@ -72,7 +72,7 @@ protected:
     /// \return True to start the capture, or false to abort it
     ///
     ////////////////////////////////////////////////////////////
-    bool onStart() override;
+    [[nodiscard]] bool onStart() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Process a new chunk of recorded samples
@@ -83,7 +83,7 @@ protected:
     /// \return True to continue the capture, or false to stop it
     ///
     ////////////////////////////////////////////////////////////
-    bool onProcessSamples(const Int16* samples, std::size_t sampleCount) override;
+    [[nodiscard]] bool onProcessSamples(const Int16* samples, std::size_t sampleCount) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop capturing audio data
@@ -127,7 +127,10 @@ private:
 /// {
 ///     // Record some audio data
 ///     sf::SoundBufferRecorder recorder;
-///     recorder.start();
+///     if (!recorder.start())
+///     {
+///         // Handle error...
+///     }
 ///     ...
 ///     recorder.stop();
 ///
@@ -135,7 +138,10 @@ private:
 ///     const sf::SoundBuffer& buffer = recorder.getBuffer();
 ///
 ///     // Save it to a file (for example...)
-///     buffer.saveToFile("my_record.ogg");
+///     if (!buffer.saveToFile("my_record.ogg"))
+///     {
+///         // Handle error...
+///     }
 /// }
 /// \endcode
 ///

--- a/include/SFML/Audio/SoundFileReader.hpp
+++ b/include/SFML/Audio/SoundFileReader.hpp
@@ -73,7 +73,7 @@ public:
     /// \return True if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool open(InputStream& stream, Info& info) = 0;
+    [[nodiscard]] virtual bool open(InputStream& stream, Info& info) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset
@@ -99,7 +99,7 @@ public:
     /// \return Number of samples actually read (may be less than \a maxCount)
     ///
     ////////////////////////////////////////////////////////////
-    virtual Uint64 read(Int16* samples, Uint64 maxCount) = 0;
+    [[nodiscard]] virtual Uint64 read(Int16* samples, Uint64 maxCount) = 0;
 };
 
 } // namespace sf

--- a/include/SFML/Audio/SoundFileWriter.hpp
+++ b/include/SFML/Audio/SoundFileWriter.hpp
@@ -58,7 +58,7 @@ public:
     /// \return True if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool open(const std::string& filename, unsigned int sampleRate, unsigned int channelCount) = 0;
+    [[nodiscard]] virtual bool open(const std::string& filename, unsigned int sampleRate, unsigned int channelCount) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Write audio samples to the open file

--- a/include/SFML/Audio/SoundRecorder.hpp
+++ b/include/SFML/Audio/SoundRecorder.hpp
@@ -74,7 +74,7 @@ public:
     /// \see stop, getAvailableDevices
     ///
     ////////////////////////////////////////////////////////////
-    bool start(unsigned int sampleRate = 44100);
+    [[nodiscard]] bool start(unsigned int sampleRate = 44100);
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop the capture
@@ -134,7 +134,7 @@ public:
     /// \see getAvailableDevices, getDefaultDevice
     ///
     ////////////////////////////////////////////////////////////
-    bool setDevice(const std::string& name);
+    [[nodiscard]] bool setDevice(const std::string& name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the name of the current audio capture device
@@ -240,7 +240,7 @@ protected:
     /// \return True to continue the capture, or false to stop it
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool onProcessSamples(const Int16* samples, std::size_t sampleCount) = 0;
+    [[nodiscard]] virtual bool onProcessSamples(const Int16* samples, std::size_t sampleCount) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop capturing audio data
@@ -392,7 +392,7 @@ private:
 ///         return true;
 ///     }
 ///
-///     bool onProcessSamples(const Int16* samples, std::size_t sampleCount) override
+///     [[nodiscard]] bool onProcessSamples(const Int16* samples, std::size_t sampleCount) override
 ///     {
 ///         // Do something with the new chunk of samples (store them, send them, ...)
 ///         ...

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -226,7 +226,7 @@ protected:
     /// \return True to continue playback, false to stop
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool onGetData(Chunk& data) = 0;
+    [[nodiscard]] virtual bool onGetData(Chunk& data) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current playing position in the stream source
@@ -290,7 +290,7 @@ private:
     /// \return True if the stream source has requested to stop, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool fillAndPushBuffer(unsigned int bufferNum, bool immediateLoop = false);
+    [[nodiscard]] bool fillAndPushBuffer(unsigned int bufferNum, bool immediateLoop = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Fill the audio buffers and put them all into the playing queue
@@ -301,7 +301,7 @@ private:
     /// \return True if the derived class has requested to stop, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool fillQueue();
+    [[nodiscard]] bool fillQueue();
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear all the audio buffers and empty the playing queue

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -58,7 +58,8 @@ m_sounds  () // don't copy the attached sounds
     alCheck(alGenBuffers(1, &m_buffer));
 
     // Update the internal buffer with the new samples
-    update(copy.getChannelCount(), copy.getSampleRate());
+    if (!update(copy.getChannelCount(), copy.getSampleRate()))
+        err() << "Failed to update copy-constructed sound buffer" << std::endl;
 }
 
 

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/SoundBufferRecorder.hpp>
+#include <SFML/System/Err.hpp>
 #include <algorithm>
 #include <iterator>
 
@@ -62,8 +63,11 @@ bool SoundBufferRecorder::onProcessSamples(const Int16* samples, std::size_t sam
 ////////////////////////////////////////////////////////////
 void SoundBufferRecorder::onStop()
 {
-    if (!m_samples.empty())
-        m_buffer.loadFromSamples(m_samples.data(), m_samples.size(), getChannelCount(), getSampleRate());
+    if (m_samples.empty())
+        return;
+
+    if (!m_buffer.loadFromSamples(m_samples.data(), m_samples.size(), getChannelCount(), getSampleRate()))
+        err() << "Failed to stop capturing audio data" << std::endl;
 }
 
 


### PR DESCRIPTION
## Description

A more targeted approach to `[[nodiscard]]` compared to #1883. This has been done completely manually, applying the attribute to functions where is either not obvious that the return value is significant or where it would be a bug to forget to handle it.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.