### PR TITLE
Remove unnecessary includes from public-facing headers

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -29,7 +29,6 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/Export.hpp>
-#include <SFML/System/Time.hpp>
 #include <memory>
 #include <string>
 #include <cstddef>
@@ -37,6 +36,7 @@
 
 namespace sf
 {
+class Time;
 class InputStream;
 class SoundFileReader;
 

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -31,13 +31,13 @@
 #include <SFML/Audio/Export.hpp>
 #include <SFML/Audio/SoundStream.hpp>
 #include <SFML/Audio/InputSoundFile.hpp>
-#include <SFML/System/Time.hpp>
 #include <string>
 #include <vector>
 
 
 namespace sf
 {
+class Time;
 class InputStream;
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -30,12 +30,12 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/Export.hpp>
 #include <SFML/Audio/SoundSource.hpp>
-#include <SFML/System/Time.hpp>
 #include <cstdlib>
 
 
 namespace sf
 {
+class Time;
 class SoundBuffer;
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Drawable.hpp
+++ b/include/SFML/Graphics/Drawable.hpp
@@ -29,12 +29,12 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
-#include <SFML/Graphics/RenderStates.hpp>
 
 
 namespace sf
 {
 class RenderTarget;
+class RenderStates;
 
 ////////////////////////////////////////////////////////////
 /// \brief Abstract base class for objects that can be drawn

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -32,7 +32,6 @@
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/View.hpp>
-#include <SFML/Graphics/Transform.hpp>
 #include <SFML/Graphics/BlendMode.hpp>
 #include <SFML/Graphics/RenderStates.hpp>
 #include <SFML/Graphics/PrimitiveType.hpp>
@@ -44,6 +43,7 @@ namespace sf
 {
 class Drawable;
 class VertexBuffer;
+class Transform;
 
 ////////////////////////////////////////////////////////////
 /// \brief Base class for all render targets (window, texture, ...)

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -30,7 +30,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/RenderTarget.hpp>
-#include <SFML/Graphics/Image.hpp>
 #include <SFML/Window/Window.hpp>
 
 

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -37,6 +37,8 @@
 
 namespace sf
 {
+class Texture;
+
 ////////////////////////////////////////////////////////////
 /// \brief Base class for textured shapes with outline
 ///

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -31,7 +31,6 @@
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Drawable.hpp>
 #include <SFML/Graphics/Transformable.hpp>
-#include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
 #include <SFML/System/String.hpp>
@@ -41,6 +40,8 @@
 
 namespace sf
 {
+class Font;
+
 ////////////////////////////////////////////////////////////
 /// \brief Graphical text that can be drawn to a render target
 ///

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -29,8 +29,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
-#include <SFML/Graphics/Image.hpp>
 #include <SFML/Window/GlResource.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <string>
 
 
 namespace sf
@@ -40,6 +41,7 @@ class RenderTarget;
 class RenderTexture;
 class Text;
 class Window;
+class Image;
 
 ////////////////////////////////////////////////////////////
 /// \brief Image living on the graphics card that can be used for drawing

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -30,7 +30,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Network/Export.hpp>
 #include <SFML/Network/TcpSocket.hpp>
-
 #include <SFML/System/Time.hpp>
 #include <string>
 #include <vector>

--- a/include/SFML/System/Clock.hpp
+++ b/include/SFML/System/Clock.hpp
@@ -29,7 +29,6 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Export.hpp>
-#include <SFML/System/Time.hpp>
 #include <chrono>
 #include <ratio>
 #include <type_traits>
@@ -79,6 +78,8 @@ namespace priv
 #endif
 
 } // namespace priv
+
+class Time;
 
 ////////////////////////////////////////////////////////////
 /// \brief Utility class that measures the elapsed time

--- a/include/SFML/System/Sleep.hpp
+++ b/include/SFML/System/Sleep.hpp
@@ -29,11 +29,12 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Export.hpp>
-#include <SFML/System/Time.hpp>
 
 
 namespace sf
 {
+class Time;
+
 ////////////////////////////////////////////////////////////
 /// \ingroup system
 /// \brief Make the current thread sleep for a given duration

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -30,7 +30,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
 #include <SFML/Window/GlResource.hpp>
-#include <SFML/Window/ContextSettings.hpp>
 #include <memory>
 
 
@@ -40,6 +39,8 @@ namespace priv
 {
     class GlContext;
 }
+
+struct ContextSettings;
 
 using GlFunctionPointer = void (*)();
 

--- a/include/SFML/Window/Sensor.hpp
+++ b/include/SFML/Window/Sensor.hpp
@@ -30,7 +30,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
 #include <SFML/System/Vector3.hpp>
-#include <SFML/System/Time.hpp>
 
 
 namespace sf

--- a/include/SFML/Window/Vulkan.hpp
+++ b/include/SFML/Window/Vulkan.hpp
@@ -29,7 +29,6 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
-#include <SFML/Window/WindowHandle.hpp>
 #include <vector>
 #include <cstdint>
 

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -31,6 +31,7 @@
 #include <SFML/Window/ContextSettings.hpp>
 #include <SFML/Window/GlResource.hpp>
 #include <SFML/Window/WindowBase.hpp>
+#include <SFML/System/Time.hpp>
 #include <memory>
 
 

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -32,6 +32,7 @@
 #include <SFML/System/FileInputStream.hpp>
 #include <SFML/System/MemoryInputStream.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Time.hpp>
 #include <iostream>
 #include <algorithm>
 

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Audio/Music.hpp>
 #include <SFML/Audio/ALCheck.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Time.hpp>
 #include <fstream>
 #include <algorithm>
 #include <mutex>

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -32,6 +32,7 @@
 #include <SFML/Audio/AudioDevice.hpp>
 #include <SFML/Audio/ALCheck.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Time.hpp>
 #include <memory>
 
 #if defined(__APPLE__)

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/GLCheck.hpp>
+#include <SFML/Graphics/Image.hpp>
 #ifdef SFML_SYSTEM_ANDROID
     #include <SFML/System/Android/ResourceStream.hpp>
 #endif

--- a/src/SFML/Graphics/RenderTextureImplDefault.cpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Graphics/GLCheck.hpp>
 #include <SFML/Graphics/TextureSaver.hpp>
 #include <SFML/Window/Context.hpp>
+#include <SFML/Window/ContextSettings.hpp>
 #include <memory>
 
 

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/GLCheck.hpp>
 #include <SFML/Window/Context.hpp>
+#include <SFML/Window/ContextSettings.hpp>
 #include <SFML/System/Err.hpp>
 #include <mutex>
 #include <set>

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Graphics/Text.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/Font.hpp>
 #include <algorithm>
 #include <cmath>
 

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -41,6 +41,7 @@
 #include <SFML/System/Android/Activity.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Time.hpp>
 #include <android/window.h>
 #include <android/native_activity.h>
 #include <cstring>

--- a/src/SFML/System/Clock.cpp
+++ b/src/SFML/System/Clock.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Clock.hpp>
+#include <SFML/System/Time.hpp>
 
 
 namespace sf

--- a/src/SFML/System/Sleep.cpp
+++ b/src/SFML/System/Sleep.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Sleep.hpp>
+#include <SFML/System/Time.hpp>
 
 #if defined(SFML_SYSTEM_WINDOWS)
     #include <SFML/System/Win32/SleepImpl.hpp>

--- a/src/SFML/System/Unix/SleepImpl.cpp
+++ b/src/SFML/System/Unix/SleepImpl.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Unix/SleepImpl.hpp>
+#include <SFML/System/Time.hpp>
 #include <cerrno>
 #include <ctime>
 

--- a/src/SFML/System/Unix/SleepImpl.hpp
+++ b/src/SFML/System/Unix/SleepImpl.hpp
@@ -29,8 +29,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
-#include <SFML/System/Time.hpp>
 
+
+namespace sf { class Time; }
 
 namespace sf::priv
 {

--- a/src/SFML/System/Win32/SleepImpl.cpp
+++ b/src/SFML/System/Win32/SleepImpl.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Win32/SleepImpl.hpp>
 #include <SFML/System/Win32/WindowsHeader.hpp>
+#include <SFML/System/Time.hpp>
 #include <mmsystem.h>
 
 namespace sf::priv

--- a/src/SFML/System/Win32/SleepImpl.hpp
+++ b/src/SFML/System/Win32/SleepImpl.hpp
@@ -29,11 +29,12 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
-#include <SFML/System/Time.hpp>
 
+namespace sf { class Time; }
 
 namespace sf::priv
 {
+
 ////////////////////////////////////////////////////////////
 /// \brief Windows implementation of sf::Sleep
 ///

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Window/Unix/Display.hpp>
 #include <SFML/System/Clock.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Time.hpp>
 #include <X11/Xatom.h>
 #include <vector>
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -33,6 +33,7 @@
 #include <SFML/System/Utf.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Sleep.hpp>
+#include <SFML/System/Time.hpp>
 
 #include <X11/Xlibint.h>
 #undef min // Defined by `Xlibint.h`, conflicts with standard headers

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -29,6 +29,7 @@
 #include <SFML/System/Win32/WindowsHeader.hpp>
 #include <SFML/System/Clock.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Time.hpp>
 #include <tchar.h>
 #include <regstr.h>
 #include <cmath>

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -31,6 +31,7 @@
 #include <SFML/Window/JoystickManager.hpp>
 #include <SFML/Window/SensorManager.hpp>
 #include <SFML/System/Sleep.hpp>
+#include <SFML/System/Time.hpp>
 #include <algorithm>
 #include <memory>
 #include <cmath>

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -30,6 +30,7 @@
 #include <SFML/Window/iOS/SFView.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Sleep.hpp>
+#include <SFML/System/Time.hpp>
 #include <OpenGLES/EAGL.h>
 #include <OpenGLES/EAGLDrawable.h>
 #include <QuartzCore/CAEAGLLayer.h>

--- a/test/System/Clock.cpp
+++ b/test/System/Clock.cpp
@@ -1,4 +1,5 @@
 #include <SFML/System/Clock.hpp>
+#include <SFML/System/Time.hpp>
 #include "SystemUtil.hpp"
 #include <thread>
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This PR cleans up some include directives from public headers, sometimes removing them entirely, other times replacing them with a forward declaration. The purpose is to reduce transitive include usage and to improve compilation parallelism.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.