### PR TITLE
Remove redundant API taking x,y pair instead of sf::Vector

### DIFF
--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -97,22 +97,6 @@ public:
     /// This check is non-inclusive. If the point lies on the
     /// edge of the rectangle, this function will return false.
     ///
-    /// \param x X coordinate of the point to test
-    /// \param y Y coordinate of the point to test
-    ///
-    /// \return True if the point is inside, false otherwise
-    ///
-    /// \see intersects
-    ///
-    ////////////////////////////////////////////////////////////
-    constexpr bool contains(T x, T y) const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Check if a point is inside the rectangle's area
-    ///
-    /// This check is non-inclusive. If the point lies on the
-    /// edge of the rectangle, this function will return false.
-    ///
     /// \param point Point to test
     ///
     /// \return True if the point is inside, false otherwise

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -73,7 +73,7 @@ height(static_cast<T>(rectangle.height))
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr bool Rect<T>::contains(T x, T y) const
+constexpr bool Rect<T>::contains(const Vector2<T>& point) const
 {
     // Not using 'std::min' and 'std::max' to avoid depending on '<algorithm>'
     const auto min = [](T a, T b){ return (a < b) ? a : b; };
@@ -87,15 +87,7 @@ constexpr bool Rect<T>::contains(T x, T y) const
     const T minY = min(top, static_cast<T>(top + height));
     const T maxY = max(top, static_cast<T>(top + height));
 
-    return (x >= minX) && (x < maxX) && (y >= minY) && (y < maxY);
-}
-
-
-////////////////////////////////////////////////////////////
-template <typename T>
-constexpr bool Rect<T>::contains(const Vector2<T>& point) const
-{
-    return contains(point.x, point.y);
+    return (point.x >= minX) && (point.x < maxX) && (point.y >= minY) && (point.y < maxY);
 }
 
 

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -199,32 +199,6 @@ public:
     /// can be chained.
     /// \code
     /// sf::Transform transform;
-    /// transform.rotate(90, 8, 3).translate(50, 20);
-    /// \endcode
-    ///
-    /// \param angle Rotation angle, in degrees
-    /// \param centerX X coordinate of the center of rotation
-    /// \param centerY Y coordinate of the center of rotation
-    ///
-    /// \return Reference to *this
-    ///
-    /// \see translate, scale
-    ///
-    ////////////////////////////////////////////////////////////
-    Transform& rotate(float angle, float centerX, float centerY);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Combine the current transform with a rotation
-    ///
-    /// The center of rotation is provided for convenience as a second
-    /// argument, so that you can build rotations around arbitrary points
-    /// more easily (and efficiently) than the usual
-    /// translate(-center).rotate(angle).translate(center).
-    ///
-    /// This function returns a reference to *this, so that calls
-    /// can be chained.
-    /// \code
-    /// sf::Transform transform;
     /// transform.rotate(90, sf::Vector2f(8, 3)).translate(sf::Vector2f(50, 20));
     /// \endcode
     ///
@@ -237,53 +211,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     Transform& rotate(float angle, const Vector2f& center);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Combine the current transform with a scaling
-    ///
-    /// This function returns a reference to *this, so that calls
-    /// can be chained.
-    /// \code
-    /// sf::Transform transform;
-    /// transform.scale(2, 1).rotate(45);
-    /// \endcode
-    ///
-    /// \param scaleX Scaling factor on the X axis
-    /// \param scaleY Scaling factor on the Y axis
-    ///
-    /// \return Reference to *this
-    ///
-    /// \see translate, rotate
-    ///
-    ////////////////////////////////////////////////////////////
-    Transform& scale(float scaleX, float scaleY);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Combine the current transform with a scaling
-    ///
-    /// The center of scaling is provided for convenience as a second
-    /// argument, so that you can build scaling around arbitrary points
-    /// more easily (and efficiently) than the usual
-    /// translate(-center).scale(factors).translate(center).
-    ///
-    /// This function returns a reference to *this, so that calls
-    /// can be chained.
-    /// \code
-    /// sf::Transform transform;
-    /// transform.scale(2, 1, 8, 3).rotate(45);
-    /// \endcode
-    ///
-    /// \param scaleX Scaling factor on X axis
-    /// \param scaleY Scaling factor on Y axis
-    /// \param centerX X coordinate of the center of scaling
-    /// \param centerY Y coordinate of the center of scaling
-    ///
-    /// \return Reference to *this
-    ///
-    /// \see translate, rotate
-    ///
-    ////////////////////////////////////////////////////////////
-    Transform& scale(float scaleX, float scaleY, float centerX, float centerY);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a scaling

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -178,14 +178,14 @@ Transform& Transform::rotate(float angle)
 
 
 ////////////////////////////////////////////////////////////
-Transform& Transform::rotate(float angle, float centerX, float centerY)
+Transform& Transform::rotate(float angle, const Vector2f& center)
 {
     float rad = angle * 3.141592654f / 180.f;
     float cos = std::cos(rad);
     float sin = std::sin(rad);
 
-    Transform rotation(cos, -sin, centerX * (1 - cos) + centerY * sin,
-                       sin,  cos, centerY * (1 - cos) - centerX * sin,
+    Transform rotation(cos, -sin, center.x * (1 - cos) + center.y * sin,
+                       sin,  cos, center.y * (1 - cos) - center.x * sin,
                        0,    0,   1);
 
     return combine(rotation);
@@ -193,45 +193,24 @@ Transform& Transform::rotate(float angle, float centerX, float centerY)
 
 
 ////////////////////////////////////////////////////////////
-Transform& Transform::rotate(float angle, const Vector2f& center)
-{
-    return rotate(angle, center.x, center.y);
-}
-
-
-////////////////////////////////////////////////////////////
-Transform& Transform::scale(float scaleX, float scaleY)
-{
-    Transform scaling(scaleX, 0,      0,
-                      0,      scaleY, 0,
-                      0,      0,      1);
-
-    return combine(scaling);
-}
-
-
-////////////////////////////////////////////////////////////
-Transform& Transform::scale(float scaleX, float scaleY, float centerX, float centerY)
-{
-    Transform scaling(scaleX, 0,      centerX * (1 - scaleX),
-                      0,      scaleY, centerY * (1 - scaleY),
-                      0,      0,      1);
-
-    return combine(scaling);
-}
-
-
-////////////////////////////////////////////////////////////
 Transform& Transform::scale(const Vector2f& factors)
 {
-    return scale(factors.x, factors.y);
+    Transform scaling(factors.x, 0,         0,
+                      0,         factors.y, 0,
+                      0,         0,         1);
+
+    return combine(scaling);
 }
 
 
 ////////////////////////////////////////////////////////////
 Transform& Transform::scale(const Vector2f& factors, const Vector2f& center)
 {
-    return scale(factors.x, factors.y, center.x, center.y);
+    Transform scaling(factors.x, 0,         center.x * (1 - factors.x),
+                      0,         factors.y, center.y * (1 - factors.y),
+                      0,         0,         1);
+
+    return combine(scaling);
 }
 
 

--- a/test/Graphics/Rect.cpp
+++ b/test/Graphics/Rect.cpp
@@ -50,20 +50,6 @@ TEST_CASE("sf::Rect class template - [graphics]")
 
     SUBCASE("Containment")
     {
-        SUBCASE("contains(x, y)")
-        {
-            sf::IntRect rectangle(0, 0, 10, 10);
-
-            CHECK(rectangle.contains(0, 0) == true);
-            CHECK(rectangle.contains(9, 0) == true);
-            CHECK(rectangle.contains(0, 9) == true);
-            CHECK(rectangle.contains(9, 9) == true);
-            CHECK(rectangle.contains(9, 10) == false);
-            CHECK(rectangle.contains(10, 9) == false);
-            CHECK(rectangle.contains(10, 10) == false);
-            CHECK(rectangle.contains(15, 15) == false);
-        }
-
         SUBCASE("contains(Vector2)")
         {
             sf::IntRect rectangle(0, 0, 10, 10);


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Expanding on @vittorioromeo's work in https://github.com/SFML/SFML/pull/1902. I removed a few more instances of (x, y) pairs in APIs alongside `sf::Vector` variants. I grep'd around the repo for as many instances of this pattern as possible and couldn't find any more other than some `sf::Image` APIs that have no `sf::Vector` counterpart (but maybe should).

The biggest changes were in `sf::Transform` which have no tests but I have a branch where I'm starting to test it. Happy to submit a PR for the tests I've added so far but there's plenty more work to go there. 

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
