### PR TITLE
Simplify sf::Transform tests

### DIFF
--- a/test/Graphics/Transform.cpp
+++ b/test/Graphics/Transform.cpp
@@ -1,23 +1,12 @@
 #include <SFML/Graphics/Transform.hpp>
 #include "GraphicsUtil.hpp"
-#include "SystemUtil.hpp"
-#include <vector>
+#include "Array.hpp"
+#include "Approx.hpp"
 
 #include <doctest.h>
 
-using doctest::Approx;
-
-namespace std
-{
-std::ostream& operator<<(std::ostream& out, const std::vector<float>& vector)
-{
-    out << "{ ";
-    for (size_t i = 0; i + 1 < vector.size(); ++i)
-        out << vector[i] << ", ";
-    out << vector.back() << " }";
-    return out;
-}
-}
+using sf::Testing::toArray;
+using sf::Testing::Approx;
 
 TEST_CASE("sf::Transform class - [graphics]")
 {
@@ -33,21 +22,20 @@ TEST_CASE("sf::Transform class - [graphics]")
             const sf::Transform transform(10.0f, 11.0f, 12.0f,
                                           13.0f, 14.0f, 15.0f,
                                           16.0f, 17.0f, 18.0f);
-            const std::vector<float> matrix(transform.getMatrix(), transform.getMatrix() + 16);
-            CHECK(matrix == std::vector<float>{10.0f, 13.0f, 0.0f, 16.0f,
-                                               11.0f, 14.0f, 0.0f, 17.0f,
-                                                0.0f,  0.0f, 1.0f,  0.0f,
-                                               12.0f, 15.0f, 0.0f, 18.0f});
+
+            CHECK(toArray<16>(transform.getMatrix()) == std::array{10.0f, 13.0f, 0.0f, 16.0f,
+                                                                   11.0f, 14.0f, 0.0f, 17.0f,
+                                                                    0.0f,  0.0f, 1.0f,  0.0f,
+                                                                   12.0f, 15.0f, 0.0f, 18.0f});
         }
     }
 
     SUBCASE("Identity matrix")
     {
-        const std::vector<float> matrix(sf::Transform::Identity.getMatrix(), sf::Transform::Identity.getMatrix() + 16);
-        CHECK(matrix == std::vector<float>{1.0f, 0.0f, 0.0f, 0.0f,
-                                           0.0f, 1.0f, 0.0f, 0.0f,
-                                           0.0f, 0.0f, 1.0f, 0.0f,
-                                           0.0f, 0.0f, 0.0f, 1.0f});
+        CHECK(toArray<16>(sf::Transform::Identity.getMatrix()) == std::array{1.0f, 0.0f, 0.0f, 0.0f,
+                                                                             0.0f, 1.0f, 0.0f, 0.0f,
+                                                                             0.0f, 0.0f, 1.0f, 0.0f,
+                                                                             0.0f, 0.0f, 0.0f, 1.0f});
     }
 
     SUBCASE("getInverse()")
@@ -124,30 +112,18 @@ TEST_CASE("sf::Transform class - [graphics]")
         {
             sf::Transform transform;
             transform.rotate(90);
-            CHECK(transform.getMatrix()[0] == Approx(0));
-            CHECK(transform.getMatrix()[4] == Approx(-1));
-            CHECK(transform.getMatrix()[12] == Approx(0));
-            CHECK(transform.getMatrix()[1] == Approx(1));
-            CHECK(transform.getMatrix()[5] == Approx(0));
-            CHECK(transform.getMatrix()[13] == Approx(0));
-            CHECK(transform.getMatrix()[3] == Approx(0));
-            CHECK(transform.getMatrix()[7] == Approx(0));
-            CHECK(transform.getMatrix()[15] == Approx(1));
+            CHECK(transform == Approx(sf::Transform(0.0f, -1.0f, 0.0f,
+                                                    1.0f,  0.0f, 0.0f,
+                                                    0.0f,  0.0f, 1.0f)));
         }
 
         SUBCASE("Around custom point")
         {
             sf::Transform transform;
             transform.rotate(90, {1.0f, 0.0f});
-            CHECK(transform.getMatrix()[0] == Approx(0));
-            CHECK(transform.getMatrix()[4] == Approx(-1));
-            CHECK(transform.getMatrix()[12] == Approx(1));
-            CHECK(transform.getMatrix()[1] == Approx(1));
-            CHECK(transform.getMatrix()[5] == Approx(0));
-            CHECK(transform.getMatrix()[13] == Approx(-1));
-            CHECK(transform.getMatrix()[3] == Approx(0));
-            CHECK(transform.getMatrix()[7] == Approx(0));
-            CHECK(transform.getMatrix()[15] == Approx(1));
+            CHECK(transform == Approx(sf::Transform(0.0f, -1.0f,  1.0f,
+                                                    1.0f,  0.0f, -1.0f,
+                                                    0.0f,  0.0f,  1.0f)));
         }
     }
 

--- a/test/TestUtilities/Approx.hpp
+++ b/test/TestUtilities/Approx.hpp
@@ -1,0 +1,31 @@
+#ifndef SFML_TESTUTILITIES_APPROX_HPP
+#define SFML_TESTUTILITIES_APPROX_HPP
+
+#include <ostream>
+
+namespace sf::Testing
+{
+    template <typename T>
+    struct Approx
+    {
+        Approx(const T& value)
+        : value{value}
+        {}
+
+        const T& value;
+    };
+
+    template <typename T>
+    bool operator ==(const T& value, const Approx<T>& approx)
+    {
+        return almostEqual(value, approx.value);
+    }
+
+    template <typename T>
+    std::ostream& operator <<(std::ostream& out, const sf::Testing::Approx<T>& approx)
+    {
+        return out << approx.value;
+    }
+}
+
+#endif // SFML_TESTUTILITIES_APPROX_HPP

--- a/test/TestUtilities/Array.hpp
+++ b/test/TestUtilities/Array.hpp
@@ -1,0 +1,41 @@
+#ifndef SFML_TESTUTILITIES_ARRAY_HPP
+#define SFML_TESTUTILITIES_ARRAY_HPP
+
+#include <array>
+#include <limits>
+#include <ostream>
+
+namespace sf::Testing
+{
+    template <std::size_t size, typename T> // T is the second parameter so it can be omitted and deduced.
+    std::array<T, size> toArray(const T* pointer)
+    {
+        std::array<T, size> array;
+        std::copy(pointer, pointer + size, array.begin());
+        return array;
+    }
+}
+
+namespace std
+{
+    template <typename T, std::size_t size>
+    std::ostream& operator <<(std::ostream& out, const std::array<T, size>& array)
+    {
+        if (size == 0)
+            return out << "{}";
+
+        // Make sure enough digits are printed so that distinct floating-point values are uniquely represented.
+        const auto previous_precision = out.precision(std::numeric_limits<T>::max_digits10);
+
+        out << "{ ";
+        for (std::size_t i = 0; i + 1 < array.size(); ++i)
+            out << array[i] << ", ";
+        out << array.back() << " }";
+
+        out.precision(previous_precision);
+
+        return out;
+    }
+}
+
+#endif // SFML_TESTUTILITIES_ARRAY_HPP

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -1,7 +1,9 @@
-// Note: No need to increase compile time by including TestUtilities/Graphics.hpp
+// Note: No need to increase compile time by including TestUtilities/GraphicsUtil.hpp
 #include <SFML/Graphics/BlendMode.hpp>
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Transform.hpp>
+
+#include <doctest.h> // doctest::Approx
 
 #include <ostream>
 
@@ -35,5 +37,20 @@ namespace sf
         os << matrix[3] << ", " << matrix[7] << ", " << matrix[15];
 
         return os;
+    }
+
+    namespace Testing
+    {
+        bool almostEqual(const sf::Transform& lhs, const sf::Transform& rhs)
+        {
+            const auto& a = lhs.getMatrix();
+            const auto& b = rhs.getMatrix();
+
+            for (std::size_t i : { 0, 1, 3, 4, 5, 7, 12, 13, 15 })
+                if (a[i] != doctest::Approx(b[i])) // default epsilon
+                    return false;
+
+            return true;
+        }
     }
 }

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -17,6 +17,11 @@ namespace sf
     std::ostream& operator <<(std::ostream& os, const BlendMode& blendMode);
     std::ostream& operator <<(std::ostream& os, const Color& color);
     std::ostream& operator <<(std::ostream& os, const Transform& transform);
+
+    namespace Testing
+    {
+        bool almostEqual(const sf::Transform& lhs, const sf::Transform& rhs);
+    }
 }
 
 #endif // SFML_TESTUTILITIES_GRAPHICS_HPP

--- a/test/TestUtilities/WindowUtil.cpp
+++ b/test/TestUtilities/WindowUtil.cpp
@@ -1,4 +1,4 @@
-// Note: No need to increase compile time by including TestUtilities/Window.hpp
+// Note: No need to increase compile time by including TestUtilities/WindowUtil.hpp
 #include <SFML/Window/VideoMode.hpp>
 #include <ostream>
 


### PR DESCRIPTION
## Description

Add some utilities to make writing `Transform` tests simpler.

Below is the previous description. It turns out using `std::array` in this context is not so great.

> This PR replaces C-style arrays in `sf::Tranform` and `sf::priv::Matrix` with `std::array`.
>
> The main motivation is to make testing the `Transform` class easier. I created this to contribute to the discussion in #1973.
By having the underlying matrix as an `std::array`, it makes it possible to compare matrices in a single statement using comparison operators on `std::array` which plays nice with doctest macros.
> 
> As floating-point values need a tolerant comparison for tests and `doctest::Approx` only handles single values, the utility class `ApproxArray` is proposed to compare floating-point arrays.
> 
> I looked for other opportunities to replace C-style arrays with `std::array`. There are other places where C-style arrays are used, but I feel replacing them with an `std::array` brings no benefit, so I did not do it.
Many functions are taking a pointer and a size, but this is not where `std::array` would be useful. This is where `std::span` would be nice but it is not available with C++17, only from C++20.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

- CI
- Checking debug strings are sensible when running `./test-sfml-graphics --success --test-case=sf::Transform*`