### PR TITLE
Use pre-increment when post-increment is not necessary

### DIFF
--- a/examples/X11/gl.h
+++ b/examples/X11/gl.h
@@ -7559,7 +7559,7 @@ static int glad_gl_get_extensions( int version, const char **out_exts, unsigned 
         if (exts_i == NULL) {
             return 0;
         }
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             const char *gl_str_tmp = (const char*) glad_glGetStringi(GL_EXTENSIONS, index);
             size_t len = strlen(gl_str_tmp) + 1;
 
@@ -7580,7 +7580,7 @@ static int glad_gl_get_extensions( int version, const char **out_exts, unsigned 
 static void glad_gl_free_extensions(char **exts_i, unsigned int num_exts_i) {
     if (exts_i != NULL) {
         unsigned int index;
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             free((void *) (exts_i[index]));
         }
         free((void *)exts_i);
@@ -7610,7 +7610,7 @@ static int glad_gl_has_extension(int version, const char *exts, unsigned int num
         }
     } else {
         unsigned int index;
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             const char *e = exts_i[index];
             if(strcmp(e, ext) == 0) {
                 return 1;
@@ -7682,7 +7682,7 @@ static int glad_gl_find_core_gl(void) {
     };
     version = (const char*) glad_glGetString(GL_VERSION);
     if (!version) return 0;
-    for (i = 0;  prefixes[i];  i++) {
+    for (i = 0;  prefixes[i];  ++i) {
         const size_t length = strlen(prefixes[i]);
         if (strncmp(version, prefixes[i], length) == 0) {
             version += length;
@@ -7783,7 +7783,7 @@ static int glad_gl_find_core_gles1(void) {
     };
     version = (const char*) glad_glGetString(GL_VERSION);
     if (!version) return 0;
-    for (i = 0;  prefixes[i];  i++) {
+    for (i = 0;  prefixes[i];  ++i) {
         const size_t length = strlen(prefixes[i]);
         if (strncmp(version, prefixes[i], length) == 0) {
             version += length;
@@ -7830,7 +7830,7 @@ int gladLoadGLES1( GLADloadfunc load) {
 
 
 
- 
+
 
 
 #endif /* GLAD_GL_IMPLEMENTATION */

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -136,7 +136,7 @@ int main()
     else
     {
         // Start up our thread pool
-        for (unsigned int i = 0; i < threadCount; i++)
+        for (unsigned int i = 0; i < threadCount; ++i)
         {
             threads.emplace_back(threadFunction);
         }
@@ -284,7 +284,7 @@ float getElevation(float x, float y)
 
     float elevation = 0.0f;
 
-    for (int i = 0; i < perlinOctaves; i++)
+    for (int i = 0; i < perlinOctaves; ++i)
     {
         elevation += stb_perlin_noise3(
             x * perlinFrequency * static_cast<float>(std::pow(perlinFrequencyBase, i)),
@@ -467,9 +467,9 @@ void processWorkItem(std::vector<sf::Vertex>& vertices, const WorkItem& workItem
     const float scalingFactorX = static_cast<float>(windowWidth) / static_cast<float>(resolutionX);
     const float scalingFactorY = static_cast<float>(windowHeight) / static_cast<float>(resolutionY);
 
-    for (unsigned int y = rowStart; y < rowEnd; y++)
+    for (unsigned int y = rowStart; y < rowEnd; ++y)
     {
-        for (unsigned int x = 0; x < resolutionX; x++)
+        for (unsigned int x = 0; x < resolutionX; ++x)
         {
             unsigned int arrayIndexBase = ((y - rowStart) * resolutionX + x) * 6;
 
@@ -610,7 +610,7 @@ void generateTerrain(sf::Vertex* buffer)
     {
         std::scoped_lock lock(workQueueMutex);
 
-        for (unsigned int i = 0; i < blockCount; i++)
+        for (unsigned int i = 0; i < blockCount; ++i)
         {
             WorkItem workItem = {buffer, i};
             workQueue.push_back(workItem);

--- a/examples/island/stb_perlin.h
+++ b/examples/island/stb_perlin.h
@@ -34,9 +34,9 @@
 //
 // Fractal Noise:
 //
-// Three common fractal noise functions are included, which produce 
-// a wide variety of nice effects depending on the parameters 
-// provided. Note that each function will call stb_perlin_noise3 
+// Three common fractal noise functions are included, which produce
+// a wide variety of nice effects depending on the parameters
+// provided. Note that each function will call stb_perlin_noise3
 // 'octaves' times, so this parameter will affect runtime.
 //
 // float stb_perlin_ridge_noise3(float x, float y, float z,
@@ -56,7 +56,7 @@
 //     lacunarity = ~ 2.0   -- spacing between successive octaves (use exactly 2.0 for wrapping output)
 //     gain       =   0.5   -- relative weighting applied to each successive octave
 //     offset     =   1.0?  -- used to invert the ridges, may need to be larger, not sure
-//    
+//
 //
 // Contributors:
 //    Jack Mott - additional noise functions
@@ -81,40 +81,40 @@ extern float stb_perlin_turbulence_noise3(float x, float y, float z, float lacun
 // @OPTIMIZE: should this be unsigned char instead of int for cache?
 static unsigned char stb__perlin_randtab[512] =
 {
-   23, 125, 161, 52, 103, 117, 70, 37, 247, 101, 203, 169, 124, 126, 44, 123, 
-   152, 238, 145, 45, 171, 114, 253, 10, 192, 136, 4, 157, 249, 30, 35, 72, 
-   175, 63, 77, 90, 181, 16, 96, 111, 133, 104, 75, 162, 93, 56, 66, 240, 
-   8, 50, 84, 229, 49, 210, 173, 239, 141, 1, 87, 18, 2, 198, 143, 57, 
-   225, 160, 58, 217, 168, 206, 245, 204, 199, 6, 73, 60, 20, 230, 211, 233, 
-   94, 200, 88, 9, 74, 155, 33, 15, 219, 130, 226, 202, 83, 236, 42, 172, 
-   165, 218, 55, 222, 46, 107, 98, 154, 109, 67, 196, 178, 127, 158, 13, 243, 
-   65, 79, 166, 248, 25, 224, 115, 80, 68, 51, 184, 128, 232, 208, 151, 122, 
-   26, 212, 105, 43, 179, 213, 235, 148, 146, 89, 14, 195, 28, 78, 112, 76, 
-   250, 47, 24, 251, 140, 108, 186, 190, 228, 170, 183, 139, 39, 188, 244, 246, 
-   132, 48, 119, 144, 180, 138, 134, 193, 82, 182, 120, 121, 86, 220, 209, 3, 
-   91, 241, 149, 85, 205, 150, 113, 216, 31, 100, 41, 164, 177, 214, 153, 231, 
-   38, 71, 185, 174, 97, 201, 29, 95, 7, 92, 54, 254, 191, 118, 34, 221, 
-   131, 11, 163, 99, 234, 81, 227, 147, 156, 176, 17, 142, 69, 12, 110, 62, 
-   27, 255, 0, 194, 59, 116, 242, 252, 19, 21, 187, 53, 207, 129, 64, 135, 
-   61, 40, 167, 237, 102, 223, 106, 159, 197, 189, 215, 137, 36, 32, 22, 5,  
+   23, 125, 161, 52, 103, 117, 70, 37, 247, 101, 203, 169, 124, 126, 44, 123,
+   152, 238, 145, 45, 171, 114, 253, 10, 192, 136, 4, 157, 249, 30, 35, 72,
+   175, 63, 77, 90, 181, 16, 96, 111, 133, 104, 75, 162, 93, 56, 66, 240,
+   8, 50, 84, 229, 49, 210, 173, 239, 141, 1, 87, 18, 2, 198, 143, 57,
+   225, 160, 58, 217, 168, 206, 245, 204, 199, 6, 73, 60, 20, 230, 211, 233,
+   94, 200, 88, 9, 74, 155, 33, 15, 219, 130, 226, 202, 83, 236, 42, 172,
+   165, 218, 55, 222, 46, 107, 98, 154, 109, 67, 196, 178, 127, 158, 13, 243,
+   65, 79, 166, 248, 25, 224, 115, 80, 68, 51, 184, 128, 232, 208, 151, 122,
+   26, 212, 105, 43, 179, 213, 235, 148, 146, 89, 14, 195, 28, 78, 112, 76,
+   250, 47, 24, 251, 140, 108, 186, 190, 228, 170, 183, 139, 39, 188, 244, 246,
+   132, 48, 119, 144, 180, 138, 134, 193, 82, 182, 120, 121, 86, 220, 209, 3,
+   91, 241, 149, 85, 205, 150, 113, 216, 31, 100, 41, 164, 177, 214, 153, 231,
+   38, 71, 185, 174, 97, 201, 29, 95, 7, 92, 54, 254, 191, 118, 34, 221,
+   131, 11, 163, 99, 234, 81, 227, 147, 156, 176, 17, 142, 69, 12, 110, 62,
+   27, 255, 0, 194, 59, 116, 242, 252, 19, 21, 187, 53, 207, 129, 64, 135,
+   61, 40, 167, 237, 102, 223, 106, 159, 197, 189, 215, 137, 36, 32, 22, 5,
 
    // and a second copy so we don't need an extra mask or static initializer
-   23, 125, 161, 52, 103, 117, 70, 37, 247, 101, 203, 169, 124, 126, 44, 123, 
-   152, 238, 145, 45, 171, 114, 253, 10, 192, 136, 4, 157, 249, 30, 35, 72, 
-   175, 63, 77, 90, 181, 16, 96, 111, 133, 104, 75, 162, 93, 56, 66, 240, 
-   8, 50, 84, 229, 49, 210, 173, 239, 141, 1, 87, 18, 2, 198, 143, 57, 
-   225, 160, 58, 217, 168, 206, 245, 204, 199, 6, 73, 60, 20, 230, 211, 233, 
-   94, 200, 88, 9, 74, 155, 33, 15, 219, 130, 226, 202, 83, 236, 42, 172, 
-   165, 218, 55, 222, 46, 107, 98, 154, 109, 67, 196, 178, 127, 158, 13, 243, 
-   65, 79, 166, 248, 25, 224, 115, 80, 68, 51, 184, 128, 232, 208, 151, 122, 
-   26, 212, 105, 43, 179, 213, 235, 148, 146, 89, 14, 195, 28, 78, 112, 76, 
-   250, 47, 24, 251, 140, 108, 186, 190, 228, 170, 183, 139, 39, 188, 244, 246, 
-   132, 48, 119, 144, 180, 138, 134, 193, 82, 182, 120, 121, 86, 220, 209, 3, 
-   91, 241, 149, 85, 205, 150, 113, 216, 31, 100, 41, 164, 177, 214, 153, 231, 
-   38, 71, 185, 174, 97, 201, 29, 95, 7, 92, 54, 254, 191, 118, 34, 221, 
-   131, 11, 163, 99, 234, 81, 227, 147, 156, 176, 17, 142, 69, 12, 110, 62, 
-   27, 255, 0, 194, 59, 116, 242, 252, 19, 21, 187, 53, 207, 129, 64, 135, 
-   61, 40, 167, 237, 102, 223, 106, 159, 197, 189, 215, 137, 36, 32, 22, 5,  
+   23, 125, 161, 52, 103, 117, 70, 37, 247, 101, 203, 169, 124, 126, 44, 123,
+   152, 238, 145, 45, 171, 114, 253, 10, 192, 136, 4, 157, 249, 30, 35, 72,
+   175, 63, 77, 90, 181, 16, 96, 111, 133, 104, 75, 162, 93, 56, 66, 240,
+   8, 50, 84, 229, 49, 210, 173, 239, 141, 1, 87, 18, 2, 198, 143, 57,
+   225, 160, 58, 217, 168, 206, 245, 204, 199, 6, 73, 60, 20, 230, 211, 233,
+   94, 200, 88, 9, 74, 155, 33, 15, 219, 130, 226, 202, 83, 236, 42, 172,
+   165, 218, 55, 222, 46, 107, 98, 154, 109, 67, 196, 178, 127, 158, 13, 243,
+   65, 79, 166, 248, 25, 224, 115, 80, 68, 51, 184, 128, 232, 208, 151, 122,
+   26, 212, 105, 43, 179, 213, 235, 148, 146, 89, 14, 195, 28, 78, 112, 76,
+   250, 47, 24, 251, 140, 108, 186, 190, 228, 170, 183, 139, 39, 188, 244, 246,
+   132, 48, 119, 144, 180, 138, 134, 193, 82, 182, 120, 121, 86, 220, 209, 3,
+   91, 241, 149, 85, 205, 150, 113, 216, 31, 100, 41, 164, 177, 214, 153, 231,
+   38, 71, 185, 174, 97, 201, 29, 95, 7, 92, 54, 254, 191, 118, 34, 221,
+   131, 11, 163, 99, 234, 81, 227, 147, 156, 176, 17, 142, 69, 12, 110, 62,
+   27, 255, 0, 194, 59, 116, 242, 252, 19, 21, 187, 53, 207, 129, 64, 135,
+   61, 40, 167, 237, 102, 223, 106, 159, 197, 189, 215, 137, 36, 32, 22, 5,
 };
 
 static float stb__perlin_lerp(float a, float b, float t)
@@ -226,7 +226,7 @@ float stb_perlin_ridge_noise3(float x, float y, float z,float lacunarity, float 
    float amplitude = 0.5f;
    float sum = 0.0f;
 
-   for (i = 0; i < octaves; i++) {
+   for (i = 0; i < octaves; ++i) {
       float r = (float)(stb_perlin_noise3(x*frequency,y*frequency,z*frequency,x_wrap,y_wrap,z_wrap));
       r = r<0 ? -r : r; // fabs()
       r = offset - r;
@@ -245,8 +245,8 @@ float stb_perlin_fbm_noise3(float x, float y, float z,float lacunarity, float ga
    float frequency = 1.0f;
    float amplitude = 1.0f;
    float sum = 0.0f;
-   
-   for (i = 0; i < octaves; i++) {
+
+   for (i = 0; i < octaves; ++i) {
       sum += stb_perlin_noise3(x*frequency,y*frequency,z*frequency,x_wrap,y_wrap,z_wrap)*amplitude;
       frequency *= lacunarity;
       amplitude *= gain;
@@ -260,8 +260,8 @@ float stb_perlin_turbulence_noise3(float x, float y, float z, float lacunarity, 
    float frequency = 1.0f;
    float amplitude = 1.0f;
    float sum = 0.0f;
-   
-   for (i = 0; i < octaves; i++) {
+
+   for (i = 0; i < octaves; ++i) {
       float r = stb_perlin_noise3(x*frequency,y*frequency,z*frequency,x_wrap,y_wrap,z_wrap)*amplitude;
       r = r<0 ? -r : r; // fabs()
       sum += r;
@@ -279,38 +279,38 @@ This software is available under 2 licenses -- choose whichever you prefer.
 ------------------------------------------------------------------------------
 ALTERNATIVE A - MIT License
 Copyright (c) 2017 Sean Barrett
-Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the "Software"), to deal in 
-the Software without restriction, including without limitation the rights to 
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
-of the Software, and to permit persons to whom the Software is furnished to do 
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
 so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ------------------------------------------------------------------------------
 ALTERNATIVE B - Public Domain (www.unlicense.org)
 This is free and unencumbered software released into the public domain.
-Anyone is free to copy, modify, publish, use, compile, sell, or distribute this 
-software, either in source code form or as a compiled binary, for any purpose, 
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
 commercial or non-commercial, and by any means.
-In jurisdictions that recognize copyright laws, the author or authors of this 
-software dedicate any and all copyright interest in the software to the public 
-domain. We make this dedication for the benefit of the public at large and to 
-the detriment of our heirs and successors. We intend this dedication to be an 
-overt act of relinquishment in perpetuity of all present and future rights to 
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
 this software under copyright law.
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN 
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */

--- a/examples/opengl/gl.h
+++ b/examples/opengl/gl.h
@@ -7559,7 +7559,7 @@ static int glad_gl_get_extensions( int version, const char **out_exts, unsigned 
         if (exts_i == NULL) {
             return 0;
         }
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             const char *gl_str_tmp = (const char*) glad_glGetStringi(GL_EXTENSIONS, index);
             size_t len = strlen(gl_str_tmp) + 1;
 
@@ -7580,7 +7580,7 @@ static int glad_gl_get_extensions( int version, const char **out_exts, unsigned 
 static void glad_gl_free_extensions(char **exts_i, unsigned int num_exts_i) {
     if (exts_i != NULL) {
         unsigned int index;
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             free((void *) (exts_i[index]));
         }
         free((void *)exts_i);
@@ -7610,7 +7610,7 @@ static int glad_gl_has_extension(int version, const char *exts, unsigned int num
         }
     } else {
         unsigned int index;
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             const char *e = exts_i[index];
             if(strcmp(e, ext) == 0) {
                 return 1;
@@ -7682,7 +7682,7 @@ static int glad_gl_find_core_gl(void) {
     };
     version = (const char*) glad_glGetString(GL_VERSION);
     if (!version) return 0;
-    for (i = 0;  prefixes[i];  i++) {
+    for (i = 0;  prefixes[i];  ++i) {
         const size_t length = strlen(prefixes[i]);
         if (strncmp(version, prefixes[i], length) == 0) {
             version += length;
@@ -7783,7 +7783,7 @@ static int glad_gl_find_core_gles1(void) {
     };
     version = (const char*) glad_glGetString(GL_VERSION);
     if (!version) return 0;
-    for (i = 0;  prefixes[i];  i++) {
+    for (i = 0;  prefixes[i];  ++i) {
         const size_t length = strlen(prefixes[i]);
         if (strncmp(version, prefixes[i], length) == 0) {
             version += length;
@@ -7830,7 +7830,7 @@ int gladLoadGLES1( GLADloadfunc load) {
 
 
 
- 
+
 
 
 #endif /* GLAD_GL_IMPLEMENTATION */

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -282,7 +282,7 @@ public:
             return false;
 
         // Move the points in the point cloud to random positions
-        for (std::size_t i = 0; i < 10000; i++)
+        for (std::size_t i = 0; i < 10000; ++i)
         {
             // Spread the coordinates from -480 to +480
             // So they'll always fill the viewport at 800x600
@@ -427,7 +427,7 @@ int main()
                         if (current == 0)
                             current = effects.size() - 1;
                         else
-                            current--;
+                            --current;
                         description.setString("Current effect: " + effects[current]->getName());
                         break;
 
@@ -436,7 +436,7 @@ int main()
                         if (current == effects.size() - 1)
                             current = 0;
                         else
-                            current++;
+                            ++current;
                         description.setString("Current effect: " + effects[current]->getName());
                         break;
 

--- a/examples/shader/resources/billboard.geom
+++ b/examples/shader/resources/billboard.geom
@@ -25,7 +25,7 @@ void main()
     half_size /= resolution;
 
     // Iterate over all vertices
-    for (int i = 0; i < gl_in.length(); i++)
+    for (int i = 0; i < gl_in.length(); ++i)
     {
         // Retrieve the passed vertex position
         vec2 pos = gl_in[i].gl_Position.xy;

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -29,9 +29,9 @@ namespace
     {
         Matrix temp;
 
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < 4; ++i)
         {
-            for (int j = 0; j < 4; j++)
+            for (int j = 0; j < 4; ++j)
                 temp[i][j] = left[0][j] * right[i][0] + left[1][j] * right[i][1] + left[2][j] * right[i][2] + left[3][j] * right[i][3];
         }
 
@@ -665,7 +665,7 @@ public:
 
         vkGetPhysicalDeviceQueueFamilyProperties(gpu, &objectCount, queueFamilyProperties.data());
 
-        for (std::size_t i = 0; i < queueFamilyProperties.size(); i++)
+        for (std::size_t i = 0; i < queueFamilyProperties.size(); ++i)
         {
             VkBool32 surfaceSupported = VK_FALSE;
 
@@ -870,7 +870,7 @@ public:
         imageViewCreateInfo.subresourceRange.layerCount = 1;
 
         // Create an image view for each swapchain image
-        for (std::size_t i = 0; i < swapchainImages.size(); i++)
+        for (std::size_t i = 0; i < swapchainImages.size(); ++i)
         {
             imageViewCreateInfo.image = swapchainImages[i];
 
@@ -1220,7 +1220,7 @@ public:
         framebufferCreateInfo.height = swapchainExtent.height;
         framebufferCreateInfo.layers = 1;
 
-        for (std::size_t i = 0; i < swapchainFramebuffers.size(); i++)
+        for (std::size_t i = 0; i < swapchainFramebuffers.size(); ++i)
         {
             // Each framebuffer consists of a corresponding swapchain image and the shared depth image
             VkImageView attachments[] = {swapchainImageViews[i], depthImageView};
@@ -1277,7 +1277,7 @@ public:
 
         uint32_t memoryType = 0;
 
-        for (; memoryType < memoryProperties.memoryTypeCount; memoryType++)
+        for (; memoryType < memoryProperties.memoryTypeCount; ++memoryType)
         {
             if ((memoryRequirements.memoryTypeBits & static_cast<unsigned int>(1 << memoryType)) &&
                 ((memoryProperties.memoryTypes[memoryType].propertyFlags & properties) == properties))
@@ -1546,7 +1546,7 @@ public:
     void setupUniformBuffers()
     {
         // Create a uniform buffer for every frame that might be in flight to prevent clobbering
-        for (size_t i = 0; i < swapchainImages.size(); i++)
+        for (size_t i = 0; i < swapchainImages.size(); ++i)
         {
             uniformBuffers.push_back(0);
             uniformBuffersMemory.push_back(0);
@@ -1599,7 +1599,7 @@ public:
 
         uint32_t memoryType = 0;
 
-        for (; memoryType < memoryProperties.memoryTypeCount; memoryType++)
+        for (; memoryType < memoryProperties.memoryTypeCount; ++memoryType)
         {
             if ((memoryRequirements.memoryTypeBits & static_cast<unsigned int>(1 << memoryType)) &&
                 ((memoryProperties.memoryTypes[memoryType].propertyFlags & properties) == properties))
@@ -2124,7 +2124,7 @@ public:
         }
 
         // For every descriptor set, set up the bindings to our uniform buffer and texture sampler
-        for (std::size_t i = 0; i < descriptorSets.size(); i++)
+        for (std::size_t i = 0; i < descriptorSets.size(); ++i)
         {
             VkWriteDescriptorSet writeDescriptorSets[2];
 
@@ -2218,7 +2218,7 @@ public:
         commandBufferBeginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
 
         // Set up the command buffers for each frame in flight
-        for (std::size_t i = 0; i < commandBuffers.size(); i++)
+        for (std::size_t i = 0; i < commandBuffers.size(); ++i)
         {
             // Begin the command buffer
             if (vkBeginCommandBuffer(commandBuffers[i], &commandBufferBeginInfo) != VK_SUCCESS)
@@ -2268,7 +2268,7 @@ public:
         semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
         // Create a semaphore to track when an swapchain image is available for each frame in flight
-        for (std::size_t i = 0; i < maxFramesInFlight; i++)
+        for (std::size_t i = 0; i < maxFramesInFlight; ++i)
         {
             imageAvailableSemaphores.push_back(0);
 
@@ -2281,7 +2281,7 @@ public:
         }
 
         // Create a semaphore to track when rendering is complete for each frame in flight
-        for (std::size_t i = 0; i < maxFramesInFlight; i++)
+        for (std::size_t i = 0; i < maxFramesInFlight; ++i)
         {
             renderFinishedSemaphores.push_back(0);
 
@@ -2303,7 +2303,7 @@ public:
         fenceCreateInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
         // Create a fence to track when queue submission is complete for each frame in flight
-        for (std::size_t i = 0; i < maxFramesInFlight; i++)
+        for (std::size_t i = 0; i < maxFramesInFlight; ++i)
         {
             fences.push_back(0);
 

--- a/examples/window/gl.h
+++ b/examples/window/gl.h
@@ -7559,7 +7559,7 @@ static int glad_gl_get_extensions( int version, const char **out_exts, unsigned 
         if (exts_i == NULL) {
             return 0;
         }
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             const char *gl_str_tmp = (const char*) glad_glGetStringi(GL_EXTENSIONS, index);
             size_t len = strlen(gl_str_tmp) + 1;
 
@@ -7580,7 +7580,7 @@ static int glad_gl_get_extensions( int version, const char **out_exts, unsigned 
 static void glad_gl_free_extensions(char **exts_i, unsigned int num_exts_i) {
     if (exts_i != NULL) {
         unsigned int index;
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             free((void *) (exts_i[index]));
         }
         free((void *)exts_i);
@@ -7610,7 +7610,7 @@ static int glad_gl_has_extension(int version, const char *exts, unsigned int num
         }
     } else {
         unsigned int index;
-        for(index = 0; index < num_exts_i; index++) {
+        for(index = 0; index < num_exts_i; ++index) {
             const char *e = exts_i[index];
             if(strcmp(e, ext) == 0) {
                 return 1;
@@ -7682,7 +7682,7 @@ static int glad_gl_find_core_gl(void) {
     };
     version = (const char*) glad_glGetString(GL_VERSION);
     if (!version) return 0;
-    for (i = 0;  prefixes[i];  i++) {
+    for (i = 0;  prefixes[i];  ++i) {
         const size_t length = strlen(prefixes[i]);
         if (strncmp(version, prefixes[i], length) == 0) {
             version += length;
@@ -7783,7 +7783,7 @@ static int glad_gl_find_core_gles1(void) {
     };
     version = (const char*) glad_glGetString(GL_VERSION);
     if (!version) return 0;
-    for (i = 0;  prefixes[i];  i++) {
+    for (i = 0;  prefixes[i];  ++i) {
         const size_t length = strlen(prefixes[i]);
         if (strncmp(version, prefixes[i], length) == 0) {
             version += length;
@@ -7830,7 +7830,7 @@ int gladLoadGLES1( GLADloadfunc load) {
 
 
 
- 
+
 
 
 #endif /* GLAD_GL_IMPLEMENTATION */

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -465,7 +465,7 @@ Out Utf<16>::toLatin1(In begin, In end, Out output, char replacement)
     while (begin < end)
     {
         *output++ = *begin < 256 ? static_cast<char>(*begin) : replacement;
-        begin++;
+        ++begin;
     }
 
     return output;
@@ -607,7 +607,7 @@ Out Utf<32>::toLatin1(In begin, In end, Out output, char replacement)
     while (begin < end)
     {
         *output++ = *begin < 256 ? static_cast<char>(*begin) : replacement;
-        begin++;
+        ++begin;
     }
 
     return output;

--- a/src/SFML/Audio/AlResource.cpp
+++ b/src/SFML/Audio/AlResource.cpp
@@ -57,7 +57,7 @@ AlResource::AlResource()
         globalDevice = std::make_unique<priv::AudioDevice>();
 
     // Increment the resources counter
-    count++;
+    ++count;
 }
 
 
@@ -68,7 +68,7 @@ AlResource::~AlResource()
     std::scoped_lock lock(mutex);
 
     // Decrement the resources counter
-    count--;
+    --count;
 
     // If there's no more resource alive, we can destroy the device
     if (count == 0)

--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -143,7 +143,7 @@ namespace
                 {
                     // If there's room in the output buffer, copy the sample there
                     *data->buffer++ = sample;
-                    data->remaining--;
+                    --data->remaining;
                 }
                 else
                 {

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -508,7 +508,7 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
     states->inputQueue = nullptr;
     states->config     = nullptr;
 
-    for (unsigned int i = 0; i < sf::Mouse::ButtonCount; i++)
+    for (unsigned int i = 0; i < sf::Mouse::ButtonCount; ++i)
         states->isButtonPressed[i] = false;
 
     gladLoaderLoadEGL(EGL_DEFAULT_DISPLAY);

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -563,11 +563,11 @@ Ftp::Response Ftp::DataChannel::open(Ftp::TransferMode mode)
                 while (isdigit(str[index]))
                 {
                     datum = static_cast<Uint8>(static_cast<Uint8>(datum * 10) + static_cast<Uint8>(str[index] - '0'));
-                    index++;
+                    ++index;
                 }
 
                 // Skip separator
-                index++;
+                ++index;
             }
 
             // Reconstruct connection port and address

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -245,7 +245,7 @@ void Http::Response::parse(const std::string& data)
             // Copy the actual content data
             std::istreambuf_iterator<char> it(in);
             std::istreambuf_iterator<char> itEnd;
-            for (std::size_t i = 0; ((i < length) && (it != itEnd)); i++)
+            for (std::size_t i = 0; ((i < length) && (it != itEnd)); ++i)
                 m_body.push_back(*it++);
         }
 

--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -91,7 +91,7 @@ void SocketSelector::add(Socket& socket)
         if (FD_ISSET(handle, &m_impl->allSockets))
             return;
 
-        m_impl->socketCount++;
+        ++m_impl->socketCount;
 
 #else
 
@@ -125,7 +125,7 @@ void SocketSelector::remove(Socket& socket)
         if (!FD_ISSET(handle, &m_impl->allSockets))
             return;
 
-        m_impl->socketCount--;
+        --m_impl->socketCount;
 
 #else
 

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -465,7 +465,7 @@ int WindowImplAndroid::processMotionEvent(AInputEvent* _event, ActivityStates& s
 
     size_t pointerCount = AMotionEvent_getPointerCount(_event);
 
-    for (size_t p = 0; p < pointerCount; p++)
+    for (size_t p = 0; p < pointerCount; ++p)
     {
         int32_t id = AMotionEvent_getPointerId(_event, p);
 

--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -256,7 +256,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
 
             if (usage == HUP_BUTTON)
             {
-                caps.buttonCount++;
+                ++caps.buttonCount;
                 break;
             }
             else if (usage == HUP_GENERIC_DESKTOP)

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -275,7 +275,7 @@ namespace
                     const char* extension = extensionString;
 
                     while (*extensionString && (*extensionString != ' '))
-                        extensionString++;
+                        ++extensionString;
 
                     extensions.emplace_back(extension, extensionString);
                 }
@@ -343,7 +343,7 @@ void GlContext::initResource()
         if (sharedContext)
         {
             // Increment the resources counter
-            resourceCount++;
+            ++resourceCount;
 
             return;
         }
@@ -360,7 +360,7 @@ void GlContext::initResource()
     }
 
     // Increment the resources counter
-    resourceCount++;
+    ++resourceCount;
 }
 
 
@@ -375,7 +375,7 @@ void GlContext::cleanupResource()
     std::scoped_lock lock(mutex);
 
     // Decrement the resources counter
-    resourceCount--;
+    --resourceCount;
 
     // If there's no more resource alive, we can trigger the global context cleanup
     if (resourceCount == 0)
@@ -412,7 +412,7 @@ void GlContext::acquireTransientContext()
         transientContext = std::make_unique<TransientContext>();
 
     // Increase the reference count
-    transientContext->referenceCount++;
+    ++transientContext->referenceCount;
 }
 
 
@@ -429,7 +429,7 @@ void GlContext::releaseTransientContext()
     assert(transientContext);
 
     // Decrease the reference count
-    transientContext->referenceCount--;
+    --transientContext->referenceCount;
 
     // If this is the last TransientContextLock that is released
     // destroy the state object

--- a/src/SFML/Window/NetBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/NetBSD/JoystickImpl.cpp
@@ -261,7 +261,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
 
             if (usage == HUP_BUTTON)
             {
-                caps.buttonCount++;
+                ++caps.buttonCount;
                 break;
             }
             else if (usage == HUP_GENERIC_DESKTOP)

--- a/src/SFML/Window/OSX/HIDJoystickManager.cpp
+++ b/src/SFML/Window/OSX/HIDJoystickManager.cpp
@@ -134,7 +134,7 @@ void HIDJoystickManager::update()
 void HIDJoystickManager::pluggedIn(void* context, IOReturn, void*, IOHIDDeviceRef)
 {
     HIDJoystickManager* manager = static_cast<HIDJoystickManager*>(context);
-    manager->m_joystickCount++;
+    ++manager->m_joystickCount;
 }
 
 
@@ -142,7 +142,7 @@ void HIDJoystickManager::pluggedIn(void* context, IOReturn, void*, IOHIDDeviceRe
 void HIDJoystickManager::pluggedOut(void* context, IOReturn, void*, IOHIDDeviceRef)
 {
     HIDJoystickManager* manager = static_cast<HIDJoystickManager*>(context);
-    manager->m_joystickCount--;
+    --manager->m_joystickCount;
 }
 
 

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -128,7 +128,7 @@ bool JoystickImpl::isConnected(unsigned int index)
         for (unsigned int i(0); i < sf::Joystick::Count; ++i)
         {
             if (m_locationIDs[i] != 0)
-                openedCount++;
+                ++openedCount;
         }
 
 

--- a/src/SFML/Window/OSX/VideoModeImpl.cpp
+++ b/src/SFML/Window/OSX/VideoModeImpl.cpp
@@ -55,7 +55,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 
     // Loop on each mode and convert it into a sf::VideoMode object.
     const CFIndex modesCount = CFArrayGetCount(cgmodes);
-    for (CFIndex i = 0; i < modesCount; i++)
+    for (CFIndex i = 0; i < modesCount; ++i)
     {
         CGDisplayModeRef cgmode = static_cast<CGDisplayModeRef>(const_cast<void*>(CFArrayGetValueAtIndex(cgmodes, i)));
 

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -70,7 +70,7 @@ Display* OpenDisplay()
         }
     }
 
-    referenceCount++;
+    ++referenceCount;
     return sharedDisplay;
 }
 
@@ -82,7 +82,7 @@ void CloseDisplay(Display* display)
 
     assert(display == sharedDisplay);
 
-    referenceCount--;
+    --referenceCount;
     if (referenceCount == 0)
         XCloseDisplay(display);
 }
@@ -120,7 +120,7 @@ XIM OpenXIM()
             XSetLocaleModifiers(prevXLoc.c_str());
     }
 
-    referenceCountXIM++;
+    ++referenceCountXIM;
 
     return sharedXIM;
 }
@@ -132,7 +132,7 @@ void CloseXIM(XIM xim)
 
     assert(xim == sharedXIM);
 
-    referenceCountXIM--;
+    --referenceCountXIM;
 
     if ((referenceCountXIM == 0) && (xim != nullptr))
         XCloseIM(xim);

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -740,14 +740,14 @@ void GlxContext::createContext(GlxContext* shared)
                 else if (m_settings.minorVersion > 0)
                 {
                     // If the minor version is not 0, we decrease it and try again
-                    m_settings.minorVersion--;
+                    --m_settings.minorVersion;
 
                     m_settings.attributeFlags = settings.attributeFlags;
                 }
                 else
                 {
                     // If the minor version is 0, we decrease the major version
-                    m_settings.majorVersion--;
+                    --m_settings.majorVersion;
                     m_settings.minorVersion = 9;
 
                     m_settings.attributeFlags = settings.attributeFlags;

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1372,7 +1372,7 @@ void WindowImplX11::setVideoMode(const VideoMode& mode)
     bool modeFound = false;
     RRMode xRandMode;
 
-    for (int i = 0; (i < res->nmode) && !modeFound; i++)
+    for (int i = 0; (i < res->nmode) && !modeFound; ++i)
     {
         if (crtcInfo->rotation == RR_Rotate_90 || crtcInfo->rotation == RR_Rotate_270)
             std::swap(res->modes[i].height, res->modes[i].width);

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -683,14 +683,14 @@ void WglContext::createContext(WglContext* shared)
             else if (m_settings.minorVersion > 0)
             {
                 // If the minor version is not 0, we decrease it and try again
-                m_settings.minorVersion--;
+                --m_settings.minorVersion;
 
                 m_settings.attributeFlags = settings.attributeFlags;
             }
             else
             {
                 // If the minor version is 0, we decrease the major version
-                m_settings.majorVersion--;
+                --m_settings.majorVersion;
                 m_settings.minorVersion = 9;
 
                 m_settings.attributeFlags = settings.attributeFlags;

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -233,7 +233,7 @@ m_cursorGrabbed   (m_fullscreen)
         switchToFullscreen(mode);
 
     // Increment window count
-    windowCount++;
+    ++windowCount;
 }
 
 
@@ -262,7 +262,7 @@ WindowImplWin32::~WindowImplWin32()
             DestroyWindow(m_handle);
 
         // Decrement the window count
-        windowCount--;
+        --windowCount;
 
         // Unregister window class if we were the last window
         if (windowCount == 0)

--- a/src/SFML/Window/iOS/SensorImpl.mm
+++ b/src/SFML/Window/iOS/SensorImpl.mm
@@ -220,11 +220,11 @@ void SensorImpl::setEnabled(bool enabled)
             {
                 if (deviceMotionEnabledCount == 0)
                     [[SFAppDelegate getInstance].motionManager startDeviceMotionUpdates];
-                deviceMotionEnabledCount++;
+                ++deviceMotionEnabledCount;
             }
             else
             {
-                deviceMotionEnabledCount--;
+                --deviceMotionEnabledCount;
                 if (deviceMotionEnabledCount == 0)
                     [[SFAppDelegate getInstance].motionManager stopDeviceMotionUpdates];
             }


### PR DESCRIPTION
## Description

This PR changes `x++` to `++x` in every occasion where the side-effect of returning the previous value of post-increment is not necessary. The main reason for this change is clarity and simplicity, but there might be minor performance gains when compiling in debug mode without optimization. 

Generally speaking:
- `x++` means *"make a copy of `x`, increment `x`, return the copy"*
- `++x` means *"increment `x`"*

You can see that one is simpler than the other. If we don't need the extra effects of post-increment, we should stick to pre-increment. It also promotes good practice to our users.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.