### PR TITLE
Abort infinite looping in SoundStream::streamData

### DIFF
--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -38,6 +38,15 @@
     #endif
 #endif
 
+namespace
+{
+    // A nested named namespace is used here to allow unity builds of SFML.
+    namespace AlCheckImpl
+    {
+        thread_local ALenum lastError(AL_NO_ERROR);
+    }
+}
+
 namespace sf
 {
 namespace priv
@@ -50,6 +59,8 @@ void alCheckError(const std::filesystem::path& file, unsigned int line, const ch
 
     if (errorCode != AL_NO_ERROR)
     {
+        AlCheckImpl::lastError = errorCode;
+
         std::string error = "Unknown error";
         std::string description = "No description";
 
@@ -99,6 +110,13 @@ void alCheckError(const std::filesystem::path& file, unsigned int line, const ch
               << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
     }
+}
+
+
+////////////////////////////////////////////////////////////
+ALenum alGetLastErrorImpl()
+{
+    return std::exchange(AlCheckImpl::lastError, AL_NO_ERROR);
 }
 
 } // namespace priv

--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -56,11 +56,13 @@ namespace priv
     // If in debug mode, perform a test on every call
     // The do-while loop is needed so that alCheck can be used as a single statement in if/else branches
     #define alCheck(expr) do { expr; sf::priv::alCheckError(__FILE__, __LINE__, #expr); } while (false)
+    #define alGetLastError sf::priv::alGetLastErrorImpl
 
 #else
 
     // Else, we don't add any overhead
     #define alCheck(expr) (expr)
+    #define alGetLastError alGetError
 
 #endif
 
@@ -74,6 +76,15 @@ namespace priv
 ///
 ////////////////////////////////////////////////////////////
 void alCheckError(const std::filesystem::path& file, unsigned int line, const char* expression);
+
+
+////////////////////////////////////////////////////////////
+/// Get the last OpenAL error on this thread
+///
+/// \return The last OpenAL error on this thread
+///
+////////////////////////////////////////////////////////////
+ALenum alGetLastErrorImpl();
 
 } // namespace priv
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -385,6 +385,15 @@ void SoundStream::streamData()
             }
         }
 
+        // Check if any error has occurred
+        if (alGetLastError() != AL_NO_ERROR)
+        {
+            // Abort streaming (exit main loop)
+            std::scoped_lock lock(m_threadMutex);
+            m_isStreaming = false;
+            break;
+        }
+
         // Leave some time for the other threads if the stream is still playing
         if (SoundSource::getStatus() != Stopped)
             sleep(m_processingInterval);


### PR DESCRIPTION
Fixes #1831.

It is not uncommon that audio adapters are used that have a USB interface. When all audio adapters are no longer available on Windows, OpenAL will "go crazy". Most OpenAL function calls will cause an OpenAL error to be reported, and any queries will return unpredictable data.

When running the sound example using an OpenAL DLL from the latest release (version 1.21.1) and disabling all audio adapters while music is playing, certain conditions in OpenAL could lead to the main loop in `SoundStream::streamData` never terminating and also never sleeping causing 100% CPU load on that thread.

This PR fixes this problem by forcibly terminating the loop if an OpenAL error is detected.

Steps to reproduce:
1. Build latest SFML with examples
2. Replace the bundled openal32.dll with a DLL from https://openal-soft.org/openal-binaries/openal-soft-1.21.1-bin.zip (rename the DLL to openal32.dll)
3. Run the sound example
4. When the music is playing, disable all audio output devices in Windows
5. If you are (un-)lucky you will end up in an infinite loop, if testing in debug, the console will get flooded so fast with error messages that the program might end up crashing
6. If you can't reproduce the problem, keep repeating steps 3 and 4 until it occurs