### PR TITLE
Fix runtests target for multi-configuration generators

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,5 +59,5 @@ add_custom_target(runtests ALL
 
 add_custom_command(TARGET runtests
                    COMMENT "Run tests"
-                   POST_BUILD COMMAND ctest ARGS --output-on-failure
+                   POST_BUILD COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure -C $<CONFIG>
 )


### PR DESCRIPTION
## Description

I was doing some experiments on SFML using the Ninja Multi-Config generator.
I expected some tests not to pass but the report given by the `runtests` target automatically run after build was showing success.

It turns out it is running tests for the Release configuration, but I was building the Debug configuration.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

- Run CMake with a multi-configuration generator and SFML_BUILD_TEST_SUITE option enabled.
- Build the Release configuration: tests are successful.
- Add a broken unit test.
- Build the Debug configuration: tests fail as expected. Before this patch, tests would be successful.