### PR TITLE
Add tests for sf::VideoMode

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(test-sfml-system PRIVATE sfml-test-main)
 
 if(SFML_BUILD_WINDOW)
     SET(WINDOW_SRC
+        "${SRCROOT}/Window/VideoMode.cpp"
         "${SRCROOT}/TestUtilities/WindowUtil.hpp"
         "${SRCROOT}/TestUtilities/WindowUtil.cpp"
     )

--- a/test/Window/VideoMode.cpp
+++ b/test/Window/VideoMode.cpp
@@ -1,0 +1,100 @@
+#include <SFML/Window/VideoMode.hpp>
+
+#include <doctest.h>
+#include <ostream>
+
+namespace sf
+{
+std::ostream& operator <<(std::ostream& os, const sf::VideoMode& videoMode)
+{
+    os << videoMode.width << " x " << videoMode.height << " x " << videoMode.bitsPerPixel;
+    return os;
+}
+}
+
+TEST_CASE("sf::VideoMode class - [window]")
+{
+    SUBCASE("Construction")
+    {
+        SUBCASE("Default constructor")
+        {
+            sf::VideoMode videoMode;
+            CHECK(videoMode.width == 0);
+            CHECK(videoMode.height == 0);
+            CHECK(videoMode.bitsPerPixel == 0);
+        }
+
+        SUBCASE("Width, height constructor")
+        {
+            sf::VideoMode videoMode(800, 600);
+            CHECK(videoMode.width == 800);
+            CHECK(videoMode.height == 600);
+            CHECK(videoMode.bitsPerPixel == 32);
+        }
+
+        SUBCASE("Width, height, bit depth constructor")
+        {
+            sf::VideoMode videoMode(800, 600, 24);
+            CHECK(videoMode.width == 800);
+            CHECK(videoMode.height == 600);
+            CHECK(videoMode.bitsPerPixel == 24);
+        }
+    }
+
+    SUBCASE("Operators")
+    {
+        SUBCASE("operator==")
+        {
+            CHECK(sf::VideoMode() == sf::VideoMode());
+            CHECK(sf::VideoMode(0, 0, 0) == sf::VideoMode(0, 0, 0));
+            CHECK(sf::VideoMode(1080, 1920, 64) == sf::VideoMode(1080, 1920, 64));
+        }
+
+        SUBCASE("operator!=")
+        {
+            CHECK(sf::VideoMode() != sf::VideoMode(1, 0));
+            CHECK(sf::VideoMode() != sf::VideoMode(0, 1));
+            CHECK(sf::VideoMode() != sf::VideoMode(0, 0, 1));
+            CHECK(sf::VideoMode(720, 720) != sf::VideoMode(720, 720, 24));
+            CHECK(sf::VideoMode(1080, 1920, 16) != sf::VideoMode(400, 600));
+        }
+
+        SUBCASE("operator<")
+        {
+            CHECK(sf::VideoMode() < sf::VideoMode(0, 0, 1));
+            CHECK(sf::VideoMode(800, 800, 24) < sf::VideoMode(1080, 1920, 48));
+            CHECK(sf::VideoMode(400, 600, 48) < sf::VideoMode(600, 400, 48));
+            CHECK(sf::VideoMode(400, 400, 48) < sf::VideoMode(400, 600, 48));
+        }
+
+        SUBCASE("operator>")
+        {
+            CHECK(sf::VideoMode(1, 0) > sf::VideoMode(0, 0, 1));
+            CHECK(sf::VideoMode(800, 800, 48) > sf::VideoMode(1080, 1920, 24));
+            CHECK(sf::VideoMode(600, 400, 48) > sf::VideoMode(400, 600, 48));
+            CHECK(sf::VideoMode(400, 600, 48) > sf::VideoMode(400, 400, 48));
+        }
+
+        SUBCASE("operator<=")
+        {
+            CHECK(sf::VideoMode() <= sf::VideoMode(0, 0, 1));
+            CHECK(sf::VideoMode(800, 800, 24) <= sf::VideoMode(1080, 1920, 48));
+            CHECK(sf::VideoMode(400, 600, 48) <= sf::VideoMode(600, 400, 48));
+            CHECK(sf::VideoMode(400, 400, 48) <= sf::VideoMode(400, 600, 48));
+            CHECK(sf::VideoMode() <= sf::VideoMode());
+            CHECK(sf::VideoMode(0, 0, 0) <= sf::VideoMode(0, 0, 0));
+            CHECK(sf::VideoMode(1080, 1920, 64) <= sf::VideoMode(1080, 1920, 64));
+        }
+
+        SUBCASE("operator>=")
+        {
+            CHECK(sf::VideoMode(1, 0) >= sf::VideoMode(0, 0, 1));
+            CHECK(sf::VideoMode(800, 800, 48) >= sf::VideoMode(1080, 1920, 24));
+            CHECK(sf::VideoMode(600, 400, 48) >= sf::VideoMode(400, 600, 48));
+            CHECK(sf::VideoMode(400, 600, 48) >= sf::VideoMode(400, 400, 48));
+            CHECK(sf::VideoMode() >= sf::VideoMode());
+            CHECK(sf::VideoMode(0, 0, 0) >= sf::VideoMode(0, 0, 0));
+            CHECK(sf::VideoMode(1080, 1920, 64) >= sf::VideoMode(1080, 1920, 64));
+        }
+    }
+}


### PR DESCRIPTION
## Description

I added tests for `sf::VideoMode`. I was unsure how to test `sf::VideoMode::getDesktopMode`, `sf::VideoMode::getFullscreenMode`, and `sf::VideoMode::isValid` in a way that would work on all machines including the presumably headless CI runners. The `test-sfml-window` executable has always been compiled but until now didn't actually include any test assertions so now this test executable will provide some meaningful feedback.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
