### PR TITLE
Unify toLower implementations

### DIFF
--- a/src/SFML/Audio/SoundFileWriterFlac.cpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.cpp
@@ -27,18 +27,11 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/SoundFileWriterFlac.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Utils.hpp>
 #include <algorithm>
 #include <cctype>
 #include <cassert>
 
-
-namespace
-{
-    unsigned char toLower(unsigned char character)
-    {
-        return static_cast<unsigned char>(std::tolower(character));
-    }
-}
 
 namespace sf
 {
@@ -47,8 +40,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 bool SoundFileWriterFlac::check(const std::string& filename)
 {
-    std::string extension = filename.substr(filename.find_last_of('.') + 1);
-    std::transform(extension.begin(), extension.end(), extension.begin(), toLower);
+    const std::string extension = toLower(filename.substr(filename.find_last_of('.') + 1));
 
     return extension == "flac";
 }

--- a/src/SFML/Audio/SoundFileWriterOgg.cpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.cpp
@@ -27,19 +27,12 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/SoundFileWriterOgg.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Utils.hpp>
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
 #include <cassert>
 
-
-namespace
-{
-    unsigned char toLower(unsigned char character)
-    {
-        return static_cast<unsigned char>(std::tolower(character));
-    }
-}
 
 namespace sf
 {
@@ -48,8 +41,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 bool SoundFileWriterOgg::check(const std::string& filename)
 {
-    std::string extension = filename.substr(filename.find_last_of('.') + 1);
-    std::transform(extension.begin(), extension.end(), extension.begin(), toLower);
+    const std::string extension = toLower(filename.substr(filename.find_last_of('.') + 1));
 
     return extension == "ogg";
 }

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -27,8 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/SoundFileWriterWav.hpp>
 #include <SFML/System/Err.hpp>
-#include <algorithm>
-#include <cctype>
+#include <SFML/System/Utils.hpp>
 #include <cassert>
 
 
@@ -68,11 +67,6 @@ namespace
         };
         stream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
     }
-
-    unsigned char toLower(unsigned char character)
-    {
-        return static_cast<unsigned char>(std::tolower(character));
-    }
 }
 
 namespace sf
@@ -82,8 +76,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 bool SoundFileWriterWav::check(const std::string& filename)
 {
-    std::string extension = filename.substr(filename.find_last_of('.') + 1);
-    std::transform(extension.begin(), extension.end(), extension.begin(), toLower);
+    const std::string extension = toLower(filename.substr(filename.find_last_of('.') + 1));
 
     return extension == "wav";
 }

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -28,25 +28,16 @@
 #include <SFML/Graphics/ImageLoader.hpp>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Utils.hpp>
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
-#include <cctype>
 #include <iterator>
 
 
 namespace
 {
-    // Convert a string to lower case
-    std::string toLower(std::string str)
-    {
-        for (char& c : str)
-            c = static_cast<char>(std::tolower(c));
-
-        return str;
-    }
-
     // stb_image callbacks that operate on a sf::InputStream
     int read(void* user, char* data, int size)
     {

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -27,23 +27,10 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Network/Http.hpp>
 #include <SFML/System/Err.hpp>
-#include <cctype>
+#include <SFML/System/Utils.hpp>
 #include <iterator>
 #include <sstream>
 #include <limits>
-
-
-namespace
-{
-    // Convert a string to lower case
-    std::string toLower(std::string str)
-    {
-        for (char& c : str)
-            c = static_cast<char>(std::tolower(c));
-
-        return str;
-    }
-}
 
 
 namespace sf

--- a/src/SFML/System/Utils.hpp
+++ b/src/SFML/System/Utils.hpp
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2021 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_UTILS_HPP
+#define SFML_UTILS_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <cctype>
+#include <string>
+
+
+namespace sf
+{
+    [[nodiscard]] inline std::string toLower(std::string str)
+    {
+        for (char& c : str)
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        return str;
+    }
+} // namespace sf
+
+#endif // SFML_UTILS_HPP


### PR DESCRIPTION
## Description

I found 3 instances where different files needed to transform a string into all lower case letters. Two implementations were identical and a 3rd used a standard algorithm. 3 reimplementations of the same thing seemed like justification to create a new private abstraction to handle this. Following patterns I saw elsewhere, I added a `priv` namespace to String.hpp within which `sf::priv::toLower` is implemented. 

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
