### PR TITLE
Strategic use of '[[nodiscard]]' in 'Network' module

### DIFF
--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -87,7 +87,11 @@ private:
         // Send a "end-of-stream" packet
         sf::Packet packet;
         packet << clientEndOfStream;
-        m_socket.send(packet);
+
+        if (!m_socket.send(packet))
+        {
+            std::cerr << "Failed to send end-of-stream packet" << std::endl;
+        }
 
         // Close the socket
         m_socket.disconnect();

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -278,7 +278,7 @@ public:
     /// \see disconnect
     ///
     ////////////////////////////////////////////////////////////
-    Response connect(const IpAddress& server, unsigned short port = 21, Time timeout = Time::Zero);
+    [[nodiscard]] Response connect(const IpAddress& server, unsigned short port = 21, Time timeout = Time::Zero);
 
     ////////////////////////////////////////////////////////////
     /// \brief Close the connection with the server
@@ -288,7 +288,7 @@ public:
     /// \see connect
     ///
     ////////////////////////////////////////////////////////////
-    Response disconnect();
+    [[nodiscard]] Response disconnect();
 
     ////////////////////////////////////////////////////////////
     /// \brief Log in using an anonymous account
@@ -299,7 +299,7 @@ public:
     /// \return Server response to the request
     ///
     ////////////////////////////////////////////////////////////
-    Response login();
+    [[nodiscard]] Response login();
 
     ////////////////////////////////////////////////////////////
     /// \brief Log in using a username and a password
@@ -313,7 +313,7 @@ public:
     /// \return Server response to the request
     ///
     ////////////////////////////////////////////////////////////
-    Response login(const std::string& name, const std::string& password);
+    [[nodiscard]] Response login(const std::string& name, const std::string& password);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a null command to keep the connection alive
@@ -324,7 +324,7 @@ public:
     /// \return Server response to the request
     ///
     ////////////////////////////////////////////////////////////
-    Response keepAlive();
+    [[nodiscard]] Response keepAlive();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current working directory
@@ -337,7 +337,7 @@ public:
     /// \see getDirectoryListing, changeDirectory, parentDirectory
     ///
     ////////////////////////////////////////////////////////////
-    DirectoryResponse getWorkingDirectory();
+    [[nodiscard]] DirectoryResponse getWorkingDirectory();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the contents of the given directory
@@ -354,7 +354,7 @@ public:
     /// \see getWorkingDirectory, changeDirectory, parentDirectory
     ///
     ////////////////////////////////////////////////////////////
-    ListingResponse getDirectoryListing(const std::string& directory = "");
+    [[nodiscard]] ListingResponse getDirectoryListing(const std::string& directory = "");
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current working directory
@@ -368,7 +368,7 @@ public:
     /// \see getWorkingDirectory, getDirectoryListing, parentDirectory
     ///
     ////////////////////////////////////////////////////////////
-    Response changeDirectory(const std::string& directory);
+    [[nodiscard]] Response changeDirectory(const std::string& directory);
 
     ////////////////////////////////////////////////////////////
     /// \brief Go to the parent directory of the current one
@@ -378,7 +378,7 @@ public:
     /// \see getWorkingDirectory, getDirectoryListing, changeDirectory
     ///
     ////////////////////////////////////////////////////////////
-    Response parentDirectory();
+    [[nodiscard]] Response parentDirectory();
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new directory
@@ -393,7 +393,7 @@ public:
     /// \see deleteDirectory
     ///
     ////////////////////////////////////////////////////////////
-    Response createDirectory(const std::string& name);
+    [[nodiscard]] Response createDirectory(const std::string& name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Remove an existing directory
@@ -410,7 +410,7 @@ public:
     /// \see createDirectory
     ///
     ////////////////////////////////////////////////////////////
-    Response deleteDirectory(const std::string& name);
+    [[nodiscard]] Response deleteDirectory(const std::string& name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Rename an existing file
@@ -426,7 +426,7 @@ public:
     /// \see deleteFile
     ///
     ////////////////////////////////////////////////////////////
-    Response renameFile(const std::string& file, const std::string& newName);
+    [[nodiscard]] Response renameFile(const std::string& file, const std::string& newName);
 
     ////////////////////////////////////////////////////////////
     /// \brief Remove an existing file
@@ -443,7 +443,7 @@ public:
     /// \see renameFile
     ///
     ////////////////////////////////////////////////////////////
-    Response deleteFile(const std::string& name);
+    [[nodiscard]] Response deleteFile(const std::string& name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Download a file from the server
@@ -465,7 +465,7 @@ public:
     /// \see upload
     ///
     ////////////////////////////////////////////////////////////
-    Response download(const std::string& remoteFile, const std::string& localPath, TransferMode mode = Binary);
+    [[nodiscard]] Response download(const std::string& remoteFile, const std::string& localPath, TransferMode mode = Binary);
 
     ////////////////////////////////////////////////////////////
     /// \brief Upload a file to the server
@@ -488,7 +488,7 @@ public:
     /// \see download
     ///
     ////////////////////////////////////////////////////////////
-    Response upload(const std::string& localFile, const std::string& remotePath, TransferMode mode = Binary, bool append = false);
+    [[nodiscard]] Response upload(const std::string& localFile, const std::string& remotePath, TransferMode mode = Binary, bool append = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a command to the FTP server
@@ -506,7 +506,7 @@ public:
     /// \return Server response to the request
     ///
     ////////////////////////////////////////////////////////////
-    Response sendCommand(const std::string& command, const std::string& parameter = "");
+    [[nodiscard]] Response sendCommand(const std::string& command, const std::string& parameter = "");
 
 private:
 

--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -156,7 +156,7 @@ public:
         /// \return String containing the request, ready to be sent
         ///
         ////////////////////////////////////////////////////////////
-        std::string prepare() const;
+        [[nodiscard]] std::string prepare() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Check if the request defines a field
@@ -402,7 +402,7 @@ public:
     /// \return Server's response
     ///
     ////////////////////////////////////////////////////////////
-    Response sendRequest(const Request& request, Time timeout = Time::Zero);
+    [[nodiscard]] Response sendRequest(const Request& request, Time timeout = Time::Zero);
 
 private:
 

--- a/include/SFML/Network/SocketSelector.hpp
+++ b/include/SFML/Network/SocketSelector.hpp
@@ -120,7 +120,7 @@ public:
     /// \see isReady
     ///
     ////////////////////////////////////////////////////////////
-    bool wait(Time timeout = Time::Zero);
+    [[nodiscard]] bool wait(Time timeout = Time::Zero);
 
     ////////////////////////////////////////////////////////////
     /// \brief Test a socket to know if it is ready to receive data

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -86,7 +86,7 @@ public:
     /// \see accept, close
     ///
     ////////////////////////////////////////////////////////////
-    Status listen(unsigned short port, const IpAddress& address = IpAddress::Any);
+    [[nodiscard]] Status listen(unsigned short port, const IpAddress& address = IpAddress::Any);
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop listening and close the socket
@@ -112,7 +112,7 @@ public:
     /// \see listen
     ///
     ////////////////////////////////////////////////////////////
-    Status accept(TcpSocket& socket);
+    [[nodiscard]] Status accept(TcpSocket& socket);
 };
 
 

--- a/include/SFML/Network/TcpSocket.hpp
+++ b/include/SFML/Network/TcpSocket.hpp
@@ -109,7 +109,7 @@ public:
     /// \see disconnect
     ///
     ////////////////////////////////////////////////////////////
-    Status connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout = Time::Zero);
+    [[nodiscard]] Status connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout = Time::Zero);
 
     ////////////////////////////////////////////////////////////
     /// \brief Disconnect the socket from its remote peer
@@ -138,7 +138,7 @@ public:
     /// \see receive
     ///
     ////////////////////////////////////////////////////////////
-    Status send(const void* data, std::size_t size);
+    [[nodiscard]] Status send(const void* data, std::size_t size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send raw data to the remote peer
@@ -154,7 +154,7 @@ public:
     /// \see receive
     ///
     ////////////////////////////////////////////////////////////
-    Status send(const void* data, std::size_t size, std::size_t& sent);
+    [[nodiscard]] Status send(const void* data, std::size_t size, std::size_t& sent);
 
     ////////////////////////////////////////////////////////////
     /// \brief Receive raw data from the remote peer
@@ -172,7 +172,7 @@ public:
     /// \see send
     ///
     ////////////////////////////////////////////////////////////
-    Status receive(void* data, std::size_t size, std::size_t& received);
+    [[nodiscard]] Status receive(void* data, std::size_t size, std::size_t& received);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a formatted packet of data to the remote peer
@@ -190,7 +190,7 @@ public:
     /// \see receive
     ///
     ////////////////////////////////////////////////////////////
-    Status send(Packet& packet);
+    [[nodiscard]] Status send(Packet& packet);
 
     ////////////////////////////////////////////////////////////
     /// \brief Receive a formatted packet of data from the remote peer
@@ -206,7 +206,7 @@ public:
     /// \see send
     ///
     ////////////////////////////////////////////////////////////
-    Status receive(Packet& packet);
+    [[nodiscard]] Status receive(Packet& packet);
 
 private:
 

--- a/include/SFML/Network/UdpSocket.hpp
+++ b/include/SFML/Network/UdpSocket.hpp
@@ -96,7 +96,7 @@ public:
     /// \see unbind, getLocalPort
     ///
     ////////////////////////////////////////////////////////////
-    Status bind(unsigned short port, const IpAddress& address = IpAddress::Any);
+    [[nodiscard]] Status bind(unsigned short port, const IpAddress& address = IpAddress::Any);
 
     ////////////////////////////////////////////////////////////
     /// \brief Unbind the socket from the local port to which it is bound
@@ -129,7 +129,7 @@ public:
     /// \see receive
     ///
     ////////////////////////////////////////////////////////////
-    Status send(const void* data, std::size_t size, const IpAddress& remoteAddress, unsigned short remotePort);
+    [[nodiscard]] Status send(const void* data, std::size_t size, const IpAddress& remoteAddress, unsigned short remotePort);
 
     ////////////////////////////////////////////////////////////
     /// \brief Receive raw data from a remote peer
@@ -152,7 +152,7 @@ public:
     /// \see send
     ///
     ////////////////////////////////////////////////////////////
-    Status receive(void* data, std::size_t size, std::size_t& received, IpAddress& remoteAddress, unsigned short& remotePort);
+    [[nodiscard]] Status receive(void* data, std::size_t size, std::size_t& received, IpAddress& remoteAddress, unsigned short& remotePort);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a formatted packet of data to a remote peer
@@ -170,7 +170,7 @@ public:
     /// \see receive
     ///
     ////////////////////////////////////////////////////////////
-    Status send(Packet& packet, const IpAddress& remoteAddress, unsigned short remotePort);
+    [[nodiscard]] Status send(Packet& packet, const IpAddress& remoteAddress, unsigned short remotePort);
 
     ////////////////////////////////////////////////////////////
     /// \brief Receive a formatted packet of data from a remote peer
@@ -187,7 +187,7 @@ public:
     /// \see send
     ///
     ////////////////////////////////////////////////////////////
-    Status receive(Packet& packet, IpAddress& remoteAddress, unsigned short& remotePort);
+    [[nodiscard]] Status receive(Packet& packet, IpAddress& remoteAddress, unsigned short& remotePort);
 
 private:
 

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -143,7 +143,7 @@ const std::vector<std::string>& Ftp::ListingResponse::getListing() const
 ////////////////////////////////////////////////////////////
 Ftp::~Ftp()
 {
-    disconnect();
+    (void) disconnect();
 }
 
 


### PR DESCRIPTION
## Description

A more targeted approach to `[[nodiscard]]` compared to #1883. This has been done completely manually, applying the attribute to functions where is either not obvious that the return value is significant or where it would be a bug to forget to handle it.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.