### PR TITLE
Add SFML:: namespace to targets

### DIFF
--- a/cmake/SFMLConfig.cmake.in
+++ b/cmake/SFMLConfig.cmake.in
@@ -4,10 +4,10 @@
 # Usage
 # -----
 #
-# When you try to locate the SFML libraries, you must specify which modules you want to use (system, window, graphics, network, audio, main).
+# When you try to locate the SFML libraries, you must specify which modules you want to use (System, Window, Graphics, Network, Audio, Main).
 # If none is given, no imported target will be created and you won't be able to link to SFML libraries.
 # example:
-#   find_package(SFML COMPONENTS graphics window system) # find the graphics, window and system modules
+#   find_package(SFML COMPONENTS Graphics Window System) # find the graphics, window and system modules
 #
 # You can enforce a specific version, either MAJOR.MINOR or only MAJOR.
 # If nothing is specified, the version won't be checked (i.e. any version will be accepted).
@@ -22,7 +22,7 @@
 # they will all be configured automatically, even if you use SFML static libraries.
 # example:
 #   set(SFML_STATIC_LIBRARIES TRUE)
-#   find_package(SFML 3 COMPONENTS network system)
+#   find_package(SFML 3 COMPONENTS Network System)
 #
 # When searching for SFML with find_package(), keep in mind that it will also find versions which are
 # in development (i.e. between two released versions), if you have them in your search path.
@@ -49,24 +49,24 @@
 # ------
 #
 # This script defines the following variables:
-# - For each specified module XXX (system, window, graphics, network, audio, main):
+# - For each specified module XXX (System, Window, Graphics, Network, Audio, Main):
 #   - SFML_XXX_FOUND:  true if either the debug or release library of the xxx module is found
 # - SFML_FOUND:        true if all the required modules are found
 #
 # And the following targets:
-# - For each specified module XXX (system, window, graphics, network, audio, main):
-#   - sfml-XXX
+# - For each specified module XXX (System, Window, Graphics, Network, Audio, Main):
+#   - SFML::XXX
 # The SFML targets are the same for both Debug and Release build configurations and will automatically provide
 # correct settings based on your currently active build configuration. The SFML targets name also do not change
 # when using dynamic or static SFML libraries.
 #
 # When linking against a SFML target, you do not need to specify indirect dependencies. For example, linking
-# against sfml-graphics will also automatically link against sfml-window and sfml-system.
+# against SFML::Graphics will also automatically link against SFML::Window and SFML::System.
 #
 # example:
-#   find_package(SFML 2 COMPONENTS graphics audio REQUIRED)
+#   find_package(SFML 3 COMPONENTS Graphics Audio REQUIRED)
 #   add_executable(myapp ...)
-#   target_link_libraries(myapp sfml-graphics sfml-audio)
+#   target_link_libraries(myapp PRIVATE SFML::Graphics SFML::Audio)
 
 if (NOT SFML_FIND_COMPONENTS)
     message(FATAL_ERROR "find_package(SFML) called with no component")
@@ -93,10 +93,10 @@ find_path(SFML_DOC_DIR SFML.tag
 # Update requested components (eg. request window component if graphics component was requested)
 set(FIND_SFML_SYSTEM_DEPENDENCIES "")
 set(FIND_SFML_MAIN_DEPENDENCIES "")
-set(FIND_SFML_AUDIO_DEPENDENCIES system)
-set(FIND_SFML_NETWORK_DEPENDENCIES system)
-set(FIND_SFML_WINDOW_DEPENDENCIES system)
-set(FIND_SFML_GRAPHICS_DEPENDENCIES window system)
+set(FIND_SFML_AUDIO_DEPENDENCIES System)
+set(FIND_SFML_NETWORK_DEPENDENCIES System)
+set(FIND_SFML_WINDOW_DEPENDENCIES System)
+set(FIND_SFML_GRAPHICS_DEPENDENCIES Window System)
 set(FIND_SFML_ADDITIONAL_COMPONENTS "")
 foreach(component ${SFML_FIND_COMPONENTS})
     string(TOUPPER "${component}" UPPER_COMPONENT)
@@ -130,7 +130,7 @@ if (EXISTS "${targets_config_file}")
 
         foreach (component ${SFML_FIND_COMPONENTS})
             string(TOUPPER "${component}" UPPER_COMPONENT)
-            if (TARGET sfml-${component})
+            if (TARGET SFML::${component})
                 set(SFML_${UPPER_COMPONENT}_FOUND TRUE)
             else()
                 set(FIND_SFML_ERROR "Found SFML but requested component '${component}' is missing in the config defined in ${SFML_DIR}.")

--- a/cmake/SFMLConfigDependencies.cmake.in
+++ b/cmake/SFMLConfigDependencies.cmake.in
@@ -36,8 +36,8 @@ if(SFML_STATIC_LIBRARIES)
         endif()
     endfunction()
 
-    # sfml-window
-    list(FIND SFML_FIND_COMPONENTS "window" FIND_SFML_WINDOW_COMPONENT_INDEX)
+    # SFML::Window
+    list(FIND SFML_FIND_COMPONENTS "Window" FIND_SFML_WINDOW_COMPONENT_INDEX)
     if(FIND_SFML_WINDOW_COMPONENT_INDEX GREATER -1)
         if(FIND_SFML_OS_LINUX OR FIND_SFML_OS_FREEBSD)
             sfml_bind_dependency(TARGET X11 FRIENDLY_NAME "X11" SEARCH_NAMES "X11")
@@ -56,14 +56,14 @@ if(SFML_STATIC_LIBRARIES)
         endif()
     endif()
 
-    # sfml-graphics
-    list(FIND SFML_FIND_COMPONENTS "graphics" FIND_SFML_GRAPHICS_COMPONENT_INDEX)
+    # SFML::Graphics
+    list(FIND SFML_FIND_COMPONENTS "Graphics" FIND_SFML_GRAPHICS_COMPONENT_INDEX)
     if(FIND_SFML_GRAPHICS_COMPONENT_INDEX GREATER -1)
         sfml_bind_dependency(TARGET Freetype FRIENDLY_NAME "FreeType" SEARCH_NAMES "freetype")
     endif()
 
-    # sfml-audio
-    list(FIND SFML_FIND_COMPONENTS "audio" FIND_SFML_AUDIO_COMPONENT_INDEX)
+    # SFML::Audio
+    list(FIND SFML_FIND_COMPONENTS "Audio" FIND_SFML_AUDIO_COMPONENT_INDEX)
     if(FIND_SFML_AUDIO_COMPONENT_INDEX GREATER -1)
         sfml_bind_dependency(TARGET OpenAL FRIENDLY_NAME "OpenAL" SEARCH_NAMES "OpenAL" "openal" "openal32")
         if (NOT FIND_SFML_OS_IOS)

--- a/examples/X11/CMakeLists.txt
+++ b/examples/X11/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SRC ${SRCROOT}/X11.cpp)
 # define the X11 target
 sfml_add_example(X11Example GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-window X11)
+                 DEPENDS SFML::Window X11)
 
 # external dependency headers
 target_include_directories(X11Example SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/X11)

--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -54,8 +54,8 @@ set_source_files_properties(${RESOURCES} PROPERTIES
 sfml_add_example(cocoa
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
-                 DEPENDS sfml-system sfml-window sfml-graphics)
+                 DEPENDS SFML::System SFML::Window SFML::Graphics)
 set_target_properties(cocoa PROPERTIES
                       MACOSX_BUNDLE TRUE
                       MACOSX_BUNDLE_INFO_PLIST ${SRCROOT}/resources/Cocoa-Info.plist)
-target_link_libraries(cocoa PRIVATE "-framework Cocoa" "-framework Foundation" sfml-graphics)
+target_link_libraries(cocoa PRIVATE "-framework Cocoa" "-framework Foundation" SFML::Graphics)

--- a/examples/ftp/CMakeLists.txt
+++ b/examples/ftp/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SRC ${SRCROOT}/Ftp.cpp)
 # define the ftp target
 sfml_add_example(ftp
                  SOURCES ${SRC}
-                 DEPENDS sfml-network)
+                 DEPENDS SFML::Network)

--- a/examples/island/CMakeLists.txt
+++ b/examples/island/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SRC ${SRCROOT}/Island.cpp)
 # define the island target
 sfml_add_example(island GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics
+                 DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
 
 # external dependency headers

--- a/examples/joystick/CMakeLists.txt
+++ b/examples/joystick/CMakeLists.txt
@@ -7,5 +7,5 @@ set(SRC ${SRCROOT}/Joystick.cpp)
 # define the joystick target
 sfml_add_example(joystick GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics
+                 DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 sfml_add_example(opengl GUI_APP
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
-                 DEPENDS sfml-graphics
+                 DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
 
 # external dependency headers

--- a/examples/shader/CMakeLists.txt
+++ b/examples/shader/CMakeLists.txt
@@ -9,5 +9,5 @@ set(SRC
 # define the shader target
 sfml_add_example(shader GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics
+                 DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)

--- a/examples/sockets/CMakeLists.txt
+++ b/examples/sockets/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SRC ${SRCROOT}/Sockets.cpp
 # define the sockets target
 sfml_add_example(sockets
                  SOURCES ${SRC}
-                 DEPENDS sfml-network)
+                 DEPENDS SFML::Network)

--- a/examples/sound/CMakeLists.txt
+++ b/examples/sound/CMakeLists.txt
@@ -7,5 +7,5 @@ set(SRC ${SRCROOT}/Sound.cpp)
 # define the sound target
 sfml_add_example(sound
                  SOURCES ${SRC}
-                 DEPENDS sfml-audio
+                 DEPENDS SFML::Audio
                  RESOURCES_DIR resources)

--- a/examples/sound_capture/CMakeLists.txt
+++ b/examples/sound_capture/CMakeLists.txt
@@ -7,4 +7,4 @@ set(SRC ${SRCROOT}/SoundCapture.cpp)
 # define the sound-capture target
 sfml_add_example(sound-capture
                  SOURCES ${SRC}
-                 DEPENDS sfml-audio)
+                 DEPENDS SFML::Audio)

--- a/examples/tennis/CMakeLists.txt
+++ b/examples/tennis/CMakeLists.txt
@@ -14,5 +14,5 @@ endif()
 sfml_add_example(tennis GUI_APP
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
-                 DEPENDS sfml-audio sfml-graphics
+                 DEPENDS SFML::Audio SFML::Graphics
                  RESOURCES_DIR resources)

--- a/examples/voip/CMakeLists.txt
+++ b/examples/voip/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SRC ${SRCROOT}/VoIP.cpp
 # define the voip target
 sfml_add_example(voip
                  SOURCES ${SRC}
-                 DEPENDS sfml-audio sfml-network)
+                 DEPENDS SFML::Audio SFML::Network)

--- a/examples/vulkan/CMakeLists.txt
+++ b/examples/vulkan/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SRC ${SRCROOT}/Vulkan.cpp)
 # define the window target
 sfml_add_example(vulkan GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics
+                 DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
 
 # external dependency headers

--- a/examples/win32/CMakeLists.txt
+++ b/examples/win32/CMakeLists.txt
@@ -7,5 +7,5 @@ set(SRC ${SRCROOT}/Win32.cpp)
 # define the win32 target
 sfml_add_example(win32 GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-graphics
+                 DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)

--- a/examples/window/CMakeLists.txt
+++ b/examples/window/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SRC ${SRCROOT}/Window.cpp)
 # define the window target
 sfml_add_example(window GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS sfml-window)
+                 DEPENDS SFML::Window)
 
 # external dependency headers
 target_include_directories(window SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/window)

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -77,7 +77,7 @@ target_compile_definitions(VORBIS INTERFACE "OV_EXCLUDE_STATIC_CALLBACKS")
 target_compile_definitions(FLAC INTERFACE "FLAC__NO_DLL")
 
 # define the sfml-audio target
-sfml_add_library(sfml-audio
+sfml_add_library(Audio
                  SOURCES ${SRC} ${CODECS_SRC})
 
 # setup dependencies
@@ -91,5 +91,5 @@ if(SFML_OS_ANDROID)
 endif()
 
 target_link_libraries(sfml-audio
-                      PUBLIC sfml-system
+                      PUBLIC SFML::System
                       PRIVATE VORBIS FLAC)

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -87,11 +87,11 @@ source_group("render texture" FILES ${RENDER_TEXTURE_SRC})
 
 
 # define the sfml-graphics target
-sfml_add_library(sfml-graphics
+sfml_add_library(Graphics
                  SOURCES ${SRC} ${DRAWABLES_SRC} ${RENDER_TEXTURE_SRC} ${STB_SRC})
 
 # setup dependencies
-target_link_libraries(sfml-graphics PUBLIC sfml-window)
+target_link_libraries(sfml-graphics PUBLIC SFML::Window)
 
 # stb_image sources
 target_include_directories(sfml-graphics SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/stb_image")

--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
 endif()
 
 # define the sfml-main target
-sfml_add_library(sfml-main STATIC SOURCES ${SRC})
+sfml_add_library(Main STATIC SOURCES ${SRC})
 
 if(SFML_OS_ANDROID)
     # glad sources
@@ -32,5 +32,5 @@ set_target_properties(sfml-main PROPERTIES
 # from depending on shared libraries), we need a boostrap activity which
 # will load our shared libraries manually
 if(SFML_OS_ANDROID)
-    sfml_add_library(sfml-activity SOURCES ${SRCROOT}/SFMLActivity.cpp)
+    sfml_add_library(Activity SOURCES ${SRCROOT}/SFMLActivity.cpp)
 endif()

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -45,11 +45,11 @@ endif()
 source_group("" FILES ${SRC})
 
 # define the sfml-network target
-sfml_add_library(sfml-network
+sfml_add_library(Network
                  SOURCES ${SRC})
 
 # setup dependencies
-target_link_libraries(sfml-network PUBLIC sfml-system)
+target_link_libraries(sfml-network PUBLIC SFML::System)
 if(SFML_OS_WINDOWS)
     target_link_libraries(sfml-network PRIVATE ws2_32)
 endif()

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 source_group("unix" FILES ${PLATFORM_SRC})
 
 # define the sfml-system target
-sfml_add_library(sfml-system
+sfml_add_library(System
                  SOURCES ${SRC} ${PLATFORM_SRC})
 
 if(SFML_OS_ANDROID)

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -234,9 +234,9 @@ elseif(SFML_OS_ANDROID)
 endif()
 
 # define the sfml-window target
-sfml_add_library(sfml-window
+sfml_add_library(Window
                  SOURCES ${SRC} ${PLATFORM_SRC})
-target_link_libraries(sfml-window PUBLIC sfml-system)
+target_link_libraries(sfml-window PUBLIC SFML::System)
 
 # glad sources
 target_include_directories(sfml-window SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/glad/include")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,8 +15,7 @@ SET(SYSTEM_SRC
     "${SRCROOT}/TestUtilities/SystemUtil.hpp"
     "${SRCROOT}/TestUtilities/SystemUtil.cpp"
 )
-
-sfml_add_test(test-sfml-system "${SYSTEM_SRC}" sfml-system)
+sfml_add_test(test-sfml-system "${SYSTEM_SRC}" SFML::System)
 target_link_libraries(test-sfml-system PRIVATE sfml-test-main)
 
 if(SFML_BUILD_WINDOW)
@@ -25,7 +24,7 @@ if(SFML_BUILD_WINDOW)
         "${SRCROOT}/TestUtilities/WindowUtil.hpp"
         "${SRCROOT}/TestUtilities/WindowUtil.cpp"
     )
-    sfml_add_test(test-sfml-window "${WINDOW_SRC}" sfml-window)
+    sfml_add_test(test-sfml-window "${WINDOW_SRC}" SFML::Window)
     target_link_libraries(test-sfml-window PRIVATE sfml-test-main)
 endif()
 
@@ -38,7 +37,7 @@ if(SFML_BUILD_GRAPHICS)
         "${SRCROOT}/TestUtilities/GraphicsUtil.hpp"
         "${SRCROOT}/TestUtilities/GraphicsUtil.cpp"
     )
-    sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" sfml-graphics)
+    sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" SFML::Graphics)
     target_link_libraries(test-sfml-graphics PRIVATE sfml-test-main)
 endif()
 
@@ -46,7 +45,7 @@ if(SFML_BUILD_NETWORK)
     SET(NETWORK_SRC
         "${SRCROOT}/Network/Packet.cpp"
     )
-    sfml_add_test(test-sfml-network "${NETWORK_SRC}" sfml-network)
+    sfml_add_test(test-sfml-network "${NETWORK_SRC}" SFML::Network)
     target_link_libraries(test-sfml-network PRIVATE sfml-test-main)
 endif()
 


### PR DESCRIPTION
## Description

This removes the sfml- prefixed targets from the export set. The sfml- prefixed targets are still available within the build tree but not to downstream users thus making this an API breaking change when compared to the 2.x releases. To keep things consistent, usage of the sfml- targets were replaced with their namespaced counterparts.

This has a number of benefits:

  1. It's more idiomatic. Modern CMake libraries are expected to
     have namespaced targets.

  2. Namespaces targets are less likely to collide with user-defined
     targets. No one will accidentally define a SFML:: target.

This PR is related to the issue #1562

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Build and install SFML. Find and use the package in the following way:

```cmake
find_package(SFML 3.0.0 REQUIRED COMPONENTS graphics)
...
target_link_libraries(some-target PRIVATE SFML::graphics)
```