### PR TITLE
Extension methods for Vector2

### DIFF
--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -25,11 +25,16 @@
 #ifndef SFML_VECTOR2_HPP
 #define SFML_VECTOR2_HPP
 
+#include <SFML/System/Angle.hpp>
+#include <cassert>
+#include <cmath>
+#include <type_traits>
+
 
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-/// \brief Utility template class for manipulating
+/// \brief Class template for manipulating
 ///        2-dimensional vectors
 ///
 ////////////////////////////////////////////////////////////
@@ -68,13 +73,142 @@ public:
     ////////////////////////////////////////////////////////////
     template <typename U>
     constexpr explicit Vector2(const Vector2<U>& vector);
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Length of the vector <i><b>(floating-point)</b></i>.
+    ///
+    /// If you are not interested in the actual length, but only in comparisons, consider using lengthSq().
+    ///
+    ////////////////////////////////////////////////////////////
+    T length() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Square of vector's length.
+    /// 
+    /// Suitable for comparisons, more efficient than length().
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr T lengthSq() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
+    /// 
+    /// \pre \c *this is no zero vector.
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] Vector2 normalized() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Signed angle from \c *this to \c rhs <i><b>(floating-point)</b></i>.
+    /// 
+    /// \return The smallest angle which rotates \c *this in positive
+    /// or negative direction, until it has the same direction as \c rhs.
+    /// The result has a sign and lies in the range [-180, 180°).
+    /// \pre Neither \c *this nor \c rhs is a zero vector.
+    ///
+    ////////////////////////////////////////////////////////////
+    Angle angleTo(const Vector2& rhs) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Signed angle from +X or (1,0) vector <i><b>(floating-point)</b></i>.
+    /// 
+    /// For example, the vector (1,0) corresponds to 0 degrees, (0,1) corresponds to 90 degrees.
+    /// 
+    /// \return Angle in the range [-180°, 180°).
+    /// \pre This vector is no zero vector.
+    ///
+    ////////////////////////////////////////////////////////////
+    Angle angle() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Rotate by angle \c phi <i><b>(floating-point)</b></i>.
+    /// 
+    /// Returns a vector with same length but different direction.
+    ///
+    /// In SFML's default coordinate system with +X right and +Y down,
+    /// this amounts to a clockwise rotation by \c phi.
+    /// 
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] Vector2 rotatedBy(Angle phi) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Projection of this vector onto \c axis <i><b>(floating-point)</b></i>.
+    /// 
+    /// \param axis Vector being projected onto. Need not be normalized.
+    /// \pre \c axis must not have length zero.
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] constexpr Vector2 projectedOnto(const Vector2& axis) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Returns a perpendicular vector.
+    /// 
+    /// Returns \c *this rotated by +90 degrees; (x,y) becomes (-y,x).
+    /// For example, the vector (1,0) is transformed to (0,1).
+    ///
+    /// In SFML's default coordinate system with +X right and +Y down,
+    /// this amounts to a clockwise rotation.
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2 perpendicular() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Dot product of two 2D vectors.
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr T dot(const Vector2& rhs) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Z component of the cross product of two 2D vectors.
+    /// 
+    /// Treats the operands as 3D vectors, computes their cross product
+    /// and returns the result's Z component (X and Y components are always zero).
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr T cross(const Vector2& rhs) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Component-wise multiplication of \c *this and \c rhs.
+    ///
+    /// Computes <tt>(lhs.x*rhs.x, lhs.y*rhs.y)</tt>.
+    /// 
+    /// Scaling is the most common use case for component-wise multiplication/division.
+    /// This operation is also known as the Hadamard or Schur product.
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2 cwiseMul(const Vector2& rhs) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Component-wise division of \c *this and \c rhs.
+    /// 
+    /// Computes <tt>(lhs.x/rhs.x, lhs.y/rhs.y)</tt>.
+    /// 
+    /// Scaling is the most common use case for component-wise multiplication/division.
+    /// 
+    /// \pre Neither component of \c rhs is zero.
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
+
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     T x; //!< X coordinate of the vector
     T y; //!< Y coordinate of the vector
+
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const Vector2 UnitX; //!< The X unit vector (1, 0), usually facing right
+    static const Vector2 UnitY; //!< The Y unit vector (0, 1), usually facing down
 };
+
+// Define the most common types
+using Vector2i = Vector2<int>;
+using Vector2u = Vector2<unsigned int>;
+using Vector2f = Vector2<float>;
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -93,12 +227,12 @@ template <typename T>
 /// \brief Overload of binary operator +=
 ///
 /// This operator performs a memberwise addition of both vectors,
-/// and assigns the result to \a left.
+/// and assigns the result to \c left.
 ///
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a vector)
 ///
-/// \return Reference to \a left
+/// \return Reference to \c left
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -109,12 +243,12 @@ constexpr Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right);
 /// \brief Overload of binary operator -=
 ///
 /// This operator performs a memberwise subtraction of both vectors,
-/// and assigns the result to \a left.
+/// and assigns the result to \c left.
 ///
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a vector)
 ///
-/// \return Reference to \a left
+/// \return Reference to \c left
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -153,7 +287,7 @@ template <typename T>
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a scalar value)
 ///
-/// \return Memberwise multiplication by \a right
+/// \return Memberwise multiplication by \c right
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -166,7 +300,7 @@ template <typename T>
 /// \param left  Left operand (a scalar value)
 /// \param right Right operand (a vector)
 ///
-/// \return Memberwise multiplication by \a left
+/// \return Memberwise multiplication by \c left
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -176,13 +310,13 @@ template <typename T>
 /// \relates Vector2
 /// \brief Overload of binary operator *=
 ///
-/// This operator performs a memberwise multiplication by \a right,
-/// and assigns the result to \a left.
+/// This operator performs a memberwise multiplication by \c right,
+/// and assigns the result to \c left.
 ///
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a scalar value)
 ///
-/// \return Reference to \a left
+/// \return Reference to \c left
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -195,7 +329,7 @@ constexpr Vector2<T>& operator *=(Vector2<T>& left, T right);
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a scalar value)
 ///
-/// \return Memberwise division by \a right
+/// \return Memberwise division by \c right
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -205,13 +339,13 @@ template <typename T>
 /// \relates Vector2
 /// \brief Overload of binary operator /=
 ///
-/// This operator performs a memberwise division by \a right,
-/// and assigns the result to \a left.
+/// This operator performs a memberwise division by \c right,
+/// and assigns the result to \c left.
 ///
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a scalar value)
 ///
-/// \return Reference to \a left
+/// \return Reference to \c left
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -226,7 +360,7 @@ constexpr Vector2<T>& operator /=(Vector2<T>& left, T right);
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a vector)
 ///
-/// \return True if \a left is equal to \a right
+/// \return True if \c left is equal to \c right
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
@@ -241,18 +375,13 @@ template <typename T>
 /// \param left  Left operand (a vector)
 /// \param right Right operand (a vector)
 ///
-/// \return True if \a left is not equal to \a right
+/// \return True if \c left is not equal to \c right
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
 [[nodiscard]] constexpr bool operator !=(const Vector2<T>& left, const Vector2<T>& right);
 
 #include <SFML/System/Vector2.inl>
-
-// Define the most common types
-using Vector2i = Vector2<int>;
-using Vector2u = Vector2<unsigned int>;
-using Vector2f = Vector2<float>;
 
 } // namespace sf
 
@@ -267,31 +396,40 @@ using Vector2f = Vector2<float>;
 /// sf::Vector2 is a simple class that defines a mathematical
 /// vector with two coordinates (x and y). It can be used to
 /// represent anything that has two dimensions: a size, a point,
-/// a velocity, etc.
+/// a velocity, a scale, etc.
 ///
+/// The API provides basic arithmetic (addition, subtraction, scale), as
+/// well as more advanced geometric operations, such as dot/cross products,
+/// length and angle computations, projections, rotations, etc.
+/// 
 /// The template parameter T is the type of the coordinates. It
 /// can be any type that supports arithmetic operations (+, -, /, *)
 /// and comparisons (==, !=), for example int or float.
-///
+/// Note that some operations are only meaningful for vectors where T is
+/// a floating point type (e.g. float or double), often because
+/// results cannot be represented accurately with integers.
+/// The method documentation mentions "(floating-point)" in those cases.
+/// 
 /// You generally don't have to care about the templated form (sf::Vector2<T>),
 /// the most common specializations have special type aliases:
 /// \li sf::Vector2<float> is sf::Vector2f
 /// \li sf::Vector2<int> is sf::Vector2i
 /// \li sf::Vector2<unsigned int> is sf::Vector2u
 ///
-/// The sf::Vector2 class has a small and simple interface, its x and y members
-/// can be accessed directly (there are no accessors like setX(), getX()) and it
-/// contains no mathematical function like dot product, cross product, length, etc.
+/// The sf::Vector2 class has a simple interface, its x and y members
+/// can be accessed directly (there are no accessors like setX(), getX()).
 ///
 /// Usage example:
 /// \code
-/// sf::Vector2f v1(16.5f, 24.f);
-/// v1.x = 18.2f;
-/// float y = v1.y;
+/// sf::Vector2f v(16.5f, 24.f);
+/// v.x = 18.2f;
+/// float y = v.y;
 ///
-/// sf::Vector2f v2 = v1 * 5.f;
-/// sf::Vector2f v3;
-/// v3 = v1 + v2;
+/// sf::Vector2f w = v * 5.f;
+/// sf::Vector2f u;
+/// u = v + w;
+///
+/// float s = v.dot(w);
 ///
 /// bool different = (v2 != v3);
 /// \endcode

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -55,6 +55,128 @@ y(static_cast<T>(vector.y))
 
 ////////////////////////////////////////////////////////////
 template <typename T>
+T Vector2<T>::length() const
+{
+    static_assert(std::is_floating_point_v<T>, "Vector2::length() is only supported for floating point types");
+
+    return std::hypot(x, y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+constexpr T Vector2<T>::lengthSq() const
+{
+    return this->dot(*this);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> Vector2<T>::normalized() const
+{
+    static_assert(std::is_floating_point_v<T>, "Vector2::normalized() is only supported for floating point types");
+
+    assert(*this != Vector2<T>());
+    return (*this) / length();
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Angle Vector2<T>::angleTo(const Vector2<T>& rhs) const
+{
+    static_assert(std::is_floating_point_v<T>, "Vector2::angleTo() is only supported for floating point types");
+
+    assert(*this != Vector2<T>());
+    assert(rhs != Vector2<T>());
+    return radians(std::atan2(this->cross(rhs), this->dot(rhs)));
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Angle Vector2<T>::angle() const
+{
+    static_assert(std::is_floating_point_v<T>, "Vector2::angle() is only supported for floating point types");
+
+    assert(*this != Vector2<T>());
+    return radians(std::atan2(y, x));
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> Vector2<T>::rotatedBy(Angle angle) const
+{
+    static_assert(std::is_floating_point_v<T>, "Vector2::rotatedBy() is only supported for floating point types");
+   
+    // No zero vector assert, because rotating a zero vector is well-defined (yields always itself)
+    T cos = std::cos(angle.asRadians());
+    T sin = std::sin(angle.asRadians());
+
+    // Don't manipulate x and y separately, otherwise they're overwritten too early
+    return Vector2<T>(
+        cos * x - sin * y,
+        sin * x + cos * y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+constexpr Vector2<T> Vector2<T>::projectedOnto(const Vector2<T>& axis) const
+{
+    static_assert(std::is_floating_point_v<T>, "Vector2::projectedOnto() is only supported for floating point types");
+
+    assert(axis != Vector2<T>());
+    return this->dot(axis) / axis.lengthSq() * axis;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+constexpr Vector2<T> Vector2<T>::perpendicular() const
+{
+    return Vector2<T>(-y, x);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+constexpr T Vector2<T>::dot(const Vector2<T>& rhs) const
+{
+    return x * rhs.x + y * rhs.y;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+constexpr T Vector2<T>::cross(const Vector2<T>& rhs) const
+{
+    return x * rhs.y - y * rhs.x;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+constexpr Vector2<T> Vector2<T>::cwiseMul(const Vector2<T>& rhs) const
+{
+    return Vector2<T>(x * rhs.x, y * rhs.y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+constexpr Vector2<T> Vector2<T>::cwiseDiv(const Vector2<T>& rhs) const
+{
+    assert(rhs.x != 0);
+    assert(rhs.y != 0);
+    return Vector2<T>(x / rhs.x, y / rhs.y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
 constexpr Vector2<T> operator -(const Vector2<T>& right)
 {
     return Vector2<T>(-right.x, -right.y);
@@ -159,3 +281,14 @@ constexpr bool operator !=(const Vector2<T>& left, const Vector2<T>& right)
 {
     return (left.x != right.x) || (left.y != right.y);
 }
+
+
+////////////////////////////////////////////////////////////
+// Static member data
+////////////////////////////////////////////////////////////
+
+template <typename T>
+constexpr Vector2<T> Vector2<T>::UnitX(static_cast<T>(1), static_cast<T>(0));
+
+template <typename T>
+constexpr Vector2<T> Vector2<T>::UnitY(static_cast<T>(0), static_cast<T>(1));

--- a/test/System/Vector2.cpp
+++ b/test/System/Vector2.cpp
@@ -4,7 +4,12 @@
 
 #include <doctest.h>
 
-// Use sf::Vector2i for tests. Test coverage is given, as there are no template specializations.
+using namespace sf::Literals;
+using doctest::Approx;
+
+// Use sf::Vector2i for tests (except for float vector algebra).
+// Test coverage is given, as there are no template specializations.
+
 
 TEST_CASE("sf::Vector2 class template - [system]")
 {
@@ -184,11 +189,97 @@ TEST_CASE("sf::Vector2 class template - [system]")
         }
     }
 
+    SUBCASE("Length and normalization")
+    {
+        sf::Vector2f v(2.4f, 3.0f);
+
+        CHECK(v.length() == Approx(3.84187));
+        CHECK(v.lengthSq() == Approx(14.7599650969));
+        CHECK(v.normalized() == ApproxVec(0.624695, 0.780869));
+
+        sf::Vector2f w(-0.7f, -2.2f);
+        
+        CHECK(w.length() == Approx(2.30868));
+        CHECK(w.lengthSq() == Approx(5.3300033));
+        CHECK(w.normalized() == ApproxVec(-0.303204, -0.952926));
+    }
+
+    SUBCASE("Rotations and angles")
+    {
+        sf::Vector2f v(2.4f, 3.0f);
+        
+        CHECK(v.angle() == ApproxDeg(51.3402));
+        CHECK(sf::Vector2f::UnitX.angleTo(v) == ApproxDeg(51.3402));
+        CHECK(sf::Vector2f::UnitY.angleTo(v) == ApproxDeg(-38.6598));
+
+        sf::Vector2f w(-0.7f, -2.2f);
+
+        CHECK(w.angle() == ApproxDeg(-107.65));
+        CHECK(sf::Vector2f::UnitX.angleTo(w) == ApproxDeg(-107.65));
+        CHECK(sf::Vector2f::UnitY.angleTo(w) == ApproxDeg(162.35));
+
+        CHECK(v.angleTo(w) == ApproxDeg(-158.9902));
+        CHECK(w.angleTo(v) == ApproxDeg(158.9902));
+
+        float ratio = w.length() / v.length();
+        CHECK(v.rotatedBy(-158.9902_deg) * ratio  == ApproxVec(w));
+        CHECK(w.rotatedBy(158.9902_deg) / ratio == ApproxVec(v));
+
+        CHECK(v.perpendicular() == sf::Vector2f(-3.0f, 2.4f));
+        CHECK(v.perpendicular().perpendicular().perpendicular().perpendicular() == v);
+
+        CHECK(v.rotatedBy(90_deg) == ApproxVec(-3.0, 2.4));
+        CHECK(v.rotatedBy(27.14_deg) == ApproxVec(0.767248, 3.76448));
+        CHECK(v.rotatedBy(-36.11_deg) == ApproxVec(3.70694, 1.00925));
+    }
+    
+    SUBCASE("Products and quotients")
+    {
+        sf::Vector2f v(2.4f, 3.0f);
+        sf::Vector2f w(-0.7f, -2.2f);
+
+        CHECK(v.dot(w) == Approx(-8.28));
+        CHECK(w.dot(v) == Approx(-8.28));
+
+        CHECK(v.cross(w) == Approx(-3.18));
+        CHECK(w.cross(v) == Approx(+3.18));
+        
+        CHECK(v.cwiseMul(w) == ApproxVec(-1.68, -6.6));
+        CHECK(w.cwiseMul(v) == ApproxVec(-1.68, -6.6));
+        CHECK(v.cwiseDiv(w) == ApproxVec(-3.428571, -1.363636));
+        CHECK(w.cwiseDiv(v) == ApproxVec(-0.291666, -0.733333));
+    }
+    
+    SUBCASE("Projection")
+    {
+        sf::Vector2f v(2.4f, 3.0f);
+        sf::Vector2f w(-0.7f, -2.2f);
+        
+        CHECK(v.projectedOnto(w) == ApproxVec(1.087430, 3.417636));
+        CHECK(v.projectedOnto(w) == ApproxVec(-1.55347f * w));
+
+        CHECK(w.projectedOnto(v) == ApproxVec(-1.346342, -1.682927));
+        CHECK(w.projectedOnto(v) == ApproxVec(-0.560976f * v));
+
+        CHECK(v.projectedOnto(sf::Vector2f::UnitX) == ApproxVec(2.4, 0.0));
+        CHECK(v.projectedOnto(sf::Vector2f::UnitY) == ApproxVec(0.0, 3.0));
+    }
+
     SUBCASE("Constexpr support")
     {
-        constexpr sf::Vector2i vector(1, 2);
-        static_assert(vector.x == 1);
-        static_assert(vector.y == 2);
-        static_assert(vector + sf::Vector2i(2, 1) == sf::Vector2i(3, 3));
+        constexpr sf::Vector2i v(1, 2);
+        constexpr sf::Vector2i w(2, -3);
+
+        static_assert(v.x == 1);
+        static_assert(v.y == 2);
+        static_assert(v + w == sf::Vector2i(3, -1));
+
+        static_assert(v.lengthSq() == 5);
+        static_assert(v.perpendicular() == sf::Vector2i(-2, 1));
+
+        static_assert(v.dot(w) == -4);
+        static_assert(v.cross(w) == -7);
+        static_assert(v.cwiseMul(w) == sf::Vector2i(2, -6));
+        static_assert(w.cwiseDiv(v) == sf::Vector2i(2, -1));
     }
 }

--- a/test/System/Vector2.cpp
+++ b/test/System/Vector2.cpp
@@ -31,8 +31,8 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("Conversion constructor")
         {
-            sf::Vector2f sourceVector(1.0f, 2.0f);
-            sf::Vector2i vector(sourceVector);
+            const sf::Vector2f sourceVector(1.0f, 2.0f);
+            const sf::Vector2i vector(sourceVector);
 
             CHECK(vector.x == static_cast<int>(sourceVector.x));
             CHECK(vector.y == static_cast<int>(sourceVector.y));
@@ -43,8 +43,8 @@ TEST_CASE("sf::Vector2 class template - [system]")
     {
         SUBCASE("-vector")
         {
-            sf::Vector2i vector(1, 2);
-            sf::Vector2i negatedVector = -vector;
+            const sf::Vector2i vector(1, 2);
+            const sf::Vector2i negatedVector = -vector;
 
             CHECK(negatedVector.x == -1);
             CHECK(negatedVector.y == -2);
@@ -54,7 +54,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
     SUBCASE("Arithmetic operations between two vectors")
     {
         sf::Vector2i firstVector(2, 5);
-        sf::Vector2i secondVector(8, 3);
+        const sf::Vector2i secondVector(8, 3);
 
         SUBCASE("vector += vector")
         {
@@ -74,7 +74,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("vector + vector")
         {
-            sf::Vector2i result = firstVector + secondVector;
+            const sf::Vector2i result = firstVector + secondVector;
 
             CHECK(result.x == 10);
             CHECK(result.y == 8);
@@ -82,7 +82,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("vector - vector")
         {
-            sf::Vector2i result = firstVector - secondVector;
+            const sf::Vector2i result = firstVector - secondVector;
 
             CHECK(result.x == -6);
             CHECK(result.y == 2);
@@ -96,7 +96,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("vector * scalar")
         {
-            sf::Vector2i result = vector * scalar;
+            const sf::Vector2i result = vector * scalar;
 
             CHECK(result.x == 52);
             CHECK(result.y == 24);
@@ -104,7 +104,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("scalar * vector")
         {
-            sf::Vector2i result = scalar * vector;
+            const sf::Vector2i result = scalar * vector;
 
             CHECK(result.x == 52);
             CHECK(result.y == 24);
@@ -120,7 +120,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("vector / scalar")
         {
-            sf::Vector2i result = vector / scalar;
+            const sf::Vector2i result = vector / scalar;
 
             CHECK(result.x == 13);
             CHECK(result.y == 6);
@@ -137,9 +137,9 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
     SUBCASE("Comparison operations (two equal and one different vector)")
     {
-        sf::Vector2i firstEqualVector(1, 5);
-        sf::Vector2i secondEqualVector(1, 5);
-        sf::Vector2i differentVector(6, 9);
+        const sf::Vector2i firstEqualVector(1, 5);
+        const sf::Vector2i secondEqualVector(1, 5);
+        const sf::Vector2i differentVector(6, 9);
 
         SUBCASE("vector == vector")
         {
@@ -191,13 +191,13 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
     SUBCASE("Length and normalization")
     {
-        sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f v(2.4f, 3.0f);
 
         CHECK(v.length() == Approx(3.84187));
         CHECK(v.lengthSq() == Approx(14.7599650969));
         CHECK(v.normalized() == ApproxVec(0.624695, 0.780869));
 
-        sf::Vector2f w(-0.7f, -2.2f);
+        const sf::Vector2f w(-0.7f, -2.2f);
         
         CHECK(w.length() == Approx(2.30868));
         CHECK(w.lengthSq() == Approx(5.3300033));
@@ -206,13 +206,13 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
     SUBCASE("Rotations and angles")
     {
-        sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f v(2.4f, 3.0f);
         
         CHECK(v.angle() == ApproxDeg(51.3402));
         CHECK(sf::Vector2f::UnitX.angleTo(v) == ApproxDeg(51.3402));
         CHECK(sf::Vector2f::UnitY.angleTo(v) == ApproxDeg(-38.6598));
 
-        sf::Vector2f w(-0.7f, -2.2f);
+        const sf::Vector2f w(-0.7f, -2.2f);
 
         CHECK(w.angle() == ApproxDeg(-107.65));
         CHECK(sf::Vector2f::UnitX.angleTo(w) == ApproxDeg(-107.65));
@@ -221,7 +221,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
         CHECK(v.angleTo(w) == ApproxDeg(-158.9902));
         CHECK(w.angleTo(v) == ApproxDeg(158.9902));
 
-        float ratio = w.length() / v.length();
+        const float ratio = w.length() / v.length();
         CHECK(v.rotatedBy(-158.9902_deg) * ratio  == ApproxVec(w));
         CHECK(w.rotatedBy(158.9902_deg) / ratio == ApproxVec(v));
 
@@ -235,8 +235,8 @@ TEST_CASE("sf::Vector2 class template - [system]")
     
     SUBCASE("Products and quotients")
     {
-        sf::Vector2f v(2.4f, 3.0f);
-        sf::Vector2f w(-0.7f, -2.2f);
+        const sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f w(-0.7f, -2.2f);
 
         CHECK(v.dot(w) == Approx(-8.28));
         CHECK(w.dot(v) == Approx(-8.28));
@@ -252,8 +252,8 @@ TEST_CASE("sf::Vector2 class template - [system]")
     
     SUBCASE("Projection")
     {
-        sf::Vector2f v(2.4f, 3.0f);
-        sf::Vector2f w(-0.7f, -2.2f);
+        const sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f w(-0.7f, -2.2f);
         
         CHECK(v.projectedOnto(w) == ApproxVec(1.087430, 3.417636));
         CHECK(v.projectedOnto(w) == ApproxVec(-1.55347f * w));

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -4,6 +4,7 @@
 #include <SFML/System/String.hpp>
 #include <SFML/System/Time.hpp>
 
+#include <doctest.h> // for Approx
 #include <cassert>
 #include <filesystem>
 #include <fstream>
@@ -32,6 +33,28 @@ namespace sf
         os << time.asMicroseconds() << "us";
         return os;
     }
+}
+
+bool operator==(const sf::Vector2f& lhs, const ApproxVec& rhs)
+{
+    return (lhs - rhs.vector).length() == doctest::Approx(0.0);
+}
+
+bool operator==(const sf::Angle& lhs, const ApproxDeg& rhs)
+{
+    return lhs.asDegrees() == doctest::Approx(rhs.degrees);
+}
+
+std::ostream& operator <<(std::ostream& os, const ApproxVec& approx)
+{
+    os << approx.vector;
+    return os;
+}
+
+std::ostream& operator <<(std::ostream& os, const ApproxDeg& approx)
+{
+    os << sf::degrees(approx.degrees);
+    return os;
 }
 
 namespace sf::Testing

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -39,6 +39,33 @@ namespace sf
     }
 }
 
+// Utilities for approximate equality
+struct ApproxVec
+{
+    ApproxVec(double x, double y)
+        : vector(static_cast<float>(x), static_cast<float>(y)) {}
+
+    explicit ApproxVec(const sf::Vector2f& v)
+        : vector(v) {}
+
+    sf::Vector2f vector;
+};
+
+// Utilities for approximate equality
+struct ApproxDeg
+{
+    ApproxDeg(double degrees)
+        : degrees(static_cast<float>(degrees)) {}
+
+    float degrees;
+};
+
+bool operator==(const sf::Vector2f& lhs, const ApproxVec& rhs);
+bool operator==(const sf::Angle& lhs, const ApproxDeg& rhs);
+
+std::ostream& operator <<(std::ostream& os, const ApproxVec& approx);
+std::ostream& operator <<(std::ostream& os, const ApproxDeg& approx);
+
 namespace sf::Testing
 {
     class TemporaryFile


### PR DESCRIPTION
## Description

Adds extension methods to `sf::Vector2f`, heavily inspired by my library [**Thor/Vectors**](https://github.com/Bromeon/Thor/tree/master/include/Thor/Vectors) (API doc for [2D](https://bromeon.ch/libraries/thor/documentation/v2.1/_vector_algebra2_d_8hpp.html) and [3D](https://bromeon.ch/libraries/thor/documentation/v2.1/_vector_algebra3_d_8hpp.html)).

First and foremost, I apologize for creating this PR while others are working on something similar. But [I did mention this](https://github.com/SFML/SFML/issues/1810#issuecomment-990214480) more than a month ago, which was overlooked. I wanted to avoid that people spend even more time thinking of an API and implementation, when a lot of prior work has already been available and widely used over the past decade. Unfortunately, as [ChrisTrasher noted correctly](https://github.com/SFML/SFML/issues/1810#issuecomment-1021503712), writing a useful vector library is not a trivial task at all.

By no means do I think the Thor implementation is ready-to-use for SFML. On the contrary, I think design goals for SFML (especially SFML 3) likely differ. However, I wanted to show a relatively feature-complete implementation as a starting point, so we don't need to start API discussions from zero.

I added the implementation on top of the pending `sf::Angle` proposal, but you can select a sub-range of commits to see only new changes.

Closes #1810.

## Tasks

This PR is in draft state; a lot of API questions need to be resolved.

### 1\. Do we want to support `sf::Vector<T>` or only `sf::Vector2f`?
   
   In Thor, I created `TrigonometricTraits` allowing generic extensions to support any type `T` (such as custom decimal). In the scope of SFML, I think that would be over-engineering. The entire SFML API accepts only `sf::Vector2f` for floating point vectors and there are no typedefs for `double` or `long double`, so I think it's reasonable to limit the extensions to `float`.

Almost all extension methods are meaningless for integer types; even those theoretically computable (dot product) will in practice be applied to float vectors.

### 2\. Should the methods be free or member functions?
   
   There are arguments for both, so even a mixture might be possible:
   * Symmetry: `sf::dot(vec0, vec1)`
   * Clarity: `vec.rotatedBy(angle)`

### 3\. File structure
   
   Should we add the functionality to `Vector2.hpp` or a separate header? It probably makes sense if the `Vector2` related functionality is self-contained. I also wanted to keep `<cmath>` out of the header, since `Vector2.hpp` is such a heavily depended-upon file.

### 4\. Which methods do we need and how do we name them?

I adopted the current set from Thor and found them useful for my own games, but opinions can differ.

Naming is also a topic, but it depends on point 2, so we should first decide if we go for free functions, methods or both. In general, one thing that would be super-nice are relatively short names. Doesn't have to be extreme like `len()`, but maybe `cross()` instead of `crossProduct()` etc. Keep in mind that those operations are often part of larger algebraic expressions.

### 5\. Component-wise operators

Having `vec0 * vec1` and `vec0 / vec1` for component-wise multiplication/division is useful for scaling. Most vector libraries I have encountered over the years implement this, and I think the risk for misunderstanding (as dot or cross product) is quite small. It's also possible to provide a named function for it, at slightly increased verbosity cost.

### 6\. 3D vectors

   Should very limited support for 3D vectors be added (dot/cross product, angle, etc)?
   If yes, I'll gladly provide my Thor implementation, but this could also be done at a later stage.