### PR TITLE
Fix calling convention for SetProcessDpiAwareness

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -85,7 +85,7 @@ namespace
                 ProcessPerMonitorDpiAware = 2
             };
 
-            using SetProcessDpiAwarenessFuncType = HRESULT (*)(ProcessDpiAwareness);
+            using SetProcessDpiAwarenessFuncType = HRESULT (WINAPI *)(ProcessDpiAwareness);
             auto SetProcessDpiAwarenessFunc = reinterpret_cast<SetProcessDpiAwarenessFuncType>(reinterpret_cast<void*>(GetProcAddress(shCoreDll, "SetProcessDpiAwareness")));
 
             if (SetProcessDpiAwarenessFunc)


### PR DESCRIPTION
## Description

A few commits ago a `WINAPI` was lost on `SetProcessDpiAwareness` function declaration.
This is incorrect because it changes calling convention from `stdcall` to `cdecl`.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

I was using Windows 10 21H1 build 19043.1348 and Visual Studio 2019 (16.11.7) with Windows SDK 10.0.22000.0 to debug and test this change.

I've manually tested `window` example application on Windows to make sure that the change isn't breaking anything.

There are no visible changes or added features.