### PR TITLE
Add tests for `sf::RectangleShape`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(GRAPHICS_SRC
     Graphics/BlendMode.cpp
     Graphics/Color.cpp
     Graphics/Rect.cpp
+    Graphics/RectangleShape.cpp
     Graphics/Shape.cpp
     Graphics/Transform.cpp
     Graphics/Transformable.cpp

--- a/test/Graphics/RectangleShape.cpp
+++ b/test/Graphics/RectangleShape.cpp
@@ -1,0 +1,36 @@
+#include <SFML/Graphics/RectangleShape.hpp>
+#include "SystemUtil.hpp"
+
+#include <doctest.h>
+
+TEST_CASE("sf::RectangleShape class - [graphics]")
+{
+    SUBCASE("Default constructor")
+    {
+        const sf::RectangleShape rectangle;
+        CHECK(rectangle.getSize() == sf::Vector2f(0, 0));
+        CHECK(rectangle.getPointCount() == 4);
+        CHECK(rectangle.getPoint(0) == sf::Vector2f(0, 0));
+        CHECK(rectangle.getPoint(1) == sf::Vector2f(0, 0));
+        CHECK(rectangle.getPoint(2) == sf::Vector2f(0, 0));
+        CHECK(rectangle.getPoint(3) == sf::Vector2f(0, 0));
+    }
+
+    SUBCASE("Size constructor")
+    {
+        const sf::RectangleShape rectangle({9, 8});
+        CHECK(rectangle.getSize() == sf::Vector2f(9, 8));
+        CHECK(rectangle.getPointCount() == 4);
+        CHECK(rectangle.getPoint(0) == sf::Vector2f(0, 0));
+        CHECK(rectangle.getPoint(1) == sf::Vector2f(9, 0));
+        CHECK(rectangle.getPoint(2) == sf::Vector2f(9, 8));
+        CHECK(rectangle.getPoint(3) == sf::Vector2f(0, 8));
+    }
+
+    SUBCASE("Set size")
+    {
+        sf::RectangleShape rectangle({7, 6});
+        rectangle.setSize({5, 4});
+        CHECK(rectangle.getSize() == sf::Vector2f(5, 4));
+    }
+}


### PR DESCRIPTION
## Description

With the `sf::Shape` test PR merged we're finally at the point of testing the prebuilt shapes! Because this API adds very little on top of `sf::Shape` there's little additional code to test.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
