### PR TITLE
Fixes compilation error on MacOS

### DIFF
--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -631,8 +631,7 @@
     NSDictionary* deviceDescription = [[m_window screen] deviceDescription];
     NSNumber* screenNumber = [deviceDescription valueForKey:@"NSScreenNumber"];
     CGDirectDisplayID screenID = static_cast<CGDirectDisplayID>([screenNumber intValue]);
-    CGFloat height = CGDisplayPixelsHigh(screenID);
-    return static_cast<float>(height);
+    return static_cast<float>(CGDisplayPixelsHigh(screenID));
 }
 
 


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This change fixes the following compilation error on MacOS with Clang 13 (mainline clang installed through HomeBrew `brew install llvm`).
```
error: implicit conversion from 'size_t' (aka 'unsigned long') to 'CGFloat' (aka 'double') may lose precision [-Werror,-Wimplicit-int-float-conversion]
```

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Compile SFML with `-Werror,-Wimplicit-int-float-conversion`