### PR TITLE
Add 'NetworkUtil' for network module tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,8 @@ endif()
 if(SFML_BUILD_NETWORK)
     SET(NETWORK_SRC
         "${SRCROOT}/Network/Packet.cpp"
+        "${SRCROOT}/TestUtilities/NetworkUtil.hpp"
+        "${SRCROOT}/TestUtilities/NetworkUtil.cpp"
     )
     sfml_add_test(test-sfml-network "${NETWORK_SRC}" sfml-network)
     target_link_libraries(test-sfml-network PRIVATE sfml-test-main)

--- a/test/Network/Packet.cpp
+++ b/test/Network/Packet.cpp
@@ -1,7 +1,8 @@
-#include <SFML/Network.hpp>
+#include <SFML/Network/Packet.hpp>
 
-#include <doctest.h>
 #include <limits>
+
+#include "NetworkUtil.hpp"
 
 template <typename IntegerType>
 static void testPacketStreamOperators(IntegerType expected)

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -1,4 +1,4 @@
-// Note: No need to increase compile time by including TestUtilities/Graphics.hpp
+// Note: No need to increase compile time by including TestUtilities/GraphicsUtil.hpp
 #include <SFML/Graphics/Color.hpp>
 #include <sstream>
 #include <doctest.h>

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -8,6 +8,8 @@
 
 #include "WindowUtil.hpp"
 
+#include <doctest.h>
+
 namespace doctest
 {
     class String;

--- a/test/TestUtilities/NetworkUtil.cpp
+++ b/test/TestUtilities/NetworkUtil.cpp
@@ -1,0 +1,1 @@
+// Note: No need to increase compile time by including TestUtilities/NetworkUtil.hpp

--- a/test/TestUtilities/NetworkUtil.hpp
+++ b/test/TestUtilities/NetworkUtil.hpp
@@ -1,0 +1,13 @@
+// Header for SFML unit tests.
+//
+// For a new network module test case, include this header and not <doctest.h> directly.
+// This ensures that string conversions are visible and can be used by doctest for debug output.
+
+#ifndef SFML_TESTUTILITIES_NETWORK_HPP
+#define SFML_TESTUTILITIES_NETWORK_HPP
+
+#include "SystemUtil.hpp"
+
+#include <doctest.h>
+
+#endif // SFML_TESTUTILITIES_NETWORK_HPP

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -1,4 +1,4 @@
-// Note: No need to increase compile time by including TestUtilities/System.hpp
+// Note: No need to increase compile time by including TestUtilities/SystemUtil.hpp
 #include <SFML/System/String.hpp>
 #include <SFML/System/Time.hpp>
 #include <sstream>

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -6,11 +6,11 @@
 #ifndef SFML_TESTUTILITIES_SYSTEM_HPP
 #define SFML_TESTUTILITIES_SYSTEM_HPP
 
-#include <doctest.h>
-
 #include <SFML/System/Vector2.hpp>
 #include <SFML/System/Vector3.hpp>
 #include <sstream>
+
+#include <doctest.h>
 
 // String conversions for doctest framework
 namespace sf

--- a/test/TestUtilities/WindowUtil.cpp
+++ b/test/TestUtilities/WindowUtil.cpp
@@ -1,4 +1,4 @@
-// Note: No need to increase compile time by including TestUtilities/Window.hpp
+// Note: No need to increase compile time by including TestUtilities/WindowUtil.hpp
 #include <SFML/Window/VideoMode.hpp>
 #include <sstream>
 


### PR DESCRIPTION
Depends on #1921, I plan to add more tests here when we add stuff like move semantics so I wanted to make this module consistent with the rest.