### PR TITLE
Fix SoundStream play

### DIFF
--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -88,7 +88,7 @@ private:
         sf::Packet packet;
         packet << clientEndOfStream;
 
-        if (!m_socket.send(packet))
+        if (m_socket.send(packet) != sf::Socket::Done)
         {
             std::cerr << "Failed to send end-of-stream packet" << std::endl;
         }

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -136,6 +136,12 @@ void SoundStream::play()
         // If the sound is playing, stop it and continue as if it was stopped
         stop();
     }
+    else if (!isStreaming && m_thread.joinable())
+    {
+        // If the streaming thread reached its end, let it join so it can be restarted.
+        // Also reset the playing offset at the beginning.
+        stop();
+    }
 
     // Start updating the stream in a separate thread to avoid blocking the application
     launchStreamingThread(Playing);


### PR DESCRIPTION
## Description

This is a fix for a bug which is visible when running the voip example.

### Expected behavior
The sound recorded by the client is sent to the server. It is played live and kept in memory by the server.
After the client finishes sending the sound, it is played a second time by the server.

### Bug
The assertion in the following function fails when playing the received sound a second time:
https://github.com/SFML/SFML/blob/7dfc7f02029b039005fdb1868dccefa4e523d25c/src/SFML/Audio/SoundStream.cpp#L500-L510

### Explanation
Before replacing SFML 2 threads with standard C++ threads in https://github.com/SFML/SFML/commit/b33f4bb205a5ea3dfd2c213811b3210a895de202 there was a call to `m_thread.launch();` in `SoundStream::play` which waited for the streaming thread to finish before starting it again. This behavior was accidentally removed, so when the received sound is played a second time, the streaming thread is joinable.

In addition, the playing offset is now reset to the beginning when `play` is called a second time, which is the documented behavior.
Before https://github.com/SFML/SFML/commit/b33f4bb205a5ea3dfd2c213811b3210a895de202, calling `play` a second time was not restarting the sound from the beginning and playing was finished immediately.

---

While at it, I fixed a small mistake in the client where the result of `m_socket.send(packet)` was checked as a boolean but it is a `sf::Socket::Status`. It resulted in a bogus error message.
Switching to strong enumerations could avoid this kind of mistakes.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

- Running the voip example