### PR TITLE
Fix warnings for clang

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -4,12 +4,7 @@
 
 # Helper function to enable compiler warnings for a specific set of files
 function(set_file_warnings)
-    if(APPLE)
-        # Temporarily disable Apple default until warnings are fixed
-        option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" FALSE)
-    else()
-        option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
-    endif()
+    option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
 
     set(MSVC_WARNINGS
         /W4 # Baseline reasonable warnings

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -4,7 +4,12 @@
 
 # Helper function to enable compiler warnings for a specific set of files
 function(set_file_warnings)
-    option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
+    if(APPLE)
+        # Temporarily disable Apple default until warnings are fixed
+        option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" FALSE)
+    else()
+        option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
+    endif()
 
     set(MSVC_WARNINGS
         /W4 # Baseline reasonable warnings
@@ -69,16 +74,15 @@ function(set_file_warnings)
         ${NON_ANDROID_CLANG_AND_GCC_WARNINGS}
     )
 
+    if(WARNINGS_AS_ERRORS)
+        set(CLANG_AND_GCC_WARNINGS ${CLANG_AND_GCC_WARNINGS} -Werror)
+        set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)
+    endif()
 
     set(CLANG_WARNINGS
         ${CLANG_AND_GCC_WARNINGS}
         -Wno-unknown-warning-option # do not warn on GCC-specific warning diagnostic pragmas
     )
-
-    if(WARNINGS_AS_ERRORS)
-        set(CLANG_AND_GCC_WARNINGS ${CLANG_AND_GCC_WARNINGS} -Werror)
-        set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)
-    endif()
 
     set(GCC_WARNINGS
         ${CLANG_AND_GCC_WARNINGS}

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -31,6 +31,14 @@
 #define GREEN   @"Green"
 #define RED     @"Red"
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 // Our PIMPL
 struct SFMLmainWindow
 {
@@ -48,7 +56,7 @@ struct SFMLmainWindow
         sf::FloatRect rect = sprite.getLocalBounds();
         sf::Vector2f size(rect.width, rect.height);
         sprite.setOrigin(size / 2.f);
-        sprite.scale(0.3, 0.3);
+        sprite.scale(0.3f, 0.3f);
 
         unsigned int ww = renderWindow.getSize().x;
         unsigned int wh = renderWindow.getSize().y;
@@ -117,7 +125,7 @@ struct SFMLmainWindow
         self.visible = YES;
 
         // Launch the timer to periodically display our stuff into the Cocoa view.
-        self.renderTimer = [NSTimer timerWithTimeInterval:1.f/60.f
+        self.renderTimer = [NSTimer timerWithTimeInterval:1.0/60.0
                                                    target:self
                                                  selector:@selector(renderMainWindow:)
                                                  userInfo:nil
@@ -148,7 +156,7 @@ struct SFMLmainWindow
     self.sfmlView           = nil;
     self.textField          = nil;
 
-    delete (SFMLmainWindow*) self.mainWindow;
+    delete static_cast<SFMLmainWindow*>(self.mainWindow);
     self.mainWindow         = 0;
     self.renderTimer        = nil;
 

--- a/examples/cocoa/NSString+stdstring.mm
+++ b/examples/cocoa/NSString+stdstring.mm
@@ -42,8 +42,8 @@
 
 +(id)stringWithstdwstring:(const std::wstring&)string
 {
-    char* data = (char*)string.data();
-    unsigned size = string.size() * sizeof(wchar_t);
+    const void* data = static_cast<const void*>(string.data());
+    unsigned size = static_cast<unsigned>(string.size() * sizeof(wchar_t));
 
     NSString* str = [[[NSString alloc] initWithBytes:data length:size
                                             encoding:NSUTF32LittleEndianStringEncoding] autorelease];
@@ -67,7 +67,7 @@
     // According to Wikipedia, Mac OS X is Little Endian on x86 and x86-64
     // https://en.wikipedia.org/wiki/Endianness
     NSData* asData = [self dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
-    return std::wstring((wchar_t*)[asData bytes], [asData length] / sizeof(wchar_t));
+    return std::wstring(static_cast<const wchar_t*>([asData bytes]), [asData length] / sizeof(wchar_t));
 }
 
 @end

--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -231,8 +231,15 @@ namespace sf
         typedef signed   __int64 Int64;
         typedef unsigned __int64 Uint64;
     #else
+        #if defined(__clang__)
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wc++11-long-long"
+        #endif
         typedef signed   long long Int64;
         typedef unsigned long long Uint64;
+        #if defined(__clang__)
+            #pragma clang diagnostic pop
+        #endif
     #endif
 
 } // namespace sf

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -97,7 +97,7 @@ Out Utf<8>::encode(Uint32 input, Out output, Uint8 replacement)
     {
         // Invalid character
         if (replacement)
-            *output++ = replacement;
+            output = std::copy(&replacement, &replacement + 1, output);
     }
     else
     {

--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -29,6 +29,13 @@
 #include <SFML/System/Err.hpp>
 #include <string>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace sf
 {

--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -30,6 +30,16 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 #include <al.h>
 #include <alc.h>
 
@@ -70,3 +80,11 @@ void alCheckError(const char* file, unsigned int line, const char* expression);
 
 
 #endif // SFML_ALCHECK_HPP
+
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic pop
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic pop
+    #endif
+#endif

--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -31,6 +31,13 @@
 #include <SFML/System/Err.hpp>
 #include <vector>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace
 {

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -32,6 +32,13 @@
 #include <fstream>
 #include <algorithm>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace sf
 {

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -29,6 +29,13 @@
 #include <SFML/Audio/SoundBuffer.hpp>
 #include <SFML/Audio/ALCheck.hpp>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace sf
 {

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -34,6 +34,13 @@
 #include <SFML/System/Err.hpp>
 #include <memory>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace sf
 {

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -37,6 +37,13 @@
     #pragma warning(disable: 4355) // 'this' used in base member initializer list
 #endif
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace
 {

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -28,6 +28,13 @@
 #include <SFML/Audio/SoundSource.hpp>
 #include <SFML/Audio/ALCheck.hpp>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace sf
 {

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -36,6 +36,13 @@
     #pragma warning(disable: 4355) // 'this' used in base member initializer list
 #endif
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
 
 namespace sf
 {

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -1035,256 +1035,256 @@ Shader::~Shader()
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromFile(const std::string& filename, Type type)
+bool Shader::loadFromFile(const std::string& /* filename */, Type /* type */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::string& fragmentShaderFilename)
+bool Shader::loadFromFile(const std::string& /* vertexShaderFilename */, const std::string& /* fragmentShaderFilename */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::string& geometryShaderFilename, const std::string& fragmentShaderFilename)
+bool Shader::loadFromFile(const std::string& /* vertexShaderFilename */, const std::string& /* geometryShaderFilename */, const std::string& /* fragmentShaderFilename */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromMemory(const std::string& shader, Type type)
+bool Shader::loadFromMemory(const std::string& /* shader */, Type /* type */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromMemory(const std::string& vertexShader, const std::string& fragmentShader)
+bool Shader::loadFromMemory(const std::string& /* vertexShader */, const std::string& /* fragmentShader */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromMemory(const std::string& vertexShader, const std::string& geometryShader, const std::string& fragmentShader)
+bool Shader::loadFromMemory(const std::string& /* vertexShader */, const std::string& /* geometryShader */, const std::string& /* fragmentShader */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromStream(InputStream& stream, Type type)
+bool Shader::loadFromStream(InputStream& /* stream */, Type /* type */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream)
+bool Shader::loadFromStream(InputStream& /* vertexShaderStream */, InputStream& /* fragmentShaderStream */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& geometryShaderStream, InputStream& fragmentShaderStream)
+bool Shader::loadFromStream(InputStream& /* vertexShaderStream */, InputStream& /* geometryShaderStream */, InputStream& /* fragmentShaderStream */)
 {
     return false;
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, float x)
+void Shader::setUniform(const std::string& /* name */, float)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Vec2& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Vec2&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Vec3& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Vec3&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Vec4& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Vec4&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, int x)
+void Shader::setUniform(const std::string& /* name */, int)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Ivec2& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Ivec2&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Ivec3& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Ivec3&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Ivec4& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Ivec4&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, bool x)
+void Shader::setUniform(const std::string& /* name */, bool)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Bvec2& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Bvec2&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Bvec3& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Bvec3&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Bvec4& v)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Bvec4&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Mat3& matrix)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Mat3& /* matrix */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Mat4& matrix)
+void Shader::setUniform(const std::string& /* name */, const Glsl::Mat4& /* matrix */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Texture& texture)
+void Shader::setUniform(const std::string& /* name */, const Texture& /* texture */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, CurrentTextureType)
+void Shader::setUniform(const std::string& /* name */, CurrentTextureType)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniformArray(const std::string& name, const float* scalarArray, std::size_t length)
+void Shader::setUniformArray(const std::string& /* name */, const float* /* scalarArray */, std::size_t /* length */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniformArray(const std::string& name, const Glsl::Vec2* vectorArray, std::size_t length)
+void Shader::setUniformArray(const std::string& /* name */, const Glsl::Vec2* /* vectorArray */, std::size_t /* length */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniformArray(const std::string& name, const Glsl::Vec3* vectorArray, std::size_t length)
+void Shader::setUniformArray(const std::string& /* name */, const Glsl::Vec3* /* vectorArray */, std::size_t /* length */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniformArray(const std::string& name, const Glsl::Vec4* vectorArray, std::size_t length)
+void Shader::setUniformArray(const std::string& /* name */, const Glsl::Vec4* /* vectorArray */, std::size_t /* length */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniformArray(const std::string& name, const Glsl::Mat3* matrixArray, std::size_t length)
+void Shader::setUniformArray(const std::string& /* name */, const Glsl::Mat3* /* matrixArray */, std::size_t /* length */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniformArray(const std::string& name, const Glsl::Mat4* matrixArray, std::size_t length)
+void Shader::setUniformArray(const std::string& /* name */, const Glsl::Mat4* /* matrixArray */, std::size_t /* length */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x)
+void Shader::setParameter(const std::string& /* name */, float)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x, float y)
+void Shader::setParameter(const std::string& /* name */, float, float)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x, float y, float z)
+void Shader::setParameter(const std::string& /* name */, float, float, float)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, float x, float y, float z, float w)
+void Shader::setParameter(const std::string& /* name */, float, float, float, float)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Vector2f& v)
+void Shader::setParameter(const std::string& /* name */, const Vector2f&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Vector3f& v)
+void Shader::setParameter(const std::string& /* name */, const Vector3f&)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Color& color)
+void Shader::setParameter(const std::string& /* name */, const Color& /* color */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Transform& transform)
+void Shader::setParameter(const std::string& /* name */, const Transform& /* transform */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, const Texture& texture)
+void Shader::setParameter(const std::string& /* name */, const Texture& /* texture */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setParameter(const std::string& name, CurrentTextureType)
+void Shader::setParameter(const std::string& /* name */, CurrentTextureType)
 {
 }
 
@@ -1297,7 +1297,7 @@ unsigned int Shader::getNativeHandle() const
 
 
 ////////////////////////////////////////////////////////////
-void Shader::bind(const Shader* shader)
+void Shader::bind(const Shader* /* shader */)
 {
 }
 
@@ -1317,7 +1317,7 @@ bool Shader::isGeometryAvailable()
 
 
 ////////////////////////////////////////////////////////////
-bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCode, const char* fragmentShaderCode)
+bool Shader::compile(const char* /* vertexShaderCode */, const char* /* geometryShaderCode */, const char* /* fragmentShaderCode */)
 {
     return false;
 }

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -208,6 +208,7 @@ bool VertexBuffer::update(const VertexBuffer& vertexBuffer)
 {
 #ifdef SFML_OPENGL_ES
 
+    (void) vertexBuffer;
     return false;
 
 #else

--- a/src/SFML/Main/SFMLActivity.cpp
+++ b/src/SFML/Main/SFMLActivity.cpp
@@ -77,7 +77,7 @@ const char *getLibraryName(JNIEnv* lJNIEnv, jobject& objectActivityInfo)
         exit(1);
     }
 
-    strncpy(name, applicationName, applicationNameLength);
+    strncpy(name, applicationName, static_cast<size_t>(applicationNameLength));
     name[applicationNameLength] = '\0';
     lJNIEnv->ReleaseStringUTFChars(valueString, applicationName);
 
@@ -141,7 +141,6 @@ void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_
     // With libname being the library name such as "jpeg".
 
     // Retrieve JNI environment and JVM instance
-    // JavaVM* lJavaVM = activity->vm;
     JNIEnv* lJNIEnv = activity->env;
 
     // Retrieve the NativeActivity

--- a/src/SFML/Main/SFMLActivity.cpp
+++ b/src/SFML/Main/SFMLActivity.cpp
@@ -68,7 +68,7 @@ const char *getLibraryName(JNIEnv* lJNIEnv, jobject& objectActivityInfo)
     }
 
     // Convert the application name to a C++ string and return it
-    const jsize applicationNameLength = lJNIEnv->GetStringUTFLength(valueString);
+    const size_t applicationNameLength = static_cast<size_t>(lJNIEnv->GetStringUTFLength(valueString));
     const char* applicationName = lJNIEnv->GetStringUTFChars(valueString, NULL);
 
     if (applicationNameLength >= 256)
@@ -141,7 +141,7 @@ void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_
     // With libname being the library name such as "jpeg".
 
     // Retrieve JNI environment and JVM instance
-    JavaVM* lJavaVM = activity->vm;
+    // JavaVM* lJavaVM = activity->vm;
     JNIEnv* lJNIEnv = activity->env;
 
     // Retrieve the NativeActivity

--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -158,7 +158,7 @@ bool SocketSelector::wait(Time timeout)
     // Setup the timeout
     timeval time;
     time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1000000);
-    time.tv_usec = static_cast<long>(timeout.asMicroseconds() % 1000000);
+    time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1000000);
 
     // Initialize the set that will contain the sockets that are ready
     m_impl->socketsReady = m_impl->allSockets;

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -175,7 +175,7 @@ Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short
             // Setup the timeout
             timeval time;
             time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1000000);
-            time.tv_usec = static_cast<long>(timeout.asMicroseconds() % 1000000);
+            time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1000000);
 
             // Wait for something to write on our socket (which means that the connection request has returned)
             if (select(static_cast<int>(getHandle() + 1), NULL, &selector, NULL, &time) > 0)

--- a/src/SFML/System/Android/Activity.cpp
+++ b/src/SFML/System/Android/Activity.cpp
@@ -41,14 +41,14 @@ std::streambuf()
 
 std::streambuf::int_type LogcatStream::overflow (std::streambuf::int_type c)
 {
-    if (c == "\n"[0])
+    if (c == '\n')
     {
-        m_message.push_back(c);
+        m_message.push_back(static_cast<char>(c));
         LOGE("%s", m_message.c_str());
         m_message.clear();
     }
 
-    m_message.push_back(c);
+    m_message.push_back(static_cast<char>(c));
 
     return traits_type::not_eof(c);
 }

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -61,7 +61,7 @@ Int64 ResourceStream::read(void *data, Int64 size)
 {
     if (m_file)
     {
-        return AAsset_read(m_file, data, size);
+        return AAsset_read(m_file, data, static_cast<size_t>(size));
     }
     else
     {
@@ -75,7 +75,7 @@ Int64 ResourceStream::seek(Int64 position)
 {
     if (m_file)
     {
-        return AAsset_seek(m_file, position, SEEK_SET);
+        return AAsset_seek(m_file, static_cast<off_t>(position), SEEK_SET);
     }
     else
     {

--- a/src/SFML/Window/Android/ClipboardImpl.cpp
+++ b/src/SFML/Window/Android/ClipboardImpl.cpp
@@ -42,7 +42,7 @@ String ClipboardImpl::getString()
 
 
 ////////////////////////////////////////////////////////////
-void ClipboardImpl::setString(const String& text)
+void ClipboardImpl::setString(const String& /* text */)
 {
     sf::err() << "Clipboard API not implemented for Android.\n";
 }

--- a/src/SFML/Window/Android/CursorImpl.cpp
+++ b/src/SFML/Window/Android/CursorImpl.cpp
@@ -47,7 +47,7 @@ CursorImpl::~CursorImpl()
 
 
 ////////////////////////////////////////////////////////////
-bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hotspot)
+bool CursorImpl::loadFromPixels(const Uint8* /* pixels */, Vector2u /* size */, Vector2u /* hotspot */)
 {
     // Not supported
     return false;
@@ -55,7 +55,7 @@ bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hot
 
 
 ////////////////////////////////////////////////////////////
-bool CursorImpl::loadFromSystem(Cursor::Type type)
+bool CursorImpl::loadFromSystem(Cursor::Type /* type */)
 {
     // Not supported
     return false;

--- a/src/SFML/Window/Android/InputImpl.cpp
+++ b/src/SFML/Window/Android/InputImpl.cpp
@@ -37,7 +37,7 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-bool InputImpl::isKeyPressed(Keyboard::Key key)
+bool InputImpl::isKeyPressed(Keyboard::Key /* key */)
 {
     // Not applicable
     return false;
@@ -52,7 +52,6 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
     Lock lock(states.mutex);
 
     // Initializes JNI
-    jint lResult;
     jint lFlags = 0;
 
     JavaVM* lJavaVM = states.activity->vm;
@@ -63,7 +62,7 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
     lJavaVMAttachArgs.name = "NativeThread";
     lJavaVMAttachArgs.group = NULL;
 
-    lResult=lJavaVM->AttachCurrentThread(&lJNIEnv, &lJavaVMAttachArgs);
+    jint lResult = lJavaVM->AttachCurrentThread(&lJNIEnv, &lJavaVMAttachArgs);
 
     if (lResult == JNI_ERR)
         err() << "Failed to initialize JNI, couldn't switch the keyboard visibility" << std::endl;
@@ -105,7 +104,7 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
         // Runs lInputMethodManager.showSoftInput(...)
         jmethodID MethodShowSoftInput = lJNIEnv->GetMethodID(ClassInputMethodManager,
             "showSoftInput", "(Landroid/view/View;I)Z");
-        jboolean lResult = lJNIEnv->CallBooleanMethod(lInputMethodManager,
+        lJNIEnv->CallBooleanMethod(lInputMethodManager,
             MethodShowSoftInput, lDecorView, lFlags);
     }
     else
@@ -121,7 +120,7 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
         // lInputMethodManager.hideSoftInput(...)
         jmethodID MethodHideSoftInput = lJNIEnv->GetMethodID(ClassInputMethodManager,
             "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z");
-        jboolean lRes = lJNIEnv->CallBooleanMethod(lInputMethodManager,
+        lJNIEnv->CallBooleanMethod(lInputMethodManager,
             MethodHideSoftInput, lBinder, lFlags);
         lJNIEnv->DeleteLocalRef(lBinder);
     }
@@ -158,21 +157,21 @@ Vector2i InputImpl::getMousePosition()
 
 
 ////////////////////////////////////////////////////////////
-Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
+Vector2i InputImpl::getMousePosition(const WindowBase& /* relativeTo */)
 {
     return getMousePosition();
 }
 
 
 ////////////////////////////////////////////////////////////
-void InputImpl::setMousePosition(const Vector2i& position)
+void InputImpl::setMousePosition(const Vector2i& /* position */)
 {
     // Injecting events is impossible on Android
 }
 
 
 ////////////////////////////////////////////////////////////
-void InputImpl::setMousePosition(const Vector2i& position, const WindowBase& relativeTo)
+void InputImpl::setMousePosition(const Vector2i& position, const WindowBase& /* relativeTo */)
 {
     setMousePosition(position);
 }
@@ -186,7 +185,7 @@ bool InputImpl::isTouchDown(unsigned int finger)
     priv::ActivityStates& states = priv::getActivity();
     Lock lock(states.mutex);
 
-    return states.touchEvents.find(finger) != states.touchEvents.end();
+    return states.touchEvents.find(static_cast<int>(finger)) != states.touchEvents.end();
 }
 
 
@@ -198,12 +197,12 @@ Vector2i InputImpl::getTouchPosition(unsigned int finger)
     priv::ActivityStates& states = priv::getActivity();
     Lock lock(states.mutex);
 
-    return states.touchEvents.find(finger)->second;
+    return states.touchEvents.find(static_cast<int>(finger))->second;
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2i InputImpl::getTouchPosition(unsigned int finger, const WindowBase& relativeTo)
+Vector2i InputImpl::getTouchPosition(unsigned int finger, const WindowBase& /* relativeTo */)
 {
     return getTouchPosition(finger);
 }

--- a/src/SFML/Window/Android/JoystickImpl.cpp
+++ b/src/SFML/Window/Android/JoystickImpl.cpp
@@ -48,7 +48,7 @@ void JoystickImpl::cleanup()
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::isConnected(unsigned int index)
+bool JoystickImpl::isConnected(unsigned int /* index */)
 {
     // To implement
     return false;
@@ -56,7 +56,7 @@ bool JoystickImpl::isConnected(unsigned int index)
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::open(unsigned int index)
+bool JoystickImpl::open(unsigned int /* index */)
 {
     // To implement
     return false;

--- a/src/SFML/Window/Android/JoystickImpl.hpp
+++ b/src/SFML/Window/Android/JoystickImpl.hpp
@@ -105,7 +105,6 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int m_index;                               ///< Index of the joystick
     Joystick::Identification m_identification; ///< Joystick identification
 };
 

--- a/src/SFML/Window/Android/SensorImpl.cpp
+++ b/src/SFML/Window/Android/SensorImpl.cpp
@@ -54,7 +54,11 @@ void SensorImpl::initialize()
     looper = ALooper_forThread();
 
     // Get the unique sensor manager
-    sensorManager = ASensorManager_getInstance();
+    #if ANDROID_API >= 26 || __ANDROID_API__ >= 26
+        sensorManager = ASensorManager_getInstanceForPackage(nullptr);
+    #else
+        sensorManager = ASensorManager_getInstance();
+    #endif
 
     // Create the sensor events queue and attach it to the looper
     sensorEventQueue = ASensorManager_createEventQueue(sensorManager, looper,
@@ -93,7 +97,7 @@ bool SensorImpl::open(Sensor::Type sensor)
     Time minimumDelay = microseconds(ASensor_getMinDelay(m_sensor));
 
     // Set the event rate (not to consume too much battery)
-    ASensorEventQueue_setEventRate(sensorEventQueue, m_sensor, minimumDelay.asMicroseconds());
+    ASensorEventQueue_setEventRate(sensorEventQueue, m_sensor, static_cast<sf::Int32>(minimumDelay.asMicroseconds()));
 
     // Save the index of the sensor
     m_index = static_cast<unsigned int>(sensor);
@@ -145,7 +149,7 @@ ASensor const* SensorImpl::getDefaultSensor(Sensor::Type sensor)
 
 
 ////////////////////////////////////////////////////////////
-int SensorImpl::processSensorEvents(int fd, int events, void* data)
+int SensorImpl::processSensorEvents(int /* fd */, int /* events */, void* /* sensorData */)
 {
     ASensorEvent event;
 

--- a/src/SFML/Window/Android/SensorImpl.cpp
+++ b/src/SFML/Window/Android/SensorImpl.cpp
@@ -29,6 +29,12 @@
 #include <SFML/System/Time.hpp>
 #include <android/looper.h>
 
+#if defined(__clang__)
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 // Define missing constants
 #define ASENSOR_TYPE_GRAVITY             0x00000009
 #define ASENSOR_TYPE_LINEAR_ACCELERATION 0x0000000a
@@ -97,7 +103,7 @@ bool SensorImpl::open(Sensor::Type sensor)
     Time minimumDelay = microseconds(ASensor_getMinDelay(m_sensor));
 
     // Set the event rate (not to consume too much battery)
-    ASensorEventQueue_setEventRate(sensorEventQueue, m_sensor, static_cast<sf::Int32>(minimumDelay.asMicroseconds()));
+    ASensorEventQueue_setEventRate(sensorEventQueue, m_sensor, static_cast<Int32>(minimumDelay.asMicroseconds()));
 
     // Save the index of the sensor
     m_index = static_cast<unsigned int>(sensor);

--- a/src/SFML/Window/Android/VideoModeImpl.cpp
+++ b/src/SFML/Window/Android/VideoModeImpl.cpp
@@ -55,7 +55,7 @@ VideoMode VideoModeImpl::getDesktopMode()
     priv::ActivityStates& states = priv::getActivity();
     Lock lock(states.mutex);
 
-    return VideoMode(states.screenSize.x, states.screenSize.y);
+    return VideoMode(static_cast<unsigned int>(states.screenSize.x), static_cast<unsigned int>(states.screenSize.y));
 }
 
 } // namespace priv

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -49,7 +49,7 @@ namespace priv
 WindowImplAndroid* WindowImplAndroid::singleInstance = NULL;
 
 ////////////////////////////////////////////////////////////
-WindowImplAndroid::WindowImplAndroid(WindowHandle handle)
+WindowImplAndroid::WindowImplAndroid(WindowHandle /* handle */)
 : m_size(0, 0)
 , m_windowBeingCreated(false)
 , m_windowBeingDestroyed(false)
@@ -59,7 +59,7 @@ WindowImplAndroid::WindowImplAndroid(WindowHandle handle)
 
 
 ////////////////////////////////////////////////////////////
-WindowImplAndroid::WindowImplAndroid(VideoMode mode, const String& title, unsigned long style, const ContextSettings& settings)
+WindowImplAndroid::WindowImplAndroid(VideoMode mode, const String& /* title */, unsigned long style, const ContextSettings& /* settings */)
 : m_size(mode.width, mode.height)
 , m_windowBeingCreated(false)
 , m_windowBeingDestroyed(false)
@@ -132,7 +132,7 @@ Vector2i WindowImplAndroid::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setPosition(const Vector2i& position)
+void WindowImplAndroid::setPosition(const Vector2i& /* position */)
 {
     // Not applicable
 }
@@ -146,55 +146,55 @@ Vector2u WindowImplAndroid::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setSize(const Vector2u& size)
+void WindowImplAndroid::setSize(const Vector2u& /* size */)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setTitle(const String& title)
-{
-    // Not applicable
-}
-
-
-////////////////////////////////////////////////////////////
-void WindowImplAndroid::setIcon(unsigned int width, unsigned int height, const Uint8* pixels)
+void WindowImplAndroid::setTitle(const String& /* title */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setVisible(bool visible)
+void WindowImplAndroid::setIcon(unsigned int /* width */, unsigned int /* height */, const Uint8* /* pixels */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setMouseCursorVisible(bool visible)
+void WindowImplAndroid::setVisible(bool /* visible */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setMouseCursorGrabbed(bool grabbed)
+void WindowImplAndroid::setMouseCursorVisible(bool /* visible */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setMouseCursor(const CursorImpl& cursor)
+void WindowImplAndroid::setMouseCursorGrabbed(bool /* grabbed */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setKeyRepeatEnabled(bool enabled)
+void WindowImplAndroid::setMouseCursor(const CursorImpl& /* cursor */)
+{
+    // Not applicable
+}
+
+
+////////////////////////////////////////////////////////////
+void WindowImplAndroid::setKeyRepeatEnabled(bool /* enabled */)
 {
     // Not applicable
 }
@@ -223,8 +223,8 @@ void WindowImplAndroid::forwardEvent(const Event& event)
 
         if (event.type == Event::GainedFocus)
         {
-            WindowImplAndroid::singleInstance->m_size.x = ANativeWindow_getWidth(states.window);
-            WindowImplAndroid::singleInstance->m_size.y = ANativeWindow_getHeight(states.window);
+            WindowImplAndroid::singleInstance->m_size.x = static_cast<unsigned int>(ANativeWindow_getWidth(states.window));
+            WindowImplAndroid::singleInstance->m_size.y = static_cast<unsigned int>(ANativeWindow_getHeight(states.window));
             WindowImplAndroid::singleInstance->m_windowBeingCreated = true;
             WindowImplAndroid::singleInstance->m_hasFocus = true;
         }
@@ -240,7 +240,7 @@ void WindowImplAndroid::forwardEvent(const Event& event)
 
 
 ////////////////////////////////////////////////////////////
-int WindowImplAndroid::processEvent(int fd, int events, void* data)
+int WindowImplAndroid::processEvent(int /* fd */, int /* events */, void* /* data */)
 {
     ActivityStates& states = getActivity();
     Lock lock(states.mutex);
@@ -318,7 +318,7 @@ int WindowImplAndroid::processScrollEvent(AInputEvent* _event, ActivityStates& s
 {
     // Prepare the Java virtual machine
     jint lResult;
-    jint lFlags = 0;
+    // jint lFlags = 0;
 
     JavaVM* lJavaVM = states.activity->vm;
     JNIEnv* lJNIEnv = states.activity->env;
@@ -336,23 +336,30 @@ int WindowImplAndroid::processScrollEvent(AInputEvent* _event, ActivityStates& s
     }
 
     // Retrieve everything we need to create this MotionEvent in Java
-    jlong downTime = AMotionEvent_getDownTime(_event);
-    jlong eventTime = AMotionEvent_getEventTime(_event);
-    jint action = AMotionEvent_getAction(_event);
-    jfloat x = AMotionEvent_getX(_event, 0);
-    jfloat y = AMotionEvent_getY(_event, 0);
-    jfloat pressure = AMotionEvent_getPressure(_event, 0);
-    jfloat size = AMotionEvent_getSize(_event, 0);
-    jint metaState = AMotionEvent_getMetaState(_event);
-    jfloat xPrecision = AMotionEvent_getXPrecision(_event);
-    jfloat yPrecision = AMotionEvent_getYPrecision(_event);
-    jint deviceId = AInputEvent_getDeviceId(_event);
-    jint edgeFlags = AMotionEvent_getEdgeFlags(_event);
+    sf::Int64 downTime = AMotionEvent_getDownTime(_event);
+    sf::Int64 eventTime = AMotionEvent_getEventTime(_event);
+    sf::Int32 action = AMotionEvent_getAction(_event);
+    float x = AMotionEvent_getX(_event, 0);
+    float y = AMotionEvent_getY(_event, 0);
+    float pressure = AMotionEvent_getPressure(_event, 0);
+    float size = AMotionEvent_getSize(_event, 0);
+    sf::Int32 metaState = AMotionEvent_getMetaState(_event);
+    float xPrecision = AMotionEvent_getXPrecision(_event);
+    float yPrecision = AMotionEvent_getYPrecision(_event);
+    sf::Int32 deviceId = AInputEvent_getDeviceId(_event);
+    sf::Int32 edgeFlags = AMotionEvent_getEdgeFlags(_event);
 
     // Create the MotionEvent object in Java trough its static constructor obtain()
     jclass ClassMotionEvent = lJNIEnv->FindClass("android/view/MotionEvent");
     jmethodID StaticMethodObtain = lJNIEnv->GetStaticMethodID(ClassMotionEvent, "obtain", "(JJIFFFFIFFII)Landroid/view/MotionEvent;");
-    jobject ObjectMotionEvent = lJNIEnv->CallStaticObjectMethod(ClassMotionEvent, StaticMethodObtain, downTime, eventTime, action, x, y, pressure, size, metaState, xPrecision, yPrecision, deviceId, edgeFlags);
+    // Harmless warning related to C standard compatibility
+    // varargs automatically promote floats to doubles
+    // even though the function signature declares float
+    #pragma clang diagnostic ignored "-Wdouble-promotion"
+    jobject ObjectMotionEvent = lJNIEnv->CallStaticObjectMethod(
+        ClassMotionEvent, StaticMethodObtain, downTime,
+        eventTime, action, x, y, pressure, size, metaState,
+        xPrecision, yPrecision, deviceId, edgeFlags);
 
     // Call its getAxisValue() method to get the delta value of our wheel move event
     jmethodID MethodGetAxisValue = lJNIEnv->GetMethodID(ClassMotionEvent, "getAxisValue", "(I)F");
@@ -364,9 +371,9 @@ int WindowImplAndroid::processScrollEvent(AInputEvent* _event, ActivityStates& s
     // Create and send our mouse wheel event
     Event event;
     event.type = Event::MouseWheelMoved;
-    event.mouseWheel.delta = static_cast<double>(delta);
-    event.mouseWheel.x = AMotionEvent_getX(_event, 0);
-    event.mouseWheel.y = AMotionEvent_getY(_event, 0);
+    event.mouseWheel.delta = static_cast<int>(delta);
+    event.mouseWheel.x = static_cast<int>(AMotionEvent_getX(_event, 0));
+    event.mouseWheel.y = static_cast<int>(AMotionEvent_getY(_event, 0));
 
     forwardEvent(event);
 
@@ -378,9 +385,9 @@ int WindowImplAndroid::processScrollEvent(AInputEvent* _event, ActivityStates& s
 
 
 ////////////////////////////////////////////////////////////
-int WindowImplAndroid::processKeyEvent(AInputEvent* _event, ActivityStates& states)
+int WindowImplAndroid::processKeyEvent(AInputEvent* _event, ActivityStates& /* states */)
 {
-    int32_t device = AInputEvent_getSource(_event);
+    // int32_t device = AInputEvent_getSource(_event);
     int32_t action = AKeyEvent_getAction(_event);
 
     int32_t key = AKeyEvent_getKeyCode(_event);
@@ -402,7 +409,7 @@ int WindowImplAndroid::processKeyEvent(AInputEvent* _event, ActivityStates& stat
         event.type = Event::KeyReleased;
         forwardEvent(event);
 
-        if (int unicode = getUnicode(_event))
+        if (sf::Uint32 unicode = static_cast<sf::Uint32>(getUnicode(_event)))
         {
             event.type = Event::TextEntered;
             event.text.unicode = unicode;
@@ -425,7 +432,7 @@ int WindowImplAndroid::processKeyEvent(AInputEvent* _event, ActivityStates& stat
             // https://code.google.com/p/android/issues/detail?id=33998
             return 0;
         }
-        else if (int unicode = getUnicode(_event)) // This is a repeated sequence
+        else if (sf::Uint32 unicode = static_cast<sf::Uint32>(getUnicode(_event))) // This is a repeated sequence
         {
             event.type = Event::TextEntered;
             event.text.unicode = unicode;
@@ -445,23 +452,23 @@ int WindowImplAndroid::processKeyEvent(AInputEvent* _event, ActivityStates& stat
 int WindowImplAndroid::processMotionEvent(AInputEvent* _event, ActivityStates& states)
 {
     int32_t device = AInputEvent_getSource(_event);
-    int32_t action = AMotionEvent_getAction(_event);
+    // int32_t action = AMotionEvent_getAction(_event);
 
     Event event;
 
     if (device == AINPUT_SOURCE_MOUSE)
         event.type = Event::MouseMoved;
-    else if (device & AINPUT_SOURCE_TOUCHSCREEN)
+    else if (static_cast<sf::Uint32>(device) & AINPUT_SOURCE_TOUCHSCREEN)
         event.type = Event::TouchMoved;
 
-    int pointerCount = AMotionEvent_getPointerCount(_event);
+    size_t pointerCount = AMotionEvent_getPointerCount(_event);
 
-    for (int p = 0; p < pointerCount; p++)
+    for (size_t p = 0; p < pointerCount; p++)
     {
         int id = AMotionEvent_getPointerId(_event, p);
 
-        float x = AMotionEvent_getX(_event, p);
-        float y = AMotionEvent_getY(_event, p);
+        int x = static_cast<int>(AMotionEvent_getX(_event, p));
+        int y = static_cast<int>(AMotionEvent_getY(_event, p));
 
         if (device == AINPUT_SOURCE_MOUSE)
         {
@@ -470,12 +477,12 @@ int WindowImplAndroid::processMotionEvent(AInputEvent* _event, ActivityStates& s
 
             states.mousePosition = Vector2i(event.mouseMove.x, event.mouseMove.y);
         }
-        else if (device & AINPUT_SOURCE_TOUCHSCREEN)
+        else if (static_cast<unsigned int>(device) & AINPUT_SOURCE_TOUCHSCREEN)
         {
             if (states.touchEvents[id].x == x && states.touchEvents[id].y == y)
                 continue;
 
-            event.touch.finger = id;
+            event.touch.finger = static_cast<unsigned int>(id);
             event.touch.x = x;
             event.touch.y = y;
 
@@ -494,11 +501,11 @@ int WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* _event, Act
     int32_t device = AInputEvent_getSource(_event);
     int32_t action = AMotionEvent_getAction(_event);
 
-    int index = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
-    int id = AMotionEvent_getPointerId(_event, index);
+    size_t index = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
+    int32_t id = AMotionEvent_getPointerId(_event, index);
 
-    float x = AMotionEvent_getX(_event, index);
-    float y = AMotionEvent_getY(_event, index);
+    int x = static_cast<int>(AMotionEvent_getX(_event, index));
+    int y = static_cast<int>(AMotionEvent_getY(_event, index));
 
     Event event;
 
@@ -514,10 +521,10 @@ int WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* _event, Act
             if (id >= 0 && id < Mouse::ButtonCount)
                 states.isButtonPressed[id] = true;
         }
-        else if (device & AINPUT_SOURCE_TOUCHSCREEN)
+        else if (static_cast<unsigned int>(device) & AINPUT_SOURCE_TOUCHSCREEN)
         {
             event.type = Event::TouchBegan;
-            event.touch.finger = id;
+            event.touch.finger = static_cast<unsigned int>(id);
             event.touch.x = x;
             event.touch.y = y;
 
@@ -536,10 +543,10 @@ int WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* _event, Act
             if (id >= 0 && id < Mouse::ButtonCount)
                 states.isButtonPressed[id] = false;
         }
-        else if (device & AINPUT_SOURCE_TOUCHSCREEN)
+        else if (static_cast<unsigned int>(device) & AINPUT_SOURCE_TOUCHSCREEN)
         {
             event.type = Event::TouchEnded;
-            event.touch.finger = id;
+            event.touch.finger = static_cast<unsigned int>(id);
             event.touch.x = x;
             event.touch.y = y;
 
@@ -683,7 +690,7 @@ int WindowImplAndroid::getUnicode(AInputEvent* event)
 
     // Initializes JNI
     jint lResult;
-    jint lFlags = 0;
+    // jint lFlags = 0;
 
     JavaVM* lJavaVM = states.activity->vm;
     JNIEnv* lJNIEnv = states.activity->env;

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -138,6 +138,7 @@ m_context (EGL_NO_CONTEXT),
 m_surface (EGL_NO_SURFACE),
 m_config  (NULL)
 {
+    (void) owner;
     EglContextImpl::ensureInit();
 
 #ifdef SFML_SYSTEM_ANDROID

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -138,7 +138,6 @@ m_context (EGL_NO_CONTEXT),
 m_surface (EGL_NO_SURFACE),
 m_config  (NULL)
 {
-    (void) owner;
     EglContextImpl::ensureInit();
 
 #ifdef SFML_SYSTEM_ANDROID
@@ -165,6 +164,8 @@ m_config  (NULL)
     // Create EGL surface (except on Android because the window is created
     // asynchronously, its activity manager will call it for us)
     createSurface(owner->getSystemHandle());
+#else
+    (void) owner;
 #endif
 }
 

--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -123,7 +123,7 @@ namespace
                     name += directoryEntry->d_name;
 
                     if (isJoystick(name.c_str()))
-                        plugged[joystickCount++] = name;
+                        plugged[static_cast<unsigned int>(joystickCount++)] = name;
                 }
 
                 directoryEntry = readdir(directory);
@@ -149,8 +149,8 @@ namespace
 
     void hatValueToSfml(int value, sf::priv::JoystickState& state)
     {
-        state.axes[sf::Joystick::PovX] = hatValueMap[value].first;
-        state.axes[sf::Joystick::PovY] = hatValueMap[value].second;
+        state.axes[sf::Joystick::PovX] = static_cast<float>(hatValueMap[value].first);
+        state.axes[sf::Joystick::PovY] = static_cast<float>(hatValueMap[value].second);
     }
 }
 
@@ -220,7 +220,7 @@ bool JoystickImpl::open(unsigned int index)
 
             // Then allocate a buffer for data retrieval
             m_length = hid_report_size(m_desc, hid_input, m_id);
-            m_buffer.resize(m_length);
+            m_buffer.resize(static_cast<size_t>(m_length));
 
             m_state.connected = true;
 
@@ -292,7 +292,7 @@ Joystick::Identification JoystickImpl::getIdentification() const
 ////////////////////////////////////////////////////////////
 JoystickState JoystickImpl::JoystickImpl::update()
 {
-    while (read(m_file, &m_buffer[0], m_length) == m_length)
+    while (read(m_file, &m_buffer[0], static_cast<size_t>(m_length)) == m_length)
     {
         hid_data_t data = hid_start_parse(m_desc, 1 << hid_input, m_id);
 
@@ -328,7 +328,7 @@ JoystickState JoystickImpl::JoystickImpl::update()
                         int maximum = item.logical_maximum;
 
                         value = (value - minimum) * 200 / (maximum - minimum) - 100;
-                        m_state.axes[axis] = value;
+                        m_state.axes[axis] = static_cast<float>(value);
                     }
                 }
             }

--- a/src/SFML/Window/OSX/HIDJoystickManager.cpp
+++ b/src/SFML/Window/OSX/HIDJoystickManager.cpp
@@ -85,7 +85,7 @@ m_joystickCount(0)
     maskArray[0] = mask0;
     maskArray[1] = mask1;
 
-    CFArrayRef mask = CFArrayCreate(NULL, (const void**)maskArray, 2, NULL);
+    CFArrayRef mask = CFArrayCreate(NULL, reinterpret_cast<const void**>(maskArray), 2, NULL);
 
     IOHIDManagerSetDeviceMatchingMultiple(m_manager, mask);
     CFRelease(mask);

--- a/src/SFML/Window/OSX/InputImpl.mm
+++ b/src/SFML/Window/OSX/InputImpl.mm
@@ -58,7 +58,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const WindowBase& window)
 {
-    id nsHandle = (id)window.getSystemHandle();
+    id nsHandle = static_cast<id>(window.getSystemHandle());
 
     // Get our SFOpenGLView from ...
     SFOpenGLView* view = nil;
@@ -78,7 +78,7 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const WindowBase& window)
                 {
                     if ([subview isKindOfClass:[SFOpenGLView class]])
                     {
-                        view = (SFOpenGLView*)subview;
+                        view = static_cast<SFOpenGLView*>(subview);
                         break;
                     }
                 }
@@ -102,7 +102,7 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const WindowBase& window)
         {
             if ([subview isKindOfClass:[SFOpenGLView class]])
             {
-                view = (SFOpenGLView*)subview;
+                view = static_cast<SFOpenGLView*>(subview);
                 break;
             }
         }
@@ -156,8 +156,8 @@ Vector2i InputImpl::getMousePosition()
     NSPoint pos = [NSEvent mouseLocation];
     pos.y = sf::VideoMode::getDesktopMode().height - pos.y;
 
-    int scale = [[NSScreen mainScreen] backingScaleFactor];
-    return Vector2i(pos.x, pos.y) * scale;
+    int scale = static_cast<int>([[NSScreen mainScreen] backingScaleFactor]);
+    return Vector2i(static_cast<int>(pos.x), static_cast<int>(pos.y)) * scale;
 }
 
 
@@ -174,8 +174,8 @@ Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
     // Use -cursorPositionFromEvent: with nil.
     NSPoint pos = [view cursorPositionFromEvent:nil];
 
-    int scale = [view displayScaleFactor];
-    return Vector2i(pos.x, pos.y) * scale;
+    int scale = static_cast<int>([view displayScaleFactor]);
+    return Vector2i(static_cast<int>(pos.x), static_cast<int>(pos.y)) * scale;
 }
 
 
@@ -184,7 +184,7 @@ void InputImpl::setMousePosition(const Vector2i& position)
 {
     AutoreleasePool pool;
     // Here we don't need to reverse the coordinates.
-    int scale = [[NSScreen mainScreen] backingScaleFactor];
+    int scale = static_cast<int>([[NSScreen mainScreen] backingScaleFactor]);
     CGPoint pos = CGPointMake(position.x / scale, position.y / scale);
 
     // Place the cursor.
@@ -209,10 +209,10 @@ void InputImpl::setMousePosition(const Vector2i& position, const WindowBase& rel
         return;
 
     // Let SFOpenGLView compute the position in global coordinate
-    int scale = [view displayScaleFactor];
+    int scale = static_cast<int>([view displayScaleFactor]);
     NSPoint p = NSMakePoint(position.x / scale, position.y / scale);
     p = [view computeGlobalPositionOfRelativePoint:p];
-    setMousePosition(sf::Vector2i(p.x, p.y) * scale);
+    setMousePosition(sf::Vector2i(static_cast<int>(p.x), static_cast<int>(p.y)) * scale);
 }
 
 

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -44,7 +44,7 @@ namespace
     std::string stringFromCFString(CFStringRef cfString)
     {
         CFIndex length = CFStringGetLength(cfString);
-        std::vector<char> str(length);
+        std::vector<char> str(static_cast<std::size_t>(length));
         CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
         CFStringGetCString(cfString, &str[0], maxSize, kCFStringEncodingUTF8);
         return &str[0];
@@ -72,8 +72,8 @@ namespace
         if (typeRef && (CFGetTypeID(typeRef) == CFNumberGetTypeID()))
         {
             SInt32 value;
-            CFNumberGetValue((CFNumberRef)typeRef, kCFNumberSInt32Type, &value);
-            return value;
+            CFNumberGetValue(static_cast<CFNumberRef>(typeRef), kCFNumberSInt32Type, &value);
+            return static_cast<unsigned int>(value);
         }
 
         sf::err() << "Unable to read uint value for property '" << stringFromCFString(prop) << "' for joystick at index " << index << std::endl;
@@ -143,15 +143,15 @@ bool JoystickImpl::isConnected(unsigned int index)
                 CFIndex size = CFSetGetCount(devices);
                 if (size > 0)
                 {
-                    CFTypeRef array[size]; // array of IOHIDDeviceRef
-                    CFSetGetValues(devices, array);
+                    std::vector<CFTypeRef> array(static_cast<std::size_t>(size)); // array of IOHIDDeviceRef
+                    CFSetGetValues(devices, array.data());
 
                     // If there exists a device d s.t. there is no j s.t.
                     // m_locationIDs[j] == d's location then we have a new device.
 
                     for (CFIndex didx(0); !state && didx < size; ++didx)
                     {
-                        IOHIDDeviceRef d = (IOHIDDeviceRef)array[didx];
+                        IOHIDDeviceRef d = static_cast<IOHIDDeviceRef>(const_cast<void*>(array[static_cast<std::size_t>(didx)]));
                         Location dloc = HIDInputManager::getLocationID(d);
 
                         bool foundJ = false;
@@ -194,14 +194,14 @@ bool JoystickImpl::open(unsigned int index)
 
     // Get a usable copy of the joysticks devices.
     CFIndex joysticksCount = CFSetGetCount(devices);
-    CFTypeRef devicesArray[joysticksCount];
-    CFSetGetValues(devices, devicesArray);
+    std::vector<CFTypeRef> devicesArray(static_cast<std::size_t>(joysticksCount));
+    CFSetGetValues(devices, devicesArray.data());
 
     // Get the desired joystick.
     IOHIDDeviceRef self = 0;
     for (CFIndex i(0); self == 0 && i < joysticksCount; ++i)
     {
-        IOHIDDeviceRef d = (IOHIDDeviceRef)devicesArray[i];
+        IOHIDDeviceRef d = static_cast<IOHIDDeviceRef>(const_cast<void*>(devicesArray[static_cast<std::size_t>(i)]));
         if (deviceLoc == HIDInputManager::getLocationID(d))
             self = d;
     }
@@ -229,7 +229,7 @@ bool JoystickImpl::open(unsigned int index)
     CFIndex elementsCount = CFArrayGetCount(elements);
     for (int i = 0; i < elementsCount; ++i)
     {
-        IOHIDElementRef element = (IOHIDElementRef) CFArrayGetValueAtIndex(elements, i);
+        IOHIDElementRef element = static_cast<IOHIDElementRef>(const_cast<void*>(CFArrayGetValueAtIndex(elements, i)));
         switch (IOHIDElementGetUsagePage(element))
         {
             case kHIDPage_GenericDesktop:
@@ -353,7 +353,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
     JoystickCaps caps;
 
     // Buttons:
-    caps.buttonCount = m_buttons.size();
+    caps.buttonCount = static_cast<unsigned int>(m_buttons.size());
 
     // Axis:
     for (AxisMap::const_iterator it(m_axis.begin()); it != m_axis.end(); ++it)
@@ -395,14 +395,14 @@ JoystickState JoystickImpl::update()
 
     // Get a usable copy of the joysticks devices.
     CFIndex joysticksCount = CFSetGetCount(devices);
-    CFTypeRef devicesArray[joysticksCount];
-    CFSetGetValues(devices, devicesArray);
+    std::vector<CFTypeRef> devicesArray(static_cast<std::size_t>(joysticksCount));
+    CFSetGetValues(devices, devicesArray.data());
 
     // Search for it
     bool found = false;
     for (CFIndex i(0); !found && i < joysticksCount; ++i)
     {
-        IOHIDDeviceRef d = (IOHIDDeviceRef)devicesArray[i];
+        IOHIDDeviceRef d = static_cast<IOHIDDeviceRef>(const_cast<void*>(devicesArray[static_cast<std::size_t>(i)]));
         if (selfLoc == HIDInputManager::getLocationID(d))
             found = true;
     }
@@ -453,12 +453,12 @@ JoystickState JoystickImpl::update()
         // This method might not be very accurate (the "0 position" can be
         // slightly shift with some device) but we don't care because most
         // of devices are so sensitive that this is not relevant.
-        double  physicalMax   = IOHIDElementGetPhysicalMax(it->second);
-        double  physicalMin   = IOHIDElementGetPhysicalMin(it->second);
+        double  physicalMax   = static_cast<double>(IOHIDElementGetPhysicalMax(it->second));
+        double  physicalMin   = static_cast<double>(IOHIDElementGetPhysicalMin(it->second));
         double  scaledMin     = -100;
         double  scaledMax     =  100;
         double  physicalValue = IOHIDValueGetScaledValue(value, kIOHIDValueScaleTypePhysical);
-        float   scaledValue   = (((physicalValue - physicalMin) * (scaledMax - scaledMin)) / (physicalMax - physicalMin)) + scaledMin;
+        float   scaledValue   = static_cast<float>((((physicalValue - physicalMin) * (scaledMax - scaledMin)) / (physicalMax - physicalMin)) + scaledMin);
         state.axes[it->first] = scaledValue;
     }
 

--- a/src/SFML/Window/OSX/NSImage+raw.mm
+++ b/src/SFML/Window/OSX/NSImage+raw.mm
@@ -35,8 +35,8 @@
     // Create an empty image representation.
     NSBitmapImageRep* bitmap =
     [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:0 // if 0: only allocate memory
-                                            pixelsWide:size.width
-                                            pixelsHigh:size.height
+                                            pixelsWide:(static_cast<NSInteger>(size.width))
+                                            pixelsHigh:(static_cast<NSInteger>(size.height))
                                          bitsPerSample:8 // The number of bits used to specify
                                                          // one pixel in a single component of the data.
                                        samplesPerPixel:4 // 3 if no alpha, 4 with it

--- a/src/SFML/Window/OSX/SFApplication.m
+++ b/src/SFML/Window/OSX/SFApplication.m
@@ -28,6 +28,14 @@
 ////////////////////////////////////////////////////////////
 #import <SFML/Window/OSX/SFApplication.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 
 ////////////////////////////////////////////////////////////
 @implementation SFApplication

--- a/src/SFML/Window/OSX/SFApplicationDelegate.m
+++ b/src/SFML/Window/OSX/SFApplicationDelegate.m
@@ -28,6 +28,14 @@
 ////////////////////////////////////////////////////////////
 #import <SFML/Window/OSX/SFApplicationDelegate.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 ////////////////////////////////////////////////////////////
 @implementation SFApplicationDelegate
 

--- a/src/SFML/Window/OSX/SFContext.mm
+++ b/src/SFML/Window/OSX/SFContext.mm
@@ -33,6 +33,14 @@
 #include <dlfcn.h>
 #include <stdint.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 namespace sf
 {
 namespace priv
@@ -184,14 +192,14 @@ void SFContext::createContext(SFContext* shared,
     if (bitsPerPixel > 24)
     {
         attrs.push_back(NSOpenGLPFAAlphaSize);
-        attrs.push_back((NSOpenGLPixelFormatAttribute)8);
+        attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(8));
     }
 
     attrs.push_back(NSOpenGLPFADepthSize);
-    attrs.push_back((NSOpenGLPixelFormatAttribute)m_settings.depthBits);
+    attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(m_settings.depthBits));
 
     attrs.push_back(NSOpenGLPFAStencilSize);
-    attrs.push_back((NSOpenGLPixelFormatAttribute)m_settings.stencilBits);
+    attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(m_settings.stencilBits));
 
     if (m_settings.antialiasingLevel > 0)
     {
@@ -211,11 +219,11 @@ void SFContext::createContext(SFContext* shared,
 
         // Only one buffer is currently available
         attrs.push_back(NSOpenGLPFASampleBuffers);
-        attrs.push_back((NSOpenGLPixelFormatAttribute)1);
+        attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(1));
 
         // Antialiasing level
         attrs.push_back(NSOpenGLPFASamples);
-        attrs.push_back((NSOpenGLPixelFormatAttribute)m_settings.antialiasingLevel);
+        attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(m_settings.antialiasingLevel));
 
         // No software renderer - only hardware renderer
         attrs.push_back(NSOpenGLPFAAccelerated);
@@ -232,7 +240,7 @@ void SFContext::createContext(SFContext* shared,
 
     if (legacy)
     {
-        m_settings.attributeFlags &= ~ContextSettings::Core;
+        m_settings.attributeFlags &= ~static_cast<unsigned int>(ContextSettings::Core);
         m_settings.majorVersion = 2;
         m_settings.minorVersion = 1;
         attrs.push_back(NSOpenGLPFAOpenGLProfile);
@@ -254,10 +262,10 @@ void SFContext::createContext(SFContext* shared,
     if (m_settings.attributeFlags & ContextSettings::Debug)
     {
         sf::err() << "Warning. OpenGL debugging not supported on this platform." << std::endl;
-        m_settings.attributeFlags &= ~ContextSettings::Debug;
+        m_settings.attributeFlags &= ~static_cast<unsigned int>(ContextSettings::Debug);
     }
 
-    attrs.push_back((NSOpenGLPixelFormatAttribute)0); // end of array
+    attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(0)); // end of array
 
     // All OS X pixel formats are sRGB capable
     m_settings.sRgbCapable = true;

--- a/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
+++ b/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
@@ -30,6 +30,14 @@
 
 #import <SFML/Window/OSX/SFKeyboardModifiersHelper.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 
 ////////////////////////////////////////////////////////////
 /// Here are define the mask value for the 'modifiers'

--- a/src/SFML/Window/OSX/SFOpenGLView+keyboard.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView+keyboard.mm
@@ -33,6 +33,14 @@
 #import <SFML/Window/OSX/SFOpenGLView.h>
 #import <SFML/Window/OSX/SFOpenGLView+keyboard_priv.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 ////////////////////////////////////////////////////////////
 /// In this file, we implement keyboard handling for SFOpenGLView
 ///

--- a/src/SFML/Window/OSX/SFOpenGLView+mouse.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView+mouse.mm
@@ -32,6 +32,14 @@
 #import <SFML/Window/OSX/SFOpenGLView.h>
 #import <SFML/Window/OSX/SFOpenGLView+mouse_priv.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 
 ////////////////////////////////////////////////////////////
 /// In this file, we implement mouse handling for SFOpenGLView
@@ -136,7 +144,7 @@
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
 
         if (button != sf::Mouse::ButtonCount)
-            m_requester->mouseDownAt(button, loc.x, loc.y);
+            m_requester->mouseDownAt(button, static_cast<int>(loc.x), static_cast<int>(loc.y));
     }
 }
 
@@ -181,7 +189,7 @@
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
 
         if (button != sf::Mouse::ButtonCount)
-            m_requester->mouseUpAt(button, loc.x, loc.y);
+            m_requester->mouseUpAt(button, static_cast<int>(loc.x), static_cast<int>(loc.y));
     }
 }
 
@@ -242,7 +250,7 @@
     //  when the mouse is dragged. That would be too easy!)
     [self updateMouseState];
     if ((m_requester != 0) && m_mouseIsIn)
-        m_requester->mouseMovedAt(loc.x, loc.y);
+        m_requester->mouseMovedAt(static_cast<int>(loc.x), static_cast<int>(loc.y));
 }
 
 
@@ -290,7 +298,7 @@
 {
     NSScreen* screen = [[self window] screen];
     NSNumber* displayId = [[screen deviceDescription] objectForKey:@"NSScreenNumber"];
-    return [displayId intValue];
+    return static_cast<unsigned int>([displayId intValue]);
 }
 
 
@@ -300,7 +308,7 @@
     if (m_requester != 0)
     {
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
-        m_requester->mouseWheelScrolledAt([theEvent deltaX], [theEvent deltaY], loc.x, loc.y);
+        m_requester->mouseWheelScrolledAt(static_cast<float>([theEvent deltaX]), static_cast<float>([theEvent deltaY]), static_cast<int>(loc.x), static_cast<int>(loc.y));
     }
 
     // Transmit to non-SFML responder
@@ -396,7 +404,7 @@
     NSPoint loc = [self convertPoint:rawPos fromView:nil];
 
     // Don't forget to change to SFML coord system.
-    float h = [self frame].size.height;
+    const double h = [self frame].size.height;
     loc.y = h - loc.y;
 
     return loc;

--- a/src/SFML/Window/OSX/SFOpenGLView.h
+++ b/src/SFML/Window/OSX/SFOpenGLView.h
@@ -28,6 +28,16 @@
 ////////////////////////////////////////////////////////////
 #import <AppKit/AppKit.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 namespace sf {
     namespace priv {
         class WindowImplCocoa;
@@ -199,3 +209,11 @@ namespace sf {
 -(void)updateCursorGrabbed;
 
 @end
+
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic pop
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic pop
+    #endif
+#endif

--- a/src/SFML/Window/OSX/SFOpenGLView.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView.mm
@@ -33,6 +33,14 @@
 #import <SFML/Window/OSX/SFOpenGLView+mouse_priv.h>
 #import <SFML/Window/OSX/SFSilentResponder.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 
 ////////////////////////////////////////////////////////////
 /// SFOpenGLView class: Privates Methods Declaration
@@ -214,7 +222,7 @@
     point = [self convertPointToScreen:point];
 
     // Flip screen coordinates to match CGDisplayMoveCursorToPoint referential.
-    const float screenHeight = [[[self window] screen] frame].size.height;
+    const double screenHeight = [[[self window] screen] frame].size.height;
     point.y = screenHeight - point.y;
 
     return point;
@@ -239,7 +247,7 @@
     // Send a resize event if the scaling factor changed
     if ((m_scaleFactor != oldScaleFactor) && (m_requester != 0)) {
         NSSize newSize = [self frame].size;
-        m_requester->windowResized(newSize.width, newSize.height);
+        m_requester->windowResized(static_cast<unsigned int>(newSize.width), static_cast<unsigned int>(newSize.height));
     }
 }
 
@@ -271,7 +279,7 @@
 
     // The new size
     NSSize newSize = [self frame].size;
-    m_requester->windowResized(newSize.width, newSize.height);
+    m_requester->windowResized(static_cast<unsigned int>(newSize.width), static_cast<unsigned int>(newSize.height));
 }
 
 ////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFViewController.mm
+++ b/src/SFML/Window/OSX/SFViewController.mm
@@ -33,6 +33,14 @@
 #import <SFML/Window/OSX/SFOpenGLView.h>
 #import <SFML/Window/OSX/SFViewController.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 @implementation SFViewController
 
 

--- a/src/SFML/Window/OSX/Scaling.h
+++ b/src/SFML/Window/OSX/Scaling.h
@@ -54,7 +54,7 @@ inline CGFloat getDefaultScaleFactor()
 template <class T>
 void scaleIn(T& in, id<WindowImplDelegateProtocol> delegate)
 {
-    in /= delegate ? [delegate displayScaleFactor] : getDefaultScaleFactor();
+    in /= static_cast<T>(delegate ? [delegate displayScaleFactor] : getDefaultScaleFactor());
 }
 
 template <class T>
@@ -81,7 +81,7 @@ void scaleInXY(T& in, id<WindowImplDelegateProtocol> delegate)
 template <class T>
 void scaleOut(T& out, id<WindowImplDelegateProtocol> delegate)
 {
-    out *= delegate ? [delegate displayScaleFactor] : getDefaultScaleFactor();
+    out = out * static_cast<T>(delegate ? [delegate displayScaleFactor] : getDefaultScaleFactor());
 }
 
 template <class T>

--- a/src/SFML/Window/OSX/VideoModeImpl.cpp
+++ b/src/SFML/Window/OSX/VideoModeImpl.cpp
@@ -56,7 +56,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     const CFIndex modesCount = CFArrayGetCount(cgmodes);
     for (CFIndex i = 0; i < modesCount; i++)
     {
-        CGDisplayModeRef cgmode = (CGDisplayModeRef)CFArrayGetValueAtIndex(cgmodes, i);
+        CGDisplayModeRef cgmode = static_cast<CGDisplayModeRef>(const_cast<void*>(CFArrayGetValueAtIndex(cgmodes, i)));
 
         VideoMode mode = convertCGModeToSFMode(cgmode);
 

--- a/src/SFML/Window/OSX/WindowImplCocoa.hpp
+++ b/src/SFML/Window/OSX/WindowImplCocoa.hpp
@@ -33,6 +33,16 @@
 #include <SFML/Window/WindowImpl.hpp>
 #include <SFML/System/String.hpp>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 ////////////////////////////////////////////////////////////
 /// Predefine OBJ-C classes
 ////////////////////////////////////////////////////////////
@@ -373,5 +383,12 @@ private:
 
 } // namespace sf
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic pop
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic pop
+    #endif
+#endif
 
 #endif // SFML_WINDOWIMPLCOCOA_HPP

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -88,7 +88,7 @@ m_showCursor(true)
 {
     AutoreleasePool pool;
     // Treat the handle as it real type
-    id nsHandle = (id)handle;
+    id nsHandle = static_cast<id>(handle);
     if ([nsHandle isKindOfClass:[NSWindow class]])
     {
         // We have a window.
@@ -304,7 +304,7 @@ void WindowImplCocoa::mouseWheelScrolledAt(float deltaX, float deltaY, int x, in
     Event event;
 
     event.type = Event::MouseWheelMoved;
-    event.mouseWheel.delta = deltaY;
+    event.mouseWheel.delta = static_cast<int>(deltaY);
     event.mouseWheel.x = x;
     event.mouseWheel.y = y;
     scaleOutXY(event.mouseWheel, m_delegate);
@@ -415,7 +415,7 @@ Vector2i WindowImplCocoa::getPosition() const
 {
     AutoreleasePool pool;
     NSPoint pos = [m_delegate position];
-    sf::Vector2i ret(pos.x, pos.y);
+    sf::Vector2i ret(static_cast<int>(pos.x), static_cast<int>(pos.y));
     scaleOutXY(ret, m_delegate);
     return ret;
 }
@@ -436,7 +436,7 @@ Vector2u WindowImplCocoa::getSize() const
 {
     AutoreleasePool pool;
     NSSize size = [m_delegate size];
-    Vector2u ret(size.width, size.height);
+    Vector2u ret(static_cast<unsigned int>(size.width), static_cast<unsigned int>(size.height));
     scaleOutXY(ret, m_delegate);
     return ret;
 }

--- a/src/SFML/Window/OSX/WindowImplDelegateProtocol.h
+++ b/src/SFML/Window/OSX/WindowImplDelegateProtocol.h
@@ -31,6 +31,16 @@
 
 #import <AppKit/AppKit.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 namespace sf {
     namespace priv {
         class WindowImplCocoa;
@@ -232,3 +242,11 @@ namespace sf {
 -(void)applyContext:(NSOpenGLContext*)context;
 
 @end
+
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic pop
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic pop
+    #endif
+#endif

--- a/src/SFML/Window/OSX/cg_sf_conversion.mm
+++ b/src/SFML/Window/OSX/cg_sf_conversion.mm
@@ -31,6 +31,14 @@
 
 #import <SFML/Window/OSX/Scaling.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 namespace sf
 {
 namespace priv
@@ -87,7 +95,7 @@ VideoMode convertCGModeToSFMode(CGDisplayModeRef cgmode)
     //
     // [1]: "APIs for Supporting High Resolution" > "Additions and Changes for OS X v10.8"
     // https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/APIs/APIs.html#//apple_ref/doc/uid/TP40012302-CH5-SW27
-    VideoMode mode(CGDisplayModeGetWidth(cgmode), CGDisplayModeGetHeight(cgmode), modeBitsPerPixel(cgmode));
+    VideoMode mode(static_cast<unsigned int>(CGDisplayModeGetWidth(cgmode)), static_cast<unsigned int>(CGDisplayModeGetHeight(cgmode)), static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
     scaleOutWidthHeight(mode, nil);
     return mode;
 }

--- a/src/SFML/Window/OSX/cpp_objc_conversion.mm
+++ b/src/SFML/Window/OSX/cpp_objc_conversion.mm
@@ -44,7 +44,7 @@ NSString* stringToNSString(const std::string& string)
 ////////////////////////////////////////////////////////////
 NSString* sfStringToNSString(const sf::String& string)
 {
-    sf::Uint32 length = string.getSize() * sizeof(sf::Uint32);
+    sf::Uint32 length = static_cast<sf::Uint32>(string.getSize() * sizeof(sf::Uint32));
     const void* data = reinterpret_cast<const void*>(string.getData());
 
     NSStringEncoding encoding;

--- a/src/SFML/Window/Vulkan.cpp
+++ b/src/SFML/Window/Vulkan.cpp
@@ -51,6 +51,7 @@ bool Vulkan::isAvailable(bool requireGraphics)
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
+    (void) requireGraphics;
     return false;
 
 #else
@@ -66,6 +67,7 @@ VulkanFunctionPointer Vulkan::getFunction(const char* name)
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
+    (void) name;
     return NULL;
 
 #else

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -280,6 +280,9 @@ bool WindowImpl::createVulkanSurface(const VkInstance& instance, VkSurfaceKHR& s
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
+    (void) instance;
+    (void) surface;
+    (void) allocator;
     return false;
 
 #else

--- a/src/SFML/Window/iOS/CursorImpl.cpp
+++ b/src/SFML/Window/iOS/CursorImpl.cpp
@@ -47,7 +47,7 @@ CursorImpl::~CursorImpl()
 
 
 ////////////////////////////////////////////////////////////
-bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hotspot)
+bool CursorImpl::loadFromPixels(const Uint8* /* pixels */, Vector2u /* size */, Vector2u /* hotspot */)
 {
     // Not supported
     return false;
@@ -55,7 +55,7 @@ bool CursorImpl::loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hot
 
 
 ////////////////////////////////////////////////////////////
-bool CursorImpl::loadFromSystem(Cursor::Type type)
+bool CursorImpl::loadFromSystem(Cursor::Type /* type */)
 {
     // Not supported
     return false;

--- a/src/SFML/Window/iOS/InputImpl.mm
+++ b/src/SFML/Window/iOS/InputImpl.mm
@@ -37,7 +37,7 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-bool InputImpl::isKeyPressed(Keyboard::Key key)
+bool InputImpl::isKeyPressed(Keyboard::Key /* key */)
 {
     // Not applicable
     return false;
@@ -52,7 +52,7 @@ void InputImpl::setVirtualKeyboardVisible(bool visible)
 
 
 ////////////////////////////////////////////////////////////
-bool InputImpl::isMouseButtonPressed(Mouse::Button button)
+bool InputImpl::isMouseButtonPressed(Mouse::Button /* button */)
 {
     // Not applicable
     return false;
@@ -67,23 +67,21 @@ Vector2i InputImpl::getMousePosition()
 
 
 ////////////////////////////////////////////////////////////
-Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
+Vector2i InputImpl::getMousePosition(const WindowBase& /* relativeTo */)
 {
-    (void)relativeTo;
-
     return getMousePosition();
 }
 
 
 ////////////////////////////////////////////////////////////
-void InputImpl::setMousePosition(const Vector2i& position)
+void InputImpl::setMousePosition(const Vector2i& /* position */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void InputImpl::setMousePosition(const Vector2i& position, const WindowBase& relativeTo)
+void InputImpl::setMousePosition(const Vector2i& /* position */, const WindowBase& /* relativeTo */)
 {
     // Not applicable
 }
@@ -104,10 +102,8 @@ Vector2i InputImpl::getTouchPosition(unsigned int finger)
 
 
 ////////////////////////////////////////////////////////////
-Vector2i InputImpl::getTouchPosition(unsigned int finger, const WindowBase& relativeTo)
+Vector2i InputImpl::getTouchPosition(unsigned int finger, const WindowBase& /* relativeTo */)
 {
-    (void)relativeTo;
-
     return getTouchPosition(finger);
 }
 

--- a/src/SFML/Window/iOS/JoystickImpl.mm
+++ b/src/SFML/Window/iOS/JoystickImpl.mm
@@ -47,7 +47,7 @@ void JoystickImpl::cleanup()
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::isConnected(unsigned int index)
+bool JoystickImpl::isConnected(unsigned int /* index */)
 {
     // Not implemented
     return false;
@@ -55,7 +55,7 @@ bool JoystickImpl::isConnected(unsigned int index)
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::open(unsigned int index)
+bool JoystickImpl::open(unsigned int /* index */)
 {
     // Not implemented
     return false;

--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -171,7 +171,26 @@ namespace
     if (!self.sfWindow)
         return false;
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wold-style-cast"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wold-style-cast"
+    #endif
+#endif
+
     UIViewController* rootViewController = [((__bridge UIWindow*)(self.sfWindow->getSystemHandle())) rootViewController];
+
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic pop
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic pop
+    #endif
+#endif
+
     if (!rootViewController || ![rootViewController shouldAutorotate])
         return false;
 
@@ -189,7 +208,7 @@ namespace
     if ([supportedOrientations containsObject:@"UIInterfaceOrientationLandscapeRight"])
         appFlags += UIInterfaceOrientationMaskLandscapeRight;
 
-    return (1 << orientation) & [rootViewController supportedInterfaceOrientations] & appFlags;
+    return (1 << orientation) & [rootViewController supportedInterfaceOrientations] & static_cast<unsigned long>(appFlags);
 }
 
 - (bool)needsToFlipFrameForOrientation:(UIDeviceOrientation)orientation
@@ -244,11 +263,11 @@ namespace
 
 
 ////////////////////////////////////////////////////////////
-- (void)notifyTouchBegin:(unsigned int)index atPosition:(sf::Vector2i)position;
+- (void)notifyTouchBegin:(unsigned int)index atPosition:(sf::Vector2i)position
 {
-    position.x *= backingScaleFactor;
-    position.y *= backingScaleFactor;
-    
+    position.x *= static_cast<int>(backingScaleFactor);
+    position.y *= static_cast<int>(backingScaleFactor);
+
     // save the touch position
     if (index >= touchPositions.size())
         touchPositions.resize(index + 1, sf::Vector2i(-1, -1));
@@ -268,11 +287,11 @@ namespace
 
 
 ////////////////////////////////////////////////////////////
-- (void)notifyTouchMove:(unsigned int)index atPosition:(sf::Vector2i)position;
+- (void)notifyTouchMove:(unsigned int)index atPosition:(sf::Vector2i)position
 {
-    position.x *= backingScaleFactor;
-    position.y *= backingScaleFactor;
-    
+    position.x *= static_cast<int>(backingScaleFactor);
+    position.y *= static_cast<int>(backingScaleFactor);
+
     // save the touch position
     if (index >= touchPositions.size())
         touchPositions.resize(index + 1, sf::Vector2i(-1, -1));
@@ -292,7 +311,7 @@ namespace
 
 
 ////////////////////////////////////////////////////////////
-- (void)notifyTouchEnd:(unsigned int)index atPosition:(sf::Vector2i)position;
+- (void)notifyTouchEnd:(unsigned int)index atPosition:(sf::Vector2i)position
 {
     // clear the touch position
     if (index < touchPositions.size())
@@ -304,8 +323,8 @@ namespace
         sf::Event event;
         event.type = sf::Event::TouchEnded;
         event.touch.finger = index;
-        event.touch.x = position.x * backingScaleFactor;
-        event.touch.y = position.y * backingScaleFactor;
+        event.touch.x = position.x * static_cast<int>(backingScaleFactor);
+        event.touch.y = position.y * static_cast<int>(backingScaleFactor);
         sfWindow->forwardEvent(event);
     }
 }

--- a/src/SFML/Window/iOS/SFView.mm
+++ b/src/SFML/Window/iOS/SFView.mm
@@ -31,6 +31,14 @@
 #include <QuartzCore/CAEAGLLayer.h>
 #include <cstring>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 @interface SFView()
 
 @property (nonatomic) NSMutableArray* touches;
@@ -103,7 +111,7 @@
         sf::Vector2i position(static_cast<int>(point.x), static_cast<int>(point.y));
 
         // notify the application delegate
-        [[SFAppDelegate getInstance] notifyTouchBegin:index atPosition:position];
+        [[SFAppDelegate getInstance] notifyTouchBegin:(static_cast<unsigned int>(index)) atPosition:position];
     }
 }
 
@@ -122,7 +130,7 @@
             sf::Vector2i position(static_cast<int>(point.x), static_cast<int>(point.y));
 
             // notify the application delegate
-            [[SFAppDelegate getInstance] notifyTouchMove:index atPosition:position];
+            [[SFAppDelegate getInstance] notifyTouchMove:(static_cast<unsigned int>(index)) atPosition:position];
         }
     }
 }
@@ -142,7 +150,7 @@
             sf::Vector2i position(static_cast<int>(point.x), static_cast<int>(point.y));
 
             // notify the application delegate
-            [[SFAppDelegate getInstance] notifyTouchEnd:index atPosition:position];
+            [[SFAppDelegate getInstance] notifyTouchEnd:(static_cast<unsigned int>(index)) atPosition:position];
 
             // remove the touch
             [self.touches replaceObjectAtIndex:index withObject:[NSNull null]];
@@ -187,7 +195,7 @@
         self.touches = [NSMutableArray array];
 
         // Configure the EAGL layer
-        CAEAGLLayer* eaglLayer = (CAEAGLLayer*)self.layer;
+        CAEAGLLayer* eaglLayer = static_cast<CAEAGLLayer*>(self.layer);
         eaglLayer.opaque = YES;
         eaglLayer.drawableProperties = [NSDictionary dictionaryWithObjectsAndKeys:
                                         [NSNumber numberWithBool:FALSE], kEAGLDrawablePropertyRetainedBacking,

--- a/src/SFML/Window/iOS/SensorImpl.mm
+++ b/src/SFML/Window/iOS/SensorImpl.mm
@@ -139,37 +139,37 @@ Vector3f SensorImpl::update()
     {
         case Sensor::Accelerometer:
             // Acceleration is given in G, convert to m/s^2
-            value.x = manager.accelerometerData.acceleration.x * 9.81f;
-            value.y = manager.accelerometerData.acceleration.y * 9.81f;
-            value.z = manager.accelerometerData.acceleration.z * 9.81f;
+            value.x = static_cast<float>(manager.accelerometerData.acceleration.x * 9.81);
+            value.y = static_cast<float>(manager.accelerometerData.acceleration.y * 9.81);
+            value.z = static_cast<float>(manager.accelerometerData.acceleration.z * 9.81);
             break;
 
         case Sensor::Gyroscope:
             // Rotation rates are given in rad/s, convert to deg/s
-            value.x = toDegrees(manager.gyroData.rotationRate.x);
-            value.y = toDegrees(manager.gyroData.rotationRate.y);
-            value.z = toDegrees(manager.gyroData.rotationRate.z);
+            value.x = toDegrees(static_cast<float>(manager.gyroData.rotationRate.x));
+            value.y = toDegrees(static_cast<float>(manager.gyroData.rotationRate.y));
+            value.z = toDegrees(static_cast<float>(manager.gyroData.rotationRate.z));
             break;
 
         case Sensor::Magnetometer:
             // Magnetic field is given in microteslas
-            value.x = manager.magnetometerData.magneticField.x;
-            value.y = manager.magnetometerData.magneticField.y;
-            value.z = manager.magnetometerData.magneticField.z;
+            value.x = static_cast<float>(manager.magnetometerData.magneticField.x);
+            value.y = static_cast<float>(manager.magnetometerData.magneticField.y);
+            value.z = static_cast<float>(manager.magnetometerData.magneticField.z);
             break;
 
         case Sensor::UserAcceleration:
             // User acceleration is given in G, convert to m/s^2
-            value.x = manager.deviceMotion.userAcceleration.x * 9.81f;
-            value.y = manager.deviceMotion.userAcceleration.y * 9.81f;
-            value.z = manager.deviceMotion.userAcceleration.z * 9.81f;
+            value.x = static_cast<float>(manager.deviceMotion.userAcceleration.x * 9.81);
+            value.y = static_cast<float>(manager.deviceMotion.userAcceleration.y * 9.81);
+            value.z = static_cast<float>(manager.deviceMotion.userAcceleration.z * 9.81);
             break;
 
         case Sensor::Orientation:
             // Absolute rotation (Euler) angles are given in radians, convert to degrees
-            value.x = toDegrees(manager.deviceMotion.attitude.yaw);
-            value.y = toDegrees(manager.deviceMotion.attitude.pitch);
-            value.z = toDegrees(manager.deviceMotion.attitude.roll);
+            value.x = toDegrees(static_cast<float>(manager.deviceMotion.attitude.yaw));
+            value.y = toDegrees(static_cast<float>(manager.deviceMotion.attitude.pitch));
+            value.z = toDegrees(static_cast<float>(manager.deviceMotion.attitude.roll));
             break;
 
         default:

--- a/src/SFML/Window/iOS/VideoModeImpl.mm
+++ b/src/SFML/Window/iOS/VideoModeImpl.mm
@@ -50,8 +50,8 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 VideoMode VideoModeImpl::getDesktopMode()
 {
     CGRect bounds = [[UIScreen mainScreen] bounds];
-    float backingScale = [SFAppDelegate getInstance].backingScaleFactor;
-    return VideoMode(bounds.size.width * backingScale, bounds.size.height * backingScale);
+    double backingScale = [SFAppDelegate getInstance].backingScaleFactor;
+    return VideoMode(static_cast<unsigned int>(bounds.size.width * backingScale), static_cast<unsigned int>(bounds.size.height * backingScale));
 }
 
 } // namespace priv

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -33,12 +33,20 @@
 #include <SFML/System/Err.hpp>
 #include <UIKit/UIKit.h>
 
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    #endif
+#endif
+
 namespace sf
 {
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-WindowImplUIKit::WindowImplUIKit(WindowHandle handle)
+WindowImplUIKit::WindowImplUIKit(WindowHandle /* handle */)
 {
     // Not implemented
 }
@@ -46,11 +54,11 @@ WindowImplUIKit::WindowImplUIKit(WindowHandle handle)
 
 ////////////////////////////////////////////////////////////
 WindowImplUIKit::WindowImplUIKit(VideoMode mode,
-                                 const String& title,
+                                 const String& /* title */,
                                  unsigned long style,
-                                 const ContextSettings& /*settings*/)
+                                 const ContextSettings& /* settings */)
 {
-    m_backingScale = [SFAppDelegate getInstance].backingScaleFactor;
+    m_backingScale = static_cast<float>([SFAppDelegate getInstance].backingScaleFactor);
 
     // Apply the fullscreen flag
     [UIApplication sharedApplication].statusBarHidden = !(style & Style::Titlebar) || (style & Style::Fullscreen);
@@ -77,7 +85,7 @@ WindowImplUIKit::WindowImplUIKit(VideoMode mode,
             std::swap(viewRect.size.width, viewRect.size.height);
 
     // Create the view
-    m_view = [[SFView alloc] initWithFrame:viewRect andContentScaleFactor:m_backingScale];
+    m_view = [[SFView alloc] initWithFrame:viewRect andContentScaleFactor:(static_cast<double>(m_backingScale))];
     [m_view resignFirstResponder];
 
     // Create the view controller
@@ -108,7 +116,25 @@ void WindowImplUIKit::processEvents()
 ////////////////////////////////////////////////////////////
 WindowHandle WindowImplUIKit::getSystemHandle() const
 {
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wold-style-cast"
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wold-style-cast"
+    #endif
+#endif
+
     return (__bridge WindowHandle)m_window;
+
+#if defined(__APPLE__)
+    #if defined(__clang__)
+        #pragma clang diagnostic pop
+    #elif defined(__GNUC__)
+        #pragma GCC diagnostic pop
+    #endif
+#endif
 }
 
 
@@ -116,12 +142,12 @@ WindowHandle WindowImplUIKit::getSystemHandle() const
 Vector2i WindowImplUIKit::getPosition() const
 {
     CGPoint origin = m_window.frame.origin;
-    return Vector2i(origin.x * m_backingScale, origin.y * m_backingScale);
+    return Vector2i(static_cast<int>(origin.x * static_cast<double>(m_backingScale)), static_cast<int>(origin.y * static_cast<double>(m_backingScale)));
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setPosition(const Vector2i& position)
+void WindowImplUIKit::setPosition(const Vector2i& /* position */)
 {
 }
 
@@ -129,12 +155,12 @@ void WindowImplUIKit::setPosition(const Vector2i& position)
 ////////////////////////////////////////////////////////////
 Vector2u WindowImplUIKit::getSize() const
 {
-    auto physicalFrame = m_window.frame;
+    CGRect physicalFrame = m_window.frame;
     // iOS 7 and 8 do different stuff here. In iOS 7 frame.x<frame.y always! In iOS 8 it correctly depends on orientation
     if ((NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1)
         && UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]))
         std::swap(physicalFrame.size.width, physicalFrame.size.height);
-    return Vector2u(physicalFrame.size.width * m_backingScale, physicalFrame.size.height * m_backingScale);
+    return Vector2u(static_cast<unsigned int>(physicalFrame.size.width * static_cast<double>(m_backingScale)), static_cast<unsigned int>(physicalFrame.size.height * static_cast<double>(m_backingScale)));
 }
 
 
@@ -156,49 +182,49 @@ void WindowImplUIKit::setSize(const Vector2u& size)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setTitle(const String& title)
+void WindowImplUIKit::setTitle(const String& /* title */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setIcon(unsigned int width, unsigned int height, const Uint8* pixels)
+void WindowImplUIKit::setIcon(unsigned int /* width */, unsigned int /* height */, const Uint8* /* pixels */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setVisible(bool visible)
+void WindowImplUIKit::setVisible(bool /* visible */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setMouseCursorVisible(bool visible)
+void WindowImplUIKit::setMouseCursorVisible(bool /* visible */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setMouseCursorGrabbed(bool grabbed)
+void WindowImplUIKit::setMouseCursorGrabbed(bool /* grabbed */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setMouseCursor(const CursorImpl& cursor)
+void WindowImplUIKit::setMouseCursor(const CursorImpl& /* cursor */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setKeyRepeatEnabled(bool enabled)
+void WindowImplUIKit::setKeyRepeatEnabled(bool /* enabled */)
 {
     // Not applicable
 }


### PR DESCRIPTION
## Description

~That's a quick fix as `-DWARNINGS_AS_ERRORS=1` does not work for clang compilers because of how the logic was ordered.~

This PR can't be merged without all clang warnings removed.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

```bash
cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DWARNINGS_AS_ERRORS=1
# Assert the flag was enabled
grep 'WARNINGS_AS_ERRORS' ./build/CMakeCache.txt
# Output should be: WARNINGS_AS_ERRORS:BOOL=1
grep -om 1 '\-Werror' ./build/compile_commands.json 
# Output should be: -Werror
```