### PR TITLE
Simplify CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: ${{ matrix.platform.name }} ${{ matrix.config.name }}
+    name: ${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}
     runs-on: ${{ matrix.platform.os }}
 
     strategy:
@@ -13,16 +13,23 @@ jobs:
         platform:
         - { name: Windows VS2019, os: windows-2019 }
         - { name: Windows VS2022, os: windows-2022 }
-        - { name: Linux GCC,      os: ubuntu-latest  }
-        - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
-        - { name: MacOS XCode,    os: macos-latest   }
+        - { name: Linux GCC,      os: ubuntu-latest }
+        - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++, gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
+        - { name: MacOS XCode,    os: macos-latest }
         config:
-        - { name: Shared,       flags: -DBUILD_SHARED_LIBS=TRUE }
-        - { name: Static,       flags: -DBUILD_SHARED_LIBS=FALSE }
+        - { name: Shared, flags: -DBUILD_SHARED_LIBS=TRUE }
+        - { name: Static, flags: -DBUILD_SHARED_LIBS=FALSE }
+        type:
+        - { name: Release }
+        - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
 
         include:
         - platform: { name: Windows VS2022, os: windows-2022 }
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
+          type: { name: Release }
+        - platform: { name: Windows VS2022, os: windows-2022 }
+          config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
+          type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
         - platform: { name: MacOS XCode, os: macos-latest }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }
         - platform: { name: MacOS XCode, os: macos-latest }
@@ -31,27 +38,14 @@ jobs:
           config: { name: x86, flags: -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r23b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
         - platform: { name: Android, os: ubuntu-latest }
           config: { name: armeabi-v7a, flags: -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r23b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
+
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
 
-    - name: Detect Linux Clang Version
+    - name: Install Linux Dependencies
       if: runner.os == 'Linux'
-      run: clang++ --version | sed -n 's/.*version \([0-9]\+\)\..*/clang_version=\1/p' >> $GITHUB_ENV
-
-    - name: Install Linux Tools and Dependencies
-      if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install gcovr llvm-${{ env.clang_version }} libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev
-
-    - name: Install macOS Tools and Dependencies
-      if: runner.os == 'macOS'
-      run: brew install gcovr
-
-    - name: Install OpenCppCoverage and add to PATH
-      if: runner.os == 'Windows'
-      run: |
-        choco install OpenCppCoverage -y
-        echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+      run: sudo apt-get update && sudo apt-get install libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev
 
     - name: Install Android Components
       if: matrix.platform.name == 'Android'
@@ -61,45 +55,37 @@ jobs:
         wget -nv https://dl.google.com/android/repository/android-ndk-r23b-linux.zip -P $GITHUB_WORKSPACE
         unzip -qq -d $GITHUB_WORKSPACE android-ndk-r23b-linux.zip
 
+    - name: Install Linux Tools
+      if: matrix.type.name == 'Debug' && runner.os == 'Linux'
+      run: |
+        CLANG_VERSION=$(clang++ --version | sed -n 's/.*version \([0-9]\+\)\..*/\1/p')
+        echo "CLANG_VERSION=$CLANG_VERSION" >> $GITHUB_ENV
+        sudo apt-get install gcovr ${{ matrix.platform.name == 'Linux Clang' && 'llvm-$CLANG_VERSION' || '' }}
+
+    - name: Install macOS Tools
+      if: matrix.type.name == 'Debug' && runner.os == 'macOS'
+      run: brew install gcovr
+
+    - name: Install OpenCppCoverage and add to PATH
+      if: matrix.type.name == 'Debug' && runner.os == 'Windows'
+      run: |
+        choco install OpenCppCoverage -y
+        echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+
     - name: Configure CMake
       shell: bash
-      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install -DSFML_BUILD_EXAMPLES=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_ENABLE_COVERAGE=TRUE ${{matrix.platform.flags}} ${{matrix.config.flags}}
+      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install -DSFML_BUILD_EXAMPLES=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_BUILD_TEST_SUITE=TRUE ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
 
     - name: Build
       shell: bash
-      run: cmake --build $GITHUB_WORKSPACE/build --config Release --target install
+      run: cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
 
-    - name: Generate OpenCppCoverage Coverage Report
-      if: matrix.platform.name == 'Windows VS2019' || matrix.platform.name == 'Windows VS2022'
-      shell: bash
-      run: cmake --build $GITHUB_WORKSPACE/build --config Debug --target runtests
-
-    - name: Generate GCC Gcov Coverage Report
-      if: matrix.platform.name == 'Linux GCC'
-      shell: bash
-      run: |
-        cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install -DCMAKE_BUILD_TYPE=Debug -DSFML_BUILD_EXAMPLES=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_ENABLE_COVERAGE=TRUE ${{matrix.platform.flags}} ${{matrix.config.flags}}
-        cmake --build $GITHUB_WORKSPACE/build --target runtests
-        gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' $GITHUB_WORKSPACE
-
-    - name: Generate Clang Gcov Coverage Report
-      if: matrix.platform.name == 'Linux Clang'
-      shell: bash
-      run: |
-        cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install -DCMAKE_BUILD_TYPE=Debug -DSFML_BUILD_EXAMPLES=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_ENABLE_COVERAGE=TRUE ${{matrix.platform.flags}} ${{matrix.config.flags}}
-        cmake --build $GITHUB_WORKSPACE/build --target runtests
-        gcovr --gcov-executable="llvm-cov-${{ env.clang_version }} gcov" -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' $GITHUB_WORKSPACE
-
-    - name: Generate Apple Clang Gcov Coverage Report
-      if: matrix.platform.name == 'MacOS XCode' && (matrix.config.name == 'Shared' || matrix.config.name == 'Static')
-      shell: bash
-      run: |
-        cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install -DCMAKE_BUILD_TYPE=Debug -DSFML_BUILD_EXAMPLES=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_ENABLE_COVERAGE=TRUE ${{matrix.platform.flags}} ${{matrix.config.flags}}
-        cmake --build $GITHUB_WORKSPACE/build --target runtests
-        gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' $GITHUB_WORKSPACE
+    - name: Generate Coverage Report
+      if: matrix.type.name == 'Debug' && runner.os != 'Windows' # Coverage is already generated on Windows when running tests.
+      run: gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE
 
     - name: Upload Coverage Report to Codecov
-      if: matrix.platform.name == 'Windows VS2019' || matrix.platform.name == 'Windows VS2022' || matrix.platform.name == 'Linux GCC' || matrix.platform.name == 'Linux Clang' || (matrix.platform.name == 'MacOS XCode' && (matrix.config.name == 'Shared' || matrix.config.name == 'Static'))
+      if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' # Disable upload in forks
       uses: codecov/codecov-action@v2
       with:
         directory: ./build


### PR DESCRIPTION
## Description

I was bothered by the CI failing in my fork because it cannot upload code coverage results so I added a condition to upload coverage results only from the original repository.

While at it, I simplified the workflow file.
It changes a few things that I thought would be ok:
- Code coverage generation is done in separate jobs.
- ~~Code coverage is generated for shared libraries but no more for static libraries.~~
- ~~Code coverage is no more generated for VS Unity build.~~

@binary1248 Does it look ok?

## How to test this PR?

CI