### PR TITLE
Update GitHub Actions VS Workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2017, os: windows-2016 }
         - { name: Windows VS2019, os: windows-2019 }
         - { name: Windows VS2022, os: windows-2022 }
         - { name: Linux GCC,      os: ubuntu-latest  }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2017, os: windows-2016   }
-        - { name: Windows VS2019, os: windows-latest }
+        - { name: Windows VS2017, os: windows-2016 }
+        - { name: Windows VS2019, os: windows-2019 }
+        - { name: Windows VS2022, os: windows-2022 }
         - { name: Linux GCC,      os: ubuntu-latest  }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS XCode,    os: macos-latest   }
@@ -21,7 +22,7 @@ jobs:
         - { name: Static,       flags: -DBUILD_SHARED_LIBS=FALSE }
 
         include:
-        - platform: { name: Windows VS2019, os: windows-latest }
+        - platform: { name: Windows VS2022, os: windows-2022 }
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
         - platform: { name: MacOS XCode, os: macos-latest }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }


### PR DESCRIPTION
The `windows-2016` / VS 2017 environment have now officially been deprecated and thus I cherry-picked the two commits from #1971 and #1995 onto the `2.6.x` branch, so we don't get failing builds anymore.