### PR TITLE
Add tests for sf::Clock

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_compile_features(sfml-test-main PRIVATE cxx_std_17)
 
 # System is always built
 SET(SYSTEM_SRC
+    "${SRCROOT}/System/Clock.cpp"
     "${SRCROOT}/System/FileInputStream.cpp"
     "${SRCROOT}/System/Time.cpp"
     "${SRCROOT}/System/Vector2.cpp"

--- a/test/System/Clock.cpp
+++ b/test/System/Clock.cpp
@@ -1,0 +1,26 @@
+#include <SFML/System/Clock.hpp>
+#include "SystemUtil.hpp"
+#include <thread>
+
+#include <doctest.h>
+
+TEST_CASE("sf::Clock class - [system]")
+{
+    SUBCASE("getElapsedTime()")
+    {
+        const sf::Clock clock;
+        CHECK(clock.getElapsedTime() >= sf::microseconds(0));
+        const auto elapsed = clock.getElapsedTime();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        CHECK(clock.getElapsedTime() > elapsed);
+    }
+
+    SUBCASE("restart()")
+    {
+        sf::Clock clock;
+        CHECK(clock.restart() >= sf::microseconds(0));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        const auto elapsed = clock.restart();
+        CHECK(clock.restart() < elapsed);
+    }
+}


### PR DESCRIPTION
## Description

I added tests for `sf::Clock`. This was a little tricky. `sf::Clock` is implemented in terms of `std::chrono` and `std::chrono` is being used to test it. This shouldn't be a problem though since we must assume that our standard library implementation is correct. There's no getting around that assumption.

The idea for these tests is that if you periodically check the state of the timer at 100 millisecond intervals you can check that the clock is reporting roughly the elapsed time one would expect. I used a rather generous 10 millisecond margin since I'm not sure what level of accuracy and precision we'd expect. On my machine I see <5 millisecond deviations so I doubled that to be safe since flaky tests are a huge problem.

Another test philosophy would be to measure the elapsed time, sleep a few milliseconds, measure again, then test that the elapsed time increased. This is less prone to flakiness but is also a less rigorous test that what is currently written.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
