### PR TITLE
Let tests and examples inherit language requirement from upstream targets

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -268,9 +268,6 @@ macro(sfml_add_example target)
         add_executable(${target} ${target_input})
     endif()
 
-    # enable C++17 support
-    target_compile_features(${target} PUBLIC cxx_std_17)
-
     set_file_warnings(${target_input})
 
     # set the debug suffix
@@ -308,16 +305,11 @@ function(sfml_add_test target SOURCES DEPENDS)
     # create the target
     add_executable(${target} ${SOURCES})
 
-    # enable C++17 support
-    target_compile_features(${target} PUBLIC cxx_std_17)
-
     # set the target's folder (for IDEs that support it, e.g. Visual Studio)
     set_target_properties(${target} PROPERTIES FOLDER "Tests")
 
     # link the target to its SFML dependencies
-    if(DEPENDS)
-        target_link_libraries(${target} PRIVATE ${DEPENDS})
-    endif()
+    target_link_libraries(${target} PRIVATE ${DEPENDS})
 
     # Add the test
     add_test(${target} ${target})


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

It's not necessary to re-specify cxx_std_17 since any example or test which depends on a core target (which should be all of them) will pick up this language require that should be a public property of those targets. If that changes, these examples and tests will potentially fail to compile and correctly catch the bug that was introduced in the core library targets.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
