### PR TITLE
Don't add SFML:: namespace to external targets

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -81,7 +81,7 @@ macro(sfml_add_library module)
     set_target_properties(${target} PROPERTIES DEFINE_SYMBOL ${NAME_UPPER}_EXPORTS)
 
     # define the export name of the module
-    set_target_properties(${target} PROPERTIES EXPORT_NAME ${module})
+    set_target_properties(${target} PROPERTIES EXPORT_NAME SFML::${module})
 
     # adjust the output file prefix/suffix to match our conventions
     if(BUILD_SHARED_LIBS AND NOT THIS_STATIC)
@@ -452,7 +452,6 @@ function(sfml_export_targets)
 
     install(EXPORT SFMLConfigExport
             FILE ${targets_config_filename}
-            NAMESPACE SFML::
             DESTINATION ${config_package_location})
 
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SFMLConfig.cmake"


### PR DESCRIPTION
## Description

Closes #1981 and fixes an issue I introduced in #1947 where the `SFML::` namespace was prepended to external targets as well as our internal targets. This apparently is fine when building shared libraries but broke when @eXpl0it3r attempted to build and use static libraries. Luckily CMake lets you add namespaces in the `EXPORT_NAME` property of a target so we can simply add `SFML::` there instead of relying on CMake to add `SFML::` to all targets in the export set.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
