### PR TITLE
Fix incorrect cast in Cursor::loadFromPixels Unix implementation

### DIFF
--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -80,10 +80,10 @@ bool CursorImpl::loadFromPixelsARGB(const Uint8* pixels, Vector2u size, Vector2u
     const std::size_t numPixels = size.x * size.y;
     for (std::size_t pixelIndex = 0; pixelIndex < numPixels; ++pixelIndex)
     {
-        cursorImage->pixels[pixelIndex] = static_cast<Uint8>(pixels[pixelIndex * 4 + 2] +
-                                                            (pixels[pixelIndex * 4 + 1] << 8) +
-                                                            (pixels[pixelIndex * 4 + 0] << 16) +
-                                                            (pixels[pixelIndex * 4 + 3] << 24));
+        cursorImage->pixels[pixelIndex] = static_cast<Uint32>(pixels[pixelIndex * 4 + 2] +
+                                                              (pixels[pixelIndex * 4 + 1] << 8) +
+                                                              (pixels[pixelIndex * 4 + 0] << 16) +
+                                                              (pixels[pixelIndex * 4 + 3] << 24));
     }
 
     // Create the cursor.


### PR DESCRIPTION
## Description

Fixes #2066 

A cast was added in https://github.com/SFML/SFML/commit/e0f23561023090cf21863d3c60ea37b58e1e9f12 to avoid a warning about sign conversion, but to Uint8 which is too small for a pixel in the target ARGB format.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Running the example program provided in #2066 on a Unix platform.