### PR TITLE
Only compile Catch main once

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,44 +1,45 @@
 set(SRCROOT "${PROJECT_SOURCE_DIR}/test/src")
 
-include_directories("${PROJECT_SOURCE_DIR}/include")
-include_directories("${PROJECT_SOURCE_DIR}/extlibs/headers")
-include_directories("${SRCROOT}/TestUtilities")
+add_library(sfml-test-config "${SRCROOT}/CatchMain.cpp")
+target_include_directories(sfml-test-config PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/headers" "${SRCROOT}/TestUtilities")
+target_compile_features(sfml-test-config PRIVATE cxx_std_17)
 
 # System is always built
 SET(SYSTEM_SRC
-    "${SRCROOT}/CatchMain.cpp"
     "${SRCROOT}/System/Vector2.cpp"
     "${SRCROOT}/System/Vector3.cpp"
     "${SRCROOT}/TestUtilities/SystemUtil.hpp"
     "${SRCROOT}/TestUtilities/SystemUtil.cpp"
 )
-sfml_add_test(test-sfml-system "${SYSTEM_SRC}"  sfml-system)
+
+sfml_add_test(test-sfml-system "${SYSTEM_SRC}" sfml-system)
+target_link_libraries(test-sfml-system PRIVATE sfml-test-config)
 
 if(SFML_BUILD_WINDOW)
     SET(WINDOW_SRC
-        "${SRCROOT}/CatchMain.cpp"
         "${SRCROOT}/TestUtilities/WindowUtil.hpp"
         "${SRCROOT}/TestUtilities/WindowUtil.cpp"
     )
     sfml_add_test(test-sfml-window "${WINDOW_SRC}" sfml-window)
+    target_link_libraries(test-sfml-window PRIVATE sfml-test-config)
 endif()
 
 if(SFML_BUILD_GRAPHICS)
     SET(GRAPHICS_SRC
-        "${SRCROOT}/CatchMain.cpp"
         "${SRCROOT}/Graphics/Rect.cpp"
         "${SRCROOT}/TestUtilities/GraphicsUtil.hpp"
         "${SRCROOT}/TestUtilities/GraphicsUtil.cpp"
     )
     sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" sfml-graphics)
+    target_link_libraries(test-sfml-graphics PRIVATE sfml-test-config)
 endif()
 
 if(SFML_BUILD_NETWORK)
     SET(NETWORK_SRC
-        "${SRCROOT}/CatchMain.cpp"
         "${SRCROOT}/Network/Packet.cpp"
     )
     sfml_add_test(test-sfml-network "${NETWORK_SRC}" sfml-network)
+    target_link_libraries(test-sfml-network PRIVATE sfml-test-config)
 endif()
 
 # Automatically run the tests at the end of the build


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Because Catch is so expensive to compile, it's really helpful for initial compile times if this target doesn't have to be recompiled so often. This won't make a huge impact on developers who are mostly doing incremental builds but can have a meaningful impact on CI runners that are always doing clean builds.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
