### PR TITLE
Remove Cygwin workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,6 @@ endmacro()
 # determine whether to create a debug or release build
 sfml_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
 
-# Suppress Cygwin legacy warning
-set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-
 # Suppress Mac OS X RPATH warnings and adopt new related behaviors
 cmake_policy(SET CMP0042 NEW)
 if (NOT CMAKE_VERSION VERSION_LESS 3.9)


### PR DESCRIPTION
## Description

This line was intended to silence a warning, however in the time since that code was added in 95828a85a, the minimum required CMake version was increased from 2.8.3 to 3.8. As of CMake 2.8.4 this warning is no longer emitted which means we can remove this line.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
