### PR TITLE
Strategic use of '[[nodiscard]]' in 'System' module

### DIFF
--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -75,7 +75,7 @@ public:
     /// \return True on success, false on error
     ///
     ////////////////////////////////////////////////////////////
-    bool open(const std::string& filename);
+    [[nodiscard]] bool open(const std::string& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Read data from the stream
@@ -89,7 +89,7 @@ public:
     /// \return The number of bytes actually read, or -1 on error
     ///
     ////////////////////////////////////////////////////////////
-    Int64 read(void* data, Int64 size) override;
+    [[nodiscard]] Int64 read(void* data, Int64 size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current reading position
@@ -99,7 +99,7 @@ public:
     /// \return The position actually sought to, or -1 on error
     ///
     ////////////////////////////////////////////////////////////
-    Int64 seek(Int64 position) override;
+    [[nodiscard]] Int64 seek(Int64 position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current reading position in the stream
@@ -107,7 +107,7 @@ public:
     /// \return The current position, or -1 on error.
     ///
     ////////////////////////////////////////////////////////////
-    Int64 tell() override;
+    [[nodiscard]] Int64 tell() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the stream

--- a/include/SFML/System/InputStream.hpp
+++ b/include/SFML/System/InputStream.hpp
@@ -60,7 +60,7 @@ public:
     /// \return The number of bytes actually read, or -1 on error
     ///
     ////////////////////////////////////////////////////////////
-    virtual Int64 read(void* data, Int64 size) = 0;
+    [[nodiscard]] virtual Int64 read(void* data, Int64 size) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current reading position
@@ -70,7 +70,7 @@ public:
     /// \return The position actually sought to, or -1 on error
     ///
     ////////////////////////////////////////////////////////////
-    virtual Int64 seek(Int64 position) = 0;
+    [[nodiscard]] virtual Int64 seek(Int64 position) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current reading position in the stream
@@ -78,7 +78,7 @@ public:
     /// \return The current position, or -1 on error.
     ///
     ////////////////////////////////////////////////////////////
-    virtual Int64 tell() = 0;
+    [[nodiscard]] virtual Int64 tell() = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the stream
@@ -117,15 +117,15 @@ public:
 /// {
 /// public:
 ///
-///     ZipStream(std::string archive);
+///     ZipStream(const std::string& archive);
 ///
-///     bool open(std::string filename);
+///     [[nodiscard]] bool open(const std::string& filename);
 ///
-///     Int64 read(void* data, Int64 size);
+///     [[nodiscard]] Int64 read(void* data, Int64 size);
 ///
-///     Int64 seek(Int64 position);
+///     [[nodiscard]] Int64 seek(Int64 position);
 ///
-///     Int64 tell();
+///     [[nodiscard]] Int64 tell();
 ///
 ///     Int64 getSize();
 ///
@@ -137,14 +137,30 @@ public:
 /// // now you can load textures...
 /// sf::Texture texture;
 /// ZipStream stream("resources.zip");
-/// stream.open("images/img.png");
-/// texture.loadFromStream(stream);
+///
+/// if (!stream.open("images/img.png"))
+/// {
+///     // Handle error...
+/// }
+///
+/// if (!texture.loadFromStream(stream))
+/// {
+///     // Handle error...
+/// }
 ///
 /// // musics...
 /// sf::Music music;
 /// ZipStream stream("resources.zip");
-/// stream.open("musics/msc.ogg");
-/// music.openFromStream(stream);
+///
+/// if (!stream.open("musics/msc.ogg"))
+/// {
+///     // Handle error...
+/// }
+///
+/// if (!music.openFromStream(stream))
+/// {
+///     // Handle error...
+/// }
 ///
 /// // etc.
 /// \endcode

--- a/include/SFML/System/MemoryInputStream.hpp
+++ b/include/SFML/System/MemoryInputStream.hpp
@@ -71,7 +71,7 @@ public:
     /// \return The number of bytes actually read, or -1 on error
     ///
     ////////////////////////////////////////////////////////////
-    Int64 read(void* data, Int64 size) override;
+    [[nodiscard]] Int64 read(void* data, Int64 size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current reading position
@@ -81,7 +81,7 @@ public:
     /// \return The position actually sought to, or -1 on error
     ///
     ////////////////////////////////////////////////////////////
-    Int64 seek(Int64 position) override;
+    [[nodiscard]] Int64 seek(Int64 position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current reading position in the stream
@@ -89,7 +89,7 @@ public:
     /// \return The current position, or -1 on error.
     ///
     ////////////////////////////////////////////////////////////
-    Int64 tell() override;
+    [[nodiscard]] Int64 tell() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the stream

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -250,7 +250,7 @@ public:
     /// \see toWideString, operator std::string
     ///
     ////////////////////////////////////////////////////////////
-    std::string toAnsiString(const std::locale& locale = std::locale()) const;
+    [[nodiscard]] std::string toAnsiString(const std::locale& locale = std::locale()) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a wide string
@@ -263,7 +263,7 @@ public:
     /// \see toAnsiString, operator std::wstring
     ///
     ////////////////////////////////////////////////////////////
-    std::wstring toWideString() const;
+    [[nodiscard]] std::wstring toWideString() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-8 string
@@ -410,7 +410,7 @@ public:
     /// \return Position of \a str in the string, or String::InvalidPos if not found
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t find(const String& str, std::size_t start = 0) const;
+    [[nodiscard]] std::size_t find(const String& str, std::size_t start = 0) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Replace a substring with another string
@@ -453,7 +453,7 @@ public:
     /// \return String object containing a substring of this object
     ///
     ////////////////////////////////////////////////////////////
-    String substring(std::size_t position, std::size_t length = InvalidPos) const;
+    [[nodiscard]] String substring(std::size_t position, std::size_t length = InvalidPos) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a pointer to the C-style array of characters

--- a/src/SFML/Audio/SoundFileFactory.cpp
+++ b/src/SFML/Audio/SoundFileFactory.cpp
@@ -80,7 +80,12 @@ SoundFileReader* SoundFileFactory::createReaderFromFilename(const std::string& f
     // Test the filename in all the registered factories
     for (const ReaderFactory& readerFactory : s_readers)
     {
-        stream.seek(0);
+        if (stream.seek(0) == -1)
+        {
+            err() << "Failed to seek sound stream" << std::endl;
+            return nullptr;
+        }
+
         if (readerFactory.check(stream))
             return readerFactory.create();
     }
@@ -104,7 +109,12 @@ SoundFileReader* SoundFileFactory::createReaderFromMemory(const void* data, std:
     // Test the stream for all the registered factories
     for (const ReaderFactory& readerFactory : s_readers)
     {
-        stream.seek(0);
+        if (stream.seek(0) == -1)
+        {
+            err() << "Failed to seek sound stream" << std::endl;
+            return nullptr;
+        }
+
         if (readerFactory.check(stream))
             return readerFactory.create();
     }
@@ -124,7 +134,12 @@ SoundFileReader* SoundFileFactory::createReaderFromStream(InputStream& stream)
     // Test the stream for all the registered factories
     for (const ReaderFactory& readerFactory : s_readers)
     {
-        stream.seek(0);
+        if (stream.seek(0) == -1)
+        {
+            err() << "Failed to seek sound stream" << std::endl;
+            return nullptr;
+        }
+
         if (readerFactory.check(stream))
             return readerFactory.create();
     }

--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -145,7 +145,8 @@ void SoundFileReaderWav::seek(Uint64 sampleOffset)
 {
     assert(m_stream);
 
-    m_stream->seek(static_cast<Int64>(m_dataStart + sampleOffset * m_bytesPerSample));
+    if (m_stream->seek(static_cast<Int64>(m_dataStart + sampleOffset * m_bytesPerSample) == -1))
+        err() << "Failed to seek WAV sound stream" << std::endl;
 }
 
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -278,7 +278,11 @@ bool Font::loadFromStream(InputStream& stream)
     m_library = library;
 
     // Make sure that the stream's reading position is at the beginning
-    stream.seek(0);
+    if (stream.seek(0) == -1)
+    {
+        err() << "Failed to seek font stream" << std::endl;
+        return false;
+    }
 
     // Prepare a wrapper for our stream, that we'll pass to FreeType callbacks
     auto* rec = new FT_StreamRec;

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -56,7 +56,9 @@ namespace
     void skip(void* user, int size)
     {
         auto* stream = static_cast<sf::InputStream*>(user);
-        stream->seek(stream->tell() + size);
+
+        if (stream->seek(stream->tell() + size) == -1)
+            sf::err() << "Failed to seek image loader input stream" << std::endl;
     }
     int eof(void* user)
     {
@@ -198,7 +200,11 @@ bool ImageLoader::loadImageFromStream(InputStream& stream, std::vector<Uint8>& p
     pixels.clear();
 
     // Make sure that the stream's reading position is at the beginning
-    stream.seek(0);
+    if (stream.seek(0) == -1)
+    {
+        err() << "Failed to seek image stream" << std::endl;
+        return false;
+    }
 
     // Setup the stb_image callbacks
     stbi_io_callbacks callbacks;

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -103,7 +103,13 @@ namespace
         if (size > 0)
         {
             buffer.resize(static_cast<std::size_t>(size));
-            stream.seek(0);
+
+            if (stream.seek(0) == -1)
+            {
+                sf::err() << "Failed to seek shader stream" << std::endl;
+                return false;
+            }
+
             sf::Int64 read = stream.read(buffer.data(), size);
             success = (read == size);
         }

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -133,7 +133,10 @@ Int64 FileInputStream::getSize()
         Int64 position = tell();
         std::fseek(m_file, 0, SEEK_END);
         Int64 size = tell();
-        seek(position);
+
+        if (seek(position) == -1)
+            return -1;
+
         return size;
     }
     else


### PR DESCRIPTION
## Description

A more targeted approach to `[[nodiscard]]` compared to #1883. This has been done completely manually, applying the attribute to functions where is either not obvious that the return value is significant or where it would be a bug to forget to handle it.

I did not touch the threading primitives as they will be removed with #1863.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.