### PR TITLE
Update example android to work with ndk-r18b

### DIFF
--- a/examples/android/app/build.gradle
+++ b/examples/android/app/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "org.sfmldev.android"
         minSdkVersion 14
-        targetSdkVersion 19
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/android/app/src/main/jni/Application.mk
+++ b/examples/android/app/src/main/jni/Application.mk
@@ -1,4 +1,3 @@
-NDK_TOOLCHAIN_VERSION := 4.9
 APP_PLATFORM := android-14
 # APP_STL has to match CMAKE_ANDROID_STL_TYPE
 APP_STL := c++_static

--- a/examples/android/build.gradle
+++ b/examples/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 


### PR DESCRIPTION
Managed once more to accidentially close a PR with re-base push... 🙄 

This is a copy of #1545 

---

## Description

I have been having issues build the android example on the lasted NDK r18b. 

I made a small change to the wiki (switching to clang from gcc)
https://github.com/SFML/SFML/wiki/Tutorial:-Building-SFML-for-Android/_compare/dd8796aa4e6f8eaec0d2590b03d76bfe54859d23...545da7dea24f4a799bca0f8cb68924a688b47a0f

And these small changes to the example project to allow it to build easily on the latest NDK (which has removed GCC)

## Tasks

* [X] Tested on Android

This built and I tested a debug build on my Samsung S9.

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

Steps to setup environment and build on a Ubuntu 18.04 box:
```
sudo apt update
sudo vim /etc/hosts
sudo apt dist-upgrade
sudo reboot

sudo apt install unzip openjdk-8-jdk cmake

mkdir android && cd android

wget https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
unzip android-ndk-*-linux-x86_64.zip

wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
mkdir android-sdk-linux
unzip sdk-tools-linux-*.zip -d android-sdk-linux/

wget https://www.sfml-dev.org/files/SFML-2.5.1-sources.zip
unzip SFML-*-sources.zip

wget https://services.gradle.org/distributions/gradle-5.1.1-bin.zip
unzip gradle-*-bin.zip

nano loadsource.sh
---
NDKVERSION="android-ndk-r18b"
GRADLEVERSION="gradle-5.1.1"

export GRADLE_HOME=$HOME/android/$GRADLEVERSION
export ANDROID_NDK=$HOME/android/$NDKVERSION
export ANDROID_SDK=$HOME/android/android-sdk-linux
export NDK_MODULE_PATH=$ANDROID_NDK/sources/third_party
export PATH=${ANT_HOME}/bin:${PATH}

export PATH=$PATH:$ANDROID_SDK/tools:$HOME/android/android-sdk-linux/platform-tools:$ANDROID_NDK:$GRADLE_HOME/bin
---

source loadsource.sh

cd SFML-*/
mkdir build && cd build
mkdir armeabi-v7a && cd armeabi-v7a
cmake -DCMAKE_SYSTEM_NAME=Android -DCMAKE_ANDROID_NDK=$ANDROID_NDK -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_BUILD_TYPE=Debug -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang ../..
make -j 4
make install

cd ../../examples/android/
echo "sdk.dir=$ANDROID_SDK" >> local.properties
echo "ndk.dir=$ANDROID_NDK" >> local.properties
$ANDROID_SDK/tools/bin/sdkmanager --licenses
gradle build
```