### PR TITLE
Use `sf::Vector2<T>` for numeric parameter pairs

### DIFF
--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
 
     sf::Sprite image(texture);
-    image.setPosition({screen.width / 2.f, screen.height / 2.f});
-    image.setOrigin({texture.getSize().x / 2.f, texture.getSize().y / 2.f});
+    image.setPosition(sf::Vector2f(screen.size) / 2.f);
+    image.setOrigin(sf::Vector2f(texture.getSize()) / 2.f);
 
     sf::Font font;
     if (!font.loadFromFile("tuffy.ttf"))
@@ -123,8 +123,8 @@ int main(int argc, char *argv[])
                         window.close();
                     break;
                 case sf::Event::Resized:
-                    view.setSize(event.size.width, event.size.height);
-                    view.setCenter({event.size.width / 2.f, event.size.height / 2.f});
+                    view.setSize(sf::Vector2f(event.size.width, event.size.height));
+                    view.setCenter(sf::Vector2f(event.size.width, event.size.height) / 2.f);
                     window.setView(view);
                     break;
                 case sf::Event::LostFocus:

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -87,7 +87,7 @@ void generateTerrain(sf::Vertex* vertexBuffer);
 int main()
 {
     // Create the window of the application
-    sf::RenderWindow window(sf::VideoMode(windowWidth, windowHeight), "SFML Island",
+    sf::RenderWindow window(sf::VideoMode({windowWidth, windowHeight}), "SFML Island",
                             sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -87,7 +87,7 @@ namespace
 int main()
 {
     // Create the window of the application
-    sf::RenderWindow window(sf::VideoMode(400, 775), "Joystick", sf::Style::Close);
+    sf::RenderWindow window(sf::VideoMode({400, 775}), "Joystick", sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
     // Load the text font

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -45,7 +45,7 @@ int main()
         contextSettings.sRgbCapable = sRgb;
 
         // Create the main window
-        sf::RenderWindow window(sf::VideoMode(800, 600), "SFML graphics with OpenGL", sf::Style::Default, contextSettings);
+        sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML graphics with OpenGL", sf::Style::Default, contextSettings);
         window.setVerticalSyncEnabled(true);
 
         // Create a sprite for the background

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -192,7 +192,7 @@ public:
     bool onLoad() override
     {
         // Create the off-screen surface
-        if (!m_surface.create(800, 600))
+        if (!m_surface.create({800, 600}))
             return false;
         m_surface.setSmooth(true);
 
@@ -352,7 +352,7 @@ private:
 int main()
 {
     // Create the main window
-    sf::RenderWindow window(sf::VideoMode(800, 600), "SFML Shader",
+    sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML Shader",
                             sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -38,7 +38,7 @@ int main()
     float ballRadius = 10.f;
 
     // Create the window of the application
-    sf::RenderWindow window(sf::VideoMode(static_cast<unsigned int>(gameWidth), static_cast<unsigned int>(gameHeight), 32), "SFML Tennis",
+    sf::RenderWindow window(sf::VideoMode({static_cast<unsigned int>(gameWidth), static_cast<unsigned int>(gameHeight)}, 32), "SFML Tennis",
                             sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
@@ -151,7 +151,7 @@ int main()
             if (event.type == sf::Event::Resized)
             {
                 sf::View view;
-                view.setSize(gameWidth, gameHeight);
+                view.setSize({gameWidth, gameHeight});
                 view.setCenter({gameWidth / 2.f, gameHeight / 2.f});
                 window.setView(view);
             }

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -187,7 +187,7 @@ class VulkanExample
 public:
     // Constructor
     VulkanExample() :
-    window(sf::VideoMode(800, 600), "SFML window with Vulkan", sf::Style::Default),
+    window(sf::VideoMode({800, 600}), "SFML window with Vulkan", sf::Style::Default),
     vulkanAvailable(sf::Vulkan::isAvailable()),
     maxFramesInFlight(2),
     currentFrame(0),

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -27,7 +27,7 @@ int main()
     contextSettings.depthBits = 24;
 
     // Create the main window
-    sf::Window window(sf::VideoMode(640, 480), "SFML window with OpenGL", sf::Style::Default, contextSettings);
+    sf::Window window(sf::VideoMode({640, 480}), "SFML window with OpenGL", sf::Style::Default, contextSettings);
 
     // Make it the active window for OpenGL calls
     if (!window.setActive())

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -395,14 +395,13 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Find a suitable rectangle within the texture for a glyph
     ///
-    /// \param page   Page of glyphs to search in
-    /// \param width  Width of the rectangle
-    /// \param height Height of the rectangle
+    /// \param page Page of glyphs to search in
+    /// \param size Width and height of the rectangle
     ///
     /// \return Found rectangle within the texture
     ///
     ////////////////////////////////////////////////////////////
-    IntRect findGlyphRect(Page& page, unsigned int width, unsigned int height) const;
+    IntRect findGlyphRect(Page& page, const Vector2u& size) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Make sure that the given size is the current one

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -89,12 +89,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Create the image and fill it with a unique color
     ///
-    /// \param width  Width of the image
-    /// \param height Height of the image
-    /// \param color  Fill color
+    /// \param size  Width and height of the image
+    /// \param color Fill color
     ///
     ////////////////////////////////////////////////////////////
-    void create(unsigned int width, unsigned int height, const Color& color = Color(0, 0, 0));
+    void create(const Vector2u& size, const Color& color = Color(0, 0, 0));
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the image from an array of pixels
@@ -104,12 +103,11 @@ public:
     /// an undefined behavior.
     /// If \a pixels is null, an empty image is created.
     ///
-    /// \param width  Width of the image
-    /// \param height Height of the image
+    /// \param size   Width and height of the image
     /// \param pixels Array of pixels to copy to the image
     ///
     ////////////////////////////////////////////////////////////
-    void create(unsigned int width, unsigned int height, const Uint8* pixels);
+    void create(const Vector2u& size, const Uint8* pixels);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the image from a file on disk
@@ -237,13 +235,12 @@ public:
     /// details on the \b over operator.
     ///
     /// \param source     Source image to copy
-    /// \param destX      X coordinate of the destination position
-    /// \param destY      Y coordinate of the destination position
+    /// \param dest       Coordinates of the destination position
     /// \param sourceRect Sub-rectangle of the source image to copy
     /// \param applyAlpha Should the copy take into account the source transparency?
     ///
     ////////////////////////////////////////////////////////////
-    void copy(const Image& source, unsigned int destX, unsigned int destY, const IntRect& sourceRect = IntRect({0, 0}, {0, 0}), bool applyAlpha = false);
+    void copy(const Image& source, const Vector2u& dest, const IntRect& sourceRect = IntRect({0, 0}, {0, 0}), bool applyAlpha = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the color of a pixel
@@ -252,14 +249,13 @@ public:
     /// coordinates, using out-of-range values will result in
     /// an undefined behavior.
     ///
-    /// \param x     X coordinate of pixel to change
-    /// \param y     Y coordinate of pixel to change
-    /// \param color New color of the pixel
+    /// \param coords Coordinates of pixel to change
+    /// \param color  New color of the pixel
     ///
     /// \see getPixel
     ///
     ////////////////////////////////////////////////////////////
-    void setPixel(unsigned int x, unsigned int y, const Color& color);
+    void setPixel(const Vector2u& coords, const Color& color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the color of a pixel
@@ -268,15 +264,14 @@ public:
     /// coordinates, using out-of-range values will result in
     /// an undefined behavior.
     ///
-    /// \param x X coordinate of pixel to get
-    /// \param y Y coordinate of pixel to get
+    /// \param coords Coordinates of pixel to change
     ///
-    /// \return Color of the pixel at coordinates (x, y)
+    /// \return Color of the pixel at given coordinates
     ///
     /// \see setPixel
     ///
     ////////////////////////////////////////////////////////////
-    Color getPixel(unsigned int x, unsigned int y) const;
+    Color getPixel(const Vector2u& coords) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only pointer to the array of pixels

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -78,14 +78,13 @@ public:
     /// requires a depth or stencil buffer. Otherwise it is unnecessary, and
     /// you should leave this parameter at its default value.
     ///
-    /// \param width    Width of the render-texture
-    /// \param height   Height of the render-texture
+    /// \param size     Width and height of the render-texture
     /// \param settings Additional settings for the underlying OpenGL texture and context
     ///
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool create(unsigned int width, unsigned int height, const ContextSettings& settings = ContextSettings());
+    [[nodiscard]] bool create(const Vector2u& size, const ContextSettings& settings = ContextSettings());
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the maximum anti-aliasing level supported by the system

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -91,13 +91,12 @@ public:
     ///
     /// If this function fails, the texture is left unchanged.
     ///
-    /// \param width  Width of the texture
-    /// \param height Height of the texture
+    /// \param size Width and height of the texture
     ///
     /// \return True if creation was successful
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool create(unsigned int width, unsigned int height);
+    [[nodiscard]] bool create(const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a file on disk
@@ -272,13 +271,11 @@ public:
     /// texture was not previously created.
     ///
     /// \param pixels Array of pixels to copy to the texture
-    /// \param width  Width of the pixel region contained in \a pixels
-    /// \param height Height of the pixel region contained in \a pixels
-    /// \param x      X offset in the texture where to copy the source pixels
-    /// \param y      Y offset in the texture where to copy the source pixels
+    /// \param size   Width and height of the pixel region contained in \a pixels
+    /// \param dest   Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const Uint8* pixels, unsigned int width, unsigned int height, unsigned int x, unsigned int y);
+    void update(const Uint8* pixels, const Vector2u& size, const Vector2u& dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update a part of this texture from another texture
@@ -304,18 +301,17 @@ public:
     /// \brief Update a part of this texture from another texture
     ///
     /// No additional check is performed on the size of the texture,
-    /// passing an invalid combination of texture size and offset
+    /// passing an invalid combination of texture size and destination
     /// will lead to an undefined behavior.
     ///
     /// This function does nothing if either texture was not
     /// previously created.
     ///
     /// \param texture Source texture to copy to this texture
-    /// \param x       X offset in this texture where to copy the source texture
-    /// \param y       Y offset in this texture where to copy the source texture
+    /// \param dest    Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const Texture& texture, unsigned int x, unsigned int y);
+    void update(const Texture& texture, const Vector2u& dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the texture from an image
@@ -341,18 +337,17 @@ public:
     /// \brief Update a part of the texture from an image
     ///
     /// No additional check is performed on the size of the image,
-    /// passing an invalid combination of image size and offset
+    /// passing an invalid combination of image size and destination
     /// will lead to an undefined behavior.
     ///
     /// This function does nothing if the texture was not
     /// previously created.
     ///
     /// \param image Image to copy to the texture
-    /// \param x     X offset in the texture where to copy the source image
-    /// \param y     Y offset in the texture where to copy the source image
+    /// \param dest  Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const Image& image, unsigned int x, unsigned int y);
+    void update(const Image& image, const Vector2u& dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the texture from the contents of a window
@@ -378,18 +373,17 @@ public:
     /// \brief Update a part of the texture from the contents of a window
     ///
     /// No additional check is performed on the size of the window,
-    /// passing an invalid combination of window size and offset
+    /// passing an invalid combination of window size and destination
     /// will lead to an undefined behavior.
     ///
     /// This function does nothing if either the texture or the window
     /// was not previously created.
     ///
     /// \param window Window to copy to the texture
-    /// \param x      X offset in the texture where to copy the source window
-    /// \param y      Y offset in the texture where to copy the source window
+    /// \param dest   Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const Window& window, unsigned int x, unsigned int y);
+    void update(const Window& window, const Vector2u& dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the smooth filter

--- a/include/SFML/Graphics/View.hpp
+++ b/include/SFML/Graphics/View.hpp
@@ -83,17 +83,6 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the size of the view
     ///
-    /// \param width  New width of the view
-    /// \param height New height of the view
-    ///
-    /// \see setCenter, getCenter
-    ///
-    ////////////////////////////////////////////////////////////
-    void setSize(float width, float height);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the size of the view
-    ///
     /// \param size New size
     ///
     /// \see setCenter, getCenter
@@ -181,17 +170,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     const FloatRect& getViewport() const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Move the view relatively to its current position
-    ///
-    /// \param offsetX X coordinate of the move offset
-    /// \param offsetY Y coordinate of the move offset
-    ///
-    /// \see setCenter, rotate, zoom
-    ///
-    ////////////////////////////////////////////////////////////
-    void move(float offsetX, float offsetY);
 
     ////////////////////////////////////////////////////////////
     /// \brief Move the view relatively to its current position

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
 #include <SFML/Window/GlResource.hpp>
+#include <SFML/System/Vector2.hpp>
 #include <memory>
 
 
@@ -156,7 +157,7 @@ public:
     /// \param height   Back buffer height
     ///
     ////////////////////////////////////////////////////////////
-    Context(const ContextSettings& settings, unsigned int width, unsigned int height);
+    Context(const ContextSettings& settings, const Vector2u& size);
 
 private:
 

--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
+#include <SFML/System/Vector2.hpp>
 #include <vector>
 
 
@@ -53,12 +54,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Construct the video mode with its attributes
     ///
-    /// \param modeWidth        Width in pixels
-    /// \param modeHeight       Height in pixels
+    /// \param modeSize         Width and height in pixels
     /// \param modeBitsPerPixel Pixel depths in bits per pixel
     ///
     ////////////////////////////////////////////////////////////
-    VideoMode(unsigned int modeWidth, unsigned int modeHeight, unsigned int modeBitsPerPixel = 32);
+    explicit VideoMode(const Vector2u& modeSize, unsigned int modeBitsPerPixel = 32);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current desktop video mode
@@ -99,8 +99,7 @@ public:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int width;        //!< Video mode width, in pixels
-    unsigned int height;       //!< Video mode height, in pixels
+    Vector2u size;             //!< Video mode width and height, in pixels
     unsigned int bitsPerPixel; //!< Video mode pixel depth, in bits per pixels
 };
 

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -273,8 +273,7 @@ public:
     ///
     /// The OS default icon is used by default.
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the array of pixels in memory. The
     ///               pixels are copied, so you need not keep the
     ///               source alive after calling this function.
@@ -282,7 +281,7 @@ public:
     /// \see setTitle
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(unsigned int width, unsigned int height, const Uint8* pixels);
+    void setIcon(const Vector2u& size, const Uint8* pixels);
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -70,12 +70,12 @@ Image& Image::operator=(Image&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
-void Image::create(unsigned int width, unsigned int height, const Color& color)
+void Image::create(const Vector2u& size, const Color& color)
 {
-    if (width && height)
+    if (size.x && size.y)
     {
         // Create a new pixel buffer first for exception safety's sake
-        std::vector<Uint8> newPixels(static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4);
+        std::vector<Uint8> newPixels(static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) * 4);
 
         // Fill it with the specified color
         Uint8* ptr = newPixels.data();
@@ -92,8 +92,7 @@ void Image::create(unsigned int width, unsigned int height, const Color& color)
         m_pixels.swap(newPixels);
 
         // Assign the new size
-        m_size.x = width;
-        m_size.y = height;
+        m_size = size;
     }
     else
     {
@@ -108,19 +107,18 @@ void Image::create(unsigned int width, unsigned int height, const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-void Image::create(unsigned int width, unsigned int height, const Uint8* pixels)
+void Image::create(const Vector2u& size, const Uint8* pixels)
 {
-    if (pixels && width && height)
+    if (pixels && size.x && size.y)
     {
         // Create a new pixel buffer first for exception safety's sake
-        std::vector<Uint8> newPixels(pixels, pixels + width * height * 4);
+        std::vector<Uint8> newPixels(pixels, pixels + size.x * size.y * 4);
 
         // Commit the new pixel buffer
         m_pixels.swap(newPixels);
 
         // Assign the new size
-        m_size.x = width;
-        m_size.y = height;
+        m_size = size;
     }
     else
     {
@@ -204,7 +202,7 @@ void Image::createMaskFromColor(const Color& color, Uint8 alpha)
 
 
 ////////////////////////////////////////////////////////////
-void Image::copy(const Image& source, unsigned int destX, unsigned int destY, const IntRect& sourceRect, bool applyAlpha)
+void Image::copy(const Image& source, const Vector2u& dest, const IntRect& sourceRect, bool applyAlpha)
 {
     // Make sure that both images are valid
     if ((source.m_size.x == 0) || (source.m_size.y == 0) || (m_size.x == 0) || (m_size.y == 0))
@@ -230,8 +228,8 @@ void Image::copy(const Image& source, unsigned int destX, unsigned int destY, co
     // Then find the valid bounds of the destination rectangle
     auto width  = static_cast<unsigned int>(srcRect.width);
     auto height = static_cast<unsigned int>(srcRect.height);
-    if (destX + width  > m_size.x) width  = m_size.x - destX;
-    if (destY + height > m_size.y) height = m_size.y - destY;
+    if (dest.x + width  > m_size.x) width  = m_size.x - dest.x;
+    if (dest.y + height > m_size.y) height = m_size.y - dest.y;
 
     // Make sure the destination area is valid
     if ((width <= 0) || (height <= 0))
@@ -243,7 +241,7 @@ void Image::copy(const Image& source, unsigned int destX, unsigned int destY, co
     int          srcStride = static_cast<int>(source.m_size.x) * 4;
     int          dstStride = static_cast<int>(m_size.x) * 4;
     const Uint8* srcPixels = source.m_pixels.data() + (static_cast<unsigned int>(srcRect.left) + static_cast<unsigned int>(srcRect.top) * source.m_size.x) * 4;
-    Uint8*       dstPixels = m_pixels.data() + (destX + destY * m_size.x) * 4;
+    Uint8*       dstPixels = m_pixels.data() + (dest.x + dest.y * m_size.x) * 4;
 
     // Copy the pixels
     if (applyAlpha)
@@ -290,9 +288,9 @@ void Image::copy(const Image& source, unsigned int destX, unsigned int destY, co
 
 
 ////////////////////////////////////////////////////////////
-void Image::setPixel(unsigned int x, unsigned int y, const Color& color)
+void Image::setPixel(const Vector2u& coords, const Color& color)
 {
-    Uint8* pixel = &m_pixels[(x + y * m_size.x) * 4];
+    Uint8* pixel = &m_pixels[(coords.x + coords.y * m_size.x) * 4];
     *pixel++ = color.r;
     *pixel++ = color.g;
     *pixel++ = color.b;
@@ -301,9 +299,9 @@ void Image::setPixel(unsigned int x, unsigned int y, const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-Color Image::getPixel(unsigned int x, unsigned int y) const
+Color Image::getPixel(const Vector2u& coords) const
 {
-    const Uint8* pixel = &m_pixels[(x + y * m_size.x) * 4];
+    const Uint8* pixel = &m_pixels[(coords.x + coords.y * m_size.x) * 4];
     return Color(pixel[0], pixel[1], pixel[2], pixel[3]);
 }
 

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -44,13 +44,13 @@ RenderTexture::~RenderTexture() = default;
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTexture::create(unsigned int width, unsigned int height, const ContextSettings& settings)
+bool RenderTexture::create(const Vector2u& size, const ContextSettings& settings)
 {
     // Set texture to be in sRGB scale if requested
     m_texture.setSrgb(settings.sRgbCapable);
 
     // Create the texture
-    if (!m_texture.create(width, height))
+    if (!m_texture.create(size))
     {
         err() << "Impossible to create render texture (failed to create the target texture)" << std::endl;
         return false;
@@ -75,7 +75,7 @@ bool RenderTexture::create(unsigned int width, unsigned int height, const Contex
     }
 
     // Initialize the render texture
-    if (!m_impl->create(width, height, m_texture.m_texture, settings))
+    if (!m_impl->create(size, m_texture.m_texture, settings))
         return false;
 
     // We can now initialize the render target part

--- a/src/SFML/Graphics/RenderTextureImpl.hpp
+++ b/src/SFML/Graphics/RenderTextureImpl.hpp
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/System/Vector2.hpp>
 
 
 namespace sf
@@ -72,15 +73,14 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Create the render texture implementation
     ///
-    /// \param width      Width of the texture to render to
-    /// \param height     Height of the texture to render to
+    /// \param size       Width and height of the texture to render to
     /// \param textureId  OpenGL identifier of the target texture
     /// \param settings   Context settings to create render-texture with
     ///
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool create(unsigned int width, unsigned int height, unsigned int textureId, const ContextSettings& settings) = 0;
+    virtual bool create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering

--- a/src/SFML/Graphics/RenderTextureImplDefault.cpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.cpp
@@ -40,8 +40,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 RenderTextureImplDefault::RenderTextureImplDefault() :
 m_context(),
-m_width  (0),
-m_height (0)
+m_size   (0, 0)
 {
 
 }
@@ -62,14 +61,13 @@ unsigned int RenderTextureImplDefault::getMaximumAntialiasingLevel()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTextureImplDefault::create(unsigned int width, unsigned int height, unsigned int, const ContextSettings& settings)
+bool RenderTextureImplDefault::create(const Vector2u& size, unsigned int, const ContextSettings& settings)
 {
     // Store the dimensions
-    m_width = width;
-    m_height = height;
+    m_size = size;
 
     // Create the in-memory OpenGL context
-    m_context = std::make_unique<Context>(settings, width, height);
+    m_context = std::make_unique<Context>(settings, size);
 
     return true;
 }
@@ -97,7 +95,7 @@ void RenderTextureImplDefault::updateTexture(unsigned int textureId)
 
     // Copy the rendered pixels to the texture
     glCheck(glBindTexture(GL_TEXTURE_2D, textureId));
-    glCheck(glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, static_cast<GLsizei>(m_width), static_cast<GLsizei>(m_height)));
+    glCheck(glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, static_cast<GLsizei>(m_size.x), static_cast<GLsizei>(m_size.y)));
 }
 
 } // namespace priv

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -74,15 +74,14 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Create the render texture implementation
     ///
-    /// \param width      Width of the texture to render to
-    /// \param height     Height of the texture to render to
+    /// \param size       Width and height of the texture to render to
     /// \param textureId  OpenGL identifier of the target texture
     /// \param settings   Context settings to create render-texture with
     ///
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    bool create(unsigned int width, unsigned int height, unsigned int textureId, const ContextSettings& settings) override;
+    bool create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering
@@ -117,8 +116,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     std::unique_ptr<Context> m_context; //!< P-Buffer based context
-    unsigned int m_width;               //!< Width of the P-Buffer
-    unsigned int m_height;              //!< Height of the P-Buffer
+    Vector2u m_size;                    //!< Width and height of the P-Buffer
 };
 
 } // namespace priv

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -119,8 +119,7 @@ namespace priv
 RenderTextureImplFBO::RenderTextureImplFBO() :
 m_depthStencilBuffer(0),
 m_colorBuffer       (0),
-m_width             (0),
-m_height            (0),
+m_size              (0, 0),
 m_context           (),
 m_textureId         (0),
 m_multisample       (false),
@@ -212,11 +211,10 @@ void RenderTextureImplFBO::unbind()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsigned int textureId, const ContextSettings& settings)
+bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings)
 {
     // Store the dimensions
-    m_width = width;
-    m_height = height;
+    m_size = size;
 
     {
         TransientContextLock lock;
@@ -268,7 +266,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
                     return false;
                 }
                 glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-                glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH24_STENCIL8, static_cast<GLsizei>(width), static_cast<GLsizei>(height)));
+                glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH24_STENCIL8, static_cast<GLsizei>(size.x), static_cast<GLsizei>(size.y)));
 
 #else
 
@@ -291,7 +289,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
                     return false;
                 }
                 glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-                glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH_COMPONENT, static_cast<GLsizei>(width), static_cast<GLsizei>(height)));
+                glCheck(GLEXT_glRenderbufferStorage(GLEXT_GL_RENDERBUFFER, GLEXT_GL_DEPTH_COMPONENT, static_cast<GLsizei>(size.x), static_cast<GLsizei>(size.y)));
             }
         }
         else
@@ -309,7 +307,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
                 return false;
             }
             glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_colorBuffer));
-            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, static_cast<GLsizei>(settings.antialiasingLevel), m_sRgb ? GL_SRGB8_ALPHA8_EXT : GL_RGBA, static_cast<GLsizei>(width), static_cast<GLsizei>(height)));
+            glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, static_cast<GLsizei>(settings.antialiasingLevel), m_sRgb ? GL_SRGB8_ALPHA8_EXT : GL_RGBA, static_cast<GLsizei>(size.x), static_cast<GLsizei>(size.y)));
 
             // Create the multisample depth/stencil buffer if requested
             if (settings.stencilBits)
@@ -323,7 +321,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
                     return false;
                 }
                 glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-                glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, static_cast<GLsizei>(settings.antialiasingLevel), GLEXT_GL_DEPTH24_STENCIL8, static_cast<GLsizei>(width), static_cast<GLsizei>(height)));
+                glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, static_cast<GLsizei>(settings.antialiasingLevel), GLEXT_GL_DEPTH24_STENCIL8, static_cast<GLsizei>(size.x), static_cast<GLsizei>(size.y)));
 
                 m_stencil = true;
             }
@@ -338,7 +336,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
                     return false;
                 }
                 glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
-                glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, static_cast<GLsizei>(settings.antialiasingLevel), GLEXT_GL_DEPTH_COMPONENT, static_cast<GLsizei>(width), static_cast<GLsizei>(height)));
+                glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER, static_cast<GLsizei>(settings.antialiasingLevel), GLEXT_GL_DEPTH_COMPONENT, static_cast<GLsizei>(size.x), static_cast<GLsizei>(size.y)));
             }
 
 #else
@@ -592,7 +590,7 @@ void RenderTextureImplFBO::updateTexture(unsigned int)
 
     // In case of multisampling, make sure both FBOs
     // are already available within the current context
-    if (m_multisample && m_width && m_height && activate(true))
+    if (m_multisample && m_size.x && m_size.y && activate(true))
     {
         Uint64 contextId = Context::getActiveContextId();
 
@@ -605,7 +603,7 @@ void RenderTextureImplFBO::updateTexture(unsigned int)
         {
             // Set up the blit target (draw framebuffer) and blit (from the read framebuffer, our multisample FBO)
             glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, frameBufferIt->second));
-            glCheck(GLEXT_glBlitFramebuffer(0, 0, static_cast<GLint>(m_width), static_cast<GLint>(m_height), 0, 0, static_cast<GLint>(m_width), static_cast<GLint>(m_height), GL_COLOR_BUFFER_BIT, GL_NEAREST));
+            glCheck(GLEXT_glBlitFramebuffer(0, 0, static_cast<GLint>(m_size.x), static_cast<GLint>(m_size.y), 0, 0, static_cast<GLint>(m_size.x), static_cast<GLint>(m_size.y), GL_COLOR_BUFFER_BIT, GL_NEAREST));
             glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, multisampleIt->second));
         }
     }

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -89,15 +89,14 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Create the render texture implementation
     ///
-    /// \param width      Width of the texture to render to
-    /// \param height     Height of the texture to render to
+    /// \param size       Width and height of the texture to render to
     /// \param textureId  OpenGL identifier of the target texture
     /// \param settings   Context settings to create render-texture with
     ///
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    bool create(unsigned int width, unsigned int height, unsigned int textureId, const ContextSettings& settings) override;
+    bool create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create an FBO in the current context
@@ -143,8 +142,7 @@ private:
     std::unordered_map<Uint64, unsigned int> m_multisampleFrameBuffers; //!< Optional per-context OpenGL frame buffer objects with multisample attachments
     unsigned int                             m_depthStencilBuffer;      //!< Optional depth/stencil buffer attached to the frame buffer
     unsigned int                             m_colorBuffer;             //!< Optional multisample color buffer attached to the frame buffer
-    unsigned int                             m_width;                   //!< Width of the attachments
-    unsigned int                             m_height;                  //!< Height of the attachments
+    Vector2u                                 m_size;                    //!< Width and height of the attachments
     std::unique_ptr<Context>                 m_context;                 //!< Backup OpenGL context, used when none already exist
     unsigned int                             m_textureId;               //!< The ID of the texture to attach to the FBO
     bool                                     m_multisample;             //!< Whether we have to create a multisample frame buffer as well

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -78,22 +78,13 @@ void View::setCenter(const Vector2f& center)
     m_invTransformUpdated = false;
 }
 
-
-////////////////////////////////////////////////////////////
-void View::setSize(float width, float height)
-{
-    m_size.x = width;
-    m_size.y = height;
-
-    m_transformUpdated    = false;
-    m_invTransformUpdated = false;
-}
-
-
 ////////////////////////////////////////////////////////////
 void View::setSize(const Vector2f& size)
 {
-    setSize(size.x, size.y);
+    m_size = size;
+
+    m_transformUpdated    = false;
+    m_invTransformUpdated = false;
 }
 
 
@@ -173,7 +164,7 @@ void View::rotate(Angle angle)
 ////////////////////////////////////////////////////////////
 void View::zoom(float factor)
 {
-    setSize(m_size.x * factor, m_size.y * factor);
+    setSize(m_size * factor);
 }
 
 

--- a/src/SFML/Window/Android/VideoModeImpl.cpp
+++ b/src/SFML/Window/Android/VideoModeImpl.cpp
@@ -43,7 +43,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     // Return both portrait and landscape resolutions
     std::vector<VideoMode> modes;
     modes.push_back(desktop);
-    modes.emplace_back(desktop.height, desktop.width, desktop.bitsPerPixel);
+    modes.emplace_back(Vector2u(desktop.size.y, desktop.size.x), desktop.bitsPerPixel);
     return modes;
 }
 
@@ -55,7 +55,7 @@ VideoMode VideoModeImpl::getDesktopMode()
     priv::ActivityStates& states = priv::getActivity();
     std::scoped_lock lock(states.mutex);
 
-    return VideoMode(static_cast<unsigned int>(states.screenSize.x), static_cast<unsigned int>(states.screenSize.y));
+    return VideoMode(Vector2u(states.screenSize));
 }
 
 } // namespace priv

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -61,7 +61,7 @@ WindowImplAndroid::WindowImplAndroid(WindowHandle /* handle */)
 
 ////////////////////////////////////////////////////////////
 WindowImplAndroid::WindowImplAndroid(VideoMode mode, const String& /* title */, unsigned long style, const ContextSettings& /* settings */)
-: m_size(mode.width, mode.height)
+: m_size(mode.size)
 , m_windowBeingCreated(false)
 , m_windowBeingDestroyed(false)
 , m_hasFocus(false)
@@ -160,7 +160,7 @@ void WindowImplAndroid::setTitle(const String& /* title */)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setIcon(unsigned int /* width */, unsigned int /* height */, const Uint8* /* pixels */)
+void WindowImplAndroid::setIcon(const Vector2u& /* size */, const Uint8* /* pixels */)
 {
     // Not applicable
 }

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -123,12 +123,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(unsigned int width, unsigned int height, const Uint8* pixels) override;
+    void setIcon(const Vector2u& size, const Uint8* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -118,8 +118,8 @@ GlFunctionPointer Context::getFunction(const char* name)
 
 
 ////////////////////////////////////////////////////////////
-Context::Context(const ContextSettings& settings, unsigned int width, unsigned int height)
-: m_context(priv::GlContext::create(settings, width, height))
+Context::Context(const ContextSettings& settings, const Vector2u& size)
+: m_context(priv::GlContext::create(settings, size))
 {
     if (!setActive(true))
     {

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -204,8 +204,7 @@ m_config     (nullptr),
 m_currentBO  (nullptr),
 m_nextBO     (nullptr),
 m_gbmSurface (nullptr),
-m_width      (0),
-m_height     (0),
+m_size       (0, 0),
 m_shown      (false),
 m_scanOut    (false)
 {
@@ -222,9 +221,9 @@ m_scanOut    (false)
     createContext(shared);
 
     if (shared)
-        createSurface(shared->m_width, shared->m_height, VideoMode::getDesktopMode().bitsPerPixel, false);
+        createSurface(shared->m_size, VideoMode::getDesktopMode().bitsPerPixel, false);
     else // create a surface to force the GL to initialize (seems to be required for glGetString() etc )
-        createSurface(1, 1, VideoMode::getDesktopMode().bitsPerPixel, false);
+        createSurface({1, 1}, VideoMode::getDesktopMode().bitsPerPixel, false);
 }
 
 
@@ -237,8 +236,7 @@ m_config     (nullptr),
 m_currentBO  (nullptr),
 m_nextBO     (nullptr),
 m_gbmSurface (nullptr),
-m_width      (0),
-m_height     (0),
+m_size       (0, 0),
 m_shown      (false),
 m_scanOut    (false)
 {
@@ -255,12 +253,12 @@ m_scanOut    (false)
     createContext(shared);
 
     Vector2u size = owner.getSize();
-    createSurface(size.x, size.y, bitsPerPixel, true);
+    createSurface(size, bitsPerPixel, true);
 }
 
 
 ////////////////////////////////////////////////////////////
-DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, unsigned int width, unsigned int height) :
+DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, const Vector2u& size) :
 m_display    (EGL_NO_DISPLAY),
 m_context    (EGL_NO_CONTEXT),
 m_surface    (EGL_NO_SURFACE),
@@ -268,8 +266,7 @@ m_config     (nullptr),
 m_currentBO  (nullptr),
 m_nextBO     (nullptr),
 m_gbmSurface (nullptr),
-m_width      (0),
-m_height     (0),
+m_size       (0, 0),
 m_shown      (false),
 m_scanOut    (false)
 {
@@ -284,7 +281,7 @@ m_scanOut    (false)
 
     // Create EGL context
     createContext(shared);
-    createSurface(width, height, VideoMode::getDesktopMode().bitsPerPixel, false);
+    createSurface(size, VideoMode::getDesktopMode().bitsPerPixel, false);
 }
 
 
@@ -431,7 +428,7 @@ void DRMContext::createContext(DRMContext* shared)
 
 
 ////////////////////////////////////////////////////////////
-void DRMContext::createSurface(unsigned int width, unsigned int height, unsigned int /*bpp*/, bool scanout)
+void DRMContext::createSurface(const Vector2u& size, unsigned int /*bpp*/, bool scanout)
 {
     sf::Uint32 flags = GBM_BO_USE_RENDERING;
 
@@ -441,8 +438,8 @@ void DRMContext::createSurface(unsigned int width, unsigned int height, unsigned
 
     m_gbmSurface = gbm_surface_create(
         gbmDevice,
-        width,
-        height,
+        size.x,
+        size.y,
         GBM_FORMAT_ARGB8888,
         flags);
 
@@ -452,8 +449,7 @@ void DRMContext::createSurface(unsigned int width, unsigned int height, unsigned
         return;
     }
 
-    m_width = width;
-    m_height = height;
+    m_size = size;
 
     m_surface = eglCheck(eglCreateWindowSurface(m_display, m_config, reinterpret_cast<EGLNativeWindowType>(m_gbmSurface), nullptr));
 

--- a/src/SFML/Window/DRM/DRMContext.hpp
+++ b/src/SFML/Window/DRM/DRMContext.hpp
@@ -76,11 +76,10 @@ public:
     ///
     /// \param shared   Context to share the new one with
     /// \param settings Creation parameters
-    /// \param width    Back buffer width, in pixels
-    /// \param height   Back buffer height, in pixels
+    /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    DRMContext(DRMContext* shared, const ContextSettings& settings, unsigned int width, unsigned int height);
+    DRMContext(DRMContext* shared, const ContextSettings& settings, const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -131,13 +130,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Create the EGL surface
     ///
-    /// \param width   Back buffer width, in pixels
-    /// \param height  Back buffer height, in pixels
+    /// \param size    Back buffer width and height, in pixels
     /// \param bpp     Pixel depth, in bits per pixel
     /// \param scanout True to present the surface to the screen
     ///
     ////////////////////////////////////////////////////////////
-    void createSurface(unsigned int width, unsigned int height, unsigned int bpp, bool scanout);
+    void createSurface(const Vector2u& size, unsigned int bpp, bool scanout);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destroy the EGL surface
@@ -200,8 +198,7 @@ private:
     gbm_bo* m_currentBO;
     gbm_bo* m_nextBO;
     gbm_surface* m_gbmSurface;
-    unsigned int m_width;
-    unsigned int m_height;
+    Vector2u m_size;
     bool m_shown;
     bool m_scanOut;
 };

--- a/src/SFML/Window/DRM/VideoModeImpl.cpp
+++ b/src/SFML/Window/DRM/VideoModeImpl.cpp
@@ -47,8 +47,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     {
         for (int i = 0; i < conn->count_modes; i++)
             modes.push_back(
-                VideoMode(conn->modes[i].hdisplay,
-                    conn->modes[i].vdisplay));
+                VideoMode({conn->modes[i].hdisplay, conn->modes[i].vdisplay}));
     }
     else
         modes.push_back(getDesktopMode());
@@ -63,9 +62,9 @@ VideoMode VideoModeImpl::getDesktopMode()
     drm* drm = sf::priv::DRMContext::getDRM();
     drmModeModeInfoPtr ptr = drm->mode;
     if (ptr)
-        return VideoMode(ptr->hdisplay, ptr->vdisplay);
+        return VideoMode({ptr->hdisplay, ptr->vdisplay});
     else
-        return VideoMode(0, 0);
+        return VideoMode({0, 0});
 }
 
 } // namespace priv

--- a/src/SFML/Window/DRM/WindowImplDRM.cpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.cpp
@@ -48,7 +48,7 @@ m_size(0, 0)
 
 ////////////////////////////////////////////////////////////
 WindowImplDRM::WindowImplDRM(VideoMode mode, const String& /*title*/, unsigned long /*style*/, const ContextSettings& /*settings*/) :
-m_size(mode.width, mode.height)
+m_size(mode.size)
 {
     sf::priv::InputImpl::setTerminalConfig();
 }
@@ -101,7 +101,7 @@ void WindowImplDRM::setTitle(const String& /*title*/)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplDRM::setIcon(unsigned int /*width*/, unsigned int /*height*/, const Uint8* /*pixels*/)
+void WindowImplDRM::setIcon(const Vector2u& /*size*/, const Uint8* /*pixels*/)
 {
 }
 

--- a/src/SFML/Window/DRM/WindowImplDRM.hpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.hpp
@@ -119,12 +119,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    virtual void setIcon(unsigned int width, unsigned int height, const Uint8* pixels) override;
+    virtual void setIcon(const Vector2u& size, const Uint8* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -171,7 +171,7 @@ m_config  (nullptr)
 
 
 ////////////////////////////////////////////////////////////
-EglContext::EglContext(EglContext* /*shared*/, const ContextSettings& /*settings*/, unsigned int /*width*/, unsigned int /*height*/) :
+EglContext::EglContext(EglContext* /*shared*/, const ContextSettings& /*settings*/, const Vector2u& /*size*/) :
 m_display (EGL_NO_DISPLAY),
 m_context (EGL_NO_CONTEXT),
 m_surface (EGL_NO_SURFACE),
@@ -179,7 +179,7 @@ m_config  (nullptr)
 {
     EglContextImpl::ensureInit();
 
-    sf::err() << "Warning: context has not been initialized. The constructor EglContext(shared, settings, width, height) is currently not implemented." << std::endl;
+    sf::err() << "Warning: context has not been initialized. The constructor EglContext(shared, settings, size) is currently not implemented." << std::endl;
 }
 
 

--- a/src/SFML/Window/EglContext.hpp
+++ b/src/SFML/Window/EglContext.hpp
@@ -71,11 +71,10 @@ public:
     ///
     /// \param shared   Context to share the new one with
     /// \param settings Creation parameters
-    /// \param width    Back buffer width, in pixels
-    /// \param height   Back buffer height, in pixels
+    /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    EglContext(EglContext* shared, const ContextSettings& settings, unsigned int width, unsigned int height);
+    EglContext(EglContext* shared, const ContextSettings& settings, const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -501,7 +501,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, co
         // Re-create our shared context as a core context
         ContextSettings sharedSettings(0, 0, 0, settings.majorVersion, settings.minorVersion, settings.attributeFlags);
 
-        sharedContext = std::make_unique<ContextType>(nullptr, sharedSettings, 1, 1);
+        sharedContext = std::make_unique<ContextType>(nullptr, sharedSettings, Vector2u(1, 1));
         sharedContext->initialize(sharedSettings);
 
         // Reload our extensions vector
@@ -530,7 +530,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, co
 
 
 ////////////////////////////////////////////////////////////
-std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, unsigned int width, unsigned int height)
+std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, const Vector2u& size)
 {
     using GlContextImpl::mutex;
     using GlContextImpl::resourceCount;
@@ -553,7 +553,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, un
         // Re-create our shared context as a core context
         ContextSettings sharedSettings(0, 0, 0, settings.majorVersion, settings.minorVersion, settings.attributeFlags);
 
-        sharedContext = std::make_unique<ContextType>(nullptr, sharedSettings, 1, 1);
+        sharedContext = std::make_unique<ContextType>(nullptr, sharedSettings, Vector2u(1, 1));
         sharedContext->initialize(sharedSettings);
 
         // Reload our extensions vector
@@ -569,7 +569,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, un
         sharedContext->setActive(true);
 
         // Create the context
-        context = std::make_unique<ContextType>(sharedContext.get(), settings, width, height);
+        context = std::make_unique<ContextType>(sharedContext.get(), settings, size);
 
         sharedContext->setActive(false);
     }

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -128,13 +128,12 @@ public:
     /// to use according to the OS.
     ///
     /// \param settings Creation parameters
-    /// \param width    Back buffer width
-    /// \param height   Back buffer height
+    /// \param size     Back buffer width and height
     ///
     /// \return Pointer to the created context
     ///
     ////////////////////////////////////////////////////////////
-    static std::unique_ptr<GlContext> create(const ContextSettings& settings, unsigned int width, unsigned int height);
+    static std::unique_ptr<GlContext> create(const ContextSettings& settings, const Vector2u& size);
 
 public:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/InputImpl.mm
+++ b/src/SFML/Window/OSX/InputImpl.mm
@@ -155,7 +155,7 @@ Vector2i InputImpl::getMousePosition()
     AutoreleasePool pool;
     // Reverse Y axis to match SFML coord.
     NSPoint pos = [NSEvent mouseLocation];
-    pos.y = sf::VideoMode::getDesktopMode().height - pos.y;
+    pos.y = sf::VideoMode::getDesktopMode().size.y - pos.y;
 
     int scale = static_cast<int>([[NSScreen mainScreen] backingScaleFactor]);
     return Vector2i(static_cast<int>(pos.x), static_cast<int>(pos.y)) * scale;

--- a/src/SFML/Window/OSX/SFContext.hpp
+++ b/src/SFML/Window/OSX/SFContext.hpp
@@ -90,12 +90,11 @@ public:
     ///
     /// \param shared   Context to share the new one with
     /// \param settings Creation parameters
-    /// \param width    Back buffer width, in pixels
-    /// \param height   Back buffer height, in pixels
+    /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
     SFContext(SFContext* shared, const ContextSettings& settings,
-              unsigned int width, unsigned int height);
+              const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/OSX/SFContext.mm
+++ b/src/SFML/Window/OSX/SFContext.mm
@@ -81,7 +81,7 @@ m_window(0)
 
 ////////////////////////////////////////////////////////////
 SFContext::SFContext(SFContext* shared, const ContextSettings& settings,
-                     unsigned int width, unsigned int height) :
+                     const Vector2u& size) :
 m_context(0),
 m_view(0),
 m_window(0)
@@ -94,11 +94,11 @@ m_window(0)
     createContext(shared, VideoMode::getDesktopMode().bitsPerPixel, settings);
 
     // Create a dummy window/view pair (hidden) and assign it our context.
-    m_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, width, height)
+    m_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, size.x, size.y)
                                            styleMask:NSBorderlessWindowMask
                                              backing:NSBackingStoreBuffered
                                                defer:NO]; // Don't defer it!
-    m_view = [[NSOpenGLView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];
+    m_view = [[NSOpenGLView alloc] initWithFrame:NSMakeRect(0, 0, size.x, size.y)];
     [m_window setContentView:m_view];
     [m_view setOpenGLContext:m_context];
     [m_context setView:m_view];

--- a/src/SFML/Window/OSX/SFOpenGLView.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView.mm
@@ -247,7 +247,7 @@
     // Send a resize event if the scaling factor changed
     if ((m_scaleFactor != oldScaleFactor) && (m_requester != 0)) {
         NSSize newSize = [self frame].size;
-        m_requester->windowResized(static_cast<unsigned int>(newSize.width), static_cast<unsigned int>(newSize.height));
+        m_requester->windowResized({static_cast<unsigned int>(newSize.width), static_cast<unsigned int>(newSize.height)});
     }
 }
 
@@ -279,7 +279,7 @@
 
     // The new size
     NSSize newSize = [self frame].size;
-    m_requester->windowResized(static_cast<unsigned int>(newSize.width), static_cast<unsigned int>(newSize.height));
+    m_requester->windowResized({static_cast<unsigned int>(newSize.width), static_cast<unsigned int>(newSize.height)});
 }
 
 ////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -183,7 +183,7 @@
     // Create a screen-sized window on the main display
     sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
     sf::priv::scaleInWidthHeight(desktop, nil);
-    NSRect windowRect = NSMakeRect(0, 0, desktop.width, desktop.height);
+    NSRect windowRect = NSMakeRect(0, 0, desktop.size.x, desktop.size.y);
     m_window = [[SFWindow alloc] initWithContentRect:windowRect
                                            styleMask:NSBorderlessWindowMask
                                              backing:NSBackingStoreBuffered
@@ -223,10 +223,10 @@
     }
 
     // Create our OpenGL view size and the view
-    CGFloat width = std::min(mode.width, desktop.width);
-    CGFloat height = std::min(mode.height, desktop.height);
-    CGFloat x = (desktop.width - width) / 2.0;
-    CGFloat y = (desktop.height - height) / 2.0;
+    CGFloat width = std::min(mode.size.x, desktop.size.x);
+    CGFloat height = std::min(mode.size.y, desktop.size.y);
+    CGFloat x = (desktop.size.x - width) / 2.0;
+    CGFloat y = (desktop.size.y - height) / 2.0;
     NSRect oglRect = NSMakeRect(x, y, width, height);
 
     m_oglView = [[SFOpenGLView alloc] initWithFrame:oglRect
@@ -253,7 +253,7 @@
     // We know that style & sf::Style::Fullscreen is false.
 
     // Create our window size.
-    NSRect rect = NSMakeRect(0, 0, mode.width, mode.height);
+    NSRect rect = NSMakeRect(0, 0, mode.size.x, mode.size.y);
 
     // Convert the SFML window style to Cocoa window style.
     unsigned int nsStyle = NSBorderlessWindowMask;
@@ -451,11 +451,11 @@
         sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
         sf::priv::scaleInWidthHeight(desktop, nil);
 
-        width = std::min(width, desktop.width);
-        height = std::min(height, desktop.height);
+        width = std::min(width, desktop.size.x);
+        height = std::min(height, desktop.size.y);
 
-        CGFloat x = (desktop.width - width) / 2.0;
-        CGFloat y = (desktop.height - height) / 2.0;
+        CGFloat x = (desktop.size.x - width) / 2.0;
+        CGFloat y = (desktop.size.y - height) / 2.0;
         NSRect oglRect = NSMakeRect(x, y, width, height);
 
         [m_oglView setFrame:oglRect];
@@ -482,7 +482,7 @@
 
             // The size is not the requested one, we fire an event
             if (m_requester != 0)
-                m_requester->windowResized(width, height - static_cast<unsigned int>([self titlebarHeight]));
+                m_requester->windowResized({width, height - static_cast<unsigned int>([self titlebarHeight])});
         }
 
         NSRect frame = NSMakeRect([m_window frame].origin.x,

--- a/src/SFML/Window/OSX/Scaling.h
+++ b/src/SFML/Window/OSX/Scaling.h
@@ -60,8 +60,8 @@ void scaleIn(T& in, id<WindowImplDelegateProtocol> delegate)
 template <class T>
 void scaleInWidthHeight(T& in, id<WindowImplDelegateProtocol> delegate)
 {
-    scaleIn(in.width, delegate);
-    scaleIn(in.height, delegate);
+    scaleIn(in.size.x, delegate);
+    scaleIn(in.size.y, delegate);
 }
 
 template <class T>
@@ -85,10 +85,10 @@ void scaleOut(T& out, id<WindowImplDelegateProtocol> delegate)
 }
 
 template <class T>
-void scaleOutWidthHeight(T& out, id<WindowImplDelegateProtocol> delegate)
+void scaleOutWidthHeight(T& width, T& height, id<WindowImplDelegateProtocol> delegate)
 {
-    scaleOut(out.width, delegate);
-    scaleOut(out.height, delegate);
+    scaleOut(width, delegate);
+    scaleOut(height, delegate);
 }
 
 template <class T>

--- a/src/SFML/Window/OSX/VideoModeImpl.cpp
+++ b/src/SFML/Window/OSX/VideoModeImpl.cpp
@@ -62,7 +62,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
         VideoMode mode = convertCGModeToSFMode(cgmode);
 
         // Skip if bigger than desktop as we currently don't perform hard resolution switch
-        if ((mode.width > desktop.width) || (mode.height > desktop.height))
+        if ((mode.size.x > desktop.size.x) || (mode.size.y > desktop.size.y))
             continue;
 
         // If not yet listed we add it to our modes array.

--- a/src/SFML/Window/OSX/WindowImplCocoa.hpp
+++ b/src/SFML/Window/OSX/WindowImplCocoa.hpp
@@ -113,11 +113,10 @@ public:
     ///
     /// Send the event to SFML WindowImpl class.
     ///
-    /// \param width new width
-    /// \param height new height
+    /// \param size new width and height
     ///
     ////////////////////////////////////////////////////////////
-    void windowResized(unsigned int width, unsigned int height);
+    void windowResized(const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Window Lost Focus Event - called by the cocoa window object
@@ -301,12 +300,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(unsigned int width, unsigned int height, const Uint8* pixels) override;
+    void setIcon(const Vector2u& size, const Uint8* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -219,13 +219,13 @@ void WindowImplCocoa::windowClosed(void)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::windowResized(unsigned int width, unsigned int height)
+void WindowImplCocoa::windowResized(const Vector2u& size)
 {
     Event event;
     event.type = Event::Resized;
-    event.size.width  = width;
-    event.size.height = height;
-    scaleOutWidthHeight(event.size, m_delegate);
+    event.size.width  = size.x;
+    event.size.height = size.y;
+    scaleOutWidthHeight(event.size.width, event.size.height, m_delegate);
 
     pushEvent(event);
 }
@@ -455,10 +455,10 @@ void WindowImplCocoa::setTitle(const String& title)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::setIcon(unsigned int width, unsigned int height, const Uint8* pixels)
+void WindowImplCocoa::setIcon(const Vector2u& size, const Uint8* pixels)
 {
     AutoreleasePool pool;
-    [m_delegate setIconTo:width by:height with:pixels];
+    [m_delegate setIconTo:size.x by:size.y with:pixels];
 }
 
 

--- a/src/SFML/Window/OSX/cg_sf_conversion.mm
+++ b/src/SFML/Window/OSX/cg_sf_conversion.mm
@@ -95,8 +95,8 @@ VideoMode convertCGModeToSFMode(CGDisplayModeRef cgmode)
     //
     // [1]: "APIs for Supporting High Resolution" > "Additions and Changes for OS X v10.8"
     // https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/APIs/APIs.html#//apple_ref/doc/uid/TP40012302-CH5-SW27
-    VideoMode mode(static_cast<unsigned int>(CGDisplayModeGetWidth(cgmode)), static_cast<unsigned int>(CGDisplayModeGetHeight(cgmode)), static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
-    scaleOutWidthHeight(mode, nil);
+    VideoMode mode({static_cast<unsigned int>(CGDisplayModeGetWidth(cgmode)), static_cast<unsigned int>(CGDisplayModeGetHeight(cgmode))}, static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
+    scaleOutWidthHeight(mode.size.x, mode.size.y, nil);
     return mode;
 }
 

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -124,7 +124,7 @@ m_ownsWindow(false)
     ensureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface (window or pbuffer if supported)
-    createSurface(shared, 1, 1, VideoMode::getDesktopMode().bitsPerPixel);
+    createSurface(shared, {1, 1}, VideoMode::getDesktopMode().bitsPerPixel);
 
     // Create the context
     createContext(shared);
@@ -157,7 +157,7 @@ m_ownsWindow(false)
 
 
 ////////////////////////////////////////////////////////////
-GlxContext::GlxContext(GlxContext* shared, const ContextSettings& settings, unsigned int width, unsigned int height) :
+GlxContext::GlxContext(GlxContext* shared, const ContextSettings& settings, const Vector2u& size) :
 m_display   (nullptr),
 m_window    (0),
 m_context   (nullptr),
@@ -174,7 +174,7 @@ m_ownsWindow(false)
     ensureExtensionsInit(m_display, DefaultScreen(m_display));
 
     // Create the rendering surface (window or pbuffer if supported)
-    createSurface(shared, width, height, VideoMode::getDesktopMode().bitsPerPixel);
+    createSurface(shared, size, VideoMode::getDesktopMode().bitsPerPixel);
 
     // Create the context
     createContext(shared);
@@ -472,7 +472,7 @@ void GlxContext::updateSettingsFromWindow()
 
 
 ////////////////////////////////////////////////////////////
-void GlxContext::createSurface(GlxContext* shared, unsigned int width, unsigned int height, unsigned int bitsPerPixel)
+void GlxContext::createSurface(GlxContext* shared, const Vector2u& size, unsigned int bitsPerPixel)
 {
     // Choose the visual according to the context settings
     XVisualInfo visualInfo = selectBestVisual(m_display, bitsPerPixel, m_settings);
@@ -521,8 +521,8 @@ void GlxContext::createSurface(GlxContext* shared, unsigned int width, unsigned 
             {
                 int attributes[] =
                 {
-                    GLX_PBUFFER_WIDTH,  static_cast<int>(width),
-                    GLX_PBUFFER_HEIGHT, static_cast<int>(height),
+                    GLX_PBUFFER_WIDTH,  static_cast<int>(size.x),
+                    GLX_PBUFFER_HEIGHT, static_cast<int>(size.y),
                     0,                  0
                 };
 
@@ -553,7 +553,7 @@ void GlxContext::createSurface(GlxContext* shared, unsigned int width, unsigned 
     m_window = XCreateWindow(m_display,
                              RootWindow(m_display, screen),
                              0, 0,
-                             width, height,
+                             size.x, size.y,
                              0,
                              DefaultDepth(m_display, screen),
                              InputOutput,

--- a/src/SFML/Window/Unix/GlxContext.hpp
+++ b/src/SFML/Window/Unix/GlxContext.hpp
@@ -69,11 +69,10 @@ public:
     ///
     /// \param shared   Context to share the new one with
     /// \param settings Creation parameters
-    /// \param width    Back buffer width, in pixels
-    /// \param height   Back buffer height, in pixels
+    /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    GlxContext(GlxContext* shared, const ContextSettings& settings, unsigned int width, unsigned int height);
+    GlxContext(GlxContext* shared, const ContextSettings& settings, const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -152,12 +151,11 @@ private:
     /// \brief Create the context's drawing surface
     ///
     /// \param shared       Context to share the new one with (can be a null pointer)
-    /// \param width        Back buffer width, in pixels
-    /// \param height       Back buffer height, in pixels
+    /// \param size         Back buffer width and height, in pixels
     /// \param bitsPerPixel Pixel depth, in bits per pixel
     ///
     ////////////////////////////////////////////////////////////
-    void createSurface(GlxContext* shared, unsigned int width, unsigned int height, unsigned int bitsPerPixel);
+    void createSurface(GlxContext* shared, const Vector2u& size, unsigned int bitsPerPixel);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the context's drawing surface from an existing window

--- a/src/SFML/Window/Unix/VideoModeImpl.cpp
+++ b/src/SFML/Window/Unix/VideoModeImpl.cpp
@@ -74,15 +74,15 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
                             for (int j = 0; j < nbSizes; ++j)
                             {
                                 // Convert to VideoMode
-                                VideoMode mode(static_cast<unsigned int>(sizes[j].width),
-                                               static_cast<unsigned int>(sizes[j].height),
+                                VideoMode mode({static_cast<unsigned int>(sizes[j].width),
+                                                static_cast<unsigned int>(sizes[j].height)},
                                                static_cast<unsigned int>(depths[i]));
 
                                 Rotation currentRotation;
                                 XRRConfigRotations(config, &currentRotation);
 
                                 if (currentRotation == RR_Rotate_90 || currentRotation == RR_Rotate_270)
-                                    std::swap(mode.width, mode.height);
+                                    std::swap(mode.size.x, mode.size.y);
 
                                 // Add it only if it is not already in the array
                                 if (std::find(modes.begin(), modes.end(), mode) == modes.end())
@@ -152,15 +152,15 @@ VideoMode VideoModeImpl::getDesktopMode()
                 XRRScreenSize* sizes = XRRConfigSizes(config, &nbSizes);
                 if (sizes && (nbSizes > 0))
                 {
-                    desktopMode = VideoMode(static_cast<unsigned int>(sizes[currentMode].width),
-                                            static_cast<unsigned int>(sizes[currentMode].height),
+                    desktopMode = VideoMode({static_cast<unsigned int>(sizes[currentMode].width),
+                                             static_cast<unsigned int>(sizes[currentMode].height)},
                                             static_cast<unsigned int>(DefaultDepth(display, screen)));
 
                     Rotation modeRotation;
                     XRRConfigRotations(config, &modeRotation);
 
                     if (modeRotation == RR_Rotate_90 || modeRotation == RR_Rotate_270)
-                        std::swap(desktopMode.width, desktopMode.height);
+                        std::swap(desktopMode.size.x, desktopMode.size.y);
                 }
 
                 // Free the configuration instance

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -124,12 +124,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(unsigned int width, unsigned int height, const Uint8* pixels) override;
+    void setIcon(const Vector2u& size, const Uint8* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/VideoMode.cpp
+++ b/src/SFML/Window/VideoMode.cpp
@@ -35,8 +35,7 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 VideoMode::VideoMode() :
-width       (0),
-height      (0),
+size        (0, 0),
 bitsPerPixel(0)
 {
 
@@ -44,9 +43,8 @@ bitsPerPixel(0)
 
 
 ////////////////////////////////////////////////////////////
-VideoMode::VideoMode(unsigned int modeWidth, unsigned int modeHeight, unsigned int modeBitsPerPixel) :
-width       (modeWidth),
-height      (modeHeight),
+VideoMode::VideoMode(const Vector2u& modeSize, unsigned int modeBitsPerPixel) :
+size        (modeSize),
 bitsPerPixel(modeBitsPerPixel)
 {
 
@@ -89,8 +87,7 @@ bool VideoMode::isValid() const
 ////////////////////////////////////////////////////////////
 bool operator ==(const VideoMode& left, const VideoMode& right)
 {
-    return (left.width        == right.width)        &&
-           (left.height       == right.height)       &&
+    return (left.size         == right.size)        &&
            (left.bitsPerPixel == right.bitsPerPixel);
 }
 
@@ -107,13 +104,13 @@ bool operator <(const VideoMode& left, const VideoMode& right)
 {
     if (left.bitsPerPixel == right.bitsPerPixel)
     {
-        if (left.width == right.width)
+        if (left.size.x == right.size.x)
         {
-            return left.height < right.height;
+            return left.size.y < right.size.y;
         }
         else
         {
-            return left.width < right.width;
+            return left.size.x < right.size.x;
         }
     }
     else

--- a/src/SFML/Window/Win32/VideoModeImpl.cpp
+++ b/src/SFML/Window/Win32/VideoModeImpl.cpp
@@ -46,7 +46,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     for (int count = 0; EnumDisplaySettings(nullptr, static_cast<DWORD>(count), &win32Mode); ++count)
     {
         // Convert to sf::VideoMode
-        VideoMode mode(win32Mode.dmPelsWidth, win32Mode.dmPelsHeight, win32Mode.dmBitsPerPel);
+        VideoMode mode({win32Mode.dmPelsWidth, win32Mode.dmPelsHeight}, win32Mode.dmBitsPerPel);
 
         // Add it only if it is not already in the array
         if (std::find(modes.begin(), modes.end(), mode) == modes.end())
@@ -65,7 +65,7 @@ VideoMode VideoModeImpl::getDesktopMode()
     win32Mode.dmDriverExtra = 0;
     EnumDisplaySettings(nullptr, ENUM_CURRENT_SETTINGS, &win32Mode);
 
-    return VideoMode(win32Mode.dmPelsWidth, win32Mode.dmPelsHeight, win32Mode.dmBitsPerPel);
+    return VideoMode({win32Mode.dmPelsWidth, win32Mode.dmPelsHeight}, win32Mode.dmBitsPerPel);
 }
 
 } // namespace priv

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -103,7 +103,7 @@ String getErrorString(DWORD errorCode)
 
 ////////////////////////////////////////////////////////////
 WglContext::WglContext(WglContext* shared) :
-WglContext(shared, ContextSettings(), 1u, 1u)
+WglContext(shared, ContextSettings(), {1u, 1u})
 {
 }
 
@@ -130,7 +130,7 @@ m_ownsWindow   (false)
 
 
 ////////////////////////////////////////////////////////////
-WglContext::WglContext(WglContext* shared, const ContextSettings& settings, unsigned int width, unsigned int height) :
+WglContext::WglContext(WglContext* shared, const ContextSettings& settings, const Vector2u& size) :
 m_window       (nullptr),
 m_pbuffer      (nullptr),
 m_deviceContext(nullptr),
@@ -143,7 +143,7 @@ m_ownsWindow   (false)
     m_settings = settings;
 
     // Create the rendering surface (window or pbuffer if supported)
-    createSurface(shared, width, height, VideoMode::getDesktopMode().bitsPerPixel);
+    createSurface(shared, size, VideoMode::getDesktopMode().bitsPerPixel);
 
     // Create the context
     createContext(shared);
@@ -523,7 +523,7 @@ void WglContext::updateSettingsFromPixelFormat()
 
 
 ////////////////////////////////////////////////////////////
-void WglContext::createSurface(WglContext* shared, unsigned int width, unsigned int height, unsigned int bitsPerPixel)
+void WglContext::createSurface(WglContext* shared, const Vector2u& size, unsigned int bitsPerPixel)
 {
     // Check if the shared context already exists and pbuffers are supported
     if (shared && shared->m_deviceContext && SF_GLAD_WGL_ARB_pbuffer)
@@ -534,7 +534,7 @@ void WglContext::createSurface(WglContext* shared, unsigned int width, unsigned 
         {
             int attributes[] = {0, 0};
 
-            m_pbuffer = wglCreatePbufferARB(shared->m_deviceContext, bestFormat, static_cast<int>(width), static_cast<int>(height), attributes);
+            m_pbuffer = wglCreatePbufferARB(shared->m_deviceContext, bestFormat, static_cast<int>(size.x), static_cast<int>(size.y), attributes);
 
             if (m_pbuffer)
             {
@@ -563,7 +563,7 @@ void WglContext::createSurface(WglContext* shared, unsigned int width, unsigned 
         // with other contexts and thus wglShareLists would always fail
 
         // Create the hidden window
-        m_window = CreateWindowA("STATIC", "", WS_POPUP | WS_DISABLED, 0, 0, static_cast<int>(width), static_cast<int>(height), nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
+        m_window = CreateWindowA("STATIC", "", WS_POPUP | WS_DISABLED, 0, 0, static_cast<int>(size.x), static_cast<int>(size.y), nullptr, nullptr, GetModuleHandle(nullptr), nullptr);
         ShowWindow(m_window, SW_HIDE);
         m_deviceContext = GetDC(m_window);
 

--- a/src/SFML/Window/Win32/WglContext.hpp
+++ b/src/SFML/Window/Win32/WglContext.hpp
@@ -68,11 +68,10 @@ public:
     ///
     /// \param shared   Context to share the new one with
     /// \param settings Creation parameters
-    /// \param width    Back buffer width, in pixels
-    /// \param height   Back buffer height, in pixels
+    /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    WglContext(WglContext* shared, const ContextSettings& settings, unsigned int width, unsigned int height);
+    WglContext(WglContext* shared, const ContextSettings& settings, const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -152,12 +151,11 @@ private:
     /// \brief Create the context's drawing surface
     ///
     /// \param shared       Shared context (can be a null pointer)
-    /// \param width        Back buffer width, in pixels
-    /// \param height       Back buffer height, in pixels
+    /// \param size         Back buffer width and height, in pixels
     /// \param bitsPerPixel Pixel depth, in bits per pixel
     ///
     ////////////////////////////////////////////////////////////
-    void createSurface(WglContext* shared, unsigned int width, unsigned int height, unsigned int bitsPerPixel);
+    void createSurface(WglContext* shared, const Vector2u& size, unsigned int bitsPerPixel);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the context's drawing surface from an existing window

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -123,12 +123,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(unsigned int width, unsigned int height, const Uint8* pixels) override;
+    void setIcon(const Vector2u& size, const Uint8* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -235,10 +235,10 @@ void WindowBase::setTitle(const String& title)
 
 
 ////////////////////////////////////////////////////////////
-void WindowBase::setIcon(unsigned int width, unsigned int height, const Uint8* pixels)
+void WindowBase::setIcon(const Vector2u& size, const Uint8* pixels)
 {
     if (m_impl)
-        m_impl->setIcon(width, height, pixels);
+        m_impl->setIcon(size, pixels);
 }
 
 

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -176,12 +176,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    virtual void setIcon(unsigned int width, unsigned int height, const Uint8* pixels) = 0;
+    virtual void setIcon(const Vector2u& size, const Uint8* pixels) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/iOS/EaglContext.hpp
+++ b/src/SFML/Window/iOS/EaglContext.hpp
@@ -77,12 +77,11 @@ public:
     ///
     /// \param shared   Context to share the new one with
     /// \param settings Creation parameters
-    /// \param width    Back buffer width, in pixels
-    /// \param height   Back buffer height, in pixels
+    /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
     EaglContext(EaglContext* shared, const ContextSettings& settings,
-                unsigned int width, unsigned int height);
+                const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -126,7 +126,7 @@ m_clock       ()
 
 ////////////////////////////////////////////////////////////
 EaglContext::EaglContext(EaglContext* /* shared */, const ContextSettings& /* settings */,
-                         unsigned int /* width */, unsigned int /* height */) :
+                         const Vector2u& /* size */) :
 m_context     (nil),
 m_framebuffer (0),
 m_colorbuffer (0),

--- a/src/SFML/Window/iOS/VideoModeImpl.mm
+++ b/src/SFML/Window/iOS/VideoModeImpl.mm
@@ -41,7 +41,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     // Return both portrait and landscape resolutions
     std::vector<VideoMode> modes;
     modes.push_back(desktop);
-    modes.emplace_back(desktop.height, desktop.width, desktop.bitsPerPixel);
+    modes.emplace_back(Vector2u(desktop.size.y, desktop.size.x), desktop.bitsPerPixel);
     return modes;
 }
 
@@ -51,7 +51,7 @@ VideoMode VideoModeImpl::getDesktopMode()
 {
     CGRect bounds = [[UIScreen mainScreen] bounds];
     double backingScale = [SFAppDelegate getInstance].backingScaleFactor;
-    return VideoMode(static_cast<unsigned int>(bounds.size.width * backingScale), static_cast<unsigned int>(bounds.size.height * backingScale));
+    return VideoMode({static_cast<unsigned int>(bounds.size.width * backingScale), static_cast<unsigned int>(bounds.size.height * backingScale)});
 }
 
 } // namespace priv

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -126,12 +126,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
     ///
-    /// \param width  Icon's width, in pixels
-    /// \param height Icon's height, in pixels
+    /// \param size   Icon's width and height, in pixels
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(unsigned int width, unsigned int height, const Uint8* pixels) override;
+    void setIcon(const Vector2u& size, const Uint8* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -64,7 +64,7 @@ WindowImplUIKit::WindowImplUIKit(VideoMode mode,
     [UIApplication sharedApplication].statusBarHidden = !(style & Style::Titlebar) || (style & Style::Fullscreen);
 
     // Set the orientation according to the requested size
-    if (mode.width > mode.height)
+    if (mode.size.x > mode.size.y)
         [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationLandscapeLeft];
     else
         [[UIApplication sharedApplication] setStatusBarOrientation:UIInterfaceOrientationPortrait];
@@ -180,7 +180,7 @@ void WindowImplUIKit::setTitle(const String& /* title */)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setIcon(unsigned int /* width */, unsigned int /* height */, const Uint8* /* pixels */)
+void WindowImplUIKit::setIcon(const Vector2u& /* size */, const Uint8* /* pixels */)
 {
     // Not applicable
 }

--- a/test/TestUtilities/WindowUtil.cpp
+++ b/test/TestUtilities/WindowUtil.cpp
@@ -6,7 +6,7 @@ namespace sf
 {
     std::ostream& operator <<(std::ostream& os, const sf::VideoMode& videoMode)
     {
-        os << videoMode.width << "x" << videoMode.height << "x" << videoMode.bitsPerPixel;
+        os << videoMode.size.x << "x" << videoMode.size.y << "x" << videoMode.bitsPerPixel;
         return os;
     }
 }

--- a/test/Window/VideoMode.cpp
+++ b/test/Window/VideoMode.cpp
@@ -10,24 +10,21 @@ TEST_CASE("sf::VideoMode class - [window]")
         SUBCASE("Default constructor")
         {
             sf::VideoMode videoMode;
-            CHECK(videoMode.width == 0);
-            CHECK(videoMode.height == 0);
+            CHECK(videoMode.size == sf::Vector2u(0, 0));
             CHECK(videoMode.bitsPerPixel == 0);
         }
 
         SUBCASE("Width, height constructor")
         {
-            sf::VideoMode videoMode(800, 600);
-            CHECK(videoMode.width == 800);
-            CHECK(videoMode.height == 600);
+            sf::VideoMode videoMode({800, 600});
+            CHECK(videoMode.size == sf::Vector2u(800, 600));
             CHECK(videoMode.bitsPerPixel == 32);
         }
 
         SUBCASE("Width, height, bit depth constructor")
         {
-            sf::VideoMode videoMode(800, 600, 24);
-            CHECK(videoMode.width == 800);
-            CHECK(videoMode.height == 600);
+            sf::VideoMode videoMode({800, 600}, 24);
+            CHECK(videoMode.size == sf::Vector2u(800, 600));
             CHECK(videoMode.bitsPerPixel == 24);
         }
     }
@@ -37,55 +34,55 @@ TEST_CASE("sf::VideoMode class - [window]")
         SUBCASE("operator==")
         {
             CHECK(sf::VideoMode() == sf::VideoMode());
-            CHECK(sf::VideoMode(0, 0, 0) == sf::VideoMode(0, 0, 0));
-            CHECK(sf::VideoMode(1080, 1920, 64) == sf::VideoMode(1080, 1920, 64));
+            CHECK(sf::VideoMode({0, 0}, 0) == sf::VideoMode({0, 0}, 0));
+            CHECK(sf::VideoMode({1080, 1920}, 64) == sf::VideoMode({1080, 1920}, 64));
         }
 
         SUBCASE("operator!=")
         {
-            CHECK(sf::VideoMode() != sf::VideoMode(1, 0));
-            CHECK(sf::VideoMode() != sf::VideoMode(0, 1));
-            CHECK(sf::VideoMode() != sf::VideoMode(0, 0, 1));
-            CHECK(sf::VideoMode(720, 720) != sf::VideoMode(720, 720, 24));
-            CHECK(sf::VideoMode(1080, 1920, 16) != sf::VideoMode(400, 600));
+            CHECK(sf::VideoMode() != sf::VideoMode({1, 0}));
+            CHECK(sf::VideoMode() != sf::VideoMode({0, 1}));
+            CHECK(sf::VideoMode() != sf::VideoMode({0, 0}, 1));
+            CHECK(sf::VideoMode({720, 720}) != sf::VideoMode({720, 720}, 24));
+            CHECK(sf::VideoMode({1080, 1920}, 16) != sf::VideoMode({400, 600}));
         }
 
         SUBCASE("operator<")
         {
-            CHECK(sf::VideoMode() < sf::VideoMode(0, 0, 1));
-            CHECK(sf::VideoMode(800, 800, 24) < sf::VideoMode(1080, 1920, 48));
-            CHECK(sf::VideoMode(400, 600, 48) < sf::VideoMode(600, 400, 48));
-            CHECK(sf::VideoMode(400, 400, 48) < sf::VideoMode(400, 600, 48));
+            CHECK(sf::VideoMode() < sf::VideoMode({0, 0}, 1));
+            CHECK(sf::VideoMode({800, 800}, 24) < sf::VideoMode({1080, 1920}, 48));
+            CHECK(sf::VideoMode({400, 600}, 48) < sf::VideoMode({600, 400}, 48));
+            CHECK(sf::VideoMode({400, 400}, 48) < sf::VideoMode({400, 600}, 48));
         }
 
         SUBCASE("operator>")
         {
-            CHECK(sf::VideoMode(1, 0) > sf::VideoMode(0, 0, 1));
-            CHECK(sf::VideoMode(800, 800, 48) > sf::VideoMode(1080, 1920, 24));
-            CHECK(sf::VideoMode(600, 400, 48) > sf::VideoMode(400, 600, 48));
-            CHECK(sf::VideoMode(400, 600, 48) > sf::VideoMode(400, 400, 48));
+            CHECK(sf::VideoMode({1, 0}) > sf::VideoMode({0, 0}, 1));
+            CHECK(sf::VideoMode({800, 800}, 48) > sf::VideoMode({1080, 1920}, 24));
+            CHECK(sf::VideoMode({600, 400}, 48) > sf::VideoMode({400, 600}, 48));
+            CHECK(sf::VideoMode({400, 600}, 48) > sf::VideoMode({400, 400}, 48));
         }
 
         SUBCASE("operator<=")
         {
-            CHECK(sf::VideoMode() <= sf::VideoMode(0, 0, 1));
-            CHECK(sf::VideoMode(800, 800, 24) <= sf::VideoMode(1080, 1920, 48));
-            CHECK(sf::VideoMode(400, 600, 48) <= sf::VideoMode(600, 400, 48));
-            CHECK(sf::VideoMode(400, 400, 48) <= sf::VideoMode(400, 600, 48));
+            CHECK(sf::VideoMode() <= sf::VideoMode({0, 0}, 1));
+            CHECK(sf::VideoMode({800, 800}, 24) <= sf::VideoMode({1080, 1920}, 48));
+            CHECK(sf::VideoMode({400, 600}, 48) <= sf::VideoMode({600, 400}, 48));
+            CHECK(sf::VideoMode({400, 400}, 48) <= sf::VideoMode({400, 600}, 48));
             CHECK(sf::VideoMode() <= sf::VideoMode());
-            CHECK(sf::VideoMode(0, 0, 0) <= sf::VideoMode(0, 0, 0));
-            CHECK(sf::VideoMode(1080, 1920, 64) <= sf::VideoMode(1080, 1920, 64));
+            CHECK(sf::VideoMode({0, 0}, 0) <= sf::VideoMode({0, 0}, 0));
+            CHECK(sf::VideoMode({1080, 1920}, 64) <= sf::VideoMode({1080, 1920}, 64));
         }
 
         SUBCASE("operator>=")
         {
-            CHECK(sf::VideoMode(1, 0) >= sf::VideoMode(0, 0, 1));
-            CHECK(sf::VideoMode(800, 800, 48) >= sf::VideoMode(1080, 1920, 24));
-            CHECK(sf::VideoMode(600, 400, 48) >= sf::VideoMode(400, 600, 48));
-            CHECK(sf::VideoMode(400, 600, 48) >= sf::VideoMode(400, 400, 48));
+            CHECK(sf::VideoMode({1, 0}) >= sf::VideoMode({0, 0}, 1));
+            CHECK(sf::VideoMode({800, 800}, 48) >= sf::VideoMode({1080, 1920}, 24));
+            CHECK(sf::VideoMode({600, 400}, 48) >= sf::VideoMode({400, 600}, 48));
+            CHECK(sf::VideoMode({400, 600}, 48) >= sf::VideoMode({400, 400}, 48));
             CHECK(sf::VideoMode() >= sf::VideoMode());
-            CHECK(sf::VideoMode(0, 0, 0) >= sf::VideoMode(0, 0, 0));
-            CHECK(sf::VideoMode(1080, 1920, 64) >= sf::VideoMode(1080, 1920, 64));
+            CHECK(sf::VideoMode({0, 0}, 0) >= sf::VideoMode({0, 0}, 0));
+            CHECK(sf::VideoMode({1080, 1920}, 64) >= sf::VideoMode({1080, 1920}, 64));
         }
     }
 }


### PR DESCRIPTION
## Description

This PR further expands on the work from #1902, #1942, and #1948. It originated from a conversation in #2027 which found more instances of pairs of numeric parameters. I thought it'd be good to go ahead and fix this but quickly found just how many more numeric parameter pairs we had left in SFML. I tried to find as many instances of this pattern as possible but if any still remain, I'd love to fix them I this PR.

I know this PR is massive. While finding and changing all these interfaces, I didn't try to break this apart into multiple commits although it's not unreasonable to do so. If this is simply an unmanageably large PR to review then let me know and I'll try to break it apart.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
