### PR TITLE
Remove redundant doctest formatters

### DIFF
--- a/test/System/Time.cpp
+++ b/test/System/Time.cpp
@@ -1,18 +1,7 @@
 #include <SFML/System/Time.hpp>
-
-#include <ostream>
-#include <doctest.h>
+#include "SystemUtil.hpp"
 
 using doctest::Approx;
-
-namespace sf
-{
-std::ostream& operator <<(std::ostream& os, const sf::Time& time)
-{
-    os << time.asMicroseconds() << "us";
-    return os;
-}
-}
 
 TEST_CASE("sf::Time class - [system]")
 {

--- a/test/Window/VideoMode.cpp
+++ b/test/Window/VideoMode.cpp
@@ -1,16 +1,5 @@
 #include <SFML/Window/VideoMode.hpp>
-
-#include <doctest.h>
-#include <ostream>
-
-namespace sf
-{
-std::ostream& operator <<(std::ostream& os, const sf::VideoMode& videoMode)
-{
-    os << videoMode.width << " x " << videoMode.height << " x " << videoMode.bitsPerPixel;
-    return os;
-}
-}
+#include "WindowUtil.hpp"
 
 TEST_CASE("sf::VideoMode class - [window]")
 {


### PR DESCRIPTION
## Description

I added `operator<<` to types that already had Doctest formatters so I removed them. 

Something to keep in mind is how GraphicsUtils.hpp depends on WindowUtils.hpp which depends on SystemUtils.hpp. Is this desired? If these util headers are so tightly coupled, why not just have one big header where we put all formatters? That would be easier to maintain.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
