### PR TITLE
Make 'Vector2' and 'Vector3' 'constexpr' classes

### DIFF
--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -44,7 +44,7 @@ public:
     /// Creates a Vector2(0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    Vector2();
+    constexpr Vector2();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from its coordinates
@@ -53,7 +53,7 @@ public:
     /// \param Y Y coordinate
     ///
     ////////////////////////////////////////////////////////////
-    Vector2(T X, T Y);
+    constexpr Vector2(T X, T Y);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector
@@ -67,7 +67,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    explicit Vector2(const Vector2<U>& vector);
+    constexpr explicit Vector2(const Vector2<U>& vector);
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -86,7 +86,7 @@ public:
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T> operator -(const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator -(const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -102,7 +102,7 @@ Vector2<T> operator -(const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right);
+constexpr Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -118,7 +118,7 @@ Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right);
+constexpr Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -131,7 +131,7 @@ Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -144,7 +144,7 @@ Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -157,7 +157,7 @@ Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T> operator *(const Vector2<T>& left, T right);
+[[nodiscard]] constexpr Vector2<T> operator *(const Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -170,7 +170,7 @@ Vector2<T> operator *(const Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T> operator *(T left, const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator *(T left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -186,7 +186,7 @@ Vector2<T> operator *(T left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T>& operator *=(Vector2<T>& left, T right);
+constexpr Vector2<T>& operator *=(Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -199,7 +199,7 @@ Vector2<T>& operator *=(Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T> operator /(const Vector2<T>& left, T right);
+[[nodiscard]] constexpr Vector2<T> operator /(const Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -215,7 +215,7 @@ Vector2<T> operator /(const Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T>& operator /=(Vector2<T>& left, T right);
+constexpr Vector2<T>& operator /=(Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -230,7 +230,7 @@ Vector2<T>& operator /=(Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-bool operator ==(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr bool operator ==(const Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -245,7 +245,7 @@ bool operator ==(const Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-bool operator !=(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr bool operator !=(const Vector2<T>& left, const Vector2<T>& right);
 
 #include <SFML/System/Vector2.inl>
 

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -25,7 +25,7 @@
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T>::Vector2() :
+constexpr Vector2<T>::Vector2() :
 x(0),
 y(0)
 {
@@ -35,7 +35,7 @@ y(0)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T>::Vector2(T X, T Y) :
+constexpr Vector2<T>::Vector2(T X, T Y) :
 x(X),
 y(Y)
 {
@@ -46,7 +46,7 @@ y(Y)
 ////////////////////////////////////////////////////////////
 template <typename T>
 template <typename U>
-inline Vector2<T>::Vector2(const Vector2<U>& vector) :
+constexpr Vector2<T>::Vector2(const Vector2<U>& vector) :
 x(static_cast<T>(vector.x)),
 y(static_cast<T>(vector.y))
 {
@@ -55,7 +55,7 @@ y(static_cast<T>(vector.y))
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T> operator -(const Vector2<T>& right)
+constexpr Vector2<T> operator -(const Vector2<T>& right)
 {
     return Vector2<T>(-right.x, -right.y);
 }
@@ -63,7 +63,7 @@ inline Vector2<T> operator -(const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right)
 {
     left.x += right.x;
     left.y += right.y;
@@ -74,7 +74,7 @@ inline Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right)
 {
     left.x -= right.x;
     left.y -= right.y;
@@ -85,7 +85,7 @@ inline Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right)
 {
     return Vector2<T>(left.x + right.x, left.y + right.y);
 }
@@ -93,7 +93,7 @@ inline Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right)
 {
     return Vector2<T>(left.x - right.x, left.y - right.y);
 }
@@ -101,7 +101,7 @@ inline Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T> operator *(const Vector2<T>& left, T right)
+constexpr Vector2<T> operator *(const Vector2<T>& left, T right)
 {
     return Vector2<T>(left.x * right, left.y * right);
 }
@@ -109,7 +109,7 @@ inline Vector2<T> operator *(const Vector2<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T> operator *(T left, const Vector2<T>& right)
+constexpr Vector2<T> operator *(T left, const Vector2<T>& right)
 {
     return Vector2<T>(right.x * left, right.y * left);
 }
@@ -117,7 +117,7 @@ inline Vector2<T> operator *(T left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T>& operator *=(Vector2<T>& left, T right)
+constexpr Vector2<T>& operator *=(Vector2<T>& left, T right)
 {
     left.x *= right;
     left.y *= right;
@@ -128,7 +128,7 @@ inline Vector2<T>& operator *=(Vector2<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T> operator /(const Vector2<T>& left, T right)
+constexpr Vector2<T> operator /(const Vector2<T>& left, T right)
 {
     return Vector2<T>(left.x / right, left.y / right);
 }
@@ -136,7 +136,7 @@ inline Vector2<T> operator /(const Vector2<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector2<T>& operator /=(Vector2<T>& left, T right)
+constexpr Vector2<T>& operator /=(Vector2<T>& left, T right)
 {
     left.x /= right;
     left.y /= right;
@@ -147,7 +147,7 @@ inline Vector2<T>& operator /=(Vector2<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline bool operator ==(const Vector2<T>& left, const Vector2<T>& right)
+constexpr bool operator ==(const Vector2<T>& left, const Vector2<T>& right)
 {
     return (left.x == right.x) && (left.y == right.y);
 }
@@ -155,7 +155,7 @@ inline bool operator ==(const Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline bool operator !=(const Vector2<T>& left, const Vector2<T>& right)
+constexpr bool operator !=(const Vector2<T>& left, const Vector2<T>& right)
 {
     return (left.x != right.x) || (left.y != right.y);
 }

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -44,7 +44,7 @@ public:
     /// Creates a Vector3(0, 0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    Vector3();
+    constexpr Vector3();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from its coordinates
@@ -54,7 +54,7 @@ public:
     /// \param Z Z coordinate
     ///
     ////////////////////////////////////////////////////////////
-    Vector3(T X, T Y, T Z);
+    constexpr Vector3(T X, T Y, T Z);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector
@@ -68,7 +68,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    explicit Vector3(const Vector3<U>& vector);
+    constexpr explicit Vector3(const Vector3<U>& vector);
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -88,7 +88,7 @@ public:
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T> operator -(const Vector3<T>& left);
+[[nodiscard]] constexpr Vector3<T> operator -(const Vector3<T>& left);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -104,7 +104,7 @@ Vector3<T> operator -(const Vector3<T>& left);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right);
+constexpr Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -120,7 +120,7 @@ Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right);
+constexpr Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -133,7 +133,7 @@ Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right);
+[[nodiscard]] constexpr Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -146,7 +146,7 @@ Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right);
+[[nodiscard]] constexpr Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -159,7 +159,7 @@ Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T> operator *(const Vector3<T>& left, T right);
+[[nodiscard]] constexpr Vector3<T> operator *(const Vector3<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -172,7 +172,7 @@ Vector3<T> operator *(const Vector3<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T> operator *(T left, const Vector3<T>& right);
+[[nodiscard]] constexpr Vector3<T> operator *(T left, const Vector3<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -188,7 +188,7 @@ Vector3<T> operator *(T left, const Vector3<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T>& operator *=(Vector3<T>& left, T right);
+constexpr Vector3<T>& operator *=(Vector3<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -201,7 +201,7 @@ Vector3<T>& operator *=(Vector3<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T> operator /(const Vector3<T>& left, T right);
+[[nodiscard]] constexpr Vector3<T> operator /(const Vector3<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -217,7 +217,7 @@ Vector3<T> operator /(const Vector3<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector3<T>& operator /=(Vector3<T>& left, T right);
+constexpr Vector3<T>& operator /=(Vector3<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -232,7 +232,7 @@ Vector3<T>& operator /=(Vector3<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-bool operator ==(const Vector3<T>& left, const Vector3<T>& right);
+[[nodiscard]] constexpr bool operator ==(const Vector3<T>& left, const Vector3<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector3
@@ -247,7 +247,7 @@ bool operator ==(const Vector3<T>& left, const Vector3<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-bool operator !=(const Vector3<T>& left, const Vector3<T>& right);
+[[nodiscard]] constexpr bool operator !=(const Vector3<T>& left, const Vector3<T>& right);
 
 #include <SFML/System/Vector3.inl>
 

--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -25,7 +25,7 @@
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T>::Vector3() :
+constexpr Vector3<T>::Vector3() :
 x(0),
 y(0),
 z(0)
@@ -36,7 +36,7 @@ z(0)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T>::Vector3(T X, T Y, T Z) :
+constexpr Vector3<T>::Vector3(T X, T Y, T Z) :
 x(X),
 y(Y),
 z(Z)
@@ -48,7 +48,7 @@ z(Z)
 ////////////////////////////////////////////////////////////
 template <typename T>
 template <typename U>
-inline Vector3<T>::Vector3(const Vector3<U>& vector) :
+constexpr Vector3<T>::Vector3(const Vector3<U>& vector) :
 x(static_cast<T>(vector.x)),
 y(static_cast<T>(vector.y)),
 z(static_cast<T>(vector.z))
@@ -58,7 +58,7 @@ z(static_cast<T>(vector.z))
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T> operator -(const Vector3<T>& left)
+constexpr Vector3<T> operator -(const Vector3<T>& left)
 {
     return Vector3<T>(-left.x, -left.y, -left.z);
 }
@@ -66,7 +66,7 @@ inline Vector3<T> operator -(const Vector3<T>& left)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right)
+constexpr Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right)
 {
     left.x += right.x;
     left.y += right.y;
@@ -78,7 +78,7 @@ inline Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right)
+constexpr Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right)
 {
     left.x -= right.x;
     left.y -= right.y;
@@ -90,7 +90,7 @@ inline Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right)
+constexpr Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right)
 {
     return Vector3<T>(left.x + right.x, left.y + right.y, left.z + right.z);
 }
@@ -98,7 +98,7 @@ inline Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right)
+constexpr Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right)
 {
     return Vector3<T>(left.x - right.x, left.y - right.y, left.z - right.z);
 }
@@ -106,7 +106,7 @@ inline Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T> operator *(const Vector3<T>& left, T right)
+constexpr Vector3<T> operator *(const Vector3<T>& left, T right)
 {
     return Vector3<T>(left.x * right, left.y * right, left.z * right);
 }
@@ -114,7 +114,7 @@ inline Vector3<T> operator *(const Vector3<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T> operator *(T left, const Vector3<T>& right)
+constexpr Vector3<T> operator *(T left, const Vector3<T>& right)
 {
     return Vector3<T>(right.x * left, right.y * left, right.z * left);
 }
@@ -122,7 +122,7 @@ inline Vector3<T> operator *(T left, const Vector3<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T>& operator *=(Vector3<T>& left, T right)
+constexpr Vector3<T>& operator *=(Vector3<T>& left, T right)
 {
     left.x *= right;
     left.y *= right;
@@ -134,7 +134,7 @@ inline Vector3<T>& operator *=(Vector3<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T> operator /(const Vector3<T>& left, T right)
+constexpr Vector3<T> operator /(const Vector3<T>& left, T right)
 {
     return Vector3<T>(left.x / right, left.y / right, left.z / right);
 }
@@ -142,7 +142,7 @@ inline Vector3<T> operator /(const Vector3<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline Vector3<T>& operator /=(Vector3<T>& left, T right)
+constexpr Vector3<T>& operator /=(Vector3<T>& left, T right)
 {
     left.x /= right;
     left.y /= right;
@@ -154,7 +154,7 @@ inline Vector3<T>& operator /=(Vector3<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline bool operator ==(const Vector3<T>& left, const Vector3<T>& right)
+constexpr bool operator ==(const Vector3<T>& left, const Vector3<T>& right)
 {
     return (left.x == right.x) && (left.y == right.y) && (left.z == right.z);
 }
@@ -162,7 +162,7 @@ inline bool operator ==(const Vector3<T>& left, const Vector3<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-inline bool operator !=(const Vector3<T>& left, const Vector3<T>& right)
+constexpr bool operator !=(const Vector3<T>& left, const Vector3<T>& right)
 {
     return (left.x != right.x) || (left.y != right.y) || (left.z != right.z);
 }


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This PR turns both `sf::Vector2<T>` and `sf::Vector3<T>` into `constexpr`-friendly classes.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.