### PR TITLE
Use `std::quoted`

### DIFF
--- a/examples/sockets/TCP.cpp
+++ b/examples/sockets/TCP.cpp
@@ -3,6 +3,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Network.hpp>
+#include <iomanip>
 #include <iostream>
 
 
@@ -31,14 +32,14 @@ void runTcpServer(unsigned short port)
     const char out[] = "Hi, I'm the server";
     if (socket.send(out, sizeof(out)) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the client: \"" << out << '"' << std::endl;
+    std::cout << "Message sent to the client: " << std::quoted(out) << std::endl;
 
     // Receive a message back from the client
     char in[128];
     std::size_t received;
     if (socket.receive(in, sizeof(in), received) != sf::Socket::Done)
         return;
-    std::cout << "Answer received from the client: \"" << in << '"' << std::endl;
+    std::cout << "Answer received from the client: " << std::quoted(in) << std::endl;
 }
 
 
@@ -71,11 +72,11 @@ void runTcpClient(unsigned short port)
     std::size_t received;
     if (socket.receive(in, sizeof(in), received) != sf::Socket::Done)
         return;
-    std::cout << "Message received from the server: \"" << in << '"' << std::endl;
+    std::cout << "Message received from the server: " << std::quoted(in) << std::endl;
 
     // Send an answer to the server
     const char out[] = "Hi, I'm a client";
     if (socket.send(out, sizeof(out)) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the server: \"" << out << '"' << std::endl;
+    std::cout << "Message sent to the server: " << std::quoted(out) << std::endl;
 }

--- a/examples/sockets/UDP.cpp
+++ b/examples/sockets/UDP.cpp
@@ -3,6 +3,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Network.hpp>
+#include <iomanip>
 #include <iostream>
 
 
@@ -27,13 +28,13 @@ void runUdpServer(unsigned short port)
     unsigned short senderPort;
     if (socket.receive(in, sizeof(in), received, sender, senderPort) != sf::Socket::Done)
         return;
-    std::cout << "Message received from client " << sender << ": \"" << in << '"' << std::endl;
+    std::cout << "Message received from client " << sender << ": " << std::quoted(in) << std::endl;
 
     // Send an answer to the client
     const char out[] = "Hi, I'm the server";
     if (socket.send(out, sizeof(out), sender, senderPort) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the client: \"" << out << '"' << std::endl;
+    std::cout << "Message sent to the client: " << std::quoted(out) << std::endl;
 }
 
 
@@ -59,7 +60,7 @@ void runUdpClient(unsigned short port)
     const char out[] = "Hi, I'm a client";
     if (socket.send(out, sizeof(out), server, port) != sf::Socket::Done)
         return;
-    std::cout << "Message sent to the server: \"" << out << '"' << std::endl;
+    std::cout << "Message sent to the server: " << std::quoted(out) << std::endl;
 
     // Receive an answer from anyone (but most likely from the server)
     char in[128];
@@ -68,5 +69,5 @@ void runUdpClient(unsigned short port)
     unsigned short senderPort;
     if (socket.receive(in, sizeof(in), received, sender, senderPort) != sf::Socket::Done)
         return;
-    std::cout << "Message received from " << sender << ": \"" << in << '"' << std::endl;
+    std::cout << "Message received from " << sender << ": " << std::quoted(in) << std::endl;
 }

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -34,6 +34,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image_write.h>
 #include <filesystem>
+#include <iomanip>
 #include <iterator>
 #include <ostream>
 
@@ -318,7 +319,7 @@ bool ImageLoader::saveImageToMemory(const std::string& format, std::vector<sf::U
         }
     }
 
-    err() << "Failed to save image with format \"" << format << '"' << std::endl;
+    err() << "Failed to save image with format " << std::quoted(format) << std::endl;
     return false;
 }
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -35,6 +35,7 @@
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Err.hpp>
 #include <fstream>
+#include <iomanip>
 #include <vector>
 #include <mutex>
 #include <ostream>
@@ -571,7 +572,7 @@ void Shader::setUniform(const std::string& name, const Texture& texture)
                 // New entry, make sure there are enough texture units
                 if (m_textures.size() + 1 >= getMaxTextureUnits())
                 {
-                    err() << "Impossible to use texture \"" << name << "\" for shader: all available texture units are used" << std::endl;
+                    err() << "Impossible to use texture " << std::quoted(name) << " for shader: all available texture units are used" << std::endl;
                     return;
                 }
 
@@ -944,7 +945,7 @@ int Shader::getUniformLocation(const std::string& name)
         m_uniforms.emplace(name, location);
 
         if (location == -1)
-            err() << "Uniform \"" << name << "\" not found in shader" << std::endl;
+            err() << "Uniform " << std::quoted(name) << " not found in shader" << std::endl;
 
         return location;
     }

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -31,6 +31,7 @@
 #include <SFML/System/Err.hpp>
 #include <glad/gl.h>
 #include <algorithm>
+#include <iomanip>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -805,7 +806,7 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
                 !parseVersionString(version, "OpenGL ES ",    m_settings.majorVersion, m_settings.minorVersion) &&
                 !parseVersionString(version, "",              m_settings.majorVersion, m_settings.minorVersion))
             {
-                err() << "Unable to parse OpenGL version string: \"" << version << "\", defaulting to 1.1" << std::endl;
+                err() << "Unable to parse OpenGL version string: " << std::quoted(version) << ", defaulting to 1.1" << std::endl;
             }
         }
         else

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -32,6 +32,7 @@
 #include <SFML/System/Time.hpp>
 #include <tchar.h>
 #include <regstr.h>
+#include <iomanip>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -721,8 +722,8 @@ bool JoystickImpl::openDInput(unsigned int index)
 
                     if (FAILED(result))
                     {
-                        err() << "Failed to get DirectInput device axis mode for device \""
-                              << m_identification.name.toAnsiString() << "\": " << result << std::endl;
+                        err() << "Failed to get DirectInput device axis mode for device "
+                              << std::quoted(m_identification.name.toAnsiString()) << ": " << result << std::endl;
 
                         m_device->Release();
                         m_device = nullptr;
@@ -753,8 +754,8 @@ bool JoystickImpl::openDInput(unsigned int index)
 
                     if (FAILED(result))
                     {
-                        err() << "Failed to verify DirectInput device axis mode for device \""
-                              << m_identification.name.toAnsiString() << "\": " << result << std::endl;
+                        err() << "Failed to verify DirectInput device axis mode for device "
+                              << std::quoted(m_identification.name.toAnsiString()) << ": " << result << std::endl;
 
                         m_device->Release();
                         m_device = nullptr;
@@ -807,8 +808,8 @@ bool JoystickImpl::openDInput(unsigned int index)
             }
             else
             {
-                err() << "Failed to set DirectInput device buffer size for device \""
-                      << m_identification.name.toAnsiString() << "\": " << result << std::endl;
+                err() << "Failed to set DirectInput device buffer size for device "
+                      << std::quoted(m_identification.name.toAnsiString()) << ": " << result << std::endl;
 
                 m_device->Release();
                 m_device = nullptr;


### PR DESCRIPTION
## Description

While working on #2042 and #2043 I realized that there are a good number of instances of us manually adding quotes around something so I went about finding all those instances and replacing them with `std::quoted` which I think better expresses the intent of the code. This is my first time using `std::quoted` but I believe this is a valid use case for it. 

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
