### PR TITLE
Don't use 'sf::err' in public example code

### DIFF
--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -9,10 +9,11 @@
 #include <SFML/Graphics.hpp>
 
 #include <SFML/Window.hpp>
-#include <vector>
+#include <iostream>
 #include <limits>
-#include <cstring>
+#include <vector>
 #include <cmath>
+#include <cstring>
 
 
 ////////////////////////////////////////////////////////////
@@ -168,7 +169,7 @@ namespace
     // Debug we pass to Vulkan to call when it detects warnings or errors
     VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, uint64_t, size_t, int32_t, const char*, const char* pMessage, void*)
     {
-        sf::err() << pMessage << std::endl;
+        std::cerr << pMessage << std::endl;
 
         return VK_FALSE;
     }


### PR DESCRIPTION
`sf::err` is an *internal* error message stream, so it should not be used in example code. To be consistent with other examples, I've changed it to `std::cerr`. Includes have just been alphabetically ordered.