### PR TITLE
Simplify CMake build by removing source_group and headers as source files

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -3,7 +3,7 @@
 # https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md
 
 # Helper function to enable compiler warnings for a specific set of files
-function(set_file_warnings)
+function(set_file_warnings target)
     option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
 
     set(MSVC_WARNINGS
@@ -106,7 +106,5 @@ function(set_file_warnings)
         message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
     endif()
 
-    foreach(WARNING ${FILE_WARNINGS})
-        set_property(SOURCE ${ARGV} APPEND_STRING PROPERTY COMPILE_FLAGS " ${WARNING}")
-    endforeach()
+    target_compile_options(${target} PRIVATE ${FILE_WARNINGS})
 endfunction()

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -51,12 +51,11 @@ endfunction()
 
 # add a new target which is a SFML library
 # example: sfml_add_library(Graphics
-#                           SOURCES sprite.cpp image.cpp ...
 #                           [STATIC]) # Always create a static library and ignore BUILD_SHARED_LIBS
 macro(sfml_add_library module)
 
     # parse the arguments
-    cmake_parse_arguments(THIS "STATIC" "" "SOURCES" ${ARGN})
+    cmake_parse_arguments(THIS "STATIC" "" "" ${ARGN})
     if (NOT "${THIS_UNPARSED_ARGUMENTS}" STREQUAL "")
         message(FATAL_ERROR "Extra unparsed arguments when calling sfml_add_library: ${THIS_UNPARSED_ARGUMENTS}")
     endif()
@@ -64,9 +63,9 @@ macro(sfml_add_library module)
     # create the target
     string(TOLOWER sfml-${module} target)
     if (THIS_STATIC)
-        add_library(${target} STATIC ${THIS_SOURCES})
+        add_library(${target} STATIC)
     else()
-        add_library(${target} ${THIS_SOURCES})
+        add_library(${target})
     endif()
     add_library(SFML::${module} ALIAS ${target})
 
@@ -84,7 +83,7 @@ macro(sfml_add_library module)
         endif()
     endif()
 
-    set_file_warnings(${THIS_SOURCES})
+    set_file_warnings(${target})
 
     # define the export symbol of the module
     string(REPLACE "-" "_" NAME_UPPER "${target}")
@@ -246,22 +245,17 @@ endmacro()
 
 # add a new target which is a SFML example
 # example: sfml_add_example(ftp
-#                           SOURCES ftp.cpp ...
 #                           BUNDLE_RESOURCES MainMenu.nib ...    # Files to be added in target but not installed next to the executable
 #                           DEPENDS SFML::Network
 #                           RESOURCES_DIR resources)             # A directory to install next to the executable and sources
 macro(sfml_add_example target)
 
     # parse the arguments
-    cmake_parse_arguments(THIS "GUI_APP" "RESOURCES_DIR" "SOURCES;BUNDLE_RESOURCES;DEPENDS" ${ARGN})
-
-    # set a source group for the source files
-    source_group("" FILES ${THIS_SOURCES})
+    cmake_parse_arguments(THIS "GUI_APP" "RESOURCES_DIR" "BUNDLE_RESOURCES;DEPENDS" ${ARGN})
 
     # check whether resources must be added in target
-    set(target_input ${THIS_SOURCES})
     if(THIS_BUNDLE_RESOURCES)
-        set(target_input ${target_input} ${THIS_BUNDLE_RESOURCES})
+        set(target_input ${THIS_BUNDLE_RESOURCES})
     endif()
 
     # create the target
@@ -286,7 +280,7 @@ macro(sfml_add_example target)
         add_executable(${target} ${target_input})
     endif()
 
-    set_file_warnings(${target_input})
+    set_file_warnings(${target})
 
     # set the debug suffix
     set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -d)
@@ -312,16 +306,11 @@ macro(sfml_add_example target)
 endmacro()
 
 # add a new target which is a SFML test
-# example: sfml_add_test(sfml-test
-#                           ftp.cpp ...
-#                           SFML::Network)
-function(sfml_add_test target SOURCES DEPENDS)
-
-    # set a source group for the source files
-    source_group("" FILES ${SOURCES})
+# example: sfml_add_test(sfml-test SFML::Network)
+function(sfml_add_test target DEPENDS)
 
     # create the target
-    add_executable(${target} ${SOURCES})
+    add_executable(${target})
 
     # set the target's folder (for IDEs that support it, e.g. Visual Studio)
     set_target_properties(${target} PROPERTIES FOLDER "Tests")

--- a/examples/X11/CMakeLists.txt
+++ b/examples/X11/CMakeLists.txt
@@ -1,13 +1,7 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/X11)
-
-# all source files
-set(SRC ${SRCROOT}/X11.cpp)
-
 # define the X11 target
 sfml_add_example(X11Example GUI_APP
-                 SOURCES ${SRC}
                  DEPENDS SFML::Window X11)
+target_sources(X11Example PRIVATE X11.cpp)
 
 # external dependency headers
 target_include_directories(X11Example SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/X11)

--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/cocoa)
-
 # Usage: compile_xib(INPUT path/to/file.xib OUTPUT path/to/file.nib)
 function(compile_xib)
     cmake_parse_arguments(THIS "" "INPUT;OUTPUT" "" ${ARGN})
@@ -29,33 +26,28 @@ function(compile_xib)
         VERBATIM)
 endfunction()
 
-# all source files
-set(SRC ${SRCROOT}/CocoaAppDelegate.h
-        ${SRCROOT}/CocoaAppDelegate.mm
-        ${SRCROOT}/NSString+stdstring.h
-        ${SRCROOT}/NSString+stdstring.mm
-        ${SRCROOT}/main.m)
-
-compile_xib(INPUT "${SRCROOT}/MainMenu.xib" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib")
+compile_xib(INPUT MainMenu.xib OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib")
 
 # all resource files
-set(RESOURCES ${SRCROOT}/resources/icon.icns
-              ${SRCROOT}/resources/tuffy.ttf
-              ${SRCROOT}/resources/logo.png
-              ${SRCROOT}/resources/blue.png
-              ${SRCROOT}/resources/green.png
-              ${SRCROOT}/resources/red.png
-              ${SRCROOT}/resources/Credits.rtf
+set(RESOURCES resources/icon.icns
+              resources/tuffy.ttf
+              resources/logo.png
+              resources/blue.png
+              resources/green.png
+              resources/red.png
+              resources/Credits.rtf
               ${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib)
 set_source_files_properties(${RESOURCES} PROPERTIES
                             MACOSX_PACKAGE_LOCATION Resources)
 
 # define the cocoa target and customize it
 sfml_add_example(cocoa
-                 SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
                  DEPENDS SFML::System SFML::Window SFML::Graphics)
+target_sources(cocoa PRIVATE CocoaAppDelegate.mm
+                             NSString+stdstring.mm
+                             main.m)
 set_target_properties(cocoa PROPERTIES
                       MACOSX_BUNDLE TRUE
-                      MACOSX_BUNDLE_INFO_PLIST ${SRCROOT}/resources/Cocoa-Info.plist)
+                      MACOSX_BUNDLE_INFO_PLIST resources/Cocoa-Info.plist)
 target_link_libraries(cocoa PRIVATE "-framework Cocoa" "-framework Foundation" SFML::Graphics)

--- a/examples/ftp/CMakeLists.txt
+++ b/examples/ftp/CMakeLists.txt
@@ -1,10 +1,4 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/ftp)
-
-# all source files
-set(SRC ${SRCROOT}/Ftp.cpp)
-
 # define the ftp target
 sfml_add_example(ftp
-                 SOURCES ${SRC}
                  DEPENDS SFML::Network)
+target_sources(ftp PRIVATE Ftp.cpp)

--- a/examples/island/CMakeLists.txt
+++ b/examples/island/CMakeLists.txt
@@ -1,14 +1,8 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/island)
-
-# all source files
-set(SRC ${SRCROOT}/Island.cpp)
-
 # define the island target
 sfml_add_example(island GUI_APP
-                 SOURCES ${SRC}
                  DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
+target_sources(island PRIVATE Island.cpp)
 
 # external dependency headers
 target_include_directories(island SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/island)

--- a/examples/joystick/CMakeLists.txt
+++ b/examples/joystick/CMakeLists.txt
@@ -1,11 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/joystick)
-
-# all source files
-set(SRC ${SRCROOT}/Joystick.cpp)
-
 # define the joystick target
 sfml_add_example(joystick GUI_APP
-                 SOURCES ${SRC}
                  DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
+target_sources(joystick PRIVATE Joystick.cpp)

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -1,9 +1,4 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/opengl)
-
 # all source files
-set(SRC ${SRCROOT}/OpenGL.cpp)
-
 if (SFML_OS_IOS)
     set(RESOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/resources/background.jpg
@@ -13,10 +8,10 @@ endif()
 
 # define the opengl target
 sfml_add_example(opengl GUI_APP
-                 SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
                  DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
+target_sources(opengl PRIVATE OpenGL.cpp)
 
 # external dependency headers
 target_include_directories(opengl SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/opengl)

--- a/examples/shader/CMakeLists.txt
+++ b/examples/shader/CMakeLists.txt
@@ -1,13 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/shader)
-
-# all source files
-set(SRC
-    ${SRCROOT}/Effect.hpp
-    ${SRCROOT}/Shader.cpp)
-
 # define the shader target
 sfml_add_example(shader GUI_APP
-                 SOURCES ${SRC}
                  DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
+target_sources(shader PRIVATE Shader.cpp)

--- a/examples/sockets/CMakeLists.txt
+++ b/examples/sockets/CMakeLists.txt
@@ -1,12 +1,4 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sockets)
-
-# all source files
-set(SRC ${SRCROOT}/Sockets.cpp
-        ${SRCROOT}/TCP.cpp
-        ${SRCROOT}/UDP.cpp)
-
 # define the sockets target
 sfml_add_example(sockets
-                 SOURCES ${SRC}
                  DEPENDS SFML::Network)
+target_sources(sockets PRIVATE Sockets.cpp TCP.cpp UDP.cpp)

--- a/examples/sound/CMakeLists.txt
+++ b/examples/sound/CMakeLists.txt
@@ -1,11 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sound)
-
-# all source files
-set(SRC ${SRCROOT}/Sound.cpp)
-
 # define the sound target
 sfml_add_example(sound
-                 SOURCES ${SRC}
                  DEPENDS SFML::Audio
                  RESOURCES_DIR resources)
+target_sources(sound PRIVATE Sound.cpp)

--- a/examples/sound_capture/CMakeLists.txt
+++ b/examples/sound_capture/CMakeLists.txt
@@ -1,10 +1,4 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sound_capture)
-
-# all source files
-set(SRC ${SRCROOT}/SoundCapture.cpp)
-
 # define the sound-capture target
 sfml_add_example(sound-capture
-                 SOURCES ${SRC}
                  DEPENDS SFML::Audio)
+target_sources(sound-capture PRIVATE SoundCapture.cpp)

--- a/examples/tennis/CMakeLists.txt
+++ b/examples/tennis/CMakeLists.txt
@@ -1,8 +1,4 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/tennis)
-
 # all source files
-set(SRC ${SRCROOT}/Tennis.cpp)
 if (SFML_OS_IOS)
     set(RESOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/resources/ball.wav
@@ -12,7 +8,7 @@ endif()
 
 # define the pong target
 sfml_add_example(tennis GUI_APP
-                 SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
                  DEPENDS SFML::Audio SFML::Graphics
                  RESOURCES_DIR resources)
+target_sources(tennis PRIVATE Tennis.cpp)

--- a/examples/voip/CMakeLists.txt
+++ b/examples/voip/CMakeLists.txt
@@ -1,12 +1,4 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/voip)
-
-# all source files
-set(SRC ${SRCROOT}/VoIP.cpp
-        ${SRCROOT}/Client.cpp
-        ${SRCROOT}/Server.cpp)
-
 # define the voip target
 sfml_add_example(voip
-                 SOURCES ${SRC}
                  DEPENDS SFML::Audio SFML::Network)
+target_sources(voip PRIVATE VoIP.cpp Client.cpp Server.cpp)

--- a/examples/vulkan/CMakeLists.txt
+++ b/examples/vulkan/CMakeLists.txt
@@ -1,14 +1,8 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/vulkan)
-
-# all source files
-set(SRC ${SRCROOT}/Vulkan.cpp)
-
 # define the window target
 sfml_add_example(vulkan GUI_APP
-                 SOURCES ${SRC}
                  DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
+target_sources(vulkan PRIVATE Vulkan.cpp)
 
 # external dependency headers
 target_include_directories(vulkan SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/vulkan)

--- a/examples/win32/CMakeLists.txt
+++ b/examples/win32/CMakeLists.txt
@@ -1,11 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/win32)
-
-# all source files
-set(SRC ${SRCROOT}/Win32.cpp)
-
 # define the win32 target
 sfml_add_example(win32 GUI_APP
-                 SOURCES ${SRC}
                  DEPENDS SFML::Graphics
                  RESOURCES_DIR resources)
+target_sources(win32 PRIVATE Win32.cpp)

--- a/examples/window/CMakeLists.txt
+++ b/examples/window/CMakeLists.txt
@@ -1,13 +1,7 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/window)
-
-# all source files
-set(SRC ${SRCROOT}/Window.cpp)
-
 # define the window target
 sfml_add_example(window GUI_APP
-                 SOURCES ${SRC}
                  DEPENDS SFML::Window)
+target_sources(window PRIVATE Window.cpp)
 
 # external dependency headers
 target_include_directories(window SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/window)

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -1,9 +1,11 @@
+# define the sfml-audio target
+sfml_add_library(Audio)
 
 set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Audio)
 set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Audio)
 
 # all source files
-set(SRC
+target_sources(sfml-audio PRIVATE
     ${SRCROOT}/ALCheck.cpp
     ${SRCROOT}/ALCheck.hpp
     ${SRCROOT}/AlResource.cpp
@@ -32,9 +34,8 @@ set(SRC
     ${SRCROOT}/SoundStream.cpp
     ${INCROOT}/SoundStream.hpp
 )
-source_group("" FILES ${SRC})
 
-set(CODECS_SRC
+target_sources(sfml-audio PRIVATE
     ${SRCROOT}/SoundFileFactory.cpp
     ${INCROOT}/SoundFileFactory.hpp
     ${INCROOT}/SoundFileFactory.inl
@@ -55,7 +56,6 @@ set(CODECS_SRC
     ${SRCROOT}/SoundFileWriterWav.hpp
     ${SRCROOT}/SoundFileWriterWav.cpp
 )
-source_group("codecs" FILES ${CODECS_SRC})
 
 # let CMake know about our additional audio libraries paths (on Windows and OSX)
 if(SFML_OS_WINDOWS)
@@ -75,10 +75,6 @@ sfml_find_package(FLAC INCLUDE "FLAC_INCLUDE_DIR" LINK "FLAC_LIBRARY")
 # avoids warnings in vorbisfile.h
 target_compile_definitions(VORBIS INTERFACE "OV_EXCLUDE_STATIC_CALLBACKS")
 target_compile_definitions(FLAC INTERFACE "FLAC__NO_DLL")
-
-# define the sfml-audio target
-sfml_add_library(Audio
-                 SOURCES ${SRC} ${CODECS_SRC})
 
 # setup dependencies
 target_link_libraries(sfml-audio PRIVATE OpenAL)

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -1,60 +1,32 @@
 # define the sfml-audio target
 sfml_add_library(Audio)
 
-set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Audio)
-set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Audio)
-
 # all source files
 target_sources(sfml-audio PRIVATE
-    ${SRCROOT}/ALCheck.cpp
-    ${SRCROOT}/ALCheck.hpp
-    ${SRCROOT}/AlResource.cpp
-    ${INCROOT}/AlResource.hpp
-    ${SRCROOT}/AudioDevice.cpp
-    ${SRCROOT}/AudioDevice.hpp
-    ${INCROOT}/Export.hpp
-    ${SRCROOT}/Listener.cpp
-    ${INCROOT}/Listener.hpp
-    ${SRCROOT}/Music.cpp
-    ${INCROOT}/Music.hpp
-    ${SRCROOT}/Sound.cpp
-    ${INCROOT}/Sound.hpp
-    ${SRCROOT}/SoundBuffer.cpp
-    ${INCROOT}/SoundBuffer.hpp
-    ${SRCROOT}/SoundBufferRecorder.cpp
-    ${INCROOT}/SoundBufferRecorder.hpp
-    ${SRCROOT}/InputSoundFile.cpp
-    ${INCROOT}/InputSoundFile.hpp
-    ${SRCROOT}/OutputSoundFile.cpp
-    ${INCROOT}/OutputSoundFile.hpp
-    ${SRCROOT}/SoundRecorder.cpp
-    ${INCROOT}/SoundRecorder.hpp
-    ${SRCROOT}/SoundSource.cpp
-    ${INCROOT}/SoundSource.hpp
-    ${SRCROOT}/SoundStream.cpp
-    ${INCROOT}/SoundStream.hpp
+    ALCheck.cpp
+    AlResource.cpp
+    AudioDevice.cpp
+    Listener.cpp
+    Music.cpp
+    Sound.cpp
+    SoundBuffer.cpp
+    SoundBufferRecorder.cpp
+    InputSoundFile.cpp
+    OutputSoundFile.cpp
+    SoundRecorder.cpp
+    SoundSource.cpp
+    SoundStream.cpp
 )
 
 target_sources(sfml-audio PRIVATE
-    ${SRCROOT}/SoundFileFactory.cpp
-    ${INCROOT}/SoundFileFactory.hpp
-    ${INCROOT}/SoundFileFactory.inl
-    ${INCROOT}/SoundFileReader.hpp
-    ${SRCROOT}/SoundFileReaderFlac.hpp
-    ${SRCROOT}/SoundFileReaderFlac.cpp
-    ${SRCROOT}/SoundFileReaderMp3.hpp
-    ${SRCROOT}/SoundFileReaderMp3.cpp
-    ${SRCROOT}/SoundFileReaderOgg.hpp
-    ${SRCROOT}/SoundFileReaderOgg.cpp
-    ${SRCROOT}/SoundFileReaderWav.hpp
-    ${SRCROOT}/SoundFileReaderWav.cpp
-    ${INCROOT}/SoundFileWriter.hpp
-    ${SRCROOT}/SoundFileWriterFlac.hpp
-    ${SRCROOT}/SoundFileWriterFlac.cpp
-    ${SRCROOT}/SoundFileWriterOgg.hpp
-    ${SRCROOT}/SoundFileWriterOgg.cpp
-    ${SRCROOT}/SoundFileWriterWav.hpp
-    ${SRCROOT}/SoundFileWriterWav.cpp
+    SoundFileFactory.cpp
+    SoundFileReaderFlac.cpp
+    SoundFileReaderMp3.cpp
+    SoundFileReaderOgg.cpp
+    SoundFileReaderWav.cpp
+    SoundFileWriterFlac.cpp
+    SoundFileWriterOgg.cpp
+    SoundFileWriterWav.cpp
 )
 
 # let CMake know about our additional audio libraries paths (on Windows and OSX)

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -137,8 +137,7 @@ bool SoundFileWriterWav::writeHeader(unsigned int sampleRate, unsigned int chann
     m_file.write(mainChunkId, sizeof(mainChunkId));
 
     // Write the main chunk header
-    Uint32 mainChunkSize = 0; // placeholder, will be written later
-    encode(m_file, mainChunkSize);
+    encode(m_file, static_cast<Uint32>(0));
     char mainChunkFormat[4] = {'W', 'A', 'V', 'E'};
     m_file.write(mainChunkFormat, sizeof(mainChunkFormat));
 
@@ -182,12 +181,10 @@ void SoundFileWriterWav::close()
 
         // Update the main chunk size and data sub-chunk size
         Uint32 fileSize = static_cast<Uint32>(m_file.tellp());
-        Uint32 mainChunkSize = fileSize - 8;  // 8 bytes RIFF header
-        Uint32 dataChunkSize = fileSize - 44; // 44 bytes RIFF + WAVE headers
         m_file.seekp(4);
-        encode(m_file, mainChunkSize);
+        encode(m_file, fileSize - 8); // 8 bytes RIFF header
         m_file.seekp(40);
-        encode(m_file, dataChunkSize);
+        encode(m_file, fileSize - 44); // 44 bytes RIFF + WAVE headers
 
         m_file.close();
     }

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -1,9 +1,11 @@
+# define the sfml-graphics target
+sfml_add_library(Graphics)
 
 set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Graphics)
 set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Graphics)
 
 # all source files
-set(SRC
+target_sources(sfml-graphics PRIVATE
     ${SRCROOT}/BlendMode.cpp
     ${INCROOT}/BlendMode.hpp
     ${INCROOT}/Color.hpp
@@ -50,10 +52,9 @@ set(SRC
     ${INCROOT}/Vertex.hpp
     ${INCROOT}/Vertex.inl
 )
-source_group("" FILES ${SRC})
 
 # drawables sources
-set(DRAWABLES_SRC
+target_sources(sfml-graphics PRIVATE
     ${INCROOT}/Drawable.hpp
     ${SRCROOT}/Shape.cpp
     ${INCROOT}/Shape.hpp
@@ -72,10 +73,9 @@ set(DRAWABLES_SRC
     ${SRCROOT}/VertexBuffer.cpp
     ${INCROOT}/VertexBuffer.hpp
 )
-source_group("drawables" FILES ${DRAWABLES_SRC})
 
 # render-texture sources
-set(RENDER_TEXTURE_SRC
+target_sources(sfml-graphics PRIVATE
     ${SRCROOT}/RenderTextureImpl.cpp
     ${SRCROOT}/RenderTextureImpl.hpp
     ${SRCROOT}/RenderTextureImplFBO.cpp
@@ -83,12 +83,6 @@ set(RENDER_TEXTURE_SRC
     ${SRCROOT}/RenderTextureImplDefault.cpp
     ${SRCROOT}/RenderTextureImplDefault.hpp
 )
-source_group("render texture" FILES ${RENDER_TEXTURE_SRC})
-
-
-# define the sfml-graphics target
-sfml_add_library(Graphics
-                 SOURCES ${SRC} ${DRAWABLES_SRC} ${RENDER_TEXTURE_SRC} ${STB_SRC})
 
 # setup dependencies
 target_link_libraries(sfml-graphics PUBLIC SFML::Window)

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -1,87 +1,44 @@
 # define the sfml-graphics target
 sfml_add_library(Graphics)
 
-set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Graphics)
-set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Graphics)
-
 # all source files
 target_sources(sfml-graphics PRIVATE
-    ${SRCROOT}/BlendMode.cpp
-    ${INCROOT}/BlendMode.hpp
-    ${INCROOT}/Color.hpp
-    ${INCROOT}/Color.inl
-    ${INCROOT}/Export.hpp
-    ${SRCROOT}/Font.cpp
-    ${INCROOT}/Font.hpp
-    ${SRCROOT}/Glsl.cpp
-    ${INCROOT}/Glsl.hpp
-    ${INCROOT}/Glsl.inl
-    ${INCROOT}/Glyph.hpp
-    ${SRCROOT}/GLCheck.cpp
-    ${SRCROOT}/GLCheck.hpp
-    ${SRCROOT}/GLExtensions.hpp
-    ${SRCROOT}/GLExtensions.cpp
-    ${SRCROOT}/Image.cpp
-    ${INCROOT}/Image.hpp
-    ${SRCROOT}/ImageLoader.cpp
-    ${SRCROOT}/ImageLoader.hpp
-    ${INCROOT}/PrimitiveType.hpp
-    ${INCROOT}/Rect.hpp
-    ${INCROOT}/Rect.inl
-    ${SRCROOT}/RenderStates.cpp
-    ${INCROOT}/RenderStates.hpp
-    ${SRCROOT}/RenderTexture.cpp
-    ${INCROOT}/RenderTexture.hpp
-    ${SRCROOT}/RenderTarget.cpp
-    ${INCROOT}/RenderTarget.hpp
-    ${SRCROOT}/RenderWindow.cpp
-    ${INCROOT}/RenderWindow.hpp
-    ${SRCROOT}/Shader.cpp
-    ${INCROOT}/Shader.hpp
-    ${SRCROOT}/Texture.cpp
-    ${INCROOT}/Texture.hpp
-    ${SRCROOT}/TextureSaver.cpp
-    ${SRCROOT}/TextureSaver.hpp
-    ${SRCROOT}/Transform.cpp
-    ${INCROOT}/Transform.hpp
-    ${INCROOT}/Transform.inl
-    ${SRCROOT}/Transformable.cpp
-    ${INCROOT}/Transformable.hpp
-    ${SRCROOT}/View.cpp
-    ${INCROOT}/View.hpp
-    ${INCROOT}/Vertex.hpp
-    ${INCROOT}/Vertex.inl
+    BlendMode.cpp
+    Font.cpp
+    Glsl.cpp
+    GLCheck.cpp
+    GLExtensions.cpp
+    Image.cpp
+    ImageLoader.cpp
+    RenderStates.cpp
+    RenderTexture.cpp
+    RenderTarget.cpp
+    RenderWindow.cpp
+    Shader.cpp
+    Texture.cpp
+    TextureSaver.cpp
+    Transform.cpp
+    Transformable.cpp
+    View.cpp
 )
 
 # drawables sources
 target_sources(sfml-graphics PRIVATE
-    ${INCROOT}/Drawable.hpp
-    ${SRCROOT}/Shape.cpp
-    ${INCROOT}/Shape.hpp
-    ${SRCROOT}/CircleShape.cpp
-    ${INCROOT}/CircleShape.hpp
-    ${SRCROOT}/RectangleShape.cpp
-    ${INCROOT}/RectangleShape.hpp
-    ${SRCROOT}/ConvexShape.cpp
-    ${INCROOT}/ConvexShape.hpp
-    ${SRCROOT}/Sprite.cpp
-    ${INCROOT}/Sprite.hpp
-    ${SRCROOT}/Text.cpp
-    ${INCROOT}/Text.hpp
-    ${SRCROOT}/VertexArray.cpp
-    ${INCROOT}/VertexArray.hpp
-    ${SRCROOT}/VertexBuffer.cpp
-    ${INCROOT}/VertexBuffer.hpp
+    Shape.cpp
+    CircleShape.cpp
+    RectangleShape.cpp
+    ConvexShape.cpp
+    Sprite.cpp
+    Text.cpp
+    VertexArray.cpp
+    VertexBuffer.cpp
 )
 
 # render-texture sources
 target_sources(sfml-graphics PRIVATE
-    ${SRCROOT}/RenderTextureImpl.cpp
-    ${SRCROOT}/RenderTextureImpl.hpp
-    ${SRCROOT}/RenderTextureImplFBO.cpp
-    ${SRCROOT}/RenderTextureImplFBO.hpp
-    ${SRCROOT}/RenderTextureImplDefault.cpp
-    ${SRCROOT}/RenderTextureImplDefault.hpp
+    RenderTextureImpl.cpp
+    RenderTextureImplFBO.cpp
+    RenderTextureImplDefault.cpp
 )
 
 # setup dependencies
@@ -127,5 +84,5 @@ target_compile_definitions(sfml-graphics PRIVATE "STBI_FAILURE_USERMSG")
 # ImageLoader.cpp must be compiled with the -fno-strict-aliasing
 # when gcc is used; otherwise saving PNGs may crash in stb_image_write
 if(SFML_COMPILER_GCC)
-    set_source_files_properties(${SRCROOT}/ImageLoader.cpp PROPERTIES COMPILE_FLAGS -fno-strict-aliasing)
+    set_source_files_properties(ImageLoader.cpp PROPERTIES COMPILE_FLAGS -fno-strict-aliasing)
 endif()

--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -1,16 +1,13 @@
 # define the sfml-main target
 sfml_add_library(Main STATIC)
 
-set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Main)
-set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Main)
-
 # sources
 if(SFML_OS_WINDOWS)
-    target_sources(sfml-main PRIVATE ${SRCROOT}/MainWin32.cpp)
+    target_sources(sfml-main PRIVATE MainWin32.cpp)
 elseif(SFML_OS_IOS)
-    target_sources(sfml-main PRIVATE ${SRCROOT}/MainiOS.mm)
+    target_sources(sfml-main PRIVATE MainiOS.mm)
 elseif(SFML_OS_ANDROID)
-    target_sources(sfml-main PRIVATE ${SRCROOT}/MainAndroid.cpp)
+    target_sources(sfml-main PRIVATE MainAndroid.cpp)
 else()
     return()
 endif()
@@ -32,5 +29,5 @@ set_target_properties(sfml-main PROPERTIES
 # will load our shared libraries manually
 if(SFML_OS_ANDROID)
     sfml_add_library(Activity)
-    target_sources(sfml-activity PRIVATE ${SRCROOT}/SFMLActivity.cpp)
+    target_sources(sfml-activity PRIVATE SFMLActivity.cpp)
 endif()

--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -1,20 +1,19 @@
+# define the sfml-main target
+sfml_add_library(Main STATIC)
 
 set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Main)
 set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Main)
 
 # sources
 if(SFML_OS_WINDOWS)
-    set(SRC ${SRC} ${SRCROOT}/MainWin32.cpp)
+    target_sources(sfml-main PRIVATE ${SRCROOT}/MainWin32.cpp)
 elseif(SFML_OS_IOS)
-    set(SRC ${SRC} ${SRCROOT}/MainiOS.mm)
+    target_sources(sfml-main PRIVATE ${SRCROOT}/MainiOS.mm)
 elseif(SFML_OS_ANDROID)
-    set(SRC ${SRC} ${SRCROOT}/MainAndroid.cpp)
+    target_sources(sfml-main PRIVATE ${SRCROOT}/MainAndroid.cpp)
 else()
     return()
 endif()
-
-# define the sfml-main target
-sfml_add_library(Main STATIC SOURCES ${SRC})
 
 if(SFML_OS_ANDROID)
     # glad sources
@@ -32,5 +31,6 @@ set_target_properties(sfml-main PROPERTIES
 # from depending on shared libraries), we need a boostrap activity which
 # will load our shared libraries manually
 if(SFML_OS_ANDROID)
-    sfml_add_library(Activity SOURCES ${SRCROOT}/SFMLActivity.cpp)
+    sfml_add_library(Activity)
+    target_sources(sfml-activity PRIVATE ${SRCROOT}/SFMLActivity.cpp)
 endif()

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -1,9 +1,11 @@
+# define the sfml-network target
+sfml_add_library(Network)
 
 set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Network)
 set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Network)
 
 # all source files
-set(SRC
+target_sources(sfml-network PRIVATE
     ${INCROOT}/Export.hpp
     ${SRCROOT}/Ftp.cpp
     ${INCROOT}/Ftp.hpp
@@ -29,24 +31,16 @@ set(SRC
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
-    set(SRC
-        ${SRC}
+    target_sources(sfml-network PRIVATE
         ${SRCROOT}/Win32/SocketImpl.cpp
         ${SRCROOT}/Win32/SocketImpl.hpp
     )
 else()
-    set(SRC
-        ${SRC}
+    target_sources(sfml-network PRIVATE
         ${SRCROOT}/Unix/SocketImpl.cpp
         ${SRCROOT}/Unix/SocketImpl.hpp
     )
 endif()
-
-source_group("" FILES ${SRC})
-
-# define the sfml-network target
-sfml_add_library(Network
-                 SOURCES ${SRC})
 
 # setup dependencies
 target_link_libraries(sfml-network PUBLIC SFML::System)

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -1,45 +1,24 @@
 # define the sfml-network target
 sfml_add_library(Network)
 
-set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Network)
-set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Network)
-
 # all source files
 target_sources(sfml-network PRIVATE
-    ${INCROOT}/Export.hpp
-    ${SRCROOT}/Ftp.cpp
-    ${INCROOT}/Ftp.hpp
-    ${SRCROOT}/Http.cpp
-    ${INCROOT}/Http.hpp
-    ${SRCROOT}/IpAddress.cpp
-    ${INCROOT}/IpAddress.hpp
-    ${SRCROOT}/Packet.cpp
-    ${INCROOT}/Packet.hpp
-    ${SRCROOT}/Socket.cpp
-    ${INCROOT}/Socket.hpp
-    ${SRCROOT}/SocketImpl.hpp
-    ${INCROOT}/SocketHandle.hpp
-    ${SRCROOT}/SocketSelector.cpp
-    ${INCROOT}/SocketSelector.hpp
-    ${SRCROOT}/TcpListener.cpp
-    ${INCROOT}/TcpListener.hpp
-    ${SRCROOT}/TcpSocket.cpp
-    ${INCROOT}/TcpSocket.hpp
-    ${SRCROOT}/UdpSocket.cpp
-    ${INCROOT}/UdpSocket.hpp
+    Ftp.cpp
+    Http.cpp
+    IpAddress.cpp
+    Packet.cpp
+    Socket.cpp
+    SocketSelector.cpp
+    TcpListener.cpp
+    TcpSocket.cpp
+    UdpSocket.cpp
 )
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
-    target_sources(sfml-network PRIVATE
-        ${SRCROOT}/Win32/SocketImpl.cpp
-        ${SRCROOT}/Win32/SocketImpl.hpp
-    )
+    target_sources(sfml-network PRIVATE Win32/SocketImpl.cpp)
 else()
-    target_sources(sfml-network PRIVATE
-        ${SRCROOT}/Unix/SocketImpl.cpp
-        ${SRCROOT}/Unix/SocketImpl.hpp
-    )
+    target_sources(sfml-network PRIVATE Unix/SocketImpl.cpp)
 endif()
 
 # setup dependencies

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -1,60 +1,29 @@
 # define the sfml-system target
 sfml_add_library(System)
 
-set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/System)
-set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/System)
-
 # all source files
 target_sources(sfml-system PRIVATE
-    ${INCROOT}/Angle.hpp
-    ${INCROOT}/Angle.inl
-    ${SRCROOT}/Clock.cpp
-    ${INCROOT}/Clock.hpp
-    ${SRCROOT}/Err.cpp
-    ${INCROOT}/Err.hpp
-    ${INCROOT}/Export.hpp
-    ${INCROOT}/InputStream.hpp
-    ${INCROOT}/NativeActivity.hpp
-    ${SRCROOT}/Sleep.cpp
-    ${INCROOT}/Sleep.hpp
-    ${SRCROOT}/String.cpp
-    ${INCROOT}/String.hpp
-    ${INCROOT}/String.inl
-    ${INCROOT}/Time.hpp
-    ${INCROOT}/Time.inl
-    ${INCROOT}/Utf.hpp
-    ${INCROOT}/Utf.inl
-    ${INCROOT}/Vector2.hpp
-    ${INCROOT}/Vector2.inl
-    ${INCROOT}/Vector3.hpp
-    ${INCROOT}/Vector3.inl
-    ${SRCROOT}/FileInputStream.cpp
-    ${INCROOT}/FileInputStream.hpp
-    ${SRCROOT}/MemoryInputStream.cpp
-    ${INCROOT}/MemoryInputStream.hpp
-    ${INCROOT}/SuspendAwareClock.hpp
+    Clock.cpp
+    Err.cpp
+    Sleep.cpp
+    String.cpp
+    FileInputStream.cpp
+    MemoryInputStream.cpp
 )
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
-    target_sources(sfml-system PRIVATE
-        ${SRCROOT}/Win32/SleepImpl.cpp
-        ${SRCROOT}/Win32/SleepImpl.hpp
-    )
+    target_sources(sfml-system PRIVATE Win32/SleepImpl.cpp)
 else()
-    target_sources(sfml-system PRIVATE
-        ${SRCROOT}/Unix/SleepImpl.cpp
-        ${SRCROOT}/Unix/SleepImpl.hpp
-    )
+    target_sources(sfml-system PRIVATE Unix/SleepImpl.cpp)
 
     if(SFML_OS_ANDROID)
         target_sources(sfml-system PRIVATE
-            ${SRCROOT}/Android/Activity.hpp
-            ${SRCROOT}/Android/Activity.cpp
-            ${SRCROOT}/Android/NativeActivity.cpp
-            ${SRCROOT}/Android/ResourceStream.cpp
-            ${SRCROOT}/Android/ResourceStream.cpp
-            ${SRCROOT}/Android/SuspendAwareClock.cpp
+            Android/Activity.cpp
+            Android/NativeActivity.cpp
+            Android/ResourceStream.cpp
+            Android/ResourceStream.cpp
+            Android/SuspendAwareClock.cpp
         )
     endif()
 endif()

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -1,9 +1,11 @@
+# define the sfml-system target
+sfml_add_library(System)
 
 set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/System)
 set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/System)
 
 # all source files
-set(SRC
+target_sources(sfml-system PRIVATE
     ${INCROOT}/Angle.hpp
     ${INCROOT}/Angle.inl
     ${SRCROOT}/Clock.cpp
@@ -32,23 +34,21 @@ set(SRC
     ${INCROOT}/MemoryInputStream.hpp
     ${INCROOT}/SuspendAwareClock.hpp
 )
-source_group("" FILES ${SRC})
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
-    set(PLATFORM_SRC
+    target_sources(sfml-system PRIVATE
         ${SRCROOT}/Win32/SleepImpl.cpp
         ${SRCROOT}/Win32/SleepImpl.hpp
     )
-    source_group("windows" FILES ${PLATFORM_SRC})
 else()
-    set(PLATFORM_SRC
+    target_sources(sfml-system PRIVATE
         ${SRCROOT}/Unix/SleepImpl.cpp
         ${SRCROOT}/Unix/SleepImpl.hpp
     )
 
     if(SFML_OS_ANDROID)
-        set(PLATFORM_SRC ${PLATFORM_SRC}
+        target_sources(sfml-system PRIVATE
             ${SRCROOT}/Android/Activity.hpp
             ${SRCROOT}/Android/Activity.cpp
             ${SRCROOT}/Android/NativeActivity.cpp
@@ -57,13 +57,7 @@ else()
             ${SRCROOT}/Android/SuspendAwareClock.cpp
         )
     endif()
-
-    source_group("unix" FILES ${PLATFORM_SRC})
 endif()
-
-# define the sfml-system target
-sfml_add_library(System
-                 SOURCES ${SRC} ${PLATFORM_SRC})
 
 if(SFML_OS_ANDROID)
     # glad sources

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -1,9 +1,11 @@
+# define the sfml-window target
+sfml_add_library(Window)
 
 set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Window)
 set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Window)
 
 # all source files
-set(SRC
+target_sources(sfml-window PRIVATE
     ${INCROOT}/Clipboard.hpp
     ${SRCROOT}/Clipboard.cpp
     ${SRCROOT}/ClipboardImpl.hpp
@@ -54,11 +56,10 @@ set(SRC
     ${SRCROOT}/WindowImpl.hpp
     ${INCROOT}/WindowStyle.hpp
 )
-source_group("" FILES ${SRC})
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
-    set(PLATFORM_SRC
+    target_sources(sfml-window PRIVATE
         ${SRCROOT}/Win32/CursorImpl.hpp
         ${SRCROOT}/Win32/CursorImpl.cpp
         ${SRCROOT}/Win32/ClipboardImpl.hpp
@@ -77,12 +78,11 @@ if(SFML_OS_WINDOWS)
         ${SRCROOT}/Win32/WindowImplWin32.cpp
         ${SRCROOT}/Win32/WindowImplWin32.hpp
     )
-    source_group("windows" FILES ${PLATFORM_SRC})
 
     # make sure that we use the Unicode version of the Win API functions
     add_definitions(-DUNICODE -D_UNICODE)
 elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
-    set(PLATFORM_SRC
+    target_sources(sfml-window PRIVATE
         ${SRCROOT}/Unix/CursorImpl.hpp
         ${SRCROOT}/Unix/CursorImpl.cpp
         ${SRCROOT}/Unix/ClipboardImpl.hpp
@@ -100,41 +100,35 @@ elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
         ${SRCROOT}/Unix/WindowImplX11.hpp
     )
     if(NOT SFML_OS_ANDROID)
-        set(PLATFORM_SRC
-            ${PLATFORM_SRC}
+        target_sources(sfml-window PRIVATE
             ${SRCROOT}/Unix/GlxContext.cpp
             ${SRCROOT}/Unix/GlxContext.hpp
         )
     endif()
     if(SFML_OS_LINUX)
-        set(PLATFORM_SRC
-            ${PLATFORM_SRC}
+        target_sources(sfml-window PRIVATE
             ${SRCROOT}/Unix/JoystickImpl.cpp
             ${SRCROOT}/Unix/JoystickImpl.hpp
         )
     elseif(SFML_OS_FREEBSD)
-        set(PLATFORM_SRC
-            ${PLATFORM_SRC}
+        target_sources(sfml-window PRIVATE
             ${SRCROOT}/FreeBSD/JoystickImpl.cpp
             ${SRCROOT}/FreeBSD/JoystickImpl.hpp
         )
     elseif(SFML_OS_OPENBSD)
-        set(PLATFORM_SRC
-            ${PLATFORM_SRC}
+        target_sources(sfml-window PRIVATE
             ${SRCROOT}/OpenBSD/JoystickImpl.cpp
             ${SRCROOT}/OpenBSD/JoystickImpl.hpp
         )
     elseif(SFML_OS_NETBSD)
-        set(PLATFORM_SRC
-            ${PLATFORM_SRC}
+        target_sources(sfml-window PRIVATE
             ${SRCROOT}/NetBSD/JoystickImpl.cpp
             ${SRCROOT}/NetBSD/JoystickImpl.hpp
         )
 
     endif()
-    source_group("unix" FILES ${PLATFORM_SRC})
 elseif(SFML_OS_MACOSX)
-    set(PLATFORM_SRC
+    target_sources(sfml-window PRIVATE
         ${SRCROOT}/OSX/cpp_objc_conversion.h
         ${SRCROOT}/OSX/cpp_objc_conversion.mm
         ${SRCROOT}/OSX/cg_sf_conversion.hpp
@@ -185,9 +179,8 @@ elseif(SFML_OS_MACOSX)
         ${SRCROOT}/OSX/AutoreleasePoolWrapper.hpp
         ${SRCROOT}/OSX/AutoreleasePoolWrapper.mm
     )
-    source_group("mac" FILES ${PLATFORM_SRC})
 elseif(SFML_OS_IOS)
-    set(PLATFORM_SRC
+    target_sources(sfml-window PRIVATE
         ${SRCROOT}/iOS/CursorImpl.hpp
         ${SRCROOT}/iOS/CursorImpl.cpp
         ${SRCROOT}/iOS/ClipboardImpl.mm
@@ -213,9 +206,8 @@ elseif(SFML_OS_IOS)
         ${SRCROOT}/iOS/SFMain.hpp
         ${SRCROOT}/iOS/SFMain.mm
     )
-    source_group("ios" FILES ${PLATFORM_SRC})
 elseif(SFML_OS_ANDROID)
-    set(PLATFORM_SRC
+    target_sources(sfml-window PRIVATE
         ${SRCROOT}/Android/CursorImpl.hpp
         ${SRCROOT}/Android/CursorImpl.cpp
         ${SRCROOT}/Android/ClipboardImpl.hpp
@@ -230,12 +222,8 @@ elseif(SFML_OS_ANDROID)
         ${SRCROOT}/Android/SensorImpl.hpp
         ${SRCROOT}/Android/SensorImpl.cpp
     )
-    source_group("android" FILES ${PLATFORM_SRC})
 endif()
 
-# define the sfml-window target
-sfml_add_library(Window
-                 SOURCES ${SRC} ${PLATFORM_SRC})
 target_link_libraries(sfml-window PUBLIC SFML::System)
 
 # glad sources

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -1,226 +1,119 @@
 # define the sfml-window target
 sfml_add_library(Window)
 
-set(INCROOT ${PROJECT_SOURCE_DIR}/include/SFML/Window)
-set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Window)
-
 # all source files
 target_sources(sfml-window PRIVATE
-    ${INCROOT}/Clipboard.hpp
-    ${SRCROOT}/Clipboard.cpp
-    ${SRCROOT}/ClipboardImpl.hpp
-    ${SRCROOT}/Context.cpp
-    ${INCROOT}/Context.hpp
-    ${SRCROOT}/Cursor.cpp
-    ${INCROOT}/Cursor.hpp
-    ${SRCROOT}/CursorImpl.hpp
-    ${SRCROOT}/EGLCheck.cpp
-    ${SRCROOT}/EGLCheck.hpp
-    ${SRCROOT}/EglContext.cpp
-    ${SRCROOT}/EglContext.hpp
-    ${INCROOT}/Export.hpp
-    ${SRCROOT}/GlContext.cpp
-    ${SRCROOT}/GlContext.hpp
-    ${SRCROOT}/GlResource.cpp
-    ${INCROOT}/GlResource.hpp
-    ${INCROOT}/ContextSettings.hpp
-    ${INCROOT}/Event.hpp
-    ${SRCROOT}/InputImpl.hpp
-    ${INCROOT}/Joystick.hpp
-    ${SRCROOT}/Joystick.cpp
-    ${SRCROOT}/JoystickImpl.hpp
-    ${SRCROOT}/JoystickManager.cpp
-    ${SRCROOT}/JoystickManager.hpp
-    ${INCROOT}/Keyboard.hpp
-    ${SRCROOT}/Keyboard.cpp
-    ${INCROOT}/Mouse.hpp
-    ${SRCROOT}/Mouse.cpp
-    ${INCROOT}/Touch.hpp
-    ${SRCROOT}/Touch.cpp
-    ${INCROOT}/Sensor.hpp
-    ${SRCROOT}/Sensor.cpp
-    ${SRCROOT}/SensorImpl.hpp
-    ${SRCROOT}/SensorManager.cpp
-    ${SRCROOT}/SensorManager.hpp
-    ${SRCROOT}/VideoMode.cpp
-    ${INCROOT}/VideoMode.hpp
-    ${SRCROOT}/VideoModeImpl.hpp
-    ${SRCROOT}/Vulkan.cpp
-    ${INCROOT}/Vulkan.hpp
-    ${SRCROOT}/Window.cpp
-    ${INCROOT}/Window.hpp
-    ${SRCROOT}/WindowBase.cpp
-    ${INCROOT}/WindowBase.hpp
-    ${INCROOT}/WindowHandle.hpp
-    ${SRCROOT}/WindowImpl.cpp
-    ${SRCROOT}/WindowImpl.hpp
-    ${INCROOT}/WindowStyle.hpp
+    Clipboard.cpp
+    Context.cpp
+    Cursor.cpp
+    EGLCheck.cpp
+    EglContext.cpp
+    GlContext.cpp
+    GlResource.cpp
+    Joystick.cpp
+    JoystickManager.cpp
+    Keyboard.cpp
+    Mouse.cpp
+    Touch.cpp
+    Sensor.cpp
+    SensorManager.cpp
+    VideoMode.cpp
+    Vulkan.cpp
+    Window.cpp
+    WindowBase.cpp
+    WindowImpl.cpp
 )
 
 # add platform specific sources
 if(SFML_OS_WINDOWS)
     target_sources(sfml-window PRIVATE
-        ${SRCROOT}/Win32/CursorImpl.hpp
-        ${SRCROOT}/Win32/CursorImpl.cpp
-        ${SRCROOT}/Win32/ClipboardImpl.hpp
-        ${SRCROOT}/Win32/ClipboardImpl.cpp
-        ${SRCROOT}/Win32/WglContext.cpp
-        ${SRCROOT}/Win32/WglContext.hpp
-        ${SRCROOT}/Win32/InputImpl.cpp
-        ${SRCROOT}/Win32/InputImpl.hpp
-        ${SRCROOT}/Win32/JoystickImpl.cpp
-        ${SRCROOT}/Win32/JoystickImpl.hpp
-        ${SRCROOT}/Win32/SensorImpl.hpp
-        ${SRCROOT}/Win32/SensorImpl.cpp
-        ${SRCROOT}/Win32/VideoModeImpl.cpp
-        ${SRCROOT}/Win32/VulkanImplWin32.cpp
-        ${SRCROOT}/Win32/VulkanImplWin32.hpp
-        ${SRCROOT}/Win32/WindowImplWin32.cpp
-        ${SRCROOT}/Win32/WindowImplWin32.hpp
+        Win32/CursorImpl.cpp
+        Win32/ClipboardImpl.cpp
+        Win32/WglContext.cpp
+        Win32/InputImpl.cpp
+        Win32/JoystickImpl.cpp
+        Win32/SensorImpl.cpp
+        Win32/VideoModeImpl.cpp
+        Win32/VulkanImplWin32.cpp
+        Win32/WindowImplWin32.cpp
     )
 
     # make sure that we use the Unicode version of the Win API functions
     add_definitions(-DUNICODE -D_UNICODE)
 elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
     target_sources(sfml-window PRIVATE
-        ${SRCROOT}/Unix/CursorImpl.hpp
-        ${SRCROOT}/Unix/CursorImpl.cpp
-        ${SRCROOT}/Unix/ClipboardImpl.hpp
-        ${SRCROOT}/Unix/ClipboardImpl.cpp
-        ${SRCROOT}/Unix/Display.cpp
-        ${SRCROOT}/Unix/Display.hpp
-        ${SRCROOT}/Unix/InputImpl.cpp
-        ${SRCROOT}/Unix/InputImpl.hpp
-        ${SRCROOT}/Unix/SensorImpl.cpp
-        ${SRCROOT}/Unix/SensorImpl.hpp
-        ${SRCROOT}/Unix/VideoModeImpl.cpp
-        ${SRCROOT}/Unix/VulkanImplX11.cpp
-        ${SRCROOT}/Unix/VulkanImplX11.hpp
-        ${SRCROOT}/Unix/WindowImplX11.cpp
-        ${SRCROOT}/Unix/WindowImplX11.hpp
+        Unix/CursorImpl.cpp
+        Unix/ClipboardImpl.cpp
+        Unix/Display.cpp
+        Unix/InputImpl.cpp
+        Unix/SensorImpl.cpp
+        Unix/VideoModeImpl.cpp
+        Unix/VulkanImplX11.cpp
+        Unix/WindowImplX11.cpp
     )
     if(NOT SFML_OS_ANDROID)
-        target_sources(sfml-window PRIVATE
-            ${SRCROOT}/Unix/GlxContext.cpp
-            ${SRCROOT}/Unix/GlxContext.hpp
-        )
+        target_sources(sfml-window PRIVATE Unix/GlxContext.cpp)
     endif()
     if(SFML_OS_LINUX)
-        target_sources(sfml-window PRIVATE
-            ${SRCROOT}/Unix/JoystickImpl.cpp
-            ${SRCROOT}/Unix/JoystickImpl.hpp
-        )
+        target_sources(sfml-window PRIVATE Unix/JoystickImpl.cpp)
     elseif(SFML_OS_FREEBSD)
-        target_sources(sfml-window PRIVATE
-            ${SRCROOT}/FreeBSD/JoystickImpl.cpp
-            ${SRCROOT}/FreeBSD/JoystickImpl.hpp
-        )
+        target_sources(sfml-window PRIVATE FreeBSD/JoystickImpl.cpp)
     elseif(SFML_OS_OPENBSD)
-        target_sources(sfml-window PRIVATE
-            ${SRCROOT}/OpenBSD/JoystickImpl.cpp
-            ${SRCROOT}/OpenBSD/JoystickImpl.hpp
-        )
+        target_sources(sfml-window PRIVATE OpenBSD/JoystickImpl.cpp)
     elseif(SFML_OS_NETBSD)
-        target_sources(sfml-window PRIVATE
-            ${SRCROOT}/NetBSD/JoystickImpl.cpp
-            ${SRCROOT}/NetBSD/JoystickImpl.hpp
-        )
-
+        target_sources(sfml-window PRIVATE NetBSD/JoystickImpl.cpp)
     endif()
 elseif(SFML_OS_MACOSX)
     target_sources(sfml-window PRIVATE
-        ${SRCROOT}/OSX/cpp_objc_conversion.h
-        ${SRCROOT}/OSX/cpp_objc_conversion.mm
-        ${SRCROOT}/OSX/cg_sf_conversion.hpp
-        ${SRCROOT}/OSX/cg_sf_conversion.mm
-        ${SRCROOT}/OSX/CursorImpl.hpp
-        ${SRCROOT}/OSX/CursorImpl.mm
-        ${SRCROOT}/OSX/ClipboardImpl.hpp
-        ${SRCROOT}/OSX/ClipboardImpl.mm
-        ${SRCROOT}/OSX/InputImpl.mm
-        ${SRCROOT}/OSX/InputImpl.hpp
-        ${SRCROOT}/OSX/HIDInputManager.hpp
-        ${SRCROOT}/OSX/HIDInputManager.mm
-        ${SRCROOT}/OSX/HIDJoystickManager.hpp
-        ${SRCROOT}/OSX/HIDJoystickManager.cpp
-        ${SRCROOT}/OSX/JoystickImpl.cpp
-        ${SRCROOT}/OSX/JoystickImpl.hpp
-        ${SRCROOT}/OSX/NSImage+raw.h
-        ${SRCROOT}/OSX/NSImage+raw.mm
-        ${SRCROOT}/OSX/Scaling.h
-        ${SRCROOT}/OSX/SensorImpl.cpp
-        ${SRCROOT}/OSX/SensorImpl.hpp
-        ${SRCROOT}/OSX/SFApplication.h
-        ${SRCROOT}/OSX/SFApplication.m
-        ${SRCROOT}/OSX/SFApplicationDelegate.h
-        ${SRCROOT}/OSX/SFApplicationDelegate.m
-        ${SRCROOT}/OSX/SFContext.hpp
-        ${SRCROOT}/OSX/SFContext.mm
-        ${SRCROOT}/OSX/SFKeyboardModifiersHelper.h
-        ${SRCROOT}/OSX/SFKeyboardModifiersHelper.mm
-        ${SRCROOT}/OSX/SFOpenGLView.h
-        ${SRCROOT}/OSX/SFOpenGLView.mm
-        ${SRCROOT}/OSX/SFOpenGLView+keyboard.mm
-        ${SRCROOT}/OSX/SFOpenGLView+keyboard_priv.h
-        ${SRCROOT}/OSX/SFOpenGLView+mouse.mm
-        ${SRCROOT}/OSX/SFOpenGLView+mouse_priv.h
-        ${SRCROOT}/OSX/SFSilentResponder.h
-        ${SRCROOT}/OSX/SFSilentResponder.m
-        ${SRCROOT}/OSX/SFWindow.h
-        ${SRCROOT}/OSX/SFWindow.m
-        ${SRCROOT}/OSX/SFWindowController.h
-        ${SRCROOT}/OSX/SFWindowController.mm
-        ${SRCROOT}/OSX/SFViewController.h
-        ${SRCROOT}/OSX/SFViewController.mm
-        ${SRCROOT}/OSX/VideoModeImpl.cpp
-        ${SRCROOT}/OSX/WindowImplCocoa.hpp
-        ${SRCROOT}/OSX/WindowImplCocoa.mm
-        ${SRCROOT}/OSX/WindowImplDelegateProtocol.h
-        ${SRCROOT}/OSX/AutoreleasePoolWrapper.hpp
-        ${SRCROOT}/OSX/AutoreleasePoolWrapper.mm
+        OSX/cpp_objc_conversion.mm
+        OSX/cg_sf_conversion.mm
+        OSX/CursorImpl.mm
+        OSX/ClipboardImpl.mm
+        OSX/InputImpl.mm
+        OSX/HIDInputManager.mm
+        OSX/HIDJoystickManager.cpp
+        OSX/JoystickImpl.cpp
+        OSX/NSImage+raw.mm
+        OSX/SensorImpl.cpp
+        OSX/SFApplication.m
+        OSX/SFApplicationDelegate.m
+        OSX/SFContext.mm
+        OSX/SFKeyboardModifiersHelper.mm
+        OSX/SFOpenGLView.mm
+        OSX/SFOpenGLView+keyboard.mm
+        OSX/SFOpenGLView+mouse.mm
+        OSX/SFSilentResponder.m
+        OSX/SFWindow.m
+        OSX/SFWindowController.mm
+        OSX/SFViewController.mm
+        OSX/VideoModeImpl.cpp
+        OSX/WindowImplCocoa.mm
+        OSX/AutoreleasePoolWrapper.mm
     )
 elseif(SFML_OS_IOS)
     target_sources(sfml-window PRIVATE
-        ${SRCROOT}/iOS/CursorImpl.hpp
-        ${SRCROOT}/iOS/CursorImpl.cpp
-        ${SRCROOT}/iOS/ClipboardImpl.mm
-        ${SRCROOT}/iOS/ClipboardImpl.hpp
-        ${SRCROOT}/iOS/EaglContext.mm
-        ${SRCROOT}/iOS/EaglContext.hpp
-        ${SRCROOT}/iOS/InputImpl.mm
-        ${SRCROOT}/iOS/InputImpl.hpp
-        ${SRCROOT}/iOS/JoystickImpl.mm
-        ${SRCROOT}/iOS/JoystickImpl.hpp
-        ${SRCROOT}/iOS/SensorImpl.mm
-        ${SRCROOT}/iOS/SensorImpl.hpp
-        ${SRCROOT}/iOS/VideoModeImpl.mm
-        ${SRCROOT}/iOS/WindowImplUIKit.hpp
-        ${SRCROOT}/iOS/WindowImplUIKit.mm
-        ${SRCROOT}/iOS/ObjCType.hpp
-        ${SRCROOT}/iOS/SFAppDelegate.hpp
-        ${SRCROOT}/iOS/SFAppDelegate.mm
-        ${SRCROOT}/iOS/SFView.hpp
-        ${SRCROOT}/iOS/SFView.mm
-        ${SRCROOT}/iOS/SFViewController.hpp
-        ${SRCROOT}/iOS/SFViewController.mm
-        ${SRCROOT}/iOS/SFMain.hpp
-        ${SRCROOT}/iOS/SFMain.mm
+        iOS/CursorImpl.cpp
+        iOS/ClipboardImpl.mm
+        iOS/EaglContext.mm
+        iOS/InputImpl.mm
+        iOS/JoystickImpl.mm
+        iOS/SensorImpl.mm
+        iOS/VideoModeImpl.mm
+        iOS/WindowImplUIKit.mm
+        iOS/SFAppDelegate.mm
+        iOS/SFView.mm
+        iOS/SFViewController.mm
+        iOS/SFMain.mm
     )
 elseif(SFML_OS_ANDROID)
     target_sources(sfml-window PRIVATE
-        ${SRCROOT}/Android/CursorImpl.hpp
-        ${SRCROOT}/Android/CursorImpl.cpp
-        ${SRCROOT}/Android/ClipboardImpl.hpp
-        ${SRCROOT}/Android/ClipboardImpl.cpp
-        ${SRCROOT}/Android/WindowImplAndroid.hpp
-        ${SRCROOT}/Android/WindowImplAndroid.cpp
-        ${SRCROOT}/Android/VideoModeImpl.cpp
-        ${SRCROOT}/Android/InputImpl.hpp
-        ${SRCROOT}/Android/InputImpl.cpp
-        ${SRCROOT}/Android/JoystickImpl.hpp
-        ${SRCROOT}/Android/JoystickImpl.cpp
-        ${SRCROOT}/Android/SensorImpl.hpp
-        ${SRCROOT}/Android/SensorImpl.cpp
+        Android/CursorImpl.cpp
+        Android/ClipboardImpl.cpp
+        Android/WindowImplAndroid.cpp
+        Android/VideoModeImpl.cpp
+        Android/InputImpl.cpp
+        Android/JoystickImpl.cpp
+        Android/SensorImpl.cpp
     )
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,8 @@ target_include_directories(sfml-test-main PUBLIC TestUtilities)
 target_link_libraries(sfml-test-main PUBLIC SFML::System)
 
 # System is always built
-SET(SYSTEM_SRC
+sfml_add_test(test-sfml-system SFML::System)
+target_sources(test-sfml-system PRIVATE
     System/Angle.cpp
     System/Clock.cpp
     System/FileInputStream.cpp
@@ -20,18 +21,18 @@ SET(SYSTEM_SRC
     System/Vector2.cpp
     System/Vector3.cpp
 )
-sfml_add_test(test-sfml-system "${SYSTEM_SRC}" SFML::System)
 
 if(SFML_BUILD_WINDOW)
-    SET(WINDOW_SRC
+    sfml_add_test(test-sfml-window SFML::Window)
+    target_sources(test-sfml-window PRIVATE
         Window/ContextSettings.cpp
         Window/VideoMode.cpp
     )
-    sfml_add_test(test-sfml-window "${WINDOW_SRC}" SFML::Window)
 endif()
 
 if(SFML_BUILD_GRAPHICS)
-    SET(GRAPHICS_SRC
+    sfml_add_test(test-sfml-graphics SFML::Graphics)
+    target_sources(test-sfml-graphics PRIVATE
         Graphics/BlendMode.cpp
         Graphics/Color.cpp
         Graphics/Rect.cpp
@@ -40,21 +41,20 @@ if(SFML_BUILD_GRAPHICS)
         Graphics/Vertex.cpp
         Graphics/VertexArray.cpp
     )
-    sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" SFML::Graphics)
 endif()
 
 if(SFML_BUILD_NETWORK)
-    SET(NETWORK_SRC
+    sfml_add_test(test-sfml-network SFML::Network)
+    target_sources(test-sfml-network PRIVATE
         Network/Packet.cpp
     )
-    sfml_add_test(test-sfml-network "${NETWORK_SRC}" SFML::Network)
 endif()
 
 if(SFML_BUILD_AUDIO)
-    SET(AUDIO_SRC
+    sfml_add_test(test-sfml-audio SFML::Audio)
+    target_sources(test-sfml-audio PRIVATE
         Audio/Dummy.cpp # TODO: Remove when there are real tests
     )
-    sfml_add_test(test-sfml-audio "${AUDIO_SRC}" SFML::Audio)
 endif()
 
 # Automatically run the tests at the end of the build

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,7 @@
 add_library(sfml-test-main STATIC
     DoctestMain.cpp
-    TestUtilities/SystemUtil.hpp
     TestUtilities/SystemUtil.cpp
-    TestUtilities/WindowUtil.hpp
     TestUtilities/WindowUtil.cpp
-    TestUtilities/GraphicsUtil.hpp
     TestUtilities/GraphicsUtil.cpp
 )
 target_include_directories(sfml-test-main SYSTEM PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/headers")


### PR DESCRIPTION
## Description

Strictly speaking CMake puts no requirement on using `source_group` or listing headers as source files. As I've heard, both of these practices are conveniences to Visual Studio users. Having never used Visual Studio myself I struggle to understand how much of a convenience this is. I'm submitting this PR to get more feedback on what VS users want and to demonstrate exactly how much code can be simplified if we're willing to stop doing these things.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Build this PR in Visual Studio and try to observe any difference in your workflow, particularly if this PR makes SFML development more difficult or annoying. Share any specific observations you make. Mention what version of Visual Studio you are using.