### PR TITLE
Add sf::PrimitiveInfo

### DIFF
--- a/include/SFML/Graphics/PrimitiveInfo.hpp
+++ b/include/SFML/Graphics/PrimitiveInfo.hpp
@@ -1,0 +1,132 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_PRIMITIVEINFO_HPP
+#define SFML_PRIMITIVEINFO_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/PrimitiveType.hpp>
+#include <functional>
+#include <vector>
+
+namespace sf
+{
+class Vertex;
+
+////////////////////////////////////////////////////////////
+/// \brief Abstract base class for objects that provide access
+///        to primitive information
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API PrimitiveInfo
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~PrimitiveInfo() {}
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Callback that uses constant vertex info
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef std::function<void(const Vertex* vertices, std::size_t vertexCount, PrimitiveType type)> PrimitiveCallback;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Callback that uses mutable vertex info
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef std::function<void(std::vector<Vertex>& vertices, PrimitiveType type)> MutablePrimitiveCallback;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Iterate over each primitive and call the function
+    ///
+    /// This is a virtual function that has to be implemented by
+    /// the derived class to define what primitive info is being
+    /// provided.
+    ///
+    /// While the order of the primitives is not specified, it
+    /// would be a good idea to iterate them in draw order.
+    ///
+    /// \param callback The function to call for each primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void forEachPrimitive(PrimitiveCallback callback) const = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Iterate over each primitive and call the function
+    ///
+    /// This is a helper method that calls the virtual overload,
+    /// and puts the results inside a mutable std::vector<Vertex>
+    /// parameter.
+    ///
+    /// \param callback The function to call for each primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    void forEachMutablePrimitive(MutablePrimitiveCallback callback) const;
+};
+
+} // namespace sf
+
+
+#endif // SFML_PRIMITIVEINFO_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::PrimitiveInfo
+/// \ingroup graphics
+///
+/// sf::PrimitiveInfo is a simple interface that allows users
+/// to retrieve primitive information, for use with custom
+/// rendering methods (such as sprite batching).
+///
+/// Note that most SFML drawables (with the exception of
+/// sf::VertexBuffer) also implement sf::PrimitiveInfo.
+///
+/// Example:
+/// \code
+/// // Custom sprite batch class
+/// #include "MyGraphicsBatch.hpp"
+///
+/// void MyGraphicsBatch::addToBatch(const PrimitiveInfo& batchable, const Texture* texture,
+///                                  const Transform& transform, int order)
+/// {
+///     batchable.forEachPrimitive(
+///         [&](const Vertex* vertices, std::size_t vertexCount, sf::PrimitiveType type)
+///         {
+///             // Batch each primitive, and draw it when
+///             // MyGraphicsBatch::endBatch(...) is called
+///         }
+///     );
+/// }
+/// \endcode
+///
+/// \see sf::Drawable
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/PrimitiveInfo.hpp>
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
 #include <SFML/System/Vector2.hpp>
@@ -41,7 +42,8 @@ namespace sf
 /// \brief Base class for textured shapes with outline
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Shape : public Drawable, public Transformable
+class SFML_GRAPHICS_API Shape : public Drawable, public Transformable,
+                                public PrimitiveInfo
 {
 public:
 
@@ -246,6 +248,16 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     FloatRect getGlobalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Iterate over each primitive and call the function
+    ///
+    /// The positions of the vertices are not transformed in any way.
+    ///
+    /// \param callback The function to call for each primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    void forEachPrimitive(PrimitiveCallback callback) const override;
 
 protected:
 

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/PrimitiveInfo.hpp>
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/Vertex.hpp>
 #include <SFML/Graphics/Rect.hpp>
@@ -44,7 +45,8 @@ class Texture;
 ///        own transformations, color, etc.
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Sprite : public Drawable, public Transformable
+class SFML_GRAPHICS_API Sprite : public Drawable, public Transformable,
+                                 public PrimitiveInfo
 {
 public:
 
@@ -188,6 +190,16 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     FloatRect getGlobalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Iterate over each primitive and call the function
+    ///
+    /// The positions of the vertices are not transformed in any way.
+    ///
+    /// \param callback The function to call for each primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    void forEachPrimitive(PrimitiveCallback callback) const override;
 
 private:
 

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/PrimitiveInfo.hpp>
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/Rect.hpp>
@@ -45,7 +46,8 @@ namespace sf
 /// \brief Graphical text that can be drawn to a render target
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Text : public Drawable, public Transformable
+class SFML_GRAPHICS_API Text : public Drawable, public Transformable,
+                               public PrimitiveInfo
 {
 public:
 
@@ -379,6 +381,16 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     FloatRect getGlobalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Iterate over each primitive and call the function
+    /// 
+    /// The positions of the vertices are not transformed in any way.
+    ///
+    /// \param callback The function to call for each primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    void forEachPrimitive(PrimitiveCallback callback) const override;
 
 private:
 

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Vertex.hpp>
+#include <SFML/Graphics/PrimitiveInfo.hpp>
 #include <SFML/Graphics/PrimitiveType.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/Drawable.hpp>
@@ -42,7 +43,7 @@ namespace sf
 /// \brief Define a set of one or more 2D primitives
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API VertexArray : public Drawable
+class SFML_GRAPHICS_API VertexArray : public Drawable, public PrimitiveInfo
 {
 public:
 
@@ -169,6 +170,14 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     FloatRect getBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Iterate over each primitive and call the function
+    ///
+    /// \param callback The function to call for each primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    void forEachPrimitive(PrimitiveCallback callback) const override;
 
 private:
 

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SRC
     ${INCROOT}/Image.hpp
     ${SRCROOT}/ImageLoader.cpp
     ${SRCROOT}/ImageLoader.hpp
+    ${INCROOT}/PrimitiveInfo.hpp
+    ${SRCROOT}/PrimitiveInfo.cpp
     ${INCROOT}/PrimitiveType.hpp
     ${INCROOT}/Rect.hpp
     ${INCROOT}/Rect.inl

--- a/src/SFML/Graphics/PrimitiveInfo.cpp
+++ b/src/SFML/Graphics/PrimitiveInfo.cpp
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/PrimitiveInfo.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+void PrimitiveInfo::forEachMutablePrimitive(MutablePrimitiveCallback callback) const
+{
+    std::vector<Vertex> vec;
+
+    forEachPrimitive([&](const Vertex* vertices, std::size_t vertexCount, PrimitiveType type) {
+        vec.resize(vertexCount);
+
+        for (std::size_t i = 0; i < vertexCount; i++)
+        {
+            vec[i] = vertices[i];
+        }
+
+        callback(vec, type);
+    });
+}
+
+} // namespace sf

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -156,6 +156,19 @@ FloatRect Shape::getGlobalBounds() const
 
 
 ////////////////////////////////////////////////////////////
+void Shape::forEachPrimitive(PrimitiveCallback callback) const
+{
+    if (callback)
+    {
+        m_vertices.forEachPrimitive(callback);
+
+        if (m_outlineThickness != 0)
+            m_outlineVertices.forEachPrimitive(callback);
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 Shape::Shape() :
 m_texture         (nullptr),
 m_textureRect     (),

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -138,6 +138,16 @@ FloatRect Sprite::getGlobalBounds() const
 
 
 ////////////////////////////////////////////////////////////
+void Sprite::forEachPrimitive(PrimitiveCallback callback) const
+{
+    if (callback)
+    {
+        callback(m_vertices, 4, PrimitiveType::TriangleStrip);
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 void Sprite::draw(RenderTarget& target, RenderStates states) const
 {
     if (m_texture)

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -358,6 +358,21 @@ FloatRect Text::getGlobalBounds() const
 
 
 ////////////////////////////////////////////////////////////
+void Text::forEachPrimitive(PrimitiveCallback callback) const
+{
+    if (callback)
+    {
+        ensureGeometryUpdate();
+
+        if (m_outlineThickness != 0)
+            m_outlineVertices.forEachPrimitive(callback);
+
+        m_vertices.forEachPrimitive(callback);
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 void Text::draw(RenderTarget& target, RenderStates states) const
 {
     if (m_font)

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -141,6 +141,16 @@ FloatRect VertexArray::getBounds() const
 
 
 ////////////////////////////////////////////////////////////
+void VertexArray::forEachPrimitive(PrimitiveCallback callback) const
+{
+    if (callback)
+    {
+        callback(m_vertices.data(), m_vertices.size(), m_primitiveType);
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 void VertexArray::draw(RenderTarget& target, RenderStates states) const
 {
     if (!m_vertices.empty())


### PR DESCRIPTION
## Description

This PR adds the `sf::PrimitiveInfo` interface, which allows extracting vertex info from drawables. The interface is implemented for every drawable except `sf::VertexBatch`. This allows users to use SFML's drawables together with custom render logic (such as sprite batching), instead of recreating all of the logic using `sf::VertexArray` in specialized classes.

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Render some drawables using this code. You will need a TTF and a PNG:
```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode(1280, 720), "PrimitiveInfo", sf::Style::Default);
    window.setView({ { 0, 0 }, { 1280, 720 } });

    sf::Font font;
    sf::Texture texture;

    if (!font.loadFromFile("Font0.ttf") || !texture.loadFromFile("Texture0.png"))
    {
        sf::err() << "Oh no!";
        return 0;
    }

    sf::Text text("Primitives are cool", font, 30);
    text.setPosition({ 0, 0 });

    sf::Sprite sprite(texture);
    sprite.setPosition({ 200, 0 });

    sf::CircleShape shape(100, 6);
    shape.setPosition({ 400, 0 });
    shape.setTexture(&texture);

    const sf::Texture* drawTexture;
    sf::Transform transform;

    auto renderer = [&text, &window, &drawTexture, &transform](std::vector<sf::Vertex>& vertices, sf::PrimitiveType type)
    {
        for (auto& vertex : vertices)
        {
            vertex.position = transform.transformPoint(vertex.position);
        }

        window.draw(vertices.data(), vertices.size(), type, sf::RenderStates(drawTexture));
    };

    drawTexture = &text.getFont()->getTexture(text.getCharacterSize());
    transform = text.getTransform();

    text.forEachMutablePrimitive(renderer);

    drawTexture = sprite.getTexture();
    transform = sprite.getTransform();

    sprite.forEachMutablePrimitive(renderer);

    drawTexture = shape.getTexture();
    transform = shape.getTransform();

    shape.forEachMutablePrimitive(renderer);

    window.display();

    sf::sleep(sf::seconds(6));
}
```