### PR TITLE
Prevent crash in Unix `JoystickImpl` with too many file descriptors

### DIFF
--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -29,6 +29,7 @@
 #include <SFML/System/Err.hpp>
 #include <linux/joystick.h>
 #include <libudev.h>
+#include <poll.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -253,13 +254,9 @@ namespace
         // This will not fail since we make sure udevMonitor is valid
         int monitorFd = udev_monitor_get_fd(udevMonitor);
 
-        fd_set descriptorSet;
-        FD_ZERO(&descriptorSet);
-        FD_SET(monitorFd, &descriptorSet);
-        timeval timeout = {0, 0};
+        pollfd fds{ monitorFd, POLLIN, 0 };
 
-        return (select(monitorFd + 1, &descriptorSet, NULL, NULL, &timeout) > 0) &&
-               FD_ISSET(monitorFd, &descriptorSet);
+        return (poll(&fds, 1, 0) > 0) && ((fds.revents & POLLIN) != 0);
     }
 
     // Get a property value from a udev device


### PR DESCRIPTION
## Description

Fixes #1900 by using the check @fvallee-bnx suggested. Note that `hasMonitorEvent` is used in `isConnected` here:

```cpp
bool JoystickImpl::isConnected(unsigned int index)
{
    // See if we can skip scanning if udev monitor is available
    if (!udevMonitor)
    {
        // udev monitor is not available, perform a scan every query
        updatePluggedList();
    }
    else if (hasMonitorEvent())
    {
        // Check if new joysticks were added/removed since last update
        udev_device* udevDevice = udev_monitor_receive_device(udevMonitor);

        // If we can get the specific device, we check that,
        // otherwise just do a full scan if udevDevice == nullptr
        updatePluggedList(udevDevice);

        if (udevDevice)
            udev_device_unref(udevDevice);
    }

    if (index >= joystickList.size())
        return false;

    // Then check if the joystick is connected
    return joystickList[index].plugged;
}
```

`joystickList[index].plugged` might return the wrong value in that case, but it seems fine as it is an edge case (over 1024 file descriptors). Not sure if there's a nice way to avoid a hard limit on file descriptors, but this should at least solve the crash.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

It needs to be tested on Linux, I have not had a chance to do that yet.