### PR TITLE
Adjust .codecov.yml to make coverage have minimal impact for now.

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -11,6 +11,15 @@ coverage:
         target: auto
         threshold: 100%
         base: auto
+        if_ci_failed: success
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 100%
+        base: auto
+        if_ci_failed: success
+        informational: true
 
 parsers:
   gcov:


### PR DESCRIPTION
Makes coverage reporting purely informational for now. This can be re-adjusted once test coverage is higher.