### PR TITLE
Strategic use of '[[nodiscard]]' in 'Window' module

### DIFF
--- a/examples/X11/X11.cpp
+++ b/examples/X11/X11.cpp
@@ -18,10 +18,14 @@
 /// \param Window Target window to initialize
 ///
 ////////////////////////////////////////////////////////////
-void initialize(sf::Window& window)
+[[nodiscard]] bool initialize(sf::Window& window)
 {
     // Activate the window
-    window.setActive();
+    if (!window.setActive())
+    {
+        std::cerr << "Failed to set the window as active" << std::endl;
+        return false;
+    }
 
     // Setup OpenGL states
     // Set color and depth clear value
@@ -53,6 +57,8 @@ void initialize(sf::Window& window)
     // Enable position and texture coordinates vertex components
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_COLOR_ARRAY);
+
+    return true;
 }
 
 ////////////////////////////////////////////////////////////
@@ -63,10 +69,14 @@ void initialize(sf::Window& window)
 /// \param elapsedTime Time elapsed since the last draw
 ///
 ////////////////////////////////////////////////////////////
-void draw(sf::Window& window, float elapsedTime)
+[[nodiscard]] bool draw(sf::Window& window, float elapsedTime)
 {
     // Activate the window
-    window.setActive();
+    if (!window.setActive())
+    {
+        std::cerr << "Failed to set the window as active" << std::endl;
+        return false;
+    }
 
     // Clear color and depth buffers
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -130,6 +140,8 @@ void draw(sf::Window& window, float elapsedTime)
     glVertexPointer(3, GL_FLOAT, 6 * sizeof(GLfloat), cube);
     glColorPointer(3, GL_FLOAT, 6 * sizeof(GLfloat), cube + 3);
     glDrawArrays(GL_TRIANGLES, 0, 36);
+
+    return true;
 }
 
 
@@ -191,7 +203,11 @@ int main()
     sf::Clock clock;
 
     // Load OpenGL or OpenGL ES entry points using glad
-    sfmlView1.setActive();
+    if (!sfmlView1.setActive())
+    {
+        std::cerr << "Failed to set view 1 as active" << std::endl;
+        return EXIT_FAILURE;
+    }
 
 #ifdef SFML_OPENGL_ES
     gladLoadGLES1(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
@@ -200,8 +216,17 @@ int main()
 #endif
 
     // Initialize our views
-    initialize(sfmlView1);
-    initialize(sfmlView2);
+    if (!initialize(sfmlView1))
+    {
+        std::cerr << "Failed to initialize view 1" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    if (!initialize(sfmlView2))
+    {
+        std::cerr << "Failed to initialize view 2" << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Start the event loop
     bool running = true;
@@ -224,8 +249,18 @@ int main()
         }
 
         // Draw something into our views
-        draw(sfmlView1, clock.getElapsedTime().asSeconds());
-        draw(sfmlView2, clock.getElapsedTime().asSeconds() * 0.3f);
+        if (!draw(sfmlView1, clock.getElapsedTime().asSeconds()))
+        {
+            std::cerr << "Failed to draw on view 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        if (!draw(sfmlView2, clock.getElapsedTime().asSeconds() * 0.3f))
+        {
+            std::cerr << "Failed to draw on view 2" << std::endl;
+            return EXIT_FAILURE;
+        }
+
 
         // Display the views on screen
         sfmlView1.display();

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -2,6 +2,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window.hpp>
+#include <cstdlib>
 
 #define GLAD_GL_IMPLEMENTATION
 #include <gl.h>
@@ -9,6 +10,8 @@
 #ifdef SFML_SYSTEM_IOS
 #include <SFML/Main.hpp>
 #endif
+
+#include <iostream>
 
 ////////////////////////////////////////////////////////////
 /// Entry point of application
@@ -26,7 +29,11 @@ int main()
     sf::Window window(sf::VideoMode(640, 480), "SFML window with OpenGL", sf::Style::Default, contextSettings);
 
     // Make it the active window for OpenGL calls
-    window.setActive();
+    if (!window.setActive())
+    {
+        std::cerr << "Failed to set the window as active" << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Load OpenGL or OpenGL ES entry points using glad
 #ifdef SFML_OPENGL_ES

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -75,7 +75,7 @@ public:
     /// \return True on success, false on failure
     ///
     ////////////////////////////////////////////////////////////
-    bool setActive(bool active);
+    [[nodiscard]] bool setActive(bool active);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the settings of the context

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -160,7 +160,7 @@ public:
     ///         false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hotspot);
+    [[nodiscard]] bool loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hotspot);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a native system cursor
@@ -176,7 +176,7 @@ public:
     ///         false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool loadFromSystem(Type type);
+    [[nodiscard]] bool loadFromSystem(Type type);
 
 private:
 

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -239,7 +239,7 @@ public:
     /// \return True if operation was successful, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool setActive(bool active = true) const;
+    [[nodiscard]] bool setActive(bool active = true) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Display on screen what has been rendered to the window so far

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -167,7 +167,7 @@ public:
     /// \see waitEvent
     ///
     ////////////////////////////////////////////////////////////
-    bool pollEvent(Event& event);
+    [[nodiscard]] bool pollEvent(Event& event);
 
     ////////////////////////////////////////////////////////////
     /// \brief Wait for an event and return it
@@ -194,7 +194,7 @@ public:
     /// \see pollEvent
     ///
     ////////////////////////////////////////////////////////////
-    bool waitEvent(Event& event);
+    [[nodiscard]] bool waitEvent(Event& event);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -404,7 +404,7 @@ public:
     /// \return True if surface creation was successful, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool createVulkanSurface(const VkInstance& instance, VkSurfaceKHR& surface, const VkAllocationCallbacks* allocator = nullptr);
+    [[nodiscard]] bool createVulkanSurface(const VkInstance& instance, VkSurfaceKHR& surface, const VkAllocationCallbacks* allocator = nullptr);
 
 protected:
 
@@ -443,7 +443,7 @@ private:
     /// \param event Event to filter
     ///
     ////////////////////////////////////////////////////////////
-    bool filterEvent(const Event& event);
+    [[nodiscard]] bool filterEvent(const Event& event);
 
     ////////////////////////////////////////////////////////////
     /// \brief Perform some common internal initializations

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -524,14 +524,17 @@ bool RenderTextureImplFBO::activate(bool active)
         if (!m_context)
             m_context = new Context;
 
-        m_context->setActive(true);
+        if (!m_context->setActive(true))
+        {
+            err() << "Failed to set context as active during render texture activation" << std::endl;
+            return false;
+        }
 
         contextId = Context::getActiveContextId();
 
         if (!contextId)
         {
             err() << "Impossible to activate render texture (failed to create backup context)" << std::endl;
-
             return false;
         }
     }

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Window/Context.hpp>
 #include <SFML/Window/GlContext.hpp>
 #include <SFML/System/ThreadLocalPtr.hpp>
+#include <SFML/System/Err.hpp>
 
 
 namespace
@@ -44,16 +45,23 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 Context::Context()
+: m_context(priv::GlContext::create())
 {
-    m_context = priv::GlContext::create();
-    setActive(true);
+    if (!setActive(true))
+    {
+        err() << "Failed to set context as active during construction" << std::endl;
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
 Context::~Context()
 {
-    setActive(false);
+    if (!setActive(false))
+    {
+        err() << "Failed to set context as inactive during destruction" << std::endl;
+    }
+
     delete m_context;
 }
 
@@ -113,9 +121,12 @@ GlFunctionPointer Context::getFunction(const char* name)
 
 ////////////////////////////////////////////////////////////
 Context::Context(const ContextSettings& settings, unsigned int width, unsigned int height)
+: m_context(priv::GlContext::create(settings, width, height))
 {
-    m_context = priv::GlContext::create(settings, width, height);
-    setActive(true);
+    if (!setActive(true))
+    {
+        err() << "Failed to set context as active during construction" << std::endl;
+    }
 }
 
 } // namespace sf

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -238,7 +238,10 @@ void Window::initialize()
     m_clock.restart();
 
     // Activate the window
-    setActive();
+    if (!setActive())
+    {
+        err() << "Failed to set window as active during initialization" << std::endl;
+    }
 
     WindowBase::initialize();
 }


### PR DESCRIPTION
## Description

A more targeted approach to `[[nodiscard]]` compared to #1883. This has been done completely manually, applying the attribute to functions where is either not obvious that the return value is significant or where it would be a bug to forget to handle it.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.