### PR TITLE
Remove redundant 4-param sf::Rect<T> constructor

### DIFF
--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -208,7 +208,7 @@ public:
         // Load the moving entities
         for (int i = 0; i < 6; ++i)
         {
-            sf::Sprite entity(m_entityTexture, sf::IntRect(96 * i, 0, 96, 96));
+            sf::Sprite entity(m_entityTexture, sf::IntRect({96 * i, 0}, {96, 96}));
             m_entities.push_back(entity);
         }
 

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -214,7 +214,7 @@ public:
     /// \param applyAlpha Should the copy take into account the source transparency?
     ///
     ////////////////////////////////////////////////////////////
-    void copy(const Image& source, unsigned int destX, unsigned int destY, const IntRect& sourceRect = IntRect(0, 0, 0, 0), bool applyAlpha = false);
+    void copy(const Image& source, unsigned int destX, unsigned int destY, const IntRect& sourceRect = IntRect({0, 0}, {0, 0}), bool applyAlpha = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the color of a pixel

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -52,20 +52,6 @@ public:
     constexpr Rect();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Construct the rectangle from its coordinates
-    ///
-    /// Be careful, the last two parameters are the width
-    /// and height, not the right and bottom coordinates!
-    ///
-    /// \param rectLeft   Left coordinate of the rectangle
-    /// \param rectTop    Top coordinate of the rectangle
-    /// \param rectWidth  Width of the rectangle
-    /// \param rectHeight Height of the rectangle
-    ///
-    ////////////////////////////////////////////////////////////
-    constexpr Rect(T rectLeft, T rectTop, T rectWidth, T rectHeight);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from position and size
     ///
     /// Be careful, the last parameter is the size,

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -37,18 +37,6 @@ height(0)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Rect<T>::Rect(T rectLeft, T rectTop, T rectWidth, T rectHeight) :
-left  (rectLeft),
-top   (rectTop),
-width (rectWidth),
-height(rectHeight)
-{
-
-}
-
-
-////////////////////////////////////////////////////////////
-template <typename T>
 constexpr Rect<T>::Rect(const Vector2<T>& position, const Vector2<T>& size) :
 left  (position.x),
 top   (position.y),
@@ -131,12 +119,12 @@ constexpr bool Rect<T>::intersects(const Rect<T>& rectangle, Rect<T>& intersecti
     // If the intersection is valid (positive non zero area), then there is an intersection
     if ((interLeft < interRight) && (interTop < interBottom))
     {
-        intersection = Rect<T>(interLeft, interTop, interRight - interLeft, interBottom - interTop);
+        intersection = Rect<T>({interLeft, interTop}, {interRight - interLeft, interBottom - interTop});
         return true;
     }
     else
     {
-        intersection = Rect<T>(0, 0, 0, 0);
+        intersection = Rect<T>({0, 0}, {0, 0});
         return false;
     }
 }

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -731,7 +731,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
                 if (!newTexture.create(textureWidth * 2, textureHeight * 2))
                 {
                     err() << "Failed to create new page texture" << std::endl;
-                    return IntRect(0, 0, 2, 2);
+                    return IntRect({0, 0}, {2, 2});
                 }
 
                 newTexture.setSmooth(m_isSmooth);
@@ -742,7 +742,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
             {
                 // Oops, we've reached the maximum texture size...
                 err() << "Failed to add a new character to the font: the maximum texture size has been reached" << std::endl;
-                return IntRect(0, 0, 2, 2);
+                return IntRect({0, 0}, {2, 2});
             }
         }
 
@@ -753,7 +753,7 @@ IntRect Font::findGlyphRect(Page& page, unsigned int width, unsigned int height)
     }
 
     // Find the glyph's rectangle on the selected row
-    IntRect rect(Rect<unsigned int>(row->width, row->top, width, height));
+    IntRect rect(Rect<unsigned int>({row->width, row->top}, {width, height}));
 
     // Update the row informations
     row->width += width;

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -202,10 +202,10 @@ IntRect RenderTarget::getViewport(const View& view) const
     float height = static_cast<float>(getSize().y);
     const FloatRect& viewport = view.getViewport();
 
-    return IntRect(static_cast<int>(0.5f + width  * viewport.left),
-                   static_cast<int>(0.5f + height * viewport.top),
-                   static_cast<int>(0.5f + width  * viewport.width),
-                   static_cast<int>(0.5f + height * viewport.height));
+    return IntRect({static_cast<int>(0.5f + width  * viewport.left),
+                    static_cast<int>(0.5f + height * viewport.top)},
+                   {static_cast<int>(0.5f + width  * viewport.width),
+                    static_cast<int>(0.5f + height * viewport.height)});
 }
 
 
@@ -555,7 +555,7 @@ void RenderTarget::resetGLStates()
 void RenderTarget::initialize()
 {
     // Setup the default and current views
-    m_defaultView.reset(FloatRect(0, 0, static_cast<float>(getSize().x), static_cast<float>(getSize().y)));
+    m_defaultView.reset(FloatRect({0, 0}, Vector2f(getSize())));
     m_view = m_defaultView;
 
     // Set GL states only on first draw, so that we don't pollute user's states

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -66,7 +66,7 @@ void Shape::setTexture(const Texture* texture, bool resetRect)
     {
         // Recompute the texture area if requested, or if there was no texture & rect before
         if (resetRect || (!m_texture && (m_textureRect == IntRect())))
-            setTextureRect(IntRect(0, 0, static_cast<int>(texture->getSize().x), static_cast<int>(texture->getSize().y)));
+            setTextureRect(IntRect({0, 0}, Vector2i(texture->getSize())));
     }
 
     // Assign the new texture

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -68,8 +68,7 @@ void Sprite::setTexture(const Texture& texture, bool resetRect)
     // Recompute the texture area if requested, or if there was no valid texture & rect before
     if (resetRect || (!m_texture && (m_textureRect == sf::IntRect())))
     {
-        Vector2i size = Vector2i(texture.getSize());
-        setTextureRect(IntRect(0, 0, size.x, size.y));
+        setTextureRect(IntRect({0, 0}, Vector2i(texture.getSize())));
     }
 
     // Assign the new texture
@@ -127,7 +126,7 @@ FloatRect Sprite::getLocalBounds() const
     auto width = static_cast<float>(std::abs(m_textureRect.width));
     auto height = static_cast<float>(std::abs(m_textureRect.height));
 
-    return FloatRect(0.f, 0.f, width, height);
+    return FloatRect({0.f, 0.f}, {width, height});
 }
 
 

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -127,7 +127,7 @@ FloatRect Transform::transformRect(const FloatRect& rectangle) const
         else if (points[i].y > bottom) bottom = points[i].y;
     }
 
-    return FloatRect(left, top, right - left, bottom - top);
+    return FloatRect({left, top}, {right - left, bottom - top});
 }
 
 

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -130,7 +130,7 @@ FloatRect VertexArray::getBounds() const
                 bottom = position.y;
         }
 
-        return FloatRect(left, top, right - left, bottom - top);
+        return FloatRect({left, top}, {right - left, bottom - top});
     }
     else
     {

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -36,11 +36,11 @@ View::View() :
 m_center             (),
 m_size               (),
 m_rotation           (0),
-m_viewport           (0, 0, 1, 1),
+m_viewport           ({0, 0}, {1, 1}),
 m_transformUpdated   (false),
 m_invTransformUpdated(false)
 {
-    reset(FloatRect(0, 0, 1000, 1000));
+    reset(FloatRect({0, 0}, {1000, 1000}));
 }
 
 
@@ -49,7 +49,7 @@ View::View(const FloatRect& rectangle) :
 m_center             (),
 m_size               (),
 m_rotation           (0),
-m_viewport           (0, 0, 1, 1),
+m_viewport           ({0, 0}, {1, 1}),
 m_transformUpdated   (false),
 m_invTransformUpdated(false)
 {
@@ -62,7 +62,7 @@ View::View(const Vector2f& center, const Vector2f& size) :
 m_center             (center),
 m_size               (size),
 m_rotation           (0),
-m_viewport           (0, 0, 1, 1),
+m_viewport           ({0, 0}, {1, 1}),
 m_transformUpdated   (false),
 m_invTransformUpdated(false)
 {

--- a/test/Graphics/Rect.cpp
+++ b/test/Graphics/Rect.cpp
@@ -17,7 +17,7 @@ TEST_CASE("sf::Rect class template - [graphics]")
 
         SUBCASE("(left, top, width, height) constructor")
         {
-            sf::IntRect rectangle(1, 2, 3, 4);
+            sf::IntRect rectangle({1, 2}, {3, 4});
             CHECK(rectangle.left == 1);
             CHECK(rectangle.top == 2);
             CHECK(rectangle.width == 3);
@@ -38,7 +38,7 @@ TEST_CASE("sf::Rect class template - [graphics]")
 
         SUBCASE("Conversion constructor")
         {
-            sf::FloatRect sourceRectangle(1.0f, 2.0f, 3.0f, 4.0f);
+            sf::FloatRect sourceRectangle({1.0f, 2.0f}, {3.0f, 4.0f});
             sf::IntRect rectangle(sourceRectangle);
 
             CHECK(rectangle.left == static_cast<int>(sourceRectangle.left));
@@ -52,7 +52,7 @@ TEST_CASE("sf::Rect class template - [graphics]")
     {
         SUBCASE("contains(Vector2)")
         {
-            sf::IntRect rectangle(0, 0, 10, 10);
+            sf::IntRect rectangle({0, 0}, {10, 10});
 
             CHECK(rectangle.contains(sf::Vector2i(0, 0)) == true);
             CHECK(rectangle.contains(sf::Vector2i(9, 0)) == true);
@@ -69,9 +69,9 @@ TEST_CASE("sf::Rect class template - [graphics]")
     {
         SUBCASE("intersects(Rect)")
         {
-            sf::IntRect rectangle(0, 0, 10, 10);
-            sf::IntRect intersectingRectangle(5, 5, 10, 10);
-            sf::IntRect nonIntersectingRectangle(-5, -5, 5, 5);
+            sf::IntRect rectangle({0, 0}, {10, 10});
+            sf::IntRect intersectingRectangle({5, 5}, {10, 10});
+            sf::IntRect nonIntersectingRectangle({-5, -5}, {5, 5});
 
             CHECK(rectangle.intersects(intersectingRectangle) == true);
             CHECK(rectangle.intersects(nonIntersectingRectangle) == false);
@@ -79,9 +79,9 @@ TEST_CASE("sf::Rect class template - [graphics]")
 
         SUBCASE("intersects(Rect, Rect)")
         {
-            sf::IntRect rectangle(0, 0, 10, 10);
-            sf::IntRect intersectingRectangle(5, 5, 10, 10);
-            sf::IntRect nonIntersectingRectangle(-5, -5, 5, 5);
+            sf::IntRect rectangle({0, 0}, {10, 10});
+            sf::IntRect intersectingRectangle({5, 5}, {10, 10});
+            sf::IntRect nonIntersectingRectangle({-5, -5}, {5, 5});
             sf::IntRect intersectionResult;
 
             CHECK(rectangle.intersects(intersectingRectangle, intersectionResult) == true);
@@ -96,9 +96,9 @@ TEST_CASE("sf::Rect class template - [graphics]")
 
     SUBCASE("Comparison operations")
     {
-        sf::IntRect firstRectangle(1, 3, 2, 5);
-        sf::IntRect secondRectangle(1, 3, 2, 5);
-        sf::IntRect differentRectangle(3, 1, 5, 2);
+        sf::IntRect firstRectangle({1, 3}, {2, 5});
+        sf::IntRect secondRectangle({1, 3}, {2, 5});
+        sf::IntRect differentRectangle({3, 1}, {5, 2});
 
         CHECK(firstRectangle == secondRectangle);
         CHECK(firstRectangle != differentRectangle);


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

While writing tests for `sf::Transform` I discovered that `sf::Rect` has a constructor redundant with another overload that uses existing vocabulary types.

This PR is related to #1902 and #1942.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
