### PR TITLE
Mark external headers as SYSTEM headers

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -247,7 +247,7 @@ if ((NOT BUILD_SHARED_LIBS) AND SFML_OS_MACOSX)
 endif()
 
 # Vulkan headers
-target_include_directories(sfml-window PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/vulkan")
+target_include_directories(sfml-window SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/vulkan")
 
 # find and setup usage for external libraries
 if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
@@ -281,7 +281,7 @@ if(SFML_OS_WINDOWS AND NOT SFML_COMPILER_MSVC)
     include(CheckIncludeFile)
     check_include_file(dinput.h DINPUT_H_FOUND)
     if(NOT DINPUT_H_FOUND)
-        target_include_directories(sfml-window PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/mingw")
+        target_include_directories(sfml-window SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/mingw")
     endif()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library(sfml-test-main STATIC
     TestUtilities/GraphicsUtil.hpp
     TestUtilities/GraphicsUtil.cpp
 )
-target_include_directories(sfml-test-main PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/headers" TestUtilities)
+target_include_directories(sfml-test-main SYSTEM PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/headers")
+target_include_directories(sfml-test-main PUBLIC TestUtilities)
 target_link_libraries(sfml-test-main PUBLIC SFML::System)
 
 # System is always built


### PR DESCRIPTION
## Description

Past PRs have made a point to mark external include directories as `SYSTEM` include directories. This PR fixes the last few instances where `SYSTEM` was missing. If you're not familiar with system includes, they're include directories which the compiler knows you do not own or control so it will not emit diagnostics about headers in those paths. This is super useful because it means any compiler warnings we enable for SFML code won't also apply to 3rd party code which we cannot fix like `doctest.h` or OpenGL headers. 

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
