### PR TITLE
sf::Image::copy() - Fixed the incorrect alpha value being calculated for semi-transparent pixels on fully transparent pixels

### DIFF
--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -203,9 +203,13 @@ public:
     /// kind of feature in real-time you'd better use sf::RenderTexture.
     ///
     /// If \a sourceRect is empty, the whole image is copied.
-    /// If \a applyAlpha is set to true, the transparency of
-    /// source pixels is applied. If it is false, the pixels are
-    /// copied unchanged with their alpha value.
+    /// If \a applyAlpha is set to true, alpha blending is
+    /// applied from the source pixels to the destination pixels
+    /// using the \b over operator. If it is false, the source
+    /// pixels are copied unchanged with their alpha value.
+    ///
+    /// See https://en.wikipedia.org/wiki/Alpha_compositing for
+    /// details on the \b over operator.
     ///
     /// \param source     Source image to copy
     /// \param destX      X coordinate of the destination position

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -240,12 +240,19 @@ void Image::copy(const Image& source, unsigned int destX, unsigned int destY, co
                 const Uint8* src = srcPixels + j * 4;
                 Uint8*       dst = dstPixels + j * 4;
 
-                // Interpolate RGBA components using the alpha value of the source pixel
-                Uint8 alpha = src[3];
-                dst[0] = static_cast<Uint8>((src[0] * alpha + dst[0] * (255 - alpha)) / 255);
-                dst[1] = static_cast<Uint8>((src[1] * alpha + dst[1] * (255 - alpha)) / 255);
-                dst[2] = static_cast<Uint8>((src[2] * alpha + dst[2] * (255 - alpha)) / 255);
-                dst[3] = static_cast<Uint8>(alpha + dst[3] * (255 - alpha) / 255);
+                // Interpolate RGBA components using the alpha values of the destination and source pixels
+                Uint8 src_alpha = src[3];
+                Uint8 dst_alpha = dst[3];
+                Uint8 out_alpha = static_cast<Uint8>(src_alpha + dst_alpha - src_alpha * dst_alpha / 255);
+
+                dst[3] = out_alpha;
+
+                if (out_alpha)
+                    for (int k = 0; k < 3; k++)
+                        dst[k] = static_cast<Uint8>((src[k] * src_alpha + dst[k] * (out_alpha - src_alpha)) / out_alpha);
+                else
+                    for (int k = 0; k < 3; k++)
+                        dst[k] = src[k];
             }
 
             srcPixels += srcStride;


### PR DESCRIPTION
## Description

This PR fixes a bug where the alpha value for a semi-transparent pixel is messed up when placed on top of a transparent pixel. This bug resulting in darker pixels appearing where the transparency should be lighter.

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Run the code below, which is self-contained and has the following graphic encoded as a string literal:
![image](https://user-images.githubusercontent.com/8665431/152081707-49435b27-fa3e-430b-b16b-2e9dd16d248c.png)

Without the fix, it will look like (zoomed in 5x):
![image](https://user-images.githubusercontent.com/8665431/152081821-b0bb41d6-11ae-424f-b2b0-0b6b7f3b6d32.png)

After the fix, it will look like (zoomed in 5x):
![image](https://user-images.githubusercontent.com/8665431/152081864-6b3c17c4-ecc6-42d2-9887-3dac182d6ddf.png)


```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode(100, 100), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    // Setup the image data
    char tree_png[] = "\x89\x50\x4E\x47\xD\xA\x1A\xA\x0\x0\x0\xD\x49\x48\x44\x52\x0\x0\x0\xB\x0\x0\x0\x27\x8\x6\x0\x0\x0\xD9\xC2\xB2\x6B\x0\x0\x0\x1\x73\x52\x47\x42\x0\xAE\xCE\x1C\xE9\x0\x0\x0\x4\x67\x41\x4D\x41\x0\x0\xB1\x8F\xB\xFC\x61\x5\x0\x0\x0\x9\x70\x48\x59\x73\x0\x0\xE\xBF\x0\x0\xE\xBF\x1\x38\x5\x53\x24\x0\x0\x0\xE7\x49\x44\x41\x54\x38\x4F\xED\x95\x3B\xA\xC2\x40\x10\x86\x67\x17\xF1\x85\xA2\x47\xF0\x28\x29\xB4\xD7\x42\x11\x54\xF0\x6\xA\x9E\x43\x8C\x37\x10\xB4\x10\x6D\xD2\xC7\x43\x78\x4\x8F\x10\x4B\x2D\x1C\xFF\xD9\x6C\x24\x82\x92\x28\x8\x16\xF9\x60\xB2\xF3\xF8\x92\x62\x8B\x9\x7D\x82\x92\x87\xBF\xEB\xD6\xD4\xAD\x30\x46\xDA\x96\x9A\x88\x1B\x18\x9D\xC2\x9C\x3C\xD6\x97\x55\xAB\xB7\x3F\xE7\xA4\x82\xB8\xC2\x61\x45\xC1\x7C\x3\x2F\x18\x1C\xCC\x1D\x9C\x1D\xE5\x6F\x7\xB\x45\x6A\x1A\xF6\xDF\xC3\xC4\xAE\x4E\x23\xA\xF0\xC6\xDA\xE6\x69\xA8\x7F\x22\x53\x26\xC7\xC9\xE4\x38\x99\x1C\xE7\xB7\x72\x10\xA6\x89\x4\x90\xD9\xB3\x45\x2\xEC\x69\xD6\xD7\x29\xB6\xCD\xD1\x76\x5E\x22\x73\xF1\xCC\x52\x13\xE\xDB\xE1\x4\x6D\x6C\x27\x15\xED\x38\xC0\x58\x8E\xCA\x6D\xF6\x37\x4B\xA9\x1E\x72\x84\x3F\x1F\xB1\x4D\xA9\x35\x5B\x3F\xCD\xFF\xE8\x9E\x53\xF3\x95\x9C\x47\x54\x6D\xC4\x91\xBA\x82\x30\xBF\x13\x91\xCB\x88\x82\x14\x6F\x90\xEB\x2B\x11\x51\xF1\xE\xB6\x21\x31\x7A\x40\x47\x5F\x43\x0\x0\x0\x0\x49\x45\x4E\x44\xAE\x42\x60\x82";

    // Load the layer to place on top of the transparent background
    sf::Image layer;
    if (!layer.loadFromMemory(&tree_png, sizeof(tree_png)))
    {
        window.close();
        return 1;
    }

    // Create a transparent image
    sf::Image image;
    sf::Vector2u size = layer.getSize();
    image.create(size.x, size.y, sf::Color::Transparent);

    // Copy the layer on top of the image
    image.copy(layer, 0, 0, sf::IntRect(), true);

    // Load the resulting image into a texutre, and draw the sprite
    sf::Texture texture;
    if (texture.loadFromImage(image))
    {
        sf::Sprite sprite;
        sprite.setTexture(texture, true);

        while (window.isOpen())
        {
            sf::Event event;
            while (window.pollEvent(event))
            {
                if (event.type == sf::Event::Closed)
                    window.close();
            }

            window.clear(sf::Color::White);
            window.draw(sprite);
            window.display();
        }
    }
}
```