### PR TITLE
Remove VS 2017 as GitHub Actions compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2017, os: windows-2016 }
         - { name: Windows VS2019, os: windows-2019 }
         - { name: Windows VS2022, os: windows-2022 }
         - { name: Linux GCC,      os: ubuntu-latest  }


### PR DESCRIPTION
## Description

As discussed in #1937, due to poor C++17 support in VS 2017, we'll remove VS 2017 from the build pipeline