### PR TITLE
Remove unnecessary CMake version requirement

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
-
 set(SRCROOT "${PROJECT_SOURCE_DIR}/test")
 
 add_library(sfml-test-main STATIC "${SRCROOT}/DoctestMain.cpp")


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This is left over from 0f83e3d but we forgot to remove it. Nothing about this file requires an elevated minimum CMake version now that the FetchContent usage is gone.

The fact that its inclusion didn't break any CI jobs means we can probably safely upgrade to CMake 3.14 (or newer) in the future with minimal impact. I'm not proposing raising that requirement without cause, but we should consider what improvements can be made if we do raise that requirement. CMake really hit its stride with 3.14 and it'd be a great minimum version to target.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
