### PR TITLE
Add warning about XButton1 and 2 on X11.

### DIFF
--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -53,8 +53,8 @@ public:
         Left,       //!< The left mouse button
         Right,      //!< The right mouse button
         Middle,     //!< The middle (wheel) mouse button
-        XButton1,   //!< The first extra mouse button
-        XButton2,   //!< The second extra mouse button
+        XButton1,   //!< The first extra mouse button (not available on Linux)
+        XButton2,   //!< The second extra mouse button (not available on Linux)
 
         ButtonCount //!< Keep last -- the total number of mouse buttons
     };
@@ -171,6 +171,8 @@ public:
 /// // set mouse position relative to a window
 /// sf::Mouse::setPosition(sf::Vector2i(100, 200), window);
 /// \endcode
+///
+/// \warning sf::Mouse::XButton1 and sf::Mouse::XButton2 are not available on Linux.
 ///
 /// \see sf::Joystick, sf::Keyboard, sf::Touch
 ///


### PR DESCRIPTION
* [X] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before? Yes at https://en.sfml-dev.org/forums/index.php?topic=28414
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?

----

## Description

Adds a warning about the two XButtons not being polled on Linux. This closes a task for 2.6.0.