### PR TITLE
Use 'ccache' if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,13 @@ project(SFML VERSION 3.0.0)
 
 set(VERSION_IS_RELEASE OFF)
 
+# use ccache if available
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    message(STATUS "Found ccache in ${CCACHE_PROGRAM}")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 # include the configuration file
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake)
 


### PR DESCRIPTION
## Description

This PR enables the use of `ccache` by default if available on the current machines. `ccache` *massively* speeds up builds when most of the files have not changed. It is a beneficial default, and we should also make sure `ccache` is installed on our CI machines.

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

CI.