### PR TITLE
Use std::optional to remove extra sf::Rect::intersects overload

### DIFF
--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Vector2.hpp>
+#include <optional>
 
 
 namespace sf
@@ -87,7 +88,7 @@ public:
     ///
     /// \return True if the point is inside, false otherwise
     ///
-    /// \see intersects
+    /// \see findIntersection
     ///
     ////////////////////////////////////////////////////////////
     constexpr bool contains(const Vector2<T>& point) const;
@@ -97,28 +98,12 @@ public:
     ///
     /// \param rectangle Rectangle to test
     ///
-    /// \return True if rectangles overlap, false otherwise
+    /// \return Intersection rectangle if intersecting, std::nullopt otherwise
     ///
     /// \see contains
     ///
     ////////////////////////////////////////////////////////////
-    constexpr bool intersects(const Rect<T>& rectangle) const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Check the intersection between two rectangles
-    ///
-    /// This overload returns the overlapped rectangle in the
-    /// \a intersection parameter.
-    ///
-    /// \param rectangle    Rectangle to test
-    /// \param intersection Rectangle to be filled with the intersection
-    ///
-    /// \return True if rectangles overlap, false otherwise
-    ///
-    /// \see contains
-    ///
-    ////////////////////////////////////////////////////////////
-    constexpr bool intersects(const Rect<T>& rectangle, Rect<T>& intersection) const;
+    constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the rectangle's top-left corner
@@ -236,7 +221,7 @@ using FloatRect = Rect<float>;
 ///
 /// // Test the intersection between r1 and r2
 /// sf::IntRect result;
-/// bool b3 = r1.intersects(r2, result); // true
+/// bool b3 = r1.findIntersection(r2, result); // true
 /// // result == (4, 2, 16, 3)
 /// \endcode
 ///

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -81,16 +81,7 @@ constexpr bool Rect<T>::contains(const Vector2<T>& point) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr bool Rect<T>::intersects(const Rect<T>& rectangle) const
-{
-    Rect<T> intersection;
-    return intersects(rectangle, intersection);
-}
-
-
-////////////////////////////////////////////////////////////
-template <typename T>
-constexpr bool Rect<T>::intersects(const Rect<T>& rectangle, Rect<T>& intersection) const
+constexpr std::optional<Rect<T>> Rect<T>::findIntersection(const Rect<T>& rectangle) const
 {
     // Not using 'std::min' and 'std::max' to avoid depending on '<algorithm>'
     const auto min = [](T a, T b){ return (a < b) ? a : b; };
@@ -119,13 +110,11 @@ constexpr bool Rect<T>::intersects(const Rect<T>& rectangle, Rect<T>& intersecti
     // If the intersection is valid (positive non zero area), then there is an intersection
     if ((interLeft < interRight) && (interTop < interBottom))
     {
-        intersection = Rect<T>({interLeft, interTop}, {interRight - interLeft, interBottom - interTop});
-        return true;
+        return Rect<T>({interLeft, interTop}, {interRight - interLeft, interBottom - interTop});
     }
     else
     {
-        intersection = Rect<T>({0, 0}, {0, 0});
-        return false;
+        return std::nullopt;
     }
 }
 

--- a/test/Graphics/Rect.cpp
+++ b/test/Graphics/Rect.cpp
@@ -69,31 +69,19 @@ TEST_CASE("sf::Rect class template - [graphics]")
 
     SUBCASE("Intersection")
     {
-        SUBCASE("intersects(Rect)")
-        {
-            sf::IntRect rectangle({0, 0}, {10, 10});
-            sf::IntRect intersectingRectangle({5, 5}, {10, 10});
-            sf::IntRect nonIntersectingRectangle({-5, -5}, {5, 5});
+        const sf::IntRect rectangle({0, 0}, {10, 10});
+        const sf::IntRect intersectingRectangle({5, 5}, {10, 10});
 
-            CHECK(rectangle.intersects(intersectingRectangle) == true);
-            CHECK(rectangle.intersects(nonIntersectingRectangle) == false);
-        }
+        const auto intersectionResult = rectangle.findIntersection(intersectingRectangle);
+        REQUIRE(intersectionResult.has_value());
+        CHECK(intersectionResult->top == 5);
+        CHECK(intersectionResult->left == 5);
+        CHECK(intersectionResult->width == 5);
+        CHECK(intersectionResult->height == 5);
 
-        SUBCASE("intersects(Rect, Rect)")
-        {
-            sf::IntRect rectangle({0, 0}, {10, 10});
-            sf::IntRect intersectingRectangle({5, 5}, {10, 10});
-            sf::IntRect nonIntersectingRectangle({-5, -5}, {5, 5});
-            sf::IntRect intersectionResult;
-
-            CHECK(rectangle.intersects(intersectingRectangle, intersectionResult) == true);
-            CHECK(intersectionResult.top == 5);
-            CHECK(intersectionResult.left == 5);
-            CHECK(intersectionResult.width == 5);
-            CHECK(intersectionResult.height == 5);
-
-            CHECK(rectangle.intersects(nonIntersectingRectangle, intersectionResult) == false);
-        }
+        const sf::IntRect nonIntersectingRectangle({-5, -5}, {5, 5});
+        CHECK_FALSE(rectangle.findIntersection(nonIntersectingRectangle).has_value());
+        CHECK_FALSE(rectangle.findIntersection(nonIntersectingRectangle));
     }
 
     SUBCASE("Comparison operations")


### PR DESCRIPTION
## Description

An overload of `sf::Rect::intersects` used an out parameter to return the overlapping rectangle between two rectangles. This is a perfect use case for `std::optional` since when doing an intersection test there is sometimes an intersection to return but sometimes there is not. Because `std::optional` defines `operator bool` many existing uses of `sf::Rect::intersects` will quietly keep working.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
