### PR TITLE
Print absolute paths when file not found

### DIFF
--- a/src/SFML/Audio/SoundFileFactory.cpp
+++ b/src/SFML/Audio/SoundFileFactory.cpp
@@ -36,6 +36,7 @@
 #include <SFML/System/FileInputStream.hpp>
 #include <SFML/System/MemoryInputStream.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Utils.hpp>
 #include <ostream>
 
 
@@ -74,7 +75,7 @@ std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromFilename(cons
     // Wrap the input file into a file stream
     FileInputStream stream;
     if (!stream.open(filename)) {
-        err() << "Failed to open sound file " << filename << " (couldn't open stream)" << std::endl;
+        err() << "Failed to open sound file (couldn't open stream)\n" << formatDebugPathInfo(filename) << std::endl;
         return nullptr;
     }
 
@@ -92,7 +93,7 @@ std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromFilename(cons
     }
 
     // No suitable reader found
-    err() << "Failed to open sound file " << filename << " (format not supported)" << std::endl;
+    err() << "Failed to open sound file (format not supported)\n" << formatDebugPathInfo(filename) << std::endl;
     return nullptr;
 }
 
@@ -165,7 +166,7 @@ std::unique_ptr<SoundFileWriter> SoundFileFactory::createWriterFromFilename(cons
     }
 
     // No suitable writer found
-    err() << "Failed to open sound file " << filename << " (format not supported)" << std::endl;
+    err() << "Failed to open sound file (format not supported)\n" << formatDebugPathInfo(filename) << std::endl;
     return nullptr;
 }
 

--- a/src/SFML/Audio/SoundFileWriterFlac.cpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.cpp
@@ -68,7 +68,7 @@ bool SoundFileWriterFlac::open(const std::filesystem::path& filename, unsigned i
     m_encoder = FLAC__stream_encoder_new();
     if (!m_encoder)
     {
-        err() << "Failed to write flac file " << filename << " (failed to allocate encoder)" << std::endl;
+        err() << "Failed to write flac file (failed to allocate encoder)\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
 
@@ -80,7 +80,7 @@ bool SoundFileWriterFlac::open(const std::filesystem::path& filename, unsigned i
     // Initialize the output stream
     if (FLAC__stream_encoder_init_file(m_encoder, filename.string().c_str(), nullptr, nullptr) != FLAC__STREAM_ENCODER_INIT_STATUS_OK)
     {
-        err() << "Failed to write flac file " << filename << " (failed to open the file)" << std::endl;
+        err() << "Failed to write flac file (failed to open the file)\n" << formatDebugPathInfo(filename) << std::endl;
         close();
         return false;
     }

--- a/src/SFML/Audio/SoundFileWriterOgg.cpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.cpp
@@ -79,7 +79,7 @@ bool SoundFileWriterOgg::open(const std::filesystem::path& filename, unsigned in
     int status = vorbis_encode_init_vbr(&m_vorbis, static_cast<long>(channelCount), static_cast<long>(sampleRate), 0.4f);
     if (status < 0)
     {
-        err() << "Failed to write ogg/vorbis file " << filename << " (unsupported bitrate)" << std::endl;
+        err() << "Failed to write ogg/vorbis file (unsupported bitrate)\n" << formatDebugPathInfo(filename) << std::endl;
         close();
         return false;
     }
@@ -89,7 +89,7 @@ bool SoundFileWriterOgg::open(const std::filesystem::path& filename, unsigned in
     m_file.open(filename.c_str(), std::ios::binary);
     if (!m_file)
     {
-        err() << "Failed to write ogg/vorbis file " << filename << " (cannot open file)" << std::endl;
+        err() << "Failed to write ogg/vorbis file (cannot open file)\n" << formatDebugPathInfo(filename) << std::endl;
         close();
         return false;
     }
@@ -104,7 +104,7 @@ bool SoundFileWriterOgg::open(const std::filesystem::path& filename, unsigned in
     vorbis_comment_clear(&comment);
     if (status < 0)
     {
-        err() << "Failed to write ogg/vorbis file " << filename << " (cannot generate the headers)" << std::endl;
+        err() << "Failed to write ogg/vorbis file (cannot generate the headers)\n" << formatDebugPathInfo(filename) << std::endl;
         close();
         return false;
     }

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -102,14 +102,14 @@ bool SoundFileWriterWav::open(const std::filesystem::path& filename, unsigned in
     m_file.open(filename.c_str(), std::ios::binary);
     if (!m_file)
     {
-        err() << "Failed to open WAV sound file " << filename << " for writing" << std::endl;
+        err() << "Failed to open WAV sound file for writing\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
 
     // Write the header
     if (!writeHeader(sampleRate, channelCount))
     {
-        err() << "Failed to write header of WAV sound file " << filename << std::endl;
+        err() << "Failed to write header of WAV sound file\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -33,6 +33,7 @@
 #endif
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Utils.hpp>
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
@@ -159,7 +160,7 @@ bool Font::loadFromFile(const std::filesystem::path& filename)
     FT_Library library;
     if (FT_Init_FreeType(&library) != 0)
     {
-        err() << "Failed to load font " << filename << " (failed to initialize FreeType)" << std::endl;
+        err() << "Failed to load font (failed to initialize FreeType)\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
     fontHandles->library.reset(library);
@@ -168,7 +169,7 @@ bool Font::loadFromFile(const std::filesystem::path& filename)
     FT_Face face;
     if (FT_New_Face(library, filename.string().c_str(), 0, &face) != 0)
     {
-        err() << "Failed to load font " << filename << " (failed to create the font face)" << std::endl;
+        err() << "Failed to load font (failed to create the font face)\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
     fontHandles->face.reset(face);
@@ -177,7 +178,7 @@ bool Font::loadFromFile(const std::filesystem::path& filename)
     FT_Stroker stroker;
     if (FT_Stroker_New(library, &stroker) != 0)
     {
-        err() << "Failed to load font " << filename << " (failed to create the stroker)" << std::endl;
+        err() << "Failed to load font (failed to create the stroker)\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
     fontHandles->stroker.reset(stroker);
@@ -185,7 +186,7 @@ bool Font::loadFromFile(const std::filesystem::path& filename)
     // Select the unicode character map
     if (FT_Select_Charmap(face, FT_ENCODING_UNICODE) != 0)
     {
-        err() << "Failed to load font " << filename << " (failed to set the Unicode character set)" << std::endl;
+        err() << "Failed to load font (failed to set the Unicode character set)\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
 

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -130,7 +130,7 @@ bool ImageLoader::loadImageFromFile(const std::filesystem::path& filename, std::
     else
     {
         // Error, failed to load the image
-        err() << "Failed to load image " << filename << ". Reason: " << stbi_failure_reason() << std::endl;
+        err() << "Failed to load image\n" << formatDebugPathInfo(filename) << "\nReason: " << stbi_failure_reason() << std::endl;
 
         return false;
     }
@@ -278,7 +278,7 @@ bool ImageLoader::saveImageToFile(const std::filesystem::path& filename, const s
         }
     }
 
-    err() << "Failed to save image " << filename << std::endl;
+    err() << "Failed to save image\n" << formatDebugPathInfo(filename) << std::endl;
     return false;
 }
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -34,6 +34,7 @@
 #include <SFML/Window/Context.hpp>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Utils.hpp>
 #include <fstream>
 #include <iomanip>
 #include <vector>
@@ -260,7 +261,7 @@ bool Shader::loadFromFile(const std::filesystem::path& filename, Type type)
     std::vector<char> shader;
     if (!getFileContents(filename, shader))
     {
-        err() << "Failed to open shader file " << filename << std::endl;
+        err() << "Failed to open shader file\n" << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
 

--- a/src/SFML/System/Utils.hpp
+++ b/src/SFML/System/Utils.hpp
@@ -29,17 +29,28 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <cctype>
+#include <filesystem>
+#include <sstream>
 #include <string>
 
 
 namespace sf
 {
-    [[nodiscard]] inline std::string toLower(std::string str)
-    {
-        for (char& c : str)
-            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        return str;
-    }
+[[nodiscard]] inline std::string toLower(std::string str)
+{
+    for (char& c : str)
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return str;
+}
+
+[[nodiscard]] inline std::string formatDebugPathInfo(const std::filesystem::path& path)
+{
+    std::ostringstream stream;
+    stream << "    Provided path: " << path << '\n';
+    stream << "    Absolute path: " << std::filesystem::absolute(path);
+    return stream.str();
+}
+
 } // namespace sf
 
 #endif // SFML_UTILS_HPP


### PR DESCRIPTION
## Description

Printing absolute paths is helpful when debugging why files won't load. By printing the whole path we're making it more clear to the user exactly what file is failing to load instead of simply repeating the relative path they already wrote in their code.

Here's some more info on [`std::filesystem::absolute`](https://en.cppreference.com/w/cpp/filesystem/absolute). If a path isn't already absolute, it creates an absolute path. This means our APIs still work whether users use relative or absolute paths. I don't believe a change like this would have been feasible before switching over to `std::filesystem`.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

For an easy example of this, build the master branch then try to run `./examples/tennis/tennis` from the CMake binary directory. This will fail with an error that looks like this:

```
AL lib: (EE) FillCPUCaps: Failed to open /proc/cpuinfo, cannot check for NEON support
Failed to open sound file "resources/ball.wav" (couldn't open stream)
```

After this PR, the error instead looks like this:

```
AL lib: (EE) FillCPUCaps: Failed to open /proc/cpuinfo, cannot check for NEON support
Failed to open sound file "/Users/thrasher/Projects/sfml/build/resources/ball.wav" (couldn't open stream)
```

The first output is a bit unclear because there is certainly a file called `ball.wav` in the `resources` directory which lives next to the source file where that code is written. However the second output shows the real truth that I'm actually attempting to load a file from the CMake binary direction which doesn't exist.