### PR TITLE
Fix null pointer dereference in Font

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -401,7 +401,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::shared_ptr<FontHandles>          m_font;        //!< Shared information about the internal font instance
+    std::shared_ptr<FontHandles>          m_fontHandles; //!< Shared information about the internal font instance
     bool                                  m_isSmooth;    //!< Status of the smooth filter
     Info                                  m_info;        //!< Information about the font
     mutable PageTable                     m_pages;       //!< Table containing the glyphs pages by character size


### PR DESCRIPTION
* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before? -> on discord
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

## Description

As discussed on discord with @vittorioromeo, a bug was introduced in #1911. 
Font methods can be used before a font is loaded, dereferencing a pointer initialized to nullptr, causing segfault.

I first renamed `m_font` into `m_fontHandles` as suggested. I did it in a separate commit for easier reviewing and will squash when it is approved.

Then, I thought about several solutions:
1. Initialize the `m_fontHandles` and make sure it is never null (i.e. do not `.reset()` it). This needs to allocate a dummy instance of FontHandles on construction. It could be done only once for all fonts with a static instance.
2. Having private getters accessing `m_fontHandles` members with caution. FreeType types are not available in Font.hpp though so it requires some static_casts.
3. Have four raw pointers to FreeType objects as before and keep them in sync with `m_fontHandles`. Requires static_casts as before.
4. Check manually if `m_fontHandles` is not null when using it.

I implemented the last idea, but maybe there is a better way.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Running this program and notice that it does not segfault.

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    const unsigned int characterSize = 18;

    sf::Font font;
    font.getGlyph(0, characterSize, false);
    font.hasGlyph(42);
    font.getKerning(1, 2, characterSize);
    font.getLineSpacing(characterSize);
    font.getUnderlinePosition(characterSize);
    font.getUnderlineThickness(characterSize);
}
```
```cmake
cmake_minimum_required(VERSION 3.22)
project(test)
find_package(SFML 3.0 COMPONENTS graphics REQUIRED)
add_executable(test main.cpp)
target_link_libraries(test sfml-graphics)
```