### PR TITLE
Make 'Vertex' a 'constexpr' class

### DIFF
--- a/include/SFML/Graphics/Vertex.hpp
+++ b/include/SFML/Graphics/Vertex.hpp
@@ -28,7 +28,6 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/System/Vector2.hpp>
 
@@ -39,7 +38,7 @@ namespace sf
 /// \brief Define a point with color and texture coordinates
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Vertex
+class Vertex
 {
 public:
 
@@ -47,7 +46,7 @@ public:
     /// \brief Default constructor
     ///
     ////////////////////////////////////////////////////////////
-    Vertex();
+    constexpr Vertex();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vertex from its position
@@ -57,7 +56,7 @@ public:
     /// \param thePosition Vertex position
     ///
     ////////////////////////////////////////////////////////////
-    Vertex(const Vector2f& thePosition);
+    constexpr Vertex(const Vector2f& thePosition);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vertex from its position and color
@@ -68,7 +67,7 @@ public:
     /// \param theColor    Vertex color
     ///
     ////////////////////////////////////////////////////////////
-    Vertex(const Vector2f& thePosition, const Color& theColor);
+    constexpr Vertex(const Vector2f& thePosition, const Color& theColor);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vertex from its position and texture coordinates
@@ -79,7 +78,7 @@ public:
     /// \param theTexCoords Vertex texture coordinates
     ///
     ////////////////////////////////////////////////////////////
-    Vertex(const Vector2f& thePosition, const Vector2f& theTexCoords);
+    constexpr Vertex(const Vector2f& thePosition, const Vector2f& theTexCoords);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vertex from its position, color and texture coordinates
@@ -89,7 +88,7 @@ public:
     /// \param theTexCoords Vertex texture coordinates
     ///
     ////////////////////////////////////////////////////////////
-    Vertex(const Vector2f& thePosition, const Color& theColor, const Vector2f& theTexCoords);
+    constexpr Vertex(const Vector2f& thePosition, const Color& theColor, const Vector2f& theTexCoords);
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -98,6 +97,8 @@ public:
     Color     color;     //!< Color of the vertex
     Vector2f  texCoords; //!< Coordinates of the texture's pixel to map to the vertex
 };
+
+#include <SFML/Graphics/Vertex.inl>
 
 } // namespace sf
 

--- a/include/SFML/Graphics/Vertex.inl
+++ b/include/SFML/Graphics/Vertex.inl
@@ -22,16 +22,9 @@
 //
 ////////////////////////////////////////////////////////////
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-#include <SFML/Graphics/Vertex.hpp>
 
-
-namespace sf
-{
 ////////////////////////////////////////////////////////////
-Vertex::Vertex() :
+constexpr Vertex::Vertex() :
 position (0, 0),
 color    (255, 255, 255),
 texCoords(0, 0)
@@ -40,7 +33,7 @@ texCoords(0, 0)
 
 
 ////////////////////////////////////////////////////////////
-Vertex::Vertex(const Vector2f& thePosition) :
+constexpr Vertex::Vertex(const Vector2f& thePosition) :
 position (thePosition),
 color    (255, 255, 255),
 texCoords(0, 0)
@@ -49,7 +42,7 @@ texCoords(0, 0)
 
 
 ////////////////////////////////////////////////////////////
-Vertex::Vertex(const Vector2f& thePosition, const Color& theColor) :
+constexpr Vertex::Vertex(const Vector2f& thePosition, const Color& theColor) :
 position (thePosition),
 color    (theColor),
 texCoords(0, 0)
@@ -58,7 +51,7 @@ texCoords(0, 0)
 
 
 ////////////////////////////////////////////////////////////
-Vertex::Vertex(const Vector2f& thePosition, const Vector2f& theTexCoords) :
+constexpr Vertex::Vertex(const Vector2f& thePosition, const Vector2f& theTexCoords) :
 position (thePosition),
 color    (255, 255, 255),
 texCoords(theTexCoords)
@@ -67,11 +60,9 @@ texCoords(theTexCoords)
 
 
 ////////////////////////////////////////////////////////////
-Vertex::Vertex(const Vector2f& thePosition, const Color& theColor, const Vector2f& theTexCoords) :
+constexpr Vertex::Vertex(const Vector2f& thePosition, const Color& theColor, const Vector2f& theTexCoords) :
 position (thePosition),
 color    (theColor),
 texCoords(theTexCoords)
 {
 }
-
-} // namespace sf

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -47,8 +47,8 @@ set(SRC
     ${INCROOT}/Transformable.hpp
     ${SRCROOT}/View.cpp
     ${INCROOT}/View.hpp
-    ${SRCROOT}/Vertex.cpp
     ${INCROOT}/Vertex.hpp
+    ${INCROOT}/Vertex.inl
 )
 source_group("" FILES ${SRC})
 


### PR DESCRIPTION
## Description

This PR turns `sf::Vertex` into a `constexpr`-friendly class. It depends on #1904, I am creating the PR before that one is merged just for early code review. CI is expected to fail at this stage.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.