### PR TITLE
Added back missing WINAPI calling convention declaration

### DIFF
--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -405,7 +405,7 @@ void JoystickImpl::initializeDInput()
     if (dinput8dll)
     {
         // Try to get the address of the DirectInput8Create entry point
-        using DirectInput8CreateFunc = HRESULT (*)(HINSTANCE, DWORD, const IID &, LPVOID *, LPUNKNOWN);
+        using DirectInput8CreateFunc = HRESULT (WINAPI *)(HINSTANCE, DWORD, const IID &, LPVOID *, LPUNKNOWN);
         auto directInput8Create = reinterpret_cast<DirectInput8CreateFunc>(reinterpret_cast<void*>(GetProcAddress(dinput8dll, "DirectInput8Create")));
 
         if (directInput8Create)


### PR DESCRIPTION
Commit 9a0cc4b7dc8dae79fc912a04a9d4679d42815a4a inadvertently removed 3 `WINAPI` calling convention declarations. 2 of them were added back in in following commits. This adds in the final missing `WINAPI` and fixes the issue reported in #2057.