### PR TITLE
Add `sf::LineShape`

### DIFF
--- a/include/SFML/Graphics.hpp
+++ b/include/SFML/Graphics.hpp
@@ -37,6 +37,7 @@
 #include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/Glyph.hpp>
 #include <SFML/Graphics/Image.hpp>
+#include <SFML/Graphics/LineShape.hpp>
 #include <SFML/Graphics/PrimitiveType.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/RectangleShape.hpp>

--- a/include/SFML/Graphics/LineShape.hpp
+++ b/include/SFML/Graphics/LineShape.hpp
@@ -1,0 +1,160 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_LINESHAPE_HPP
+#define SFML_LINESHAPE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+
+#include <SFML/Graphics/Shape.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Specialized shape representing a line
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API LineShape : public Shape
+{
+public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// \param beginning Beginning of line
+    /// \param end       End of line
+    /// \param thickness Thickness of line
+    ///
+    ////////////////////////////////////////////////////////////
+    LineShape(const Vector2f& beginning, const Vector2f& end, float thickness);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the thickness of the line
+    ///
+    /// \param size New thickness of the line
+    ///
+    /// \see getThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    void setThickness(float thickness);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the end point of the line
+    ///
+    /// \param size New end point of the line
+    ///
+    /// \see setEndPoint
+    ///
+    ////////////////////////////////////////////////////////////
+    void setEndPoint(const Vector2f& point);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the thickness of the line
+    ///
+    /// \return Thickness of the line
+    ///
+    /// \see setThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    float getThickness() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the end point of the line
+    ///
+    /// \return End point of the line
+    ///
+    /// \see setEndPoint
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2f getEndPoint() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the length of the line
+    ///
+    /// \return Length of the line
+    ///
+    ////////////////////////////////////////////////////////////
+    float getLength() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of points defining the shape
+    ///
+    /// \return Number of points of the shape. For line
+    ///         shapes, this number is always 4.
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t getPointCount() const override;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a point of the line
+    ///
+    /// The returned point is in local coordinates, that is,
+    /// the shape's transforms (position, rotation, scale) are
+    /// not taken into account.
+    /// The result is undefined if \a index is out of the valid range.
+    ///
+    /// \param index Index of the point to get, in range [0 .. 3]
+    ///
+    /// \return index-th point of the shape
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2f getPoint(std::size_t index) const override;
+
+private:
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vector2f m_direction; //!< Direction of the line
+    float    m_thickness; //!< Thickness of the line
+};
+
+} // namespace sf
+
+
+#endif // SFML_LINESHAPE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::LineShape
+/// \ingroup graphics
+///
+/// This class inherits all the functions of sf::Transformable
+/// (position, rotation, scale, bounds, ...) as well as the
+/// functions of sf::Shape (outline, color, texture, ...).
+///
+/// Usage example:
+/// \code
+/// sf::LineShape line({0, 0}, {10, 10}, 10.f);
+/// line.setOutlineColor(sf::Color::Red);
+/// line.setOutlineThickness(5);
+/// ...
+/// window.draw(line);
+/// \endcode
+///
+/// \see sf::Shape, sf::CircleShape, sf::ConvexShape, sf::RectangleShape
+///
+////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -23,6 +23,8 @@ set(SRC
     ${INCROOT}/Image.hpp
     ${SRCROOT}/ImageLoader.cpp
     ${SRCROOT}/ImageLoader.hpp
+    ${INCROOT}/LineShape.hpp
+    ${SRCROOT}/LineShape.cpp
     ${INCROOT}/PrimitiveType.hpp
     ${INCROOT}/Rect.hpp
     ${INCROOT}/Rect.inl

--- a/src/SFML/Graphics/LineShape.cpp
+++ b/src/SFML/Graphics/LineShape.cpp
@@ -1,0 +1,108 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/LineShape.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+LineShape::LineShape(const Vector2f& beginning, const Vector2f& end, float thickness) :
+m_direction(end - beginning),
+m_thickness(thickness)
+{
+    setPosition(beginning);
+    update();
+}
+
+
+////////////////////////////////////////////////////////////
+void LineShape::setThickness(float thickness)
+{
+    m_thickness = thickness;
+    update();
+}
+
+
+////////////////////////////////////////////////////////////
+void LineShape::setEndPoint(const Vector2f& point)
+{
+    m_direction = point - getPosition();
+    update();
+}
+
+
+////////////////////////////////////////////////////////////
+float LineShape::getThickness() const
+{
+    return m_thickness;
+}
+
+
+////////////////////////////////////////////////////////////
+Vector2f LineShape::getEndPoint() const
+{
+    return getPosition() + m_direction;
+}
+
+
+////////////////////////////////////////////////////////////
+float LineShape::getLength() const
+{
+    return m_direction.length();
+}
+
+
+////////////////////////////////////////////////////////////
+std::size_t LineShape::getPointCount() const
+{
+    return 4;
+}
+
+
+////////////////////////////////////////////////////////////
+Vector2f LineShape::getPoint(const std::size_t index) const
+{
+    auto offset = Vector2f();
+    if (m_direction != Vector2f(0, 0))
+        offset = (m_thickness / 2.f) * m_direction.normalized().perpendicular();
+
+    switch (index)
+    {
+        default:
+        case 0:
+            return offset;
+        case 1:
+            return m_direction + offset;
+        case 2:
+            return m_direction - offset;
+        case 3:
+            return -offset;
+    }
+}
+
+} // namespace sf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(GRAPHICS_SRC
     Graphics/Font.test.cpp
     Graphics/Glyph.test.cpp
     Graphics/Image.test.cpp
+    Graphics/LineShape.test.cpp
     Graphics/Rect.test.cpp
     Graphics/RectangleShape.test.cpp
     Graphics/RenderStates.test.cpp

--- a/test/Graphics/LineShape.test.cpp
+++ b/test/Graphics/LineShape.test.cpp
@@ -1,0 +1,48 @@
+#include <SFML/Graphics/LineShape.hpp>
+
+#include <doctest/doctest.h>
+
+#include <SystemUtil.hpp>
+#include <type_traits>
+
+static_assert(std::is_copy_constructible_v<sf::LineShape>);
+static_assert(std::is_copy_assignable_v<sf::LineShape>);
+static_assert(std::is_move_constructible_v<sf::LineShape>);
+static_assert(std::is_move_assignable_v<sf::LineShape>);
+
+TEST_CASE("sf::LineShape class - [graphics]")
+{
+    SUBCASE("Construction")
+    {
+        const sf::LineShape line({10, 20}, {20, 20}, 2.f);
+        CHECK(line.getThickness() == 2.f);
+        CHECK(line.getEndPoint() == sf::Vector2f(20, 20));
+        CHECK(line.getLength() == 10.f);
+        CHECK(line.getPointCount() == 4);
+        CHECK(line.getPoint(0) == sf::Vector2f(0, 1));
+        CHECK(line.getPoint(1) == sf::Vector2f(10, 1));
+        CHECK(line.getPoint(2) == sf::Vector2f(10, -1));
+        CHECK(line.getPoint(3) == sf::Vector2f(0, -1));
+    }
+
+    SUBCASE("Set thickness")
+    {
+        sf::LineShape line({0, 0}, {1, 1}, 0);
+        line.setThickness(3.14f);
+        CHECK(line.getThickness() == 3.14f);
+    }
+
+    SUBCASE("Set end point")
+    {
+        sf::LineShape line({1, 2}, {3, 4}, 0);
+        line.setEndPoint({5, 6});
+        CHECK(line.getEndPoint() == sf::Vector2f(5, 6));
+    }
+
+    SUBCASE("Coincident start and end point")
+    {
+        const sf::LineShape line({}, {}, 0);
+        CHECK(line.getPosition() == line.getEndPoint());
+        CHECK(line.getLength() == 0.f);
+    }
+}


### PR DESCRIPTION
## Description

`sf::LineShape` models a line segment defined by two points. The first point specifies the position of the line segment and the segment is drawn to the second point. The goal is to give users the simplest possible API for something they're already doing, drawing lines.

[Here](https://github.com/ChrisThrasher/fourier-draw/commit/14498cce2755ca25e8359f2d313da62fa6be70c4) is an example of me using `sf::LineShape` to replace `sf::RectangleShape` in a project of mine. 

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
