### PR TITLE
Cleanup `sf::err` includes

### DIFF
--- a/include/SFML/System/Err.hpp
+++ b/include/SFML/System/Err.hpp
@@ -29,7 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Export.hpp>
-#include <ostream>
+#include <iosfwd>
 
 
 namespace sf

--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Audio/ALCheck.hpp>
 #include <SFML/System/Err.hpp>
 #include <string>
+#include <ostream>
 
 #if defined(__APPLE__)
     #if defined(__clang__)

--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Audio/Listener.hpp>
 #include <SFML/System/Err.hpp>
 #include <optional>
+#include <ostream>
 
 #if defined(__APPLE__)
     #if defined(__clang__)

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -33,8 +33,8 @@
 #include <SFML/System/MemoryInputStream.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Time.hpp>
-#include <iostream>
 #include <algorithm>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -32,6 +32,7 @@
 #include <fstream>
 #include <algorithm>
 #include <mutex>
+#include <ostream>
 
 #if defined(__APPLE__)
     #if defined(__clang__)

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -34,6 +34,7 @@
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Time.hpp>
 #include <memory>
+#include <ostream>
 
 #if defined(__APPLE__)
     #if defined(__clang__)

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -29,6 +29,7 @@
 #include <SFML/System/Err.hpp>
 #include <algorithm>
 #include <iterator>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Audio/SoundFileFactory.cpp
+++ b/src/SFML/Audio/SoundFileFactory.cpp
@@ -36,6 +36,7 @@
 #include <SFML/System/FileInputStream.hpp>
 #include <SFML/System/MemoryInputStream.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -29,6 +29,7 @@
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Err.hpp>
 #include <cassert>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -47,7 +47,6 @@
 
 #include <SFML/Audio/SoundFileReaderMp3.hpp>
 #include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Err.hpp>
 #include <algorithm>
 #include <cstring>
 

--- a/src/SFML/Audio/SoundFileReaderOgg.cpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.cpp
@@ -30,6 +30,7 @@
 #include <SFML/System/Err.hpp>
 #include <cctype>
 #include <cassert>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -32,6 +32,7 @@
 #include <cctype>
 #include <cassert>
 #include <cstring>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Audio/SoundFileWriterFlac.cpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cassert>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Audio/SoundFileWriterOgg.cpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.cpp
@@ -29,6 +29,7 @@
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Utils.hpp>
 #include <algorithm>
+#include <ostream>
 #include <cctype>
 #include <cstdlib>
 #include <cassert>

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Audio/SoundFileWriterWav.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Utils.hpp>
+#include <ostream>
 #include <cassert>
 
 

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Audio/ALCheck.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 #include <cstring>
 #include <cassert>
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -30,8 +30,9 @@
 #include <SFML/Audio/ALCheck.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Err.hpp>
-#include <cassert>
 #include <mutex>
+#include <ostream>
+#include <cassert>
 
 #ifdef _MSC_VER
     #pragma warning(disable: 4355) // 'this' used in base member initializer list

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -40,6 +40,7 @@
 #include FT_BITMAP_H
 #include FT_STROKER_H
 #include <type_traits>
+#include <ostream>
 #include <cstdlib>
 #include <cstring>
 #include <cmath>

--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Graphics/GLCheck.hpp>
 #include <SFML/System/Err.hpp>
 #include <string>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Graphics/GLExtensions.cpp
+++ b/src/SFML/Graphics/GLExtensions.cpp
@@ -37,6 +37,8 @@
 #include <glad/gl.h>
 #endif
 
+#include <ostream>
+
 #if !defined(GL_MAJOR_VERSION)
     #define GL_MAJOR_VERSION 0x821B
 #endif

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -32,6 +32,7 @@
     #include <SFML/System/Android/ResourceStream.hpp>
 #endif
 #include <algorithm>
+#include <ostream>
 #include <cstring>
 
 

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -34,6 +34,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 #include <iterator>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <mutex>
 #include <unordered_map>
+#include <ostream>
 #include <cassert>
 
 

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Graphics/RenderTextureImplDefault.hpp>
 #include <SFML/System/Err.hpp>
 #include <memory>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -36,6 +36,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <vector>
 #include <mutex>
+#include <ostream>
 
 
 #ifndef SFML_OPENGL_ES

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -36,6 +36,7 @@
 #include <cstring>
 #include <climits>
 #include <mutex>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -32,6 +32,7 @@
 #include <SFML/System/Err.hpp>
 #include <mutex>
 #include <utility>
+#include <ostream>
 #include <cstddef>
 #include <cstring>
 

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -33,6 +33,7 @@
 #include <fstream>
 #include <iterator>
 #include <sstream>
+#include <ostream>
 #include <cstdio>
 
 

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -31,6 +31,7 @@
 #include <iterator>
 #include <sstream>
 #include <limits>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Network/Socket.cpp
+++ b/src/SFML/Network/Socket.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Network/Socket.hpp>
 #include <SFML/Network/SocketImpl.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -31,6 +31,7 @@
 #include <SFML/System/Err.hpp>
 #include <algorithm>
 #include <memory>
+#include <ostream>
 #include <utility>
 
 #ifdef _MSC_VER

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Network/TcpSocket.hpp>
 #include <SFML/Network/SocketImpl.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -31,6 +31,7 @@
 #include <SFML/Network/SocketImpl.hpp>
 #include <SFML/System/Err.hpp>
 #include <algorithm>
+#include <ostream>
 #include <cstring>
 
 #ifdef _MSC_VER

--- a/src/SFML/Network/UdpSocket.cpp
+++ b/src/SFML/Network/UdpSocket.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Network/Packet.hpp>
 #include <SFML/Network/SocketImpl.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 #include <cstddef>
 
 

--- a/src/SFML/Network/Unix/SocketImpl.cpp
+++ b/src/SFML/Network/Unix/SocketImpl.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Network/Unix/SocketImpl.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 #include <cerrno>
 #include <cstring>
 #include <fcntl.h>

--- a/src/SFML/Window/Android/ClipboardImpl.cpp
+++ b/src/SFML/Window/Android/ClipboardImpl.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Window/Android/ClipboardImpl.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/String.hpp>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Window/Android/InputImpl.cpp
+++ b/src/SFML/Window/Android/InputImpl.cpp
@@ -29,6 +29,7 @@
 #include <SFML/System/Android/Activity.hpp>
 #include <SFML/System/Err.hpp>
 #include <mutex>
+#include <ostream>
 #include <jni.h>
 
 

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -31,6 +31,7 @@
 #include <SFML/Window/Event.hpp>
 #include <SFML/System/Err.hpp>
 #include <mutex>
+#include <ostream>
 #include <android/looper.h>
 
 // Define missing constants for older API levels

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Window/Context.hpp>
 #include <SFML/Window/GlContext.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -30,6 +30,7 @@
 #include <SFML/System/Err.hpp>
 #include <glad/egl.h>
 #include <string>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -31,6 +31,7 @@
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <mutex>
+#include <ostream>
 #ifdef SFML_SYSTEM_ANDROID
     #include <SFML/System/Android/Activity.hpp>
 #endif

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/src/SFML/Window/OSX/HIDInputManager.mm
+++ b/src/SFML/Window/OSX/HIDInputManager.mm
@@ -29,6 +29,7 @@
 #include <SFML/Window/OSX/HIDInputManager.hpp>
 #include <SFML/System/Err.hpp>
 #include <AppKit/AppKit.h>
+#include <ostream>
 
 namespace sf
 {

--- a/src/SFML/Window/OSX/InputImpl.mm
+++ b/src/SFML/Window/OSX/InputImpl.mm
@@ -32,6 +32,7 @@
 #include <SFML/Window/OSX/InputImpl.hpp>
 #include <SFML/Window/OSX/HIDInputManager.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 #import <SFML/Window/OSX/SFOpenGLView.h>
 #import <AppKit/AppKit.h>

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -31,6 +31,7 @@
 #include <SFML/Window/OSX/HIDInputManager.hpp>
 #include <SFML/Window/OSX/HIDJoystickManager.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Window/OSX/SFContext.mm
+++ b/src/SFML/Window/OSX/SFContext.mm
@@ -32,6 +32,7 @@
 #include <SFML/System/Err.hpp>
 #include <dlfcn.h>
 #include <stdint.h>
+#include <ostream>
 
 #if defined(__APPLE__)
     #if defined(__clang__)

--- a/src/SFML/Window/OSX/SFViewController.mm
+++ b/src/SFML/Window/OSX/SFViewController.mm
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Err.hpp>
 #include <SFML/Window/OSX/WindowImplCocoa.hpp>
+#include <ostream>
 
 #import <SFML/Window/OSX/SFApplication.h>
 #import <SFML/Window/OSX/SFOpenGLView.h>

--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -33,6 +33,7 @@
 #include <SFML/System/Err.hpp>
 #include <ApplicationServices/ApplicationServices.h>
 #include <algorithm>
+#include <ostream>
 
 #import <SFML/Window/OSX/NSImage+raw.h>
 #import <SFML/Window/OSX/Scaling.h>
@@ -133,7 +134,7 @@
 
         // Set the view to the window as its content view.
         [m_window setContentView:m_oglView];
-        
+
         [m_oglView finishInit];
     }
 

--- a/src/SFML/Window/OSX/VideoModeImpl.cpp
+++ b/src/SFML/Window/OSX/VideoModeImpl.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Window/OSX/cg_sf_conversion.hpp>
 #include <SFML/System/Err.hpp>
 #include <algorithm>
+#include <ostream>
 
 namespace sf
 {

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -30,6 +30,7 @@
 #include <SFML/Window/OSX/WindowImplCocoa.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/String.hpp>
+#include <ostream>
 
 #import <SFML/Window/OSX/cpp_objc_conversion.h>
 #import <SFML/Window/OSX/Scaling.h>

--- a/src/SFML/Window/SensorManager.cpp
+++ b/src/SFML/Window/SensorManager.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/SensorManager.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -32,6 +32,7 @@
 #include <SFML/System/Time.hpp>
 #include <X11/Xatom.h>
 #include <vector>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -30,6 +30,7 @@
 #include <X11/keysym.h>
 #include <mutex>
 #include <unordered_map>
+#include <ostream>
 #include <cassert>
 #include <cstdlib>
 

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -31,6 +31,7 @@
 #include <SFML/System/Err.hpp>
 #include <mutex>
 #include <vector>
+#include <ostream>
 
 // We check for this definition in order to avoid multiple definitions of GLAD
 // entities during unity builds of SFML.

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -31,9 +31,10 @@
 #include <libudev.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <cerrno>
-#include <vector>
 #include <string>
+#include <vector>
+#include <ostream>
+#include <cerrno>
 #include <cstring>
 
 namespace

--- a/src/SFML/Window/Unix/VideoModeImpl.cpp
+++ b/src/SFML/Window/Unix/VideoModeImpl.cpp
@@ -31,6 +31,7 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 #include <algorithm>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -49,11 +49,12 @@
 #include <libgen.h>
 #include <fcntl.h>
 #include <algorithm>
-#include <vector>
-#include <string>
-#include <cstring>
-#include <cassert>
 #include <mutex>
+#include <ostream>
+#include <string>
+#include <vector>
+#include <cassert>
+#include <cstring>
 
 #ifdef SFML_OPENGL_ES
     #include <SFML/Window/EglContext.hpp>

--- a/src/SFML/Window/Win32/ClipboardImpl.cpp
+++ b/src/SFML/Window/Win32/ClipboardImpl.cpp
@@ -28,7 +28,8 @@
 #include <SFML/Window/Win32/ClipboardImpl.hpp>
 #include <SFML/System/Win32/WindowsHeader.hpp>
 #include <SFML/System/String.hpp>
-#include <iostream>
+#include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace sf
@@ -42,13 +43,13 @@ String ClipboardImpl::getString()
 
     if (!IsClipboardFormatAvailable(CF_UNICODETEXT))
     {
-        std::cerr << "Failed to get the clipboard data in Unicode format." << std::endl;
+        err() << "Failed to get the clipboard data in Unicode format." << std::endl;
         return text;
     }
 
     if (!OpenClipboard(nullptr))
     {
-        std::cerr << "Failed to open the Win32 clipboard." << std::endl;
+        err() << "Failed to open the Win32 clipboard." << std::endl;
         return text;
     }
 
@@ -56,7 +57,7 @@ String ClipboardImpl::getString()
 
     if (!clipboard_handle)
     {
-        std::cerr << "Failed to get Win32 handle for clipboard content." << std::endl;
+        err() << "Failed to get Win32 handle for clipboard content." << std::endl;
         CloseClipboard();
         return text;
     }
@@ -74,13 +75,13 @@ void ClipboardImpl::setString(const String& text)
 {
     if (!OpenClipboard(nullptr))
     {
-        std::cerr << "Failed to open the Win32 clipboard." << std::endl;
+        err() << "Failed to open the Win32 clipboard." << std::endl;
         return;
     }
 
     if (!EmptyClipboard())
     {
-        std::cerr << "Failed to empty the Win32 clipboard." << std::endl;
+        err() << "Failed to empty the Win32 clipboard." << std::endl;
         return;
     }
 

--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Window/Win32/CursorImpl.hpp>
 #include <SFML/System/Win32/WindowsHeader.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 #include <cstring>
 
 

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -32,11 +32,12 @@
 #include <SFML/System/Time.hpp>
 #include <tchar.h>
 #include <regstr.h>
-#include <cmath>
-#include <cstring>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cmath>
+#include <cstring>
 
 
 

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Window/Win32/WglContext.hpp>
 #include <SFML/System/Err.hpp>
 #include <mutex>
+#include <ostream>
 #include <sstream>
 #include <vector>
 

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -35,7 +35,9 @@
 // expects lowercase, and a native compile on windows, whether via msvc
 // or mingw-w64 addresses files in a case insensitive manner.
 #include <dbt.h>
+#include <ostream>
 #include <vector>
+
 #include <cstring>
 
 // MinGW lacks the definition of some Win32 constants

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Window/WindowImpl.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace sf

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Window/ContextSettings.hpp>
 #include <SFML/Window/WindowImpl.hpp>
 #include <SFML/System/Err.hpp>
+#include <ostream>
 
 
 namespace

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -35,6 +35,8 @@
 #include <OpenGLES/EAGLDrawable.h>
 #include <QuartzCore/CAEAGLLayer.h>
 #include <dlfcn.h>
+#include <ostream>
+
 
 #if defined(__APPLE__)
     #if defined(__clang__)


### PR DESCRIPTION
## Description

`Err.hpp` now only includes `<iosfwd>`, and `<ostream>` is explicitly included everywhere required. 

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.