### PR TITLE
Avoid overuse of 'std::endl'

### DIFF
--- a/examples/ftp/Ftp.cpp
+++ b/examples/ftp/Ftp.cpp
@@ -59,19 +59,19 @@ int main()
     do
     {
         // Main FTP menu
-        std::cout << std::endl;
-        std::cout << "Choose an action:"                      << std::endl;
-        std::cout << "1. Print working directory"             << std::endl;
-        std::cout << "2. Print contents of working directory" << std::endl;
-        std::cout << "3. Change directory"                    << std::endl;
-        std::cout << "4. Create directory"                    << std::endl;
-        std::cout << "5. Delete directory"                    << std::endl;
-        std::cout << "6. Rename file"                         << std::endl;
-        std::cout << "7. Remove file"                         << std::endl;
-        std::cout << "8. Download file"                       << std::endl;
-        std::cout << "9. Upload file"                         << std::endl;
-        std::cout << "0. Disconnect"                          << std::endl;
-        std::cout << std::endl;
+        std::cout << '\n'
+                  << "Choose an action:\n"
+                  << "1. Print working directory\n"
+                  << "2. Print contents of working directory\n"
+                  << "3. Change directory\n"
+                  << "4. Create directory\n"
+                  << "5. Delete directory\n"
+                  << "6. Rename file\n"
+                  << "7. Remove file\n"
+                  << "8. Download file\n"
+                  << "9. Upload file\n"
+                  << "0. Disconnect\n"
+                  << std::endl;
 
         std::cout << "Your choice: ";
         std::cin  >> choice;
@@ -92,8 +92,8 @@ int main()
             {
                 // Print the current server directory
                 sf::Ftp::DirectoryResponse response = server.getWorkingDirectory();
-                std::cout << response << std::endl;
-                std::cout << "Current directory is " << response.getDirectory() << std::endl;
+                std::cout << response << '\n'
+                          << "Current directory is " << response.getDirectory() << std::endl;
                 break;
             }
 
@@ -101,9 +101,10 @@ int main()
             {
                 // Print the contents of the current server directory
                 sf::Ftp::ListingResponse response = server.getDirectoryListing();
-                std::cout << response << std::endl;
+                std::cout << response << '\n';
                 for (const std::string& name : response.getListing())
-                    std::cout << name << std::endl;
+                    std::cout << name << '\n';
+                std::cout.flush();
                 break;
             }
 
@@ -193,8 +194,8 @@ int main()
     } while (choice != 0);
 
     // Disconnect from the server
-    std::cout << "Disconnecting from server..." << std::endl;
-    std::cout << server.disconnect() << std::endl;
+    std::cout << "Disconnecting from server...\n"
+              << server.disconnect() << '\n';
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -246,7 +246,7 @@ int main()
                   << "Use the arrow keys to change the values.\nUse the return key to regenerate the terrain.\n\n";
 
             for (int i = 0; i < settingCount; ++i)
-                osstr << ((i == currentSetting) ? ">>  " : "       ") << settings[i].name << ":  " << *(settings[i].value) << "\n";
+                osstr << ((i == currentSetting) ? ">>  " : "       ") << settings[i].name << ":  " << *(settings[i].value) << '\n';
 
             hudText.setString(osstr.str());
 

--- a/examples/sockets/TCP.cpp
+++ b/examples/sockets/TCP.cpp
@@ -31,14 +31,14 @@ void runTcpServer(unsigned short port)
     const char out[] = "Hi, I'm the server";
     if (socket.send(out, sizeof(out)) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the client: \"" << out << "\"" << std::endl;
+    std::cout << "Message sent to the client: \"" << out << '"' << std::endl;
 
     // Receive a message back from the client
     char in[128];
     std::size_t received;
     if (socket.receive(in, sizeof(in), received) != sf::Socket::Done)
         return;
-    std::cout << "Answer received from the client: \"" << in << "\"" << std::endl;
+    std::cout << "Answer received from the client: \"" << in << '"' << std::endl;
 }
 
 
@@ -71,11 +71,11 @@ void runTcpClient(unsigned short port)
     std::size_t received;
     if (socket.receive(in, sizeof(in), received) != sf::Socket::Done)
         return;
-    std::cout << "Message received from the server: \"" << in << "\"" << std::endl;
+    std::cout << "Message received from the server: \"" << in << '"' << std::endl;
 
     // Send an answer to the server
     const char out[] = "Hi, I'm a client";
     if (socket.send(out, sizeof(out)) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the server: \"" << out << "\"" << std::endl;
+    std::cout << "Message sent to the server: \"" << out << '"' << std::endl;
 }

--- a/examples/sockets/UDP.cpp
+++ b/examples/sockets/UDP.cpp
@@ -27,13 +27,13 @@ void runUdpServer(unsigned short port)
     unsigned short senderPort;
     if (socket.receive(in, sizeof(in), received, sender, senderPort) != sf::Socket::Done)
         return;
-    std::cout << "Message received from client " << sender << ": \"" << in << "\"" << std::endl;
+    std::cout << "Message received from client " << sender << ": \"" << in << '"' << std::endl;
 
     // Send an answer to the client
     const char out[] = "Hi, I'm the server";
     if (socket.send(out, sizeof(out), sender, senderPort) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the client: \"" << out << "\"" << std::endl;
+    std::cout << "Message sent to the client: \"" << out << '"' << std::endl;
 }
 
 
@@ -59,7 +59,7 @@ void runUdpClient(unsigned short port)
     const char out[] = "Hi, I'm a client";
     if (socket.send(out, sizeof(out), server, port) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the server: \"" << out << "\"" << std::endl;
+    std::cout << "Message sent to the server: \"" << out << '"' << std::endl;
 
     // Receive an answer from anyone (but most likely from the server)
     char in[128];
@@ -68,5 +68,5 @@ void runUdpClient(unsigned short port)
     unsigned short senderPort;
     if (socket.receive(in, sizeof(in), received, sender, senderPort) != sf::Socket::Done)
         return;
-    std::cout << "Message received from " << sender << ": \"" << in << "\"" << std::endl;
+    std::cout << "Message received from " << sender << ": \"" << in << '"' << std::endl;
 }

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -19,10 +19,10 @@ void playSound()
         return;
 
     // Display sound informations
-    std::cout << "killdeer.wav:" << std::endl;
-    std::cout << " " << buffer.getDuration().asSeconds() << " seconds"       << std::endl;
-    std::cout << " " << buffer.getSampleRate()           << " samples / sec" << std::endl;
-    std::cout << " " << buffer.getChannelCount()         << " channels"      << std::endl;
+    std::cout << "killdeer.wav:" << '\n'
+              << " " << buffer.getDuration().asSeconds() << " seconds"       << '\n'
+              << " " << buffer.getSampleRate()           << " samples / sec" << '\n'
+              << " " << buffer.getChannelCount()         << " channels"      << std::endl;
 
     // Create a sound instance and play it
     sf::Sound sound(buffer);
@@ -54,10 +54,10 @@ void playMusic(const std::string& filename)
         return;
 
     // Display music informations
-    std::cout << filename << ":" << std::endl;
-    std::cout << " " << music.getDuration().asSeconds() << " seconds"       << std::endl;
-    std::cout << " " << music.getSampleRate()           << " samples / sec" << std::endl;
-    std::cout << " " << music.getChannelCount()         << " channels"      << std::endl;
+    std::cout << filename << ":" << '\n'
+              << " " << music.getDuration().asSeconds() << " seconds"       << '\n'
+              << " " << music.getSampleRate()           << " samples / sec" << '\n'
+              << " " << music.getChannelCount()         << " channels"      << std::endl;
 
     // Play it
     music.play();
@@ -72,7 +72,7 @@ void playMusic(const std::string& filename)
         std::cout << "\rPlaying... " << music.getPlayingOffset().asSeconds() << " sec        ";
         std::cout << std::flush;
     }
-    std::cout << std::endl << std::endl;
+    std::cout << '\n' << std::endl;
 }
 
 

--- a/examples/sound_capture/SoundCapture.cpp
+++ b/examples/sound_capture/SoundCapture.cpp
@@ -50,10 +50,10 @@ int main()
     const sf::SoundBuffer& buffer = recorder.getBuffer();
 
     // Display captured sound informations
-    std::cout << "Sound information:" << std::endl;
-    std::cout << " " << buffer.getDuration().asSeconds() << " seconds"           << std::endl;
-    std::cout << " " << buffer.getSampleRate()           << " samples / seconds" << std::endl;
-    std::cout << " " << buffer.getChannelCount()         << " channels"          << std::endl;
+    std::cout << "Sound information:" << '\n'
+              << " " << buffer.getDuration().asSeconds() << " seconds"           << '\n'
+              << " " << buffer.getSampleRate()           << " samples / seconds" << '\n'
+              << " " << buffer.getChannelCount()         << " channels"          << std::endl;
 
     // Choose what to do with the recorded sound data
     char choice;
@@ -91,7 +91,7 @@ int main()
     }
 
     // Finished!
-    std::cout << std::endl << "Done!" << std::endl;
+    std::cout << '\n' << "Done!" << std::endl;
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -272,10 +272,10 @@ private:
 ///     /* error */;
 ///
 /// // Print the sound attributes
-/// std::cout << "duration: " << file.getDuration().asSeconds() << std::endl;
-/// std::cout << "channels: " << file.getChannelCount() << std::endl;
-/// std::cout << "sample rate: " << file.getSampleRate() << std::endl;
-/// std::cout << "sample count: " << file.getSampleCount() << std::endl;
+/// std::cout << "duration: " << file.getDuration().asSeconds() << '\n'
+///           << "channels: " << file.getChannelCount() << '\n'
+///           << "sample rate: " << file.getSampleRate() << '\n'
+///           << "sample count: " << file.getSampleCount() << std::endl;
 ///
 /// // Read and process batches of samples until the end of file is reached
 /// sf::Int16 samples[1024];

--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -97,7 +97,7 @@ void alCheckError(const char* file, unsigned int line, const char* expression)
         err() << "An internal OpenAL call failed in "
               << fileString.substr(fileString.find_last_of("\\/") + 1) << "(" << line << ")."
               << "\nExpression:\n   " << expression
-              << "\nError description:\n   " << error << "\n   " << description << "\n"
+              << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
     }
 }

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -111,7 +111,7 @@ bool SoundFileWriterWav::open(const std::string& filename, unsigned int sampleRa
     // Write the header
     if (!writeHeader(sampleRate, channelCount))
     {
-        err() << "Failed to write header of WAV sound file \"" << filename << "\"" << std::endl;
+        err() << "Failed to write header of WAV sound file \"" << filename << '"' << std::endl;
         return false;
     }
 

--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -104,7 +104,7 @@ void glCheckError(const char* file, unsigned int line, const char* expression)
         err() << "An internal OpenGL call failed in "
               << fileString.substr(fileString.find_last_of("\\/") + 1) << "(" << line << ")."
               << "\nExpression:\n   " << expression
-              << "\nError description:\n   " << error << "\n   " << description << "\n"
+              << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
     }
 }

--- a/src/SFML/Graphics/GLExtensions.cpp
+++ b/src/SFML/Graphics/GLExtensions.cpp
@@ -94,8 +94,8 @@ void ensureExtensionsInit()
 
         if ((majorVersion < 1) || ((majorVersion == 1) && (minorVersion < 1)))
         {
-            err() << "sfml-graphics requires support for OpenGL 1.1 or greater" << std::endl;
-            err() << "Ensure that hardware acceleration is enabled if available" << std::endl;
+            err() << "sfml-graphics requires support for OpenGL 1.1 or greater" << '\n'
+                  << "Ensure that hardware acceleration is enabled if available" << std::endl;
         }
     }
 }

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -277,7 +277,7 @@ bool ImageLoader::saveImageToFile(const std::string& filename, const std::vector
         }
     }
 
-    err() << "Failed to save image \"" << filename << "\"" << std::endl;
+    err() << "Failed to save image \"" << filename << '"' << std::endl;
     return false;
 }
 
@@ -318,7 +318,7 @@ bool ImageLoader::saveImageToMemory(const std::string& format, std::vector<sf::U
         }
     }
 
-    err() << "Failed to save image with format \"" << format << "\"" << std::endl;
+    err() << "Failed to save image with format \"" << format << '"' << std::endl;
     return false;
 }
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -128,9 +128,9 @@ namespace
             static bool warned = false;
             if (!warned)
             {
-                sf::err() << "OpenGL extension EXT_blend_minmax or EXT_blend_subtract unavailable" << std::endl;
-                sf::err() << "Some blending equations will fallback to sf::BlendMode::Add" << std::endl;
-                sf::err() << "Ensure that hardware acceleration is enabled if available" << std::endl;
+                sf::err() << "OpenGL extension EXT_blend_minmax or EXT_blend_subtract unavailable" << '\n'
+                          << "Some blending equations will fallback to sf::BlendMode::Add" << '\n'
+                          << "Ensure that hardware acceleration is enabled if available" << std::endl;
 
                 warned = true;
             }
@@ -631,8 +631,8 @@ void RenderTarget::applyBlendMode(const BlendMode& mode)
 #else
             err() << "OpenGL extension EXT_blend_minmax and EXT_blend_subtract unavailable" << std::endl;
 #endif
-            err() << "Selecting a blend equation not possible" << std::endl;
-            err() << "Ensure that hardware acceleration is enabled if available" << std::endl;
+            err() << "Selecting a blend equation not possible" << '\n'
+                  << "Ensure that hardware acceleration is enabled if available" << std::endl;
 
             warned = true;
         }

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -242,8 +242,8 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
 
             if (settings.antialiasingLevel > static_cast<unsigned int>(samples))
             {
-                err() << "Impossible to create render texture (unsupported anti-aliasing level)";
-                err() << " Requested: " << settings.antialiasingLevel << " Maximum supported: " << samples << std::endl;
+                err() << "Impossible to create render texture (unsupported anti-aliasing level)"
+                      << " Requested: " << settings.antialiasingLevel << " Maximum supported: " << samples << std::endl;
                 return false;
             }
         }

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -259,7 +259,7 @@ bool Shader::loadFromFile(const std::string& filename, Type type)
     std::vector<char> shader;
     if (!getFileContents(filename, shader))
     {
-        err() << "Failed to open shader file \"" << filename << "\"" << std::endl;
+        err() << "Failed to open shader file \"" << filename << '"' << std::endl;
         return false;
     }
 
@@ -280,7 +280,7 @@ bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::st
     std::vector<char> vertexShader;
     if (!getFileContents(vertexShaderFilename, vertexShader))
     {
-        err() << "Failed to open vertex shader file \"" << vertexShaderFilename << "\"" << std::endl;
+        err() << "Failed to open vertex shader file \"" << vertexShaderFilename << '"' << std::endl;
         return false;
     }
 
@@ -288,7 +288,7 @@ bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::st
     std::vector<char> fragmentShader;
     if (!getFileContents(fragmentShaderFilename, fragmentShader))
     {
-        err() << "Failed to open fragment shader file \"" << fragmentShaderFilename << "\"" << std::endl;
+        err() << "Failed to open fragment shader file \"" << fragmentShaderFilename << '"' << std::endl;
         return false;
     }
 
@@ -304,7 +304,7 @@ bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::st
     std::vector<char> vertexShader;
     if (!getFileContents(vertexShaderFilename, vertexShader))
     {
-        err() << "Failed to open vertex shader file \"" << vertexShaderFilename << "\"" << std::endl;
+        err() << "Failed to open vertex shader file \"" << vertexShaderFilename << '"' << std::endl;
         return false;
     }
 
@@ -312,7 +312,7 @@ bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::st
     std::vector<char> geometryShader;
     if (!getFileContents(geometryShaderFilename, geometryShader))
     {
-        err() << "Failed to open geometry shader file \"" << geometryShaderFilename << "\"" << std::endl;
+        err() << "Failed to open geometry shader file \"" << geometryShaderFilename << '"' << std::endl;
         return false;
     }
 
@@ -320,7 +320,7 @@ bool Shader::loadFromFile(const std::string& vertexShaderFilename, const std::st
     std::vector<char> fragmentShader;
     if (!getFileContents(fragmentShaderFilename, fragmentShader))
     {
-        err() << "Failed to open fragment shader file \"" << fragmentShaderFilename << "\"" << std::endl;
+        err() << "Failed to open fragment shader file \"" << fragmentShaderFilename << '"' << std::endl;
         return false;
     }
 
@@ -817,7 +817,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
         {
             char log[1024];
             glCheck(GLEXT_glGetInfoLog(vertexShader, sizeof(log), nullptr, log));
-            err() << "Failed to compile vertex shader:" << std::endl
+            err() << "Failed to compile vertex shader:" << '\n'
                   << log << std::endl;
             glCheck(GLEXT_glDeleteObject(vertexShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
@@ -844,7 +844,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
         {
             char log[1024];
             glCheck(GLEXT_glGetInfoLog(geometryShader, sizeof(log), nullptr, log));
-            err() << "Failed to compile geometry shader:" << std::endl
+            err() << "Failed to compile geometry shader:" << '\n'
                   << log << std::endl;
             glCheck(GLEXT_glDeleteObject(geometryShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
@@ -872,7 +872,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
         {
             char log[1024];
             glCheck(GLEXT_glGetInfoLog(fragmentShader, sizeof(log), nullptr, log));
-            err() << "Failed to compile fragment shader:" << std::endl
+            err() << "Failed to compile fragment shader:" << '\n'
                   << log << std::endl;
             glCheck(GLEXT_glDeleteObject(fragmentShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
@@ -894,7 +894,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
     {
         char log[1024];
         glCheck(GLEXT_glGetInfoLog(shaderProgram, sizeof(log), nullptr, log));
-        err() << "Failed to link shader:" << std::endl
+        err() << "Failed to link shader:" << '\n'
               << log << std::endl;
         glCheck(GLEXT_glDeleteObject(shaderProgram));
         return false;

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -175,9 +175,9 @@ bool Texture::create(unsigned int width, unsigned int height)
 
         if (!warned)
         {
-            err() << "OpenGL extension SGIS_texture_edge_clamp unavailable" << std::endl;
-            err() << "Artifacts may occur along texture edges" << std::endl;
-            err() << "Ensure that hardware acceleration is enabled if available" << std::endl;
+            err() << "OpenGL extension SGIS_texture_edge_clamp unavailable" << '\n'
+                  << "Artifacts may occur along texture edges" << '\n'
+                  << "Ensure that hardware acceleration is enabled if available" << std::endl;
 
             warned = true;
         }
@@ -192,9 +192,9 @@ bool Texture::create(unsigned int width, unsigned int height)
         if (!warned)
         {
 #ifndef SFML_OPENGL_ES
-            err() << "OpenGL extension EXT_texture_sRGB unavailable" << std::endl;
+            err() << "OpenGL extension EXT_texture_sRGB unavailable" << '\n';
 #else
-            err() << "OpenGL ES extension EXT_sRGB unavailable" << std::endl;
+            err() << "OpenGL ES extension EXT_sRGB unavailable" << '\n';
 #endif
             err() << "Automatic sRGB to linear conversion disabled" << std::endl;
 
@@ -668,9 +668,9 @@ void Texture::setRepeated(bool repeated)
 
                 if (!warned)
                 {
-                    err() << "OpenGL extension SGIS_texture_edge_clamp unavailable" << std::endl;
-                    err() << "Artifacts may occur along texture edges" << std::endl;
-                    err() << "Ensure that hardware acceleration is enabled if available" << std::endl;
+                    err() << "OpenGL extension SGIS_texture_edge_clamp unavailable" << '\n'
+                          << "Artifacts may occur along texture edges" << '\n'
+                          << "Ensure that hardware acceleration is enabled if available" << std::endl;
 
                     warned = true;
                 }

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -497,7 +497,7 @@ Ftp::Response Ftp::getResponse()
 
                             // Append it to the current message
                             std::ostringstream out;
-                            out << code << separator << line << "\n";
+                            out << code << separator << line << '\n';
                             message += out.str();
                         }
                     }

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -155,8 +155,8 @@ void eglCheckError(const char* file, unsigned int line, const char* expression)
         // Log the error
         err() << "An internal EGL call failed in "
               << fileString.substr(fileString.find_last_of("\\/") + 1) << " (" << line << ") : "
-            << "\nExpression:\n   " << expression
-            << "\nError description:\n   " << error << "\n   " << description << "\n"
+              << "\nExpression:\n   " << expression
+              << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
     }
 }

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -926,7 +926,7 @@ void GlContext::checkSettings(const ContextSettings& requestedSettings)
     {
         if ((std::strcmp(vendorName, "Microsoft Corporation") == 0) && (std::strcmp(rendererName, "GDI Generic") == 0))
         {
-            err() << "Warning: Detected \"Microsoft Corporation GDI Generic\" OpenGL implementation" << std::endl
+            err() << "Warning: Detected \"Microsoft Corporation GDI Generic\" OpenGL implementation" << '\n'
                   << "The current OpenGL implementation is not hardware-accelerated" << std::endl;
         }
     }
@@ -941,8 +941,8 @@ void GlContext::checkSettings(const ContextSettings& requestedSettings)
         (m_settings.depthBits         <  requestedSettings.depthBits)         ||
         (!m_settings.sRgbCapable      && requestedSettings.sRgbCapable))
     {
-        err() << "Warning: The created OpenGL context does not fully meet the settings that were requested" << std::endl;
-        err() << "Requested: version = " << requestedSettings.majorVersion << "." << requestedSettings.minorVersion
+        err() << "Warning: The created OpenGL context does not fully meet the settings that were requested" << '\n'
+              << "Requested: version = " << requestedSettings.majorVersion << "." << requestedSettings.minorVersion
               << " ; depth bits = " << requestedSettings.depthBits
               << " ; stencil bits = " << requestedSettings.stencilBits
               << " ; AA level = " << requestedSettings.antialiasingLevel
@@ -950,8 +950,8 @@ void GlContext::checkSettings(const ContextSettings& requestedSettings)
               << " ; core = " << ((requestedSettings.attributeFlags & ContextSettings::Core) != 0)
               << " ; debug = " << ((requestedSettings.attributeFlags & ContextSettings::Debug) != 0)
               << " ; sRGB = " << requestedSettings.sRgbCapable
-              << std::noboolalpha << std::endl;
-        err() << "Created: version = " << m_settings.majorVersion << "." << m_settings.minorVersion
+              << std::noboolalpha << '\n'
+              << "Created: version = " << m_settings.majorVersion << "." << m_settings.minorVersion
               << " ; depth bits = " << m_settings.depthBits
               << " ; stencil bits = " << m_settings.stencilBits
               << " ; AA level = " << m_settings.antialiasingLevel

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -754,7 +754,7 @@ bool JoystickImpl::openDInput(unsigned int index)
                     if (FAILED(result))
                     {
                         err() << "Failed to verify DirectInput device axis mode for device \""
-                            << m_identification.name.toAnsiString() << "\": " << result << std::endl;
+                              << m_identification.name.toAnsiString() << "\": " << result << std::endl;
 
                         m_device->Release();
                         m_device = nullptr;

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -414,7 +414,7 @@ void WglContext::setDevicePixelFormat(unsigned int bitsPerPixel)
 
     if (bestFormat == 0)
     {
-        err() << "Failed to find a suitable pixel format for device context: " << getErrorString(GetLastError()).toAnsiString() << std::endl
+        err() << "Failed to find a suitable pixel format for device context: " << getErrorString(GetLastError()).toAnsiString() << '\n'
               << "Cannot create OpenGL context" << std::endl;
         return;
     }
@@ -428,7 +428,7 @@ void WglContext::setDevicePixelFormat(unsigned int bitsPerPixel)
     // Set the chosen pixel format
     if (SetPixelFormat(m_deviceContext, bestFormat, &actualFormat) == FALSE)
     {
-        err() << "Failed to set pixel format for device context: " << getErrorString(GetLastError()).toAnsiString() << std::endl
+        err() << "Failed to set pixel format for device context: " << getErrorString(GetLastError()).toAnsiString() << '\n'
               << "Cannot create OpenGL context" << std::endl;
         return;
     }


### PR DESCRIPTION
## Description

This PR avoid calling `std::endl` multiple times in a row to avoid unnecessary flushing and to avoid promoting bad practices.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.