### PR TITLE
Fix font pages not being created with the desired smoothness

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -335,7 +335,7 @@ private:
     ////////////////////////////////////////////////////////////
     struct Page
     {
-        Page();
+        explicit Page(bool smooth);
 
         GlyphTable       glyphs;  //!< Table mapping code points to their corresponding glyph
         Texture          texture; //!< Texture containing the pixels of the glyphs
@@ -348,6 +348,16 @@ private:
     ///
     ////////////////////////////////////////////////////////////
     void cleanup();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Find or create the glyphs page corresponding to the given character size
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return The glyphs page corresponding to \a characterSize
+    ///
+    ////////////////////////////////////////////////////////////
+    Page& loadPage(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Load a new glyph and store it in the cache


### PR DESCRIPTION
## Description

This is an alternative solution for the issue described in #2064
As `try_emplace` is not available with C++03, extra `Page` copies occur, but at most once per character size and per font.

Besides, `Page` not having a default constructor anymore implies it is not possible to use `operator[]` on `m_pages`, which is a good thing to force that the desired smoothness is always used to initialize new glyph pages.

For reference, smoothing for fonts was first added in #1690.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

An example is provided in the original PR #2064 