### PR TITLE
Add sin/cos/tan helpers for sf::Angle

### DIFF
--- a/examples/X11/X11.cpp
+++ b/examples/X11/X11.cpp
@@ -47,7 +47,7 @@
     // Setup a perspective projection
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    float extent = std::tan(sf::degrees(45).asRadians());
+    float extent = sf::tan(sf::degrees(45));
 
 #ifdef SFML_OPENGL_ES
     glFrustumf(-extent, extent, -extent, extent, 1.0f, 500.0f);

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -143,7 +143,7 @@ int main()
                         // Make sure the ball initial angle is not too much vertical
                         ballAngle = sf::degrees(static_cast<float>(std::rand() % 360));
                     }
-                    while (std::abs(std::cos(ballAngle.asRadians())) < 0.7f);
+                    while (std::abs(sf::cos(ballAngle)) < 0.7f);
                 }
             }
 
@@ -201,7 +201,7 @@ int main()
 
             // Move the ball
             float factor = ballSpeed * deltaTime;
-            ball.move({std::cos(ballAngle.asRadians()) * factor, std::sin(ballAngle.asRadians()) * factor});
+            ball.move({sf::cos(ballAngle) * factor, sf::sin(ballAngle) * factor});
 
             #ifdef SFML_SYSTEM_IOS
             const std::string inputString = "Touch the screen to restart.";

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -41,12 +41,11 @@ namespace
     // Rotate a matrix around the x-axis
     void matrixRotateX(Matrix& result, sf::Angle angle)
     {
-        float rad = angle.asRadians();
         Matrix matrix = {
-            {1.f,   0.f,           0.f,           0.f},
-            {0.f,   std::cos(rad), std::sin(rad), 0.f},
-            {0.f,  -std::sin(rad), std::cos(rad), 0.f},
-            {0.f,   0.f,           0.f,           1.f}
+            {1.f,   0.f,        0.f,        0.f},
+            {0.f,   cos(angle), sin(angle), 0.f},
+            {0.f,  -sin(angle), cos(angle), 0.f},
+            {0.f,   0.f,        0.f,        1.f}
         };
 
         matrixMultiply(result, result, matrix);
@@ -55,12 +54,11 @@ namespace
     // Rotate a matrix around the y-axis
     void matrixRotateY(Matrix& result, sf::Angle angle)
     {
-        float rad = angle.asRadians();
         Matrix matrix = {
-            { std::cos(rad), 0.f, std::sin(rad), 0.f},
-            { 0.f,           1.f, 0.f,           0.f},
-            {-std::sin(rad), 0.f, std::cos(rad), 0.f},
-            { 0.f,           0.f, 0.f,           1.f}
+            { cos(angle), 0.f, sin(angle), 0.f},
+            { 0.f,        1.f, 0.f,        0.f},
+            {-sin(angle), 0.f, cos(angle), 0.f},
+            { 0.f,        0.f, 0.f,        1.f}
         };
 
         matrixMultiply(result, result, matrix);
@@ -69,12 +67,11 @@ namespace
     // Rotate a matrix around the z-axis
     void matrixRotateZ(Matrix& result, sf::Angle angle)
     {
-        float rad = angle.asRadians();
         Matrix matrix = {
-            { std::cos(rad), std::sin(rad), 0.f, 0.f},
-            {-std::sin(rad), std::cos(rad), 0.f, 0.f},
-            { 0.f,           0.f,           1.f, 0.f},
-            { 0.f,           0.f,           0.f, 1.f}
+            { cos(angle), sin(angle), 0.f, 0.f},
+            {-sin(angle), cos(angle), 0.f, 0.f},
+            { 0.f,        0.f,        1.f, 0.f},
+            { 0.f,        0.f,        0.f, 1.f}
         };
 
         matrixMultiply(result, result, matrix);
@@ -133,7 +130,7 @@ namespace
     // Construct a perspective projection matrix
     void matrixPerspective(Matrix& result, sf::Angle fov, float aspect, float nearPlane, float farPlane)
     {
-        const float a = 1.f / std::tan(fov.asRadians() / 2.f);
+        const float a = 1.f / sf::tan(fov / 2.f);
 
         result[0][0] = a / aspect;
         result[0][1] = 0.f;

--- a/include/SFML/System/Angle.hpp
+++ b/include/SFML/System/Angle.hpp
@@ -28,8 +28,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/System/Export.hpp>
 #include <cassert>
+#include <cmath>
 
 
 namespace sf
@@ -474,6 +474,54 @@ namespace Literals
 [[nodiscard]] constexpr Angle operator "" _rad(unsigned long long int angle);
 
 } // namespace Literals
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Angle
+/// \brief Sine function
+///
+/// \param angle Angle
+///
+/// \return Sine of \a angle
+///
+/// \see cos, tan
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] inline float sin(const Angle& angle)
+{
+    return std::sin(angle.asRadians());
+}
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Angle
+/// \brief Cosine function
+///
+/// \param angle Angle
+///
+/// \return Cosine of \a angle
+///
+/// \see sin, tan
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] inline float cos(const Angle& angle)
+{
+    return std::cos(angle.asRadians());
+}
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Angle
+/// \brief Tangent function
+///
+/// \param angle Angle
+///
+/// \return Tangent of \a angle
+///
+/// \see sin, cos
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] inline float tan(const Angle& angle)
+{
+    return std::tan(angle.asRadians());
+}
 
 #include <SFML/System/Angle.inl>
 

--- a/src/SFML/Graphics/CircleShape.cpp
+++ b/src/SFML/Graphics/CircleShape.cpp
@@ -73,9 +73,8 @@ std::size_t CircleShape::getPointCount() const
 Vector2f CircleShape::getPoint(std::size_t index) const
 {
     Angle angle = static_cast<float>(index) / static_cast<float>(m_pointCount) * sf::degrees(360) - sf::degrees(90);
-    float rad = angle.asRadians();
-    float x = std::cos(rad) * m_radius;
-    float y = std::sin(rad) * m_radius;
+    float x = cos(angle) * m_radius;
+    float y = sin(angle) * m_radius;
 
     return Vector2f(m_radius + x, m_radius + y);
 }

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -35,9 +35,8 @@ namespace sf
 ////////////////////////////////////////////////////////////
 Transform& Transform::rotate(Angle angle)
 {
-    float rad = angle.asRadians();
-    float cos = std::cos(rad);
-    float sin = std::sin(rad);
+    float cos = sf::cos(angle);
+    float sin = sf::sin(angle);
 
     Transform rotation(cos, -sin, 0,
                        sin,  cos, 0,
@@ -50,9 +49,8 @@ Transform& Transform::rotate(Angle angle)
 ////////////////////////////////////////////////////////////
 Transform& Transform::rotate(Angle angle, const Vector2f& center)
 {
-    float rad = angle.asRadians();
-    float cos = std::cos(rad);
-    float sin = std::sin(rad);
+    float cos = sf::cos(angle);
+    float sin = sf::sin(angle);
 
     Transform rotation(cos, -sin, center.x * (1 - cos) + center.y * sin,
                        sin,  cos, center.y * (1 - cos) - center.x * sin,

--- a/src/SFML/Graphics/Transformable.cpp
+++ b/src/SFML/Graphics/Transformable.cpp
@@ -143,9 +143,8 @@ const Transform& Transformable::getTransform() const
     // Recompute the combined transform if needed
     if (m_transformNeedUpdate)
     {
-        float angle  = -m_rotation.asRadians();
-        float cosine = std::cos(angle);
-        float sine   = std::sin(angle);
+        float cosine = cos(-m_rotation);
+        float sine   = sin(-m_rotation);
         float sxc    = m_scale.x * cosine;
         float syc    = m_scale.y * cosine;
         float sxs    = m_scale.x * sine;

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -184,9 +184,8 @@ const Transform& View::getTransform() const
     if (!m_transformUpdated)
     {
         // Rotation components
-        float angle  = m_rotation.asRadians();
-        float cosine = std::cos(angle);
-        float sine   = std::sin(angle);
+        float cosine = cos(m_rotation);
+        float sine   = sin(m_rotation);
         float tx     = -m_center.x * cosine - m_center.y * sine + m_center.x;
         float ty     =  m_center.x * sine - m_center.y * cosine + m_center.y;
 

--- a/test/System/Angle.cpp
+++ b/test/System/Angle.cpp
@@ -299,4 +299,39 @@ TEST_CASE("sf::Angle class - [system]")
 
         static_assert(result == sf::degrees(1));
     }
+
+    SUBCASE("sin()")
+    {
+        using namespace sf::Literals;
+        CHECK(sf::sin(0_deg) == 0);
+        CHECK(sf::sin(90_deg) == 1);
+        CHECK(sf::sin(180_deg) == Approx(0));
+        CHECK(sf::sin(270_deg) == -1);
+        CHECK(sf::sin(360_deg) == Approx(0));
+    }
+
+    SUBCASE("cos()")
+    {
+        using namespace sf::Literals;
+        CHECK(sf::cos(0_deg) == 1);
+        CHECK(sf::cos(90_deg) == Approx(0));
+        CHECK(sf::cos(180_deg) == -1);
+        CHECK(sf::cos(270_deg) == Approx(0));
+        CHECK(sf::cos(360_deg) == 1);
+    }
+
+    SUBCASE("tan()")
+    {
+        using namespace sf::Literals;
+        CHECK(sf::tan(0_deg) == 0);
+        CHECK(sf::tan(45_deg) == 1);
+        CHECK(sf::tan(89_deg) == Approx(57.289962));
+        CHECK(sf::tan(91_deg) == Approx(-57.289962));
+        CHECK(sf::tan(135_deg) == -1);
+        CHECK(sf::tan(180_deg) == Approx(0));
+        CHECK(sf::tan(225_deg) == Approx(1));
+        CHECK(sf::tan(269_deg) == Approx(57.289962));
+        CHECK(sf::tan(271_deg) == Approx(-57.289962));
+        CHECK(sf::tan(360_deg) == Approx(0));
+    }
 }


### PR DESCRIPTION
## Description

I noticed there were many instances of using `asRadians` just to use standard trigonometry functions so I added some additional functions that make it more easy to use `sf::Angle` with trig functions. This is a nice bit of syntactic sugar but also avoids the pitfalls of users calling `asRadians` which eschews the type safety of `sf::Angle`. We'd prefer any use of `sf::Angle` be in a type safe manner.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
