### PR TITLE
Reduce compile-time impact of 'windows.h'

### DIFF
--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -3,6 +3,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics.hpp>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <cmath>
 

--- a/include/SFML/OpenGL.hpp
+++ b/include/SFML/OpenGL.hpp
@@ -40,6 +40,9 @@
 
     // The Visual C++ version of gl.h uses WINGDIAPI and APIENTRY but doesn't define them
     #ifdef _MSC_VER
+        #ifndef WIN32_LEAN_AND_MEAN
+            #define WIN32_LEAN_AND_MEAN
+        #endif
         #include <windows.h>
     #endif
 
@@ -67,7 +70,7 @@
 
     #include <GLES/gl.h>
     #include <GLES/glext.h>
-    
+
     // We're not using OpenGL ES 2+ yet, but we can use the sRGB extension
     #include <GLES2/gl2platform.h>
     #include <GLES2/gl2ext.h>

--- a/src/SFML/Network/Win32/SocketImpl.hpp
+++ b/src/SFML/Network/Win32/SocketImpl.hpp
@@ -28,15 +28,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#ifdef _WIN32_WINDOWS
-    #undef _WIN32_WINDOWS
-#endif
-#ifdef _WIN32_WINNT
-    #undef _WIN32_WINNT
-#endif
-#define _WIN32_WINDOWS 0x0501
-#define _WIN32_WINNT   0x0501
 #include <SFML/Network/Socket.hpp>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #include <winsock2.h>
 #include <ws2tcpip.h>
 

--- a/src/SFML/System/Win32/WindowsHeader.hpp
+++ b/src/SFML/System/Win32/WindowsHeader.hpp
@@ -2,7 +2,6 @@
 //
 // SFML - Simple and Fast Multimedia Library
 // Copyright (C) 2007-2021 Laurent Gomila (laurent@sfml-dev.org)
-// Copyright (C) 2013 Jonathan De Wachter (dewachter.jonathan@gmail.com)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.
@@ -23,35 +22,29 @@
 //
 ////////////////////////////////////////////////////////////
 
+#ifndef SFML_WINDOWSHEADER_HPP
+#define SFML_WINDOWSHEADER_HPP
 
-////////////////////////////////////////////////////////////
-// Windows specific: we define the WinMain entry point,
-// so that developers can use the standard main function
-// even in a Win32 Application project, and thus keep a
-// portable code
-////////////////////////////////////////////////////////////
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-#include <SFML/Config.hpp>
+#ifndef _WIN32_WINDOWS
+#define _WIN32_WINDOWS 0x0501
+#endif
 
-#ifdef SFML_SYSTEM_WINDOWS
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501
+#endif
 
-#include <SFML/System/Win32/WindowsHeader.hpp>
-#include <cstdlib> // for `__argc` and `__argv`
+#ifndef WINVER
+#define WINVER 0x0501
+#endif
 
-extern int main(int argc, char* argv[]);
+#include <windows.h>
 
-////////////////////////////////////////////////////////////
-int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
-{
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wpedantic"
-    return main(__argc, __argv);
-    #pragma GCC diagnostic pop
-}
-
-#endif // SFML_SYSTEM_WINDOWS
-
+#endif // SFML_WINDOWSHEADER_HPP

--- a/src/SFML/Window/Win32/ClipboardImpl.cpp
+++ b/src/SFML/Window/Win32/ClipboardImpl.cpp
@@ -26,9 +26,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Win32/ClipboardImpl.hpp>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #include <SFML/System/String.hpp>
 #include <iostream>
-#include <windows.h>
 
 
 namespace sf

--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -26,8 +26,10 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Win32/CursorImpl.hpp>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #include <SFML/System/Err.hpp>
 #include <cstring>
+
 
 namespace sf
 {
@@ -188,7 +190,7 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
 void CursorImpl::release()
 {
     if (m_cursor && !m_systemCursor) {
-        DestroyCursor(m_cursor);
+        DestroyCursor(static_cast<HCURSOR>(m_cursor));
         m_cursor = nullptr;
     }
 }

--- a/src/SFML/Window/Win32/CursorImpl.hpp
+++ b/src/SFML/Window/Win32/CursorImpl.hpp
@@ -32,8 +32,6 @@
 #include <SFML/System/NonCopyable.hpp>
 #include <SFML/System/Vector2.hpp>
 
-#include <windows.h>
-
 namespace sf
 {
 
@@ -92,8 +90,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    HCURSOR m_cursor;
-    bool m_systemCursor;
+    void* m_cursor; // Type erasure via `void*` is used here to avoid depending on `windows.h`
+    bool  m_systemCursor;
 };
 
 } // namespace priv

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -25,17 +25,9 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#ifdef _WIN32_WINDOWS
-    #undef _WIN32_WINDOWS
-#endif
-#ifdef _WIN32_WINNT
-    #undef _WIN32_WINNT
-#endif
-#define _WIN32_WINDOWS 0x0501
-#define _WIN32_WINNT   0x0501
 #include <SFML/Window/Window.hpp>
 #include <SFML/Window/Win32/InputImpl.hpp>
-#include <windows.h>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 
 
 namespace sf

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -26,9 +26,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/JoystickImpl.hpp>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #include <SFML/System/Clock.hpp>
 #include <SFML/System/Err.hpp>
-#include <windows.h>
 #include <tchar.h>
 #include <regstr.h>
 #include <algorithm>

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -28,18 +28,9 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#ifdef _WIN32_WINDOWS
-    #undef _WIN32_WINDOWS
-#endif
-#ifdef _WIN32_WINNT
-    #undef _WIN32_WINNT
-#endif
-#define _WIN32_WINDOWS      0x0501
-#define _WIN32_WINNT        0x0501
-#define DIRECTINPUT_VERSION 0x0800
 #include <SFML/Window/Joystick.hpp>
 #include <SFML/Window/JoystickImpl.hpp>
-#include <windows.h>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #include <mmsystem.h>
 #include <dinput.h>
 

--- a/src/SFML/Window/Win32/VideoModeImpl.cpp
+++ b/src/SFML/Window/Win32/VideoModeImpl.cpp
@@ -26,7 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/VideoModeImpl.hpp>
-#include <windows.h>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #include <algorithm>
 
 

--- a/src/SFML/Window/Win32/VulkanImplWin32.cpp
+++ b/src/SFML/Window/Win32/VulkanImplWin32.cpp
@@ -26,10 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Win32/VulkanImplWin32.hpp>
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #define VK_USE_PLATFORM_WIN32_KHR
 #define VK_NO_PROTOTYPES
 #include <vulkan.h>

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -25,20 +25,9 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#ifdef _WIN32_WINDOWS
-    #undef _WIN32_WINDOWS
-#endif
-#ifdef _WIN32_WINNT
-    #undef _WIN32_WINNT
-#endif
-#ifdef WINVER
-    #undef WINVER
-#endif
-#define _WIN32_WINDOWS 0x0501
-#define _WIN32_WINNT   0x0501
-#define WINVER         0x0501
 #include <SFML/Window/Win32/WindowImplWin32.hpp>
 #include <SFML/Window/WindowStyle.hpp>
+#include <SFML/Window/JoystickImpl.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Utf.hpp>
 // dbt.h is lowercase here, as a cross-compile on linux with mingw-w64
@@ -417,7 +406,7 @@ void WindowImplWin32::setMouseCursorGrabbed(bool grabbed)
 ////////////////////////////////////////////////////////////
 void WindowImplWin32::setMouseCursor(const CursorImpl& cursor)
 {
-    m_lastCursor = cursor.m_cursor;
+    m_lastCursor = static_cast<HCURSOR>(cursor.m_cursor);
     SetCursor(m_cursorVisible ? m_lastCursor : nullptr);
 }
 

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -30,8 +30,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Event.hpp>
 #include <SFML/Window/WindowImpl.hpp>
+#include <SFML/System/Win32/WindowsHeader.hpp>
 #include <SFML/System/String.hpp>
-#include <windows.h>
 
 
 namespace sf

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -35,7 +35,6 @@
 #include <SFML/Window/CursorImpl.hpp>
 #include <SFML/Window/Event.hpp>
 #include <SFML/Window/Joystick.hpp>
-#include <SFML/Window/JoystickImpl.hpp>
 #include <SFML/Window/Sensor.hpp>
 #include <SFML/Window/SensorImpl.hpp>
 #include <SFML/Window/VideoMode.hpp>
@@ -266,6 +265,7 @@ protected:
     virtual void processEvents() = 0;
 
 private:
+    struct JoystickStatesImpl;
 
     ////////////////////////////////////////////////////////////
     /// \brief Read the joysticks state and generate the appropriate events
@@ -282,11 +282,11 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::queue<Event> m_events;                                              //!< Queue of available events
-    JoystickState     m_joystickStates[Joystick::Count];                     //!< Previous state of the joysticks
-    Vector3f          m_sensorValue[Sensor::Count];                          //!< Previous value of the sensors
-    float             m_joystickThreshold;                                   //!< Joystick threshold (minimum motion for "move" event to be generated)
-    float             m_previousAxes[Joystick::Count][Joystick::AxisCount];  //!< Position of each axis last time a move event triggered, in range [-100, 100]
+    std::queue<Event>   m_events;                                              //!< Queue of available events
+    JoystickStatesImpl* m_joystickStatesImpl;                                  //!< Previous state of the joysticks (PImpl)
+    Vector3f            m_sensorValue[Sensor::Count];                          //!< Previous value of the sensors
+    float               m_joystickThreshold;                                   //!< Joystick threshold (minimum motion for "move" event to be generated)
+    float               m_previousAxes[Joystick::Count][Joystick::AxisCount];  //!< Position of each axis last time a move event triggered, in range [-100, 100]
 };
 
 } // namespace priv


### PR DESCRIPTION
## Description

This PR reduces the compile-time impact of `windows.h` by isolating it a bit more (e.g. moving it from a header to a source file) and by extensively using the `WIN32_LEAN_AND_MEAN` preprocessor definition. 

The results are very good: a clean rebuild on MSYS2/MinGW used to spend around ~39s (in total) dealing with `windows.h`. After this PR, a clean rebuild only spends ~25s on the same task. This was measured via [ClangBuildAnalyzer](https://github.com/aras-p/ClangBuildAnalyzer).

This PR is related to the issue #1893.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.