### PR TITLE
Add PCH builds via 'SFML_ENABLE_PCH' CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,17 @@ if(SFML_INSTALL_PKGCONFIG_FILES)
     endforeach()
 endif()
 
+# option to enable precompiled headers
+sfml_set_option(SFML_ENABLE_PCH FALSE BOOL "TRUE to enable precompiled headers for SFML builds -- only supported on Windows/Linux and for static library builds")
+
+if(SFML_ENABLE_PCH AND BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "Precompiled headers are currently not supported for shared library builds")
+endif()
+
+if(SFML_ENABLE_PCH AND SFML_OS_MACOSX)
+    message(FATAL_ERROR "Precompiled headers are currently not supported in MacOS builds")
+endif()
+
 # setup the install rules
 if(NOT SFML_BUILD_FRAMEWORKS)
     install(DIRECTORY include

--- a/src/SFML/PCH.hpp
+++ b/src/SFML/PCH.hpp
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SFML_PCH_HPP
+#define SFML_SFML_PCH_HPP
+
+////////////////////////////////////////////////////////////
+// Precompiled Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/Config.hpp>
+
+#ifdef SFML_SYSTEM_WINDOWS
+
+#define UNICODE  1
+#define _UNICODE 1
+#include <SFML/System/Win32/WindowsHeader.hpp>
+
+#endif // SFML_SYSTEM_WINDOWS
+
+#include <SFML/System/Err.hpp>
+#include <SFML/System/String.hpp>
+#include <SFML/System/Time.hpp>
+#include <SFML/System/Vector2.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#endif // SFML_SFML_PCH_HPP

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -67,6 +67,12 @@ endif()
 sfml_add_library(System
                  SOURCES ${SRC} ${PLATFORM_SRC})
 
+# enable precompiled headers
+if (SFML_ENABLE_PCH)
+    message(VERBOSE "enabling PCH for SFML library 'sfml-system' (reused as the PCH for other SFML libraries)")
+    target_precompile_headers(sfml-system PRIVATE ${PROJECT_SOURCE_DIR}/src/SFML/PCH.hpp)
+endif()
+
 if(SFML_OS_ANDROID)
     # glad sources
     target_include_directories(sfml-system PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/glad/include")


### PR DESCRIPTION
## Description

Enable PCH via CMake. Achieves roughly a 2x fresh compilation speedup on my machine, using MSYS2/MinGW. Looking for feedback on the direction and approach.

---

<details>
<summary>Machine Specs</summary>

- GIGABYTE Z390 AORUS MASTER-CF
- i9-9900k (stock settings)
- Corsair CMK16GX4M2B3000C15, 4x8GB sticks (XMP enabled)

</details>

---

<details>
<summary>Benchmark</summary>

Methodology:

```
cd build
rm -Rf src test examples

cmake .. -DCMAKE_BUILD_TYPE=Debug -GNinja -DSFML_BUILD_EXAMPLES=1 \ 
    -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_CXX_COMPILER=clang++ \
    -DCMAKE_CXX_FLAGS="-ftime-trace"

time ninja
```

Results without this PR:
- `ninja  0.00s user 0.01s system 0% cpu 5.599 total`

Results with this PR:
- `ninja  0.00s user 0.01s system 0% cpu 9.586 total`

</details>

---

This PR is related to the issue #1893.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Not sure yet.