### PR TITLE
Remove unused CMake variables

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -81,50 +81,19 @@ if(SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
     set(SFML_PKGCONFIG_DIR "/libdata/pkgconfig")
 endif()
 
-# detect the compiler and its version
+# detect the compiler
 # Note: The detection is order is important because:
 # - Visual Studio can both use MSVC and Clang
 # - GNUCXX can still be set on macOS when using Clang
 if(MSVC)
     set(SFML_COMPILER_MSVC 1)
-
-    if(MSVC_VERSION EQUAL 1400)
-        set(SFML_MSVC_VERSION 8)
-    elseif(MSVC_VERSION EQUAL 1500)
-        set(SFML_MSVC_VERSION 9)
-    elseif(MSVC_VERSION EQUAL 1600)
-        set(SFML_MSVC_VERSION 10)
-    elseif(MSVC_VERSION EQUAL 1700)
-        set(SFML_MSVC_VERSION 11)
-    elseif(MSVC_VERSION EQUAL 1800)
-        set(SFML_MSVC_VERSION 12)
-    elseif(MSVC_VERSION EQUAL 1900)
-        set(SFML_MSVC_VERSION 14)
-    elseif(MSVC_VERSION LESS_EQUAL 1919)
-        set(SFML_MSVC_VERSION 15)
-    elseif(MSVC_VERSION LESS_EQUAL 1929)
-        set(SFML_MSVC_VERSION 16)
-    elseif(MSVC_VERSION LESS_EQUAL 1939)
-        set(SFML_MSVC_VERSION 17)
-    endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(SFML_COMPILER_CLANG 1)
-
-    execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "--version" OUTPUT_VARIABLE CLANG_VERSION_OUTPUT)
-    string(REGEX REPLACE ".*clang version ([0-9]+\\.[0-9]+).*" "\\1" SFML_CLANG_VERSION "${CLANG_VERSION_OUTPUT}")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
     set(SFML_COMPILER_GCC 1)
 
-    execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "-dumpversion" OUTPUT_VARIABLE GCC_VERSION_OUTPUT)
-    string(REGEX REPLACE "([0-9]+\\.[0-9]+).*" "\\1" SFML_GCC_VERSION "${GCC_VERSION_OUTPUT}")
     execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "--version" OUTPUT_VARIABLE GCC_COMPILER_VERSION)
     string(REGEX MATCHALL ".*(tdm[64]*-[1-9]).*" SFML_COMPILER_GCC_TDM "${GCC_COMPILER_VERSION}")
-    execute_process(COMMAND "${CMAKE_CXX_COMPILER}" "-dumpmachine" OUTPUT_VARIABLE GCC_MACHINE)
-    string(STRIP "${GCC_MACHINE}" GCC_MACHINE)
-
-    if(GCC_MACHINE MATCHES ".*w64.*")
-        set(SFML_COMPILER_GCC_W64 1)
-    endif()
 else()
     message(FATAL_ERROR "Unsupported compiler")
     return()


### PR DESCRIPTION
## Description

This PR removes a number of compiler version CMake variables that never get used.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
