### PR TITLE
Move `sf::Rect` printer to GraphicsUtil

### DIFF
--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -8,6 +8,8 @@
 
 #include "WindowUtil.hpp"
 
+#include <SFML/Graphics/Rect.hpp>
+
 namespace sf
 {
     struct BlendMode;
@@ -17,6 +19,13 @@ namespace sf
     std::ostream& operator <<(std::ostream& os, const BlendMode& blendMode);
     std::ostream& operator <<(std::ostream& os, const Color& color);
     std::ostream& operator <<(std::ostream& os, const Transform& transform);
+
+    template <typename T>
+    std::ostream& operator <<(std::ostream& os, const sf::Rect<T>& rect)
+    {
+        os << "(left=" << rect.left << ", top=" << rect.top << ", width=" << rect.width << ", height=" << rect.height << ")";
+        return os;
+    }
 }
 
 #endif // SFML_TESTUTILITIES_GRAPHICS_HPP

--- a/test/TestUtilities/WindowUtil.hpp
+++ b/test/TestUtilities/WindowUtil.hpp
@@ -8,21 +8,12 @@
 
 #include "SystemUtil.hpp"
 
-#include <SFML/Graphics/Rect.hpp>
-
 // String conversions for doctest framework
 namespace sf
 {
     class VideoMode;
 
     std::ostream& operator <<(std::ostream& os, const sf::VideoMode& videoMode);
-
-    template <typename T>
-    std::ostream& operator <<(std::ostream& os, const sf::Rect<T>& rect)
-    {
-        os << "(left=" << rect.left << ", top=" << rect.top << ", width=" << rect.width << ", height=" << rect.height << ")";
-        return os;
-    }
 }
 
 #endif // SFML_TESTUTILITIES_WINDOW_HPP


### PR DESCRIPTION
## Description

Because `sf::Rect` is part of the Graphics module it belongs with the other Graphics test utilities.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
