### PR TITLE
Remove redundant APIs taking '(x, y)' in favour of ones taking 'sf::Vector'

### DIFF
--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
 
     sf::Sprite image(texture);
-    image.setPosition(screen.width / 2, screen.height / 2);
-    image.setOrigin(texture.getSize().x/2, texture.getSize().y/2);
+    image.setPosition({screen.width / 2.f, screen.height / 2.f});
+    image.setOrigin({texture.getSize().x / 2.f, texture.getSize().y / 2.f});
 
     sf::Font font;
     if (!font.loadFromFile("tuffy.ttf"))
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 
     sf::Text text("Tap anywhere to move the logo.", font, 64);
     text.setFillColor(sf::Color::Black);
-    text.setPosition(10, 10);
+    text.setPosition({10, 10});
 
     sf::View view = window.getDefaultView();
 
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
                     break;
                 case sf::Event::Resized:
                     view.setSize(event.size.width, event.size.height);
-                    view.setCenter(event.size.width/2, event.size.height/2);
+                    view.setCenter({event.size.width / 2.f, event.size.height / 2.f});
                     window.setView(view);
                     break;
                 case sf::Event::LostFocus:
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
                 case sf::Event::TouchBegan:
                     if (event.touch.finger == 0)
                     {
-                        image.setPosition(event.touch.x, event.touch.y);
+                        image.setPosition({static_cast<float>(event.touch.x), static_cast<float>(event.touch.y)});
 #if defined(USE_JNI)
                         vibrate(sf::milliseconds(10));
 #endif

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -48,7 +48,7 @@ struct SFMLmainWindow
         sf::FloatRect rect = sprite.getLocalBounds();
         sf::Vector2f size(rect.width, rect.height);
         sprite.setOrigin(size / 2.f);
-        sprite.scale(0.3, 0.3);
+        sprite.scale({0.3f, 0.3f});
 
         unsigned int ww = renderWindow.getSize().x;
         unsigned int wh = renderWindow.getSize().y;
@@ -162,10 +162,10 @@ struct SFMLmainWindow
     // Scaling
     /* /!\ we do this at 60fps so choose low scaling factor! /!\ */
     if (sf::Keyboard::isKeyPressed(sf::Keyboard::Up))
-        self.mainWindow->sprite.scale(1.01f, 1.01f);
+        self.mainWindow->sprite.scale({1.01f, 1.01f});
 
     if (sf::Keyboard::isKeyPressed(sf::Keyboard::Down))
-        self.mainWindow->sprite.scale(0.99f, 0.99f);
+        self.mainWindow->sprite.scale({0.99f, 0.99f});
 
     // Clear the window, display some stuff and display it into our view.
 

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -114,7 +114,7 @@ int main()
     hudText.setFillColor(sf::Color::White);
     hudText.setOutlineColor(sf::Color::Black);
     hudText.setOutlineThickness(2.0f);
-    hudText.setPosition(5.0f, 5.0f);
+    hudText.setPosition({5.0f, 5.0f});
 
     // Staging buffer for our terrain data that we will upload to our VertexBuffer
     std::vector<sf::Vertex> terrainStagingBuffer;
@@ -158,7 +158,7 @@ int main()
     }
 
     // Center the status text
-    statusText.setPosition((windowWidth - statusText.getLocalBounds().width) / 2.f, (windowHeight - statusText.getLocalBounds().height) / 2.f);
+    statusText.setPosition({(windowWidth - statusText.getLocalBounds().width) / 2.f, (windowHeight - statusText.getLocalBounds().height) / 2.f});
 
     // Set up an array of pointers to our settings for arrow navigation
     Setting settings[] =

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -101,8 +101,8 @@ int main()
     sstr.setf(std::ios::fixed | std::ios::boolalpha);
 
     // Set up our joystick identification sf::Text objects
-    texts["ID"].label.setPosition(5.f, 5.f);
-    texts["ID"].value.setPosition(80.f, 5.f);
+    texts["ID"].label.setPosition({5.f, 5.f});
+    texts["ID"].value.setPosition({80.f, 5.f});
 
     texts["ID"].label.setString("<Not Connected>");
     texts["ID"].value.setString("");
@@ -111,8 +111,8 @@ int main()
     sstr.str("");
     sstr << threshold << "  (Change with up/down arrow keys)";
 
-    texts["Threshold"].label.setPosition(5.f, 5.f + 2 * font.getLineSpacing(14));
-    texts["Threshold"].value.setPosition(80.f, 5.f + 2 * font.getLineSpacing(14));
+    texts["Threshold"].label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
+    texts["Threshold"].value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
 
     texts["Threshold"].label.setString("Threshold:");
     texts["Threshold"].value.setString(sstr.str());
@@ -122,10 +122,10 @@ int main()
     {
         JoystickObject& object = texts[axislabels[i]];
 
-        object.label.setPosition(5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14)));
+        object.label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
         object.label.setString(std::string(axislabels[i]) + ":");
 
-        object.value.setPosition(80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14)));
+        object.value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
         object.value.setString("N/A");
     }
 
@@ -135,10 +135,10 @@ int main()
         sstr << "Button " << i;
         JoystickObject& object = texts[sstr.str()];
 
-        object.label.setPosition(5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14)));
+        object.label.setPosition({5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
         object.label.setString(sstr.str() + ":");
 
-        object.value.setPosition(80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14)));
+        object.value.setPosition({80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
         object.value.setString("N/A");
     }
 

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -66,9 +66,9 @@ int main()
         text.setFillColor(sf::Color(255, 255, 255, 170));
         sRgbInstructions.setFillColor(sf::Color(255, 255, 255, 170));
         mipmapInstructions.setFillColor(sf::Color(255, 255, 255, 170));
-        text.setPosition(280.f, 450.f);
-        sRgbInstructions.setPosition(175.f, 500.f);
-        mipmapInstructions.setPosition(200.f, 550.f);
+        text.setPosition({280.f, 450.f});
+        sRgbInstructions.setPosition({175.f, 500.f});
+        mipmapInstructions.setPosition({200.f, 550.f});
 
         // Load a texture to apply to our 3D cube
         sf::Texture texture;

--- a/examples/shader/Effect.hpp
+++ b/examples/shader/Effect.hpp
@@ -50,7 +50,7 @@ public:
         else
         {
             sf::Text error("Shader not\nsupported", getFont());
-            error.setPosition(320.f, 200.f);
+            error.setPosition({320.f, 200.f});
             error.setCharacterSize(36);
             target.draw(error, states);
         }

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -90,7 +90,7 @@ public:
                          "In hac habitasse platea dictumst. Etiam fringilla est id odio dapibus sit amet semper dui laoreet.\n");
         m_text.setFont(getFont());
         m_text.setCharacterSize(22);
-        m_text.setPosition(30, 20);
+        m_text.setPosition({30.f, 20.f});
 
         // Load the shader
         if (!m_shader.loadFromFile("resources/wave.vert", "resources/blur.frag"))
@@ -203,7 +203,7 @@ public:
 
         // Initialize the background sprite
         m_backgroundSprite.setTexture(m_backgroundTexture);
-        m_backgroundSprite.setPosition(135, 100);
+        m_backgroundSprite.setPosition({135.f, 100.f});
 
         // Load the moving entities
         for (int i = 0; i < 6; ++i)
@@ -306,7 +306,7 @@ public:
         // Reset our transformation matrix
         m_transform = sf::Transform::Identity;
         // Move to the center of the window
-        m_transform.translate(400, 300);
+        m_transform.translate({400.f, 300.f});
         // Rotate everything based on cursor position
         m_transform.rotate(x * 360.f);
 
@@ -374,17 +374,17 @@ int main()
     if (!textBackgroundTexture.loadFromFile("resources/text-background.png"))
         return EXIT_FAILURE;
     sf::Sprite textBackground(textBackgroundTexture);
-    textBackground.setPosition(0, 520);
+    textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));
 
     // Create the description text
     sf::Text description("Current effect: " + effects[current]->getName(), font, 20);
-    description.setPosition(10, 530);
+    description.setPosition({10.f, 530.f});
     description.setFillColor(sf::Color(80, 80, 80));
 
     // Create the instructions text
     sf::Text instructions("Press left and right arrows to change the current shader", font, 20);
-    instructions.setPosition(280, 555);
+    instructions.setPosition({280.f, 555.f});
     instructions.setFillColor(sf::Color(80, 80, 80));
 
     // Start the game loop

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -55,7 +55,7 @@ int main()
         return EXIT_FAILURE;
     sf::Sprite sfmlLogo;
     sfmlLogo.setTexture(sfmlLogoTexture);
-    sfmlLogo.setPosition(170, 50);
+    sfmlLogo.setPosition({170.f, 50.f});
 
     // Create the left paddle
     sf::RectangleShape leftPaddle;
@@ -79,7 +79,7 @@ int main()
     ball.setOutlineThickness(2);
     ball.setOutlineColor(sf::Color::Black);
     ball.setFillColor(sf::Color::White);
-    ball.setOrigin(ballRadius / 2, ballRadius / 2);
+    ball.setOrigin({ballRadius / 2.f, ballRadius / 2.f});
 
     // Load the text font
     sf::Font font;
@@ -90,7 +90,7 @@ int main()
     sf::Text pauseMessage;
     pauseMessage.setFont(font);
     pauseMessage.setCharacterSize(40);
-    pauseMessage.setPosition(170.f, 200.f);
+    pauseMessage.setPosition({170.f, 200.f});
     pauseMessage.setFillColor(sf::Color::White);
 
     #ifdef SFML_SYSTEM_IOS
@@ -134,9 +134,9 @@ int main()
                     clock.restart();
 
                     // Reset the position of the paddles and ball
-                    leftPaddle.setPosition(10.f + paddleSize.x / 2.f, gameHeight / 2.f);
-                    rightPaddle.setPosition(gameWidth - 10.f - paddleSize.x / 2.f, gameHeight / 2.f);
-                    ball.setPosition(gameWidth / 2.f, gameHeight / 2.f);
+                    leftPaddle.setPosition({10.f + paddleSize.x / 2.f, gameHeight / 2.f});
+                    rightPaddle.setPosition({gameWidth - 10.f - paddleSize.x / 2.f, gameHeight / 2.f});
+                    ball.setPosition({gameWidth / 2.f, gameHeight / 2.f});
 
                     // Reset the ball angle
                     do
@@ -153,7 +153,7 @@ int main()
             {
                 sf::View view;
                 view.setSize(gameWidth, gameHeight);
-                view.setCenter(gameWidth / 2.f, gameHeight  /2.f);
+                view.setCenter({gameWidth / 2.f, gameHeight / 2.f});
                 window.setView(view);
             }
         }
@@ -166,26 +166,26 @@ int main()
             if (sf::Keyboard::isKeyPressed(sf::Keyboard::Up) &&
                (leftPaddle.getPosition().y - paddleSize.y / 2 > 5.f))
             {
-                leftPaddle.move(0.f, -paddleSpeed * deltaTime);
+                leftPaddle.move({0.f, -paddleSpeed * deltaTime});
             }
             if (sf::Keyboard::isKeyPressed(sf::Keyboard::Down) &&
                (leftPaddle.getPosition().y + paddleSize.y / 2 < gameHeight - 5.f))
             {
-                leftPaddle.move(0.f, paddleSpeed * deltaTime);
+                leftPaddle.move({0.f, paddleSpeed * deltaTime});
             }
 
             if (sf::Touch::isDown(0))
             {
                 sf::Vector2i pos = sf::Touch::getPosition(0);
                 sf::Vector2f mappedPos = window.mapPixelToCoords(pos);
-                leftPaddle.setPosition(leftPaddle.getPosition().x, mappedPos.y);
+                leftPaddle.setPosition({leftPaddle.getPosition().x, mappedPos.y});
             }
 
             // Move the computer's paddle
             if (((rightPaddleSpeed < 0.f) && (rightPaddle.getPosition().y - paddleSize.y / 2 > 5.f)) ||
                 ((rightPaddleSpeed > 0.f) && (rightPaddle.getPosition().y + paddleSize.y / 2 < gameHeight - 5.f)))
             {
-                rightPaddle.move(0.f, rightPaddleSpeed * deltaTime);
+                rightPaddle.move({0.f, rightPaddleSpeed * deltaTime});
             }
 
             // Update the computer's paddle direction according to the ball position
@@ -202,7 +202,7 @@ int main()
 
             // Move the ball
             float factor = ballSpeed * deltaTime;
-            ball.move(std::cos(ballAngle) * factor, std::sin(ballAngle) * factor);
+            ball.move({std::cos(ballAngle) * factor, std::sin(ballAngle) * factor});
 
             #ifdef SFML_SYSTEM_IOS
             const std::string inputString = "Touch the screen to restart.";
@@ -225,13 +225,13 @@ int main()
             {
                 ballSound.play();
                 ballAngle = -ballAngle;
-                ball.setPosition(ball.getPosition().x, ballRadius + 0.1f);
+                ball.setPosition({ball.getPosition().x, ballRadius + 0.1f});
             }
             if (ball.getPosition().y + ballRadius > gameHeight)
             {
                 ballSound.play();
                 ballAngle = -ballAngle;
-                ball.setPosition(ball.getPosition().x, gameHeight - ballRadius - 0.1f);
+                ball.setPosition({ball.getPosition().x, gameHeight - ballRadius - 0.1f});
             }
 
             // Check the collisions between the ball and the paddles
@@ -247,7 +247,7 @@ int main()
                     ballAngle = pi - ballAngle - static_cast<float>(std::rand() % 20) * pi / 180;
 
                 ballSound.play();
-                ball.setPosition(leftPaddle.getPosition().x + ballRadius + paddleSize.x / 2 + 0.1f, ball.getPosition().y);
+                ball.setPosition({leftPaddle.getPosition().x + ballRadius + paddleSize.x / 2 + 0.1f, ball.getPosition().y});
             }
 
             // Right Paddle
@@ -262,7 +262,7 @@ int main()
                     ballAngle = pi - ballAngle - static_cast<float>(std::rand() % 20) * pi / 180;
 
                 ballSound.play();
-                ball.setPosition(rightPaddle.getPosition().x - ballRadius - paddleSize.x / 2 - 0.1f, ball.getPosition().y);
+                ball.setPosition({rightPaddle.getPosition().x - ballRadius - paddleSize.x / 2 - 0.1f, ball.getPosition().y});
             }
         }
 

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -113,7 +113,7 @@ int main()
             SFMLView1.draw(sprite1);
 
             // Draw sprite 2 on view 2
-            sprite2.setPosition(std::cos(time) * 100.f, 0.f);
+            sprite2.setPosition({std::cos(time) * 100.f, 0.f});
             SFMLView2.draw(sprite2);
 
             // Display each view on screen

--- a/include/SFML/Audio/Listener.hpp
+++ b/include/SFML/Audio/Listener.hpp
@@ -72,20 +72,6 @@ public:
     ///
     /// The default listener's position is (0, 0, 0).
     ///
-    /// \param x X coordinate of the listener's position
-    /// \param y Y coordinate of the listener's position
-    /// \param z Z coordinate of the listener's position
-    ///
-    /// \see getPosition, setDirection
-    ///
-    ////////////////////////////////////////////////////////////
-    static void setPosition(float x, float y, float z);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the position of the listener in the scene
-    ///
-    /// The default listener's position is (0, 0, 0).
-    ///
     /// \param position New listener's position
     ///
     /// \see getPosition, setDirection
@@ -113,25 +99,6 @@ public:
     /// have to be normalized.
     /// The default listener's direction is (0, 0, -1).
     ///
-    /// \param x X coordinate of the listener's direction
-    /// \param y Y coordinate of the listener's direction
-    /// \param z Z coordinate of the listener's direction
-    ///
-    /// \see getDirection, setUpVector, setPosition
-    ///
-    ////////////////////////////////////////////////////////////
-    static void setDirection(float x, float y, float z);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the forward vector of the listener in the scene
-    ///
-    /// The direction (also called "at vector") is the vector
-    /// pointing forward from the listener's perspective. Together
-    /// with the up vector, it defines the 3D orientation of the
-    /// listener in the scene. The direction vector doesn't
-    /// have to be normalized.
-    /// The default listener's direction is (0, 0, -1).
-    ///
     /// \param direction New listener's direction
     ///
     /// \see getDirection, setUpVector, setPosition
@@ -148,25 +115,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     static Vector3f getDirection();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the upward vector of the listener in the scene
-    ///
-    /// The up vector is the vector that points upward from the
-    /// listener's perspective. Together with the direction, it
-    /// defines the 3D orientation of the listener in the scene.
-    /// The up vector doesn't have to be normalized.
-    /// The default listener's up vector is (0, 1, 0). It is usually
-    /// not necessary to change it, especially in 2D scenarios.
-    ///
-    /// \param x X coordinate of the listener's up vector
-    /// \param y Y coordinate of the listener's up vector
-    /// \param z Z coordinate of the listener's up vector
-    ///
-    /// \see getUpVector, setDirection, setPosition
-    ///
-    ////////////////////////////////////////////////////////////
-    static void setUpVector(float x, float y, float z);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the upward vector of the listener in the scene

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -104,22 +104,6 @@ public:
     /// spatialized.
     /// The default position of a sound is (0, 0, 0).
     ///
-    /// \param x X coordinate of the position of the sound in the scene
-    /// \param y Y coordinate of the position of the sound in the scene
-    /// \param z Z coordinate of the position of the sound in the scene
-    ///
-    /// \see getPosition
-    ///
-    ////////////////////////////////////////////////////////////
-    void setPosition(float x, float y, float z);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the 3D position of the sound in the audio scene
-    ///
-    /// Only sounds with one channel (mono sounds) can be
-    /// spatialized.
-    /// The default position of a sound is (0, 0, 0).
-    ///
     /// \param position Position of the sound in the scene
     ///
     /// \see getPosition

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -102,23 +102,6 @@ public:
     ///
     /// These two statements are equivalent:
     /// \code
-    /// sf::Vector2f transformedPoint = matrix.transformPoint(x, y);
-    /// sf::Vector2f transformedPoint = matrix * sf::Vector2f(x, y);
-    /// \endcode
-    ///
-    /// \param x X coordinate of the point to transform
-    /// \param y Y coordinate of the point to transform
-    ///
-    /// \return Transformed point
-    ///
-    ////////////////////////////////////////////////////////////
-    Vector2f transformPoint(float x, float y) const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Transform a 2D point
-    ///
-    /// These two statements are equivalent:
-    /// \code
     /// sf::Vector2f transformedPoint = matrix.transformPoint(point);
     /// sf::Vector2f transformedPoint = matrix * point;
     /// \endcode
@@ -165,26 +148,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     Transform& combine(const Transform& transform);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Combine the current transform with a translation
-    ///
-    /// This function returns a reference to *this, so that calls
-    /// can be chained.
-    /// \code
-    /// sf::Transform transform;
-    /// transform.translate(100, 200).rotate(45);
-    /// \endcode
-    ///
-    /// \param x Offset to apply on X axis
-    /// \param y Offset to apply on Y axis
-    ///
-    /// \return Reference to *this
-    ///
-    /// \see rotate, scale
-    ///
-    ////////////////////////////////////////////////////////////
-    Transform& translate(float x, float y);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a translation

--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -61,21 +61,6 @@ public:
     /// See the move function to apply an offset based on the previous position instead.
     /// The default position of a transformable object is (0, 0).
     ///
-    /// \param x X coordinate of the new position
-    /// \param y Y coordinate of the new position
-    ///
-    /// \see move, getPosition
-    ///
-    ////////////////////////////////////////////////////////////
-    void setPosition(float x, float y);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief set the position of the object
-    ///
-    /// This function completely overwrites the previous position.
-    /// See the move function to apply an offset based on the previous position instead.
-    /// The default position of a transformable object is (0, 0).
-    ///
     /// \param position New position
     ///
     /// \see move, getPosition
@@ -104,45 +89,12 @@ public:
     /// See the scale function to add a factor based on the previous scale instead.
     /// The default scale of a transformable object is (1, 1).
     ///
-    /// \param factorX New horizontal scale factor
-    /// \param factorY New vertical scale factor
-    ///
-    /// \see scale, getScale
-    ///
-    ////////////////////////////////////////////////////////////
-    void setScale(float factorX, float factorY);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief set the scale factors of the object
-    ///
-    /// This function completely overwrites the previous scale.
-    /// See the scale function to add a factor based on the previous scale instead.
-    /// The default scale of a transformable object is (1, 1).
-    ///
     /// \param factors New scale factors
     ///
     /// \see scale, getScale
     ///
     ////////////////////////////////////////////////////////////
     void setScale(const Vector2f& factors);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief set the local origin of the object
-    ///
-    /// The origin of an object defines the center point for
-    /// all transformations (position, scale, rotation).
-    /// The coordinates of this point must be relative to the
-    /// top-left corner of the object, and ignore all
-    /// transformations (position, scale, rotation).
-    /// The default origin of a transformable object is (0, 0).
-    ///
-    /// \param x X coordinate of the new origin
-    /// \param y Y coordinate of the new origin
-    ///
-    /// \see getOrigin
-    ///
-    ////////////////////////////////////////////////////////////
-    void setOrigin(float x, float y);
 
     ////////////////////////////////////////////////////////////
     /// \brief set the local origin of the object
@@ -210,25 +162,6 @@ public:
     /// unlike setPosition which overwrites it.
     /// Thus, it is equivalent to the following code:
     /// \code
-    /// sf::Vector2f pos = object.getPosition();
-    /// object.setPosition(pos.x + offsetX, pos.y + offsetY);
-    /// \endcode
-    ///
-    /// \param offsetX X offset
-    /// \param offsetY Y offset
-    ///
-    /// \see setPosition
-    ///
-    ////////////////////////////////////////////////////////////
-    void move(float offsetX, float offsetY);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Move the object by a given offset
-    ///
-    /// This function adds to the current position of the object,
-    /// unlike setPosition which overwrites it.
-    /// Thus, it is equivalent to the following code:
-    /// \code
     /// object.setPosition(object.getPosition() + offset);
     /// \endcode
     ///
@@ -253,25 +186,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     void rotate(float angle);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Scale the object
-    ///
-    /// This function multiplies the current scale of the object,
-    /// unlike setScale which overwrites it.
-    /// Thus, it is equivalent to the following code:
-    /// \code
-    /// sf::Vector2f scale = object.getScale();
-    /// object.setScale(scale.x * factorX, scale.y * factorY);
-    /// \endcode
-    ///
-    /// \param factorX Horizontal scale factor
-    /// \param factorY Vertical scale factor
-    ///
-    /// \see setScale
-    ///
-    ////////////////////////////////////////////////////////////
-    void scale(float factorX, float factorY);
 
     ////////////////////////////////////////////////////////////
     /// \brief Scale the object

--- a/include/SFML/Graphics/View.hpp
+++ b/include/SFML/Graphics/View.hpp
@@ -72,17 +72,6 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the center of the view
     ///
-    /// \param x X coordinate of the new center
-    /// \param y Y coordinate of the new center
-    ///
-    /// \see setSize, getCenter
-    ///
-    ////////////////////////////////////////////////////////////
-    void setCenter(float x, float y);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the center of the view
-    ///
     /// \param center New center
     ///
     /// \see setSize, getCenter

--- a/src/SFML/Audio/Listener.cpp
+++ b/src/SFML/Audio/Listener.cpp
@@ -46,13 +46,6 @@ float Listener::getGlobalVolume()
 
 
 ////////////////////////////////////////////////////////////
-void Listener::setPosition(float x, float y, float z)
-{
-    setPosition(Vector3f(x, y, z));
-}
-
-
-////////////////////////////////////////////////////////////
 void Listener::setPosition(const Vector3f& position)
 {
     priv::AudioDevice::setPosition(position);
@@ -67,13 +60,6 @@ Vector3f Listener::getPosition()
 
 
 ////////////////////////////////////////////////////////////
-void Listener::setDirection(float x, float y, float z)
-{
-    setDirection(Vector3f(x, y, z));
-}
-
-
-////////////////////////////////////////////////////////////
 void Listener::setDirection(const Vector3f& direction)
 {
     priv::AudioDevice::setDirection(direction);
@@ -84,13 +70,6 @@ void Listener::setDirection(const Vector3f& direction)
 Vector3f Listener::getDirection()
 {
     return priv::AudioDevice::getDirection();
-}
-
-
-////////////////////////////////////////////////////////////
-void Listener::setUpVector(float x, float y, float z)
-{
-    setUpVector(Vector3f(x, y, z));
 }
 
 

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -77,16 +77,9 @@ void SoundSource::setVolume(float volume)
 
 
 ////////////////////////////////////////////////////////////
-void SoundSource::setPosition(float x, float y, float z)
-{
-    alCheck(alSource3f(m_source, AL_POSITION, x, y, z));
-}
-
-
-////////////////////////////////////////////////////////////
 void SoundSource::setPosition(const Vector3f& position)
 {
-    setPosition(position.x, position.y, position.z);
+    alCheck(alSource3f(m_source, AL_POSITION, position.x, position.y, position.z));
 }
 
 

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -95,17 +95,10 @@ Transform Transform::getInverse() const
 
 
 ////////////////////////////////////////////////////////////
-Vector2f Transform::transformPoint(float x, float y) const
-{
-    return Vector2f(m_matrix[0] * x + m_matrix[4] * y + m_matrix[12],
-                    m_matrix[1] * x + m_matrix[5] * y + m_matrix[13]);
-}
-
-
-////////////////////////////////////////////////////////////
 Vector2f Transform::transformPoint(const Vector2f& point) const
 {
-    return transformPoint(point.x, point.y);
+    return Vector2f(m_matrix[0] * point.x + m_matrix[4] * point.y + m_matrix[12],
+                    m_matrix[1] * point.x + m_matrix[5] * point.y + m_matrix[13]);
 }
 
 
@@ -115,10 +108,10 @@ FloatRect Transform::transformRect(const FloatRect& rectangle) const
     // Transform the 4 corners of the rectangle
     const Vector2f points[] =
     {
-        transformPoint(rectangle.left, rectangle.top),
-        transformPoint(rectangle.left, rectangle.top + rectangle.height),
-        transformPoint(rectangle.left + rectangle.width, rectangle.top),
-        transformPoint(rectangle.left + rectangle.width, rectangle.top + rectangle.height)
+        transformPoint({rectangle.left, rectangle.top}),
+        transformPoint({rectangle.left, rectangle.top + rectangle.height}),
+        transformPoint({rectangle.left + rectangle.width, rectangle.top}),
+        transformPoint({rectangle.left + rectangle.width, rectangle.top + rectangle.height})
     };
 
     // Compute the bounding rectangle of the transformed points
@@ -159,20 +152,13 @@ Transform& Transform::combine(const Transform& transform)
 
 
 ////////////////////////////////////////////////////////////
-Transform& Transform::translate(float x, float y)
+Transform& Transform::translate(const Vector2f& offset)
 {
-    Transform translation(1, 0, x,
-                          0, 1, y,
+    Transform translation(1, 0, offset.x,
+                          0, 1, offset.y,
                           0, 0, 1);
 
     return combine(translation);
-}
-
-
-////////////////////////////////////////////////////////////
-Transform& Transform::translate(const Vector2f& offset)
-{
-    return translate(offset.x, offset.y);
 }
 
 

--- a/src/SFML/Graphics/Transformable.cpp
+++ b/src/SFML/Graphics/Transformable.cpp
@@ -52,19 +52,11 @@ Transformable::~Transformable()
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::setPosition(float x, float y)
-{
-    m_position.x = x;
-    m_position.y = y;
-    m_transformNeedUpdate = true;
-    m_inverseTransformNeedUpdate = true;
-}
-
-
-////////////////////////////////////////////////////////////
 void Transformable::setPosition(const Vector2f& position)
 {
-    setPosition(position.x, position.y);
+    m_position = position;
+    m_transformNeedUpdate = true;
+    m_inverseTransformNeedUpdate = true;
 }
 
 
@@ -81,27 +73,9 @@ void Transformable::setRotation(float angle)
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::setScale(float factorX, float factorY)
-{
-    m_scale.x = factorX;
-    m_scale.y = factorY;
-    m_transformNeedUpdate = true;
-    m_inverseTransformNeedUpdate = true;
-}
-
-
-////////////////////////////////////////////////////////////
 void Transformable::setScale(const Vector2f& factors)
 {
-    setScale(factors.x, factors.y);
-}
-
-
-////////////////////////////////////////////////////////////
-void Transformable::setOrigin(float x, float y)
-{
-    m_origin.x = x;
-    m_origin.y = y;
+    m_scale = factors;
     m_transformNeedUpdate = true;
     m_inverseTransformNeedUpdate = true;
 }
@@ -110,7 +84,9 @@ void Transformable::setOrigin(float x, float y)
 ////////////////////////////////////////////////////////////
 void Transformable::setOrigin(const Vector2f& origin)
 {
-    setOrigin(origin.x, origin.y);
+    m_origin = origin;
+    m_transformNeedUpdate = true;
+    m_inverseTransformNeedUpdate = true;
 }
 
 
@@ -143,16 +119,9 @@ const Vector2f& Transformable::getOrigin() const
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::move(float offsetX, float offsetY)
-{
-    setPosition(m_position.x + offsetX, m_position.y + offsetY);
-}
-
-
-////////////////////////////////////////////////////////////
 void Transformable::move(const Vector2f& offset)
 {
-    setPosition(m_position.x + offset.x, m_position.y + offset.y);
+    setPosition(m_position + offset);
 }
 
 
@@ -164,16 +133,9 @@ void Transformable::rotate(float angle)
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::scale(float factorX, float factorY)
-{
-    setScale(m_scale.x * factorX, m_scale.y * factorY);
-}
-
-
-////////////////////////////////////////////////////////////
 void Transformable::scale(const Vector2f& factor)
 {
-    setScale(m_scale.x * factor.x, m_scale.y * factor.y);
+    setScale({m_scale.x * factor.x, m_scale.y * factor.y});
 }
 
 

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -69,21 +69,13 @@ m_invTransformUpdated(false)
 
 }
 
-////////////////////////////////////////////////////////////
-void View::setCenter(float x, float y)
-{
-    m_center.x = x;
-    m_center.y = y;
-
-    m_transformUpdated    = false;
-    m_invTransformUpdated = false;
-}
-
 
 ////////////////////////////////////////////////////////////
 void View::setCenter(const Vector2f& center)
 {
-    setCenter(center.x, center.y);
+    m_center = center;
+    m_transformUpdated    = false;
+    m_invTransformUpdated = false;
 }
 
 
@@ -163,13 +155,6 @@ float View::getRotation() const
 const FloatRect& View::getViewport() const
 {
     return m_viewport;
-}
-
-
-////////////////////////////////////////////////////////////
-void View::move(float offsetX, float offsetY)
-{
-    setCenter(m_center.x + offsetX, m_center.y + offsetY);
 }
 
 


### PR DESCRIPTION
## Description

This PR removes various interfaces accepting `(float x, float y)` in favour of ones accepting `(const sf::Vector2f&)`, as they are redundant and do not promote the consistent use of one SFML's main vocabulary types.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.