### PR TITLE
Graphics: Avoid VertexBuffer extra resizing

### DIFF
--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -190,7 +190,7 @@ bool VertexBuffer::update(const Vertex* vertices, std::size_t vertexCount, unsig
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
 
     // Check if we need to resize or orphan the buffer
-    if (vertexCount >= m_size)
+    if (vertexCount > m_size)
     {
         glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER, static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexCount), nullptr, VertexBufferImpl::usageToGlEnum(m_usage)));
 


### PR DESCRIPTION
## Description

When updating the VertexBuffer with the same number of vertices, a unnecessary resize of the buffer happens.

This simple pull-request fix the condition that check if the buffer have to be resized.

I try to make a small chrono test with 1000000 updates on 3 vertices but it isn't really relevant.

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

(note that I think that the [[nodiscard]] on update/create is a little bit unnecessary :( )

```cpp
#include <iostream>
#include "SFML/Graphics.hpp"
#include <chrono>

int main()
{
    sf::RenderWindow window(sf::VideoMode(400,400), "test");
    window.setFramerateLimit(2);

    sf::VertexBuffer buffer(sf::PrimitiveType::Triangles);
    (void)buffer.create(3);

    sf::Transformable transform;
    transform.setRotation(sf::degrees(20.0f));
    transform.setOrigin({100.0f,100.0f});
    transform.setPosition({100.0f, 100.0f});

    sf::Vertex vertex1[3];
    vertex1[0].color = sf::Color::Red;
    vertex1[0].position = {0,0};
    vertex1[1].color = sf::Color::Red;
    vertex1[1].position = {200,0};
    vertex1[2].color = sf::Color::Red;
    vertex1[2].position = {100,200};
    (void)buffer.update(vertex1, 3, 0);

    auto start = std::chrono::steady_clock::now();

    for (unsigned int i=0; i<1000000; ++i)
    {
        //20498ms with fix
        //20432ms without fix
        //no real deal :P

        vertex1[0].position = transform.getInverseTransform().transformPoint(vertex1[0].position);
        vertex1[1].position = transform.getInverseTransform().transformPoint(vertex1[1].position);
        vertex1[2].position = transform.getInverseTransform().transformPoint(vertex1[2].position);
        (void)buffer.update(vertex1, 3, 0);
    }

    auto stop = std::chrono::steady_clock::now();
    auto time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(stop-start);

    std::cout << "time took : " << time_ms.count() << " ms" << std::endl;

    while (window.isOpen())
    {
        sf::Event event;

        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
            {
                window.close();
            }
        }

        window.clear(sf::Color::White);

        window.draw(buffer);

        vertex1[0].position = transform.getInverseTransform().transformPoint(vertex1[0].position);
        vertex1[1].position = transform.getInverseTransform().transformPoint(vertex1[1].position);
        vertex1[2].position = transform.getInverseTransform().transformPoint(vertex1[2].position);
        (void)buffer.update(vertex1, 3, 0);

        window.display();

    }

    return 0;
}
```

![afterFix](https://user-images.githubusercontent.com/48102745/163433030-536912bc-f254-4f2e-b265-f895e068b055.gif)

