### PR TITLE
Add tests for `sf::err`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(sfml-test-main PUBLIC SFML::System)
 SET(SYSTEM_SRC
     System/Angle.cpp
     System/Clock.cpp
+    System/Err.cpp
     System/FileInputStream.cpp
     System/Time.cpp
     System/Vector2.cpp

--- a/test/System/Err.cpp
+++ b/test/System/Err.cpp
@@ -1,0 +1,40 @@
+#include <SFML/System/Err.hpp>
+#include <sstream>
+
+#include <doctest.h>
+
+TEST_CASE("sf::err - [system]")
+{
+    SUBCASE("Overflow default buffer")
+    {
+        // No assertion macros in this subcase since nothing about this can be directly observed.
+        // Intention is to ensure DefaultErrStreamBuf::overflow gets called.
+        sf::err() << "SFML is a simple, fast, cross-platform and object-oriented multimedia API."
+            "It provides access to windowing, graphics, audio and network."
+            "It is written in C++, and has bindings for various languages such as C, .Net, Ruby, Python.";
+    }
+
+    SUBCASE("Redirect buffer to observe contents")
+    {
+        sf::err() << "We'll never be able to observe this" << std::endl; // Ensure buffer is flushed
+        const auto defaultStreamBuffer = sf::err().rdbuf();
+        CHECK(defaultStreamBuffer != nullptr);
+
+        std::stringstream stream;
+        sf::err().rdbuf(stream.rdbuf());
+        sf::err() << "Something went wrong!\n";
+        CHECK(stream.str() == "Something went wrong!\n");
+
+        sf::err().rdbuf(nullptr);
+        sf::err() << "Sent to the abyss";
+        CHECK(stream.str() == "Something went wrong!\n");
+
+        sf::err().rdbuf(stream.rdbuf());
+        sf::err() << "Back to the stringstream :)\n";
+        CHECK(stream.str() == "Something went wrong!\nBack to the stringstream :)\n");
+
+        // Restore sf::err to default stream defaultStreamBuffer
+        sf::err().rdbuf(defaultStreamBuffer);
+        CHECK(sf::err().rdbuf() == defaultStreamBuffer);
+    }
+}


### PR DESCRIPTION
## Description

Because `sf::err` is just a `std::ostream&` we can redirect it to capture whatever is printed to it. These tests are largely just testing `std::ostream` since the custom logic inside `sf::err` is difficult to observe. Regardless, these tests do a good job demonstrating how to test error text output for classes that use `sf::err` in their implementation like those which were changed in https://github.com/SFML/SFML/pull/2043.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
