### PR TITLE
Fix license detection and add helpful links to external libraries and their licenses

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,6 +1,4 @@
-# SFML
-
-SFML - Copyright (C) 2007-2021 Laurent Gomila - laurent@sfml-dev.org
+Copyright (C) 2007-2022 Laurent Gomila - laurent@sfml-dev.org
 
 This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
 
@@ -9,13 +7,3 @@ Permission is granted to anyone to use this software for any purpose, including 
   1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.  If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
   2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
-
-## External libraries used by SFML
-
-  * _OpenAL-Soft_ is under the LGPL license
-  * _stb_image_ and _stb_image_write_ are public domain
-  * _freetype_ is under the FreeType license or the GPL license
-  * _libogg_ is under the BSD license
-  * _libvorbis_ is under the BSD license
-  * _libflac_ is under the BSD license
-  * _minimp3_ is under the CC0 license

--- a/readme.md
+++ b/readme.md
@@ -38,3 +38,19 @@ There are several places to learn SFML:
 ## Contribute
 
 SFML is an open-source project, and it needs your help to go on growing and improving. If you want to get involved and suggest some additional features, file a bug report or submit a patch, please have a look at the [contribution guidelines](https://www.sfml-dev.org/contribute.php).
+
+## License
+
+The SFML libraries and source code are distributed under the [zlib/libpng license](https://opensource.org/licenses/Zlib). See [license.md](license.md). External libraries used by SFML are distributed under their own licenses.
+
+In short, SFML is free for any use (commercial or personal, proprietary or open-source). You can use SFML in your project without any restriction. You can even omit to mention that you use SFML -- although it would be appreciated.
+
+## External libraries used by SFML
+
+  * [_OpenAL-Soft_](https://github.com/kcat/openal-soft) is under the [LGPL license](https://github.com/kcat/openal-soft/blob/master/COPYING)
+  * [_stb\_image_ and _stb_image_write_](https://github.com/nothings/stb) are [public domain](https://github.com/nothings/stb/blob/master/LICENSE)
+  * [_freetype_](https://gitlab.freedesktop.org/freetype/freetype) is under the [FreeType license or the GPL license](https://gitlab.freedesktop.org/freetype/freetype/-/blob/master/LICENSE.TXT)
+  * [_libogg_](https://gitlab.xiph.org/xiph/ogg) is under the [BSD license](https://gitlab.xiph.org/xiph/ogg/-/blob/master/COPYING)
+  * [_libvorbis_](https://gitlab.xiph.org/xiph/vorbis) is under the [BSD license](https://gitlab.xiph.org/xiph/vorbis/-/blob/master/COPYING)
+  * [_libflac_](https://gitlab.xiph.org/xiph/flac) is under the [BSD license](https://gitlab.xiph.org/xiph/flac/-/blob/master/COPYING.Xiph)
+  * [_minimp3_](https://github.com/lieff/minimp3) is under the [CC0 license](https://github.com/lieff/minimp3/blob/master/LICENSE)


### PR DESCRIPTION
GitHub uses [licensee](https://github.com/licensee/licensee) to detect a repository's license for display and indexing purposes. In its current state, the license text in [license.md](https://github.com/SFML/SFML/blob/e458f4651e3cbfd168b9be0cfa328a401dccf895/license.md) isn't recognized as Zlib because there are too many discrepancies for the matcher to output a high enough confidence value. As such SFML is currently not indexed with a license. This has an impact on the discoverability/findability of the library.

If a developer is bound by legal reasons to use libraries that are clearly under certain licenses they would save themselves the time and filter during their initial search.

Compare [without license filter](https://github.com/search?q=multimedia&type=Repositories) and [with license filter](https://github.com/search?q=multimedia+license%3Azlib&type=Repositories).

This change makes licensee output a 100% match to Zlib and adds helpful links to the repositories and license texts of all external libraries.