### PR TITLE
Enable MSVC standards conformance

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -27,7 +27,7 @@ function(set_file_warnings)
         /w14905 # wide string literal cast to 'LPSTR'
         /w14906 # string literal cast to 'LPWSTR'
         /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
-        # /permissive- # standards conformance mode for MSVC compiler. Disabled until all out-of-the-box Windows SDKs can successfully build with it.
+        /permissive- # standards conformance mode
 
         # Disables, remove when appropriate
         /wd4996 # disable warnings about deprecated functions

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -288,7 +288,7 @@ constexpr bool operator !=(const Vector2<T>& left, const Vector2<T>& right)
 ////////////////////////////////////////////////////////////
 
 template <typename T>
-constexpr Vector2<T> Vector2<T>::UnitX(static_cast<T>(1), static_cast<T>(0));
+const Vector2<T> Vector2<T>::UnitX(static_cast<T>(1), static_cast<T>(0));
 
 template <typename T>
-constexpr Vector2<T> Vector2<T>::UnitY(static_cast<T>(0), static_cast<T>(1));
+const Vector2<T> Vector2<T>::UnitY(static_cast<T>(0), static_cast<T>(1));


### PR DESCRIPTION
## Description

Fixes #2039. I hope we can soon figure out how to make `sf::Vector2<T>::UnitX` and `sf::Vector2<T>::UnitY` `constexpr` but for now it's in our best interest to demote these compiletime constants to runtime constants so that we can enable `/permissive-` and fix user builds.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
