### PR TITLE
Simplify how tests are built

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -327,7 +327,7 @@ function(sfml_add_test target SOURCES DEPENDS)
     set_target_properties(${target} PROPERTIES FOLDER "Tests")
 
     # link the target to its SFML dependencies
-    target_link_libraries(${target} PRIVATE ${DEPENDS})
+    target_link_libraries(${target} PRIVATE ${DEPENDS} sfml-test-main)
 
     # If coverage is enabled for MSVC and we are linking statically, use /WHOLEARCHIVE
     # to make sure the linker doesn't discard unused code sections before coverage can be measured

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,62 +1,55 @@
-set(SRCROOT "${PROJECT_SOURCE_DIR}/test")
-
-add_library(sfml-test-main STATIC "${SRCROOT}/DoctestMain.cpp")
-target_include_directories(sfml-test-main PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/headers" "${SRCROOT}/TestUtilities")
+add_library(sfml-test-main STATIC DoctestMain.cpp)
+target_include_directories(sfml-test-main PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/headers" TestUtilities)
 target_compile_features(sfml-test-main PRIVATE cxx_std_17)
 
 # System is always built
 SET(SYSTEM_SRC
-    "${SRCROOT}/System/Angle.cpp"
-    "${SRCROOT}/System/Clock.cpp"
-    "${SRCROOT}/System/FileInputStream.cpp"
-    "${SRCROOT}/System/Time.cpp"
-    "${SRCROOT}/System/Vector2.cpp"
-    "${SRCROOT}/System/Vector3.cpp"
-    "${SRCROOT}/TestUtilities/SystemUtil.hpp"
-    "${SRCROOT}/TestUtilities/SystemUtil.cpp"
+    System/Angle.cpp
+    System/Clock.cpp
+    System/FileInputStream.cpp
+    System/Time.cpp
+    System/Vector2.cpp
+    System/Vector3.cpp
+    TestUtilities/SystemUtil.hpp
+    TestUtilities/SystemUtil.cpp
 )
 sfml_add_test(test-sfml-system "${SYSTEM_SRC}" SFML::System)
-target_link_libraries(test-sfml-system PRIVATE sfml-test-main)
 
 if(SFML_BUILD_WINDOW)
     SET(WINDOW_SRC
-        "${SRCROOT}/Window/ContextSettings.cpp"
-        "${SRCROOT}/Window/VideoMode.cpp"
-        "${SRCROOT}/TestUtilities/WindowUtil.hpp"
-        "${SRCROOT}/TestUtilities/WindowUtil.cpp"
+        Window/ContextSettings.cpp
+        Window/VideoMode.cpp
+        TestUtilities/WindowUtil.hpp
+        TestUtilities/WindowUtil.cpp
     )
     sfml_add_test(test-sfml-window "${WINDOW_SRC}" SFML::Window)
-    target_link_libraries(test-sfml-window PRIVATE sfml-test-main)
 endif()
 
 if(SFML_BUILD_GRAPHICS)
     SET(GRAPHICS_SRC
-        "${SRCROOT}/Graphics/BlendMode.cpp"
-        "${SRCROOT}/Graphics/Color.cpp"
-        "${SRCROOT}/Graphics/Rect.cpp"
-        "${SRCROOT}/Graphics/Transform.cpp"
-        "${SRCROOT}/Graphics/Vertex.cpp"
-        "${SRCROOT}/TestUtilities/GraphicsUtil.hpp"
-        "${SRCROOT}/TestUtilities/GraphicsUtil.cpp"
+        Graphics/BlendMode.cpp
+        Graphics/Color.cpp
+        Graphics/Rect.cpp
+        Graphics/Transform.cpp
+        Graphics/Vertex.cpp
+        TestUtilities/GraphicsUtil.hpp
+        TestUtilities/GraphicsUtil.cpp
     )
     sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" SFML::Graphics)
-    target_link_libraries(test-sfml-graphics PRIVATE sfml-test-main)
 endif()
 
 if(SFML_BUILD_NETWORK)
     SET(NETWORK_SRC
-        "${SRCROOT}/Network/Packet.cpp"
+        Network/Packet.cpp
     )
     sfml_add_test(test-sfml-network "${NETWORK_SRC}" SFML::Network)
-    target_link_libraries(test-sfml-network PRIVATE sfml-test-main)
 endif()
 
 if(SFML_BUILD_AUDIO)
     SET(AUDIO_SRC
-        "${SRCROOT}/Audio/Dummy.cpp" # TODO: Remove when there are real tests
+        Audio/Dummy.cpp # TODO: Remove when there are real tests
     )
     sfml_add_test(test-sfml-audio "${AUDIO_SRC}" SFML::Audio)
-    target_link_libraries(test-sfml-audio PRIVATE sfml-test-main)
 endif()
 
 # Automatically run the tests at the end of the build


### PR DESCRIPTION
## Description

Removes unnecessary CMake code which obfuscates the true intent of the build. There is no requirement that source files use absolute paths. CMake will just as happily accept these relative paths. 

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
