### PR TITLE
Revert accidental filesystem conversion

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -109,7 +109,7 @@ AudioDevice::~AudioDevice()
 
 
 ////////////////////////////////////////////////////////////
-bool AudioDevice::isExtensionSupported(const std::filesystem::path& extension)
+bool AudioDevice::isExtensionSupported(const std::string& extension)
 {
     // Create a temporary audio device in case none exists yet.
     // This device will not be used in this function and merely
@@ -119,10 +119,10 @@ bool AudioDevice::isExtensionSupported(const std::filesystem::path& extension)
     if (!audioDevice)
         device.emplace();
 
-    if ((extension.string().length() > 2) && (extension.string().substr(0, 3) == "ALC"))
-        return alcIsExtensionPresent(audioDevice, extension.string().c_str()) != AL_FALSE;
+    if ((extension.length() > 2) && (extension.substr(0, 3) == "ALC"))
+        return alcIsExtensionPresent(audioDevice, extension.c_str()) != AL_FALSE;
     else
-        return alIsExtensionPresent(extension.string().c_str()) != AL_FALSE;
+        return alIsExtensionPresent(extension.c_str()) != AL_FALSE;
 }
 
 

--- a/src/SFML/Audio/AudioDevice.hpp
+++ b/src/SFML/Audio/AudioDevice.hpp
@@ -29,7 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Vector3.hpp>
-#include <filesystem>
+#include <string>
 
 
 namespace sf
@@ -70,7 +70,7 @@ public:
     /// \return True if the extension is supported, false if not
     ///
     ////////////////////////////////////////////////////////////
-    static bool isExtensionSupported(const std::filesystem::path& extension);
+    static bool isExtensionSupported(const std::string& extension);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the OpenAL format that matches the given number of channels


### PR DESCRIPTION
## Description

This fixes a mistake I introduced in #1964. "extension" in this context is not referring to a file extension.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
