### PR TITLE
Allow examples to run from any directory

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -271,6 +271,7 @@ macro(sfml_add_example target)
     endif()
 
     set_file_warnings(${target_input})
+    target_compile_definitions(${target} PRIVATE RESOURCE_PATH=std::string\(\"${CMAKE_CURRENT_SOURCE_DIR}/resources/\"\))
 
     # set the debug suffix
     set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -92,7 +92,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
+    if (!font.loadFromFile(RESOURCE_PATH + "tuffy.ttf"))
         return EXIT_FAILURE;
 
     // Create all of our graphics resources
@@ -127,7 +127,7 @@ int main()
     {
         statusText.setString("Shaders and/or Vertex Buffers Unsupported");
     }
-    else if (!terrainShader.loadFromFile("resources/terrain.vert", "resources/terrain.frag"))
+    else if (!terrainShader.loadFromFile(RESOURCE_PATH + "terrain.vert", RESOURCE_PATH + "terrain.frag"))
     {
         prerequisitesSupported = false;
 

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -92,7 +92,7 @@ int main()
 
     // Load the text font
     sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
+    if (!font.loadFromFile(RESOURCE_PATH + "tuffy.ttf"))
         return EXIT_FAILURE;
 
     // Set up our string conversion parameters

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -22,7 +22,7 @@ std::string resourcesDir()
 #ifdef SFML_SYSTEM_IOS
     return "";
 #else
-    return "resources/";
+    return RESOURCE_PATH;
 #endif
 }
 

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -24,12 +24,12 @@ public:
     bool onLoad() override
     {
         // Load the texture and initialize the sprite
-        if (!m_texture.loadFromFile("resources/background.jpg"))
+        if (!m_texture.loadFromFile(RESOURCE_PATH + "background.jpg"))
             return false;
         m_sprite.setTexture(m_texture);
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/pixelate.frag", sf::Shader::Fragment))
+        if (!m_shader.loadFromFile(RESOURCE_PATH + "pixelate.frag", sf::Shader::Fragment))
             return false;
         m_shader.setUniform("texture", sf::Shader::CurrentTexture);
 
@@ -93,7 +93,7 @@ public:
         m_text.setPosition({30.f, 20.f});
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/wave.vert", "resources/blur.frag"))
+        if (!m_shader.loadFromFile(RESOURCE_PATH + "wave.vert", RESOURCE_PATH + "blur.frag"))
             return false;
 
         return true;
@@ -146,7 +146,7 @@ public:
         }
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/storm.vert", "resources/blink.frag"))
+        if (!m_shader.loadFromFile(RESOURCE_PATH + "storm.vert", RESOURCE_PATH + "blink.frag"))
             return false;
 
         return true;
@@ -194,10 +194,10 @@ public:
         m_surface.setSmooth(true);
 
         // Load the textures
-        if (!m_backgroundTexture.loadFromFile("resources/sfml.png"))
+        if (!m_backgroundTexture.loadFromFile(RESOURCE_PATH + "sfml.png"))
             return false;
         m_backgroundTexture.setSmooth(true);
-        if (!m_entityTexture.loadFromFile("resources/devices.png"))
+        if (!m_entityTexture.loadFromFile(RESOURCE_PATH + "devices.png"))
             return false;
         m_entityTexture.setSmooth(true);
 
@@ -213,7 +213,7 @@ public:
         }
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/edge.frag", sf::Shader::Fragment))
+        if (!m_shader.loadFromFile(RESOURCE_PATH + "edge.frag", sf::Shader::Fragment))
             return false;
         m_shader.setUniform("texture", sf::Shader::CurrentTexture);
 
@@ -287,11 +287,11 @@ public:
         }
 
         // Load the texture
-        if (!m_logoTexture.loadFromFile("resources/logo.png"))
+        if (!m_logoTexture.loadFromFile(RESOURCE_PATH + "logo.png"))
             return false;
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/billboard.vert", "resources/billboard.geom", "resources/billboard.frag"))
+        if (!m_shader.loadFromFile(RESOURCE_PATH + "billboard.vert", RESOURCE_PATH + "billboard.geom", RESOURCE_PATH + "billboard.frag"))
             return false;
         m_shader.setUniform("texture", sf::Shader::CurrentTexture);
 
@@ -352,7 +352,7 @@ int main()
 
     // Load the application font and pass it to the Effect class
     sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
+    if (!font.loadFromFile(RESOURCE_PATH + "tuffy.ttf"))
         return EXIT_FAILURE;
     Effect::setFont(font);
 
@@ -379,7 +379,7 @@ int main()
 
     // Create the messages background
     sf::Texture textBackgroundTexture;
-    if (!textBackgroundTexture.loadFromFile("resources/text-background.png"))
+    if (!textBackgroundTexture.loadFromFile(RESOURCE_PATH + "text-background.png"))
         return EXIT_FAILURE;
     sf::Sprite textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -15,7 +15,7 @@ void playSound()
 {
     // Load a sound buffer from a wav file
     sf::SoundBuffer buffer;
-    if (!buffer.loadFromFile("resources/killdeer.wav"))
+    if (!buffer.loadFromFile(RESOURCE_PATH + "killdeer.wav"))
         return;
 
     // Display sound informations
@@ -50,7 +50,7 @@ void playMusic(const std::string& filename)
 {
     // Load an ogg music file
     sf::Music music;
-    if (!music.openFromFile("resources/" + filename))
+    if (!music.openFromFile(RESOURCE_PATH + filename))
         return;
 
     // Display music informations

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -17,7 +17,7 @@ std::string resourcesDir()
 #ifdef SFML_SYSTEM_IOS
     return "";
 #else
-    return "resources/";
+    return RESOURCE_PATH;
 #endif
 }
 

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -889,7 +889,7 @@ public:
         {
             sf::FileInputStream file;
 
-            if (!file.open("resources/shader.vert.spv"))
+            if (!file.open(RESOURCE_PATH + "shader.vert.spv"))
             {
                 vulkanAvailable = false;
                 return;
@@ -917,7 +917,7 @@ public:
         {
             sf::FileInputStream file;
 
-            if (!file.open("resources/shader.frag.spv"))
+            if (!file.open(RESOURCE_PATH + "shader.frag.spv"))
             {
                 vulkanAvailable = false;
                 return;
@@ -1750,7 +1750,7 @@ public:
         // Load the image data
         sf::Image imageData;
 
-        if (!imageData.loadFromFile("resources/logo.png"))
+        if (!imageData.loadFromFile(RESOURCE_PATH + "logo.png"))
         {
             vulkanAvailable = false;
             return;

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -82,7 +82,7 @@ int main()
 
     // Load some textures to display
     sf::Texture texture1, texture2;
-    if (!texture1.loadFromFile("resources/image1.jpg") || !texture2.loadFromFile("resources/image2.jpg"))
+    if (!texture1.loadFromFile(RESOURCE_PATH + "image1.jpg") || !texture2.loadFromFile(RESOURCE_PATH + "image2.jpg"))
         return EXIT_FAILURE;
     sf::Sprite sprite1(texture1);
     sf::Sprite sprite2(texture2);


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

I added a compiler definition to each example that allows for passing absolute paths to SFML functions that expect file paths. This means any example can be run from any directory instead of having to be in the example's source directory.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Build examples and attempt to run them from any directory on your system.