### PR TITLE
Add support for VS 2022 to the GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2017, os: windows-2016   }
-        - { name: Windows VS2019, os: windows-latest }
+        - { name: Windows VS2017, os: windows-2016 }
+        - { name: Windows VS2019, os: windows-2019 }
+        - { name: Windows VS2022, os: windows-2022 }
         - { name: Linux GCC,      os: ubuntu-latest  }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS XCode,    os: macos-latest   }
@@ -21,7 +22,7 @@ jobs:
         - { name: Static,       flags: -DBUILD_SHARED_LIBS=FALSE }
 
         include:
-        - platform: { name: Windows VS2019, os: windows-latest }
+        - platform: { name: Windows VS2022, os: windows-2022 }
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
         - platform: { name: MacOS XCode, os: macos-latest }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }


### PR DESCRIPTION
## Description

Add Windows Server 2022 image + VS 2022 support to the GitHub Actions CI pipeline.

Even though Windows Server 2016 + VS 2017 [should be removed](https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/) in March 2022, I left it in for now...