### PR TITLE
Remove unnecessary lossy conversions in test utilities

### DIFF
--- a/test/System/Vector2.cpp
+++ b/test/System/Vector2.cpp
@@ -195,31 +195,31 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         CHECK(v.length() == Approx(3.84187));
         CHECK(v.lengthSq() == Approx(14.7599650969));
-        CHECK(v.normalized() == ApproxVec(0.624695, 0.780869));
+        CHECK(v.normalized() == ApproxVec(0.624695f, 0.780869f));
 
         const sf::Vector2f w(-0.7f, -2.2f);
         
         CHECK(w.length() == Approx(2.30868));
         CHECK(w.lengthSq() == Approx(5.3300033));
-        CHECK(w.normalized() == ApproxVec(-0.303204, -0.952926));
+        CHECK(w.normalized() == ApproxVec(-0.303204f, -0.952926f));
     }
 
     SUBCASE("Rotations and angles")
     {
         const sf::Vector2f v(2.4f, 3.0f);
         
-        CHECK(v.angle() == ApproxDeg(51.3402));
-        CHECK(sf::Vector2f::UnitX.angleTo(v) == ApproxDeg(51.3402));
-        CHECK(sf::Vector2f::UnitY.angleTo(v) == ApproxDeg(-38.6598));
+        CHECK(v.angle() == ApproxDeg(51.3402f));
+        CHECK(sf::Vector2f::UnitX.angleTo(v) == ApproxDeg(51.3402f));
+        CHECK(sf::Vector2f::UnitY.angleTo(v) == ApproxDeg(-38.6598f));
 
         const sf::Vector2f w(-0.7f, -2.2f);
 
-        CHECK(w.angle() == ApproxDeg(-107.65));
-        CHECK(sf::Vector2f::UnitX.angleTo(w) == ApproxDeg(-107.65));
-        CHECK(sf::Vector2f::UnitY.angleTo(w) == ApproxDeg(162.35));
+        CHECK(w.angle() == ApproxDeg(-107.65f));
+        CHECK(sf::Vector2f::UnitX.angleTo(w) == ApproxDeg(-107.65f));
+        CHECK(sf::Vector2f::UnitY.angleTo(w) == ApproxDeg(162.35f));
 
-        CHECK(v.angleTo(w) == ApproxDeg(-158.9902));
-        CHECK(w.angleTo(v) == ApproxDeg(158.9902));
+        CHECK(v.angleTo(w) == ApproxDeg(-158.9902f));
+        CHECK(w.angleTo(v) == ApproxDeg(158.9902f));
 
         const float ratio = w.length() / v.length();
         CHECK(v.rotatedBy(-158.9902_deg) * ratio  == ApproxVec(w));
@@ -228,9 +228,9 @@ TEST_CASE("sf::Vector2 class template - [system]")
         CHECK(v.perpendicular() == sf::Vector2f(-3.0f, 2.4f));
         CHECK(v.perpendicular().perpendicular().perpendicular().perpendicular() == v);
 
-        CHECK(v.rotatedBy(90_deg) == ApproxVec(-3.0, 2.4));
-        CHECK(v.rotatedBy(27.14_deg) == ApproxVec(0.767248, 3.76448));
-        CHECK(v.rotatedBy(-36.11_deg) == ApproxVec(3.70694, 1.00925));
+        CHECK(v.rotatedBy(90_deg) == ApproxVec(-3.0f, 2.4f));
+        CHECK(v.rotatedBy(27.14_deg) == ApproxVec(0.767248f, 3.76448f));
+        CHECK(v.rotatedBy(-36.11_deg) == ApproxVec(3.70694f, 1.00925f));
     }
     
     SUBCASE("Products and quotients")
@@ -244,10 +244,10 @@ TEST_CASE("sf::Vector2 class template - [system]")
         CHECK(v.cross(w) == Approx(-3.18));
         CHECK(w.cross(v) == Approx(+3.18));
         
-        CHECK(v.cwiseMul(w) == ApproxVec(-1.68, -6.6));
-        CHECK(w.cwiseMul(v) == ApproxVec(-1.68, -6.6));
-        CHECK(v.cwiseDiv(w) == ApproxVec(-3.428571, -1.363636));
-        CHECK(w.cwiseDiv(v) == ApproxVec(-0.291666, -0.733333));
+        CHECK(v.cwiseMul(w) == ApproxVec(-1.68f, -6.6f));
+        CHECK(w.cwiseMul(v) == ApproxVec(-1.68f, -6.6f));
+        CHECK(v.cwiseDiv(w) == ApproxVec(-3.428571f, -1.363636f));
+        CHECK(w.cwiseDiv(v) == ApproxVec(-0.291666f, -0.733333f));
     }
     
     SUBCASE("Projection")
@@ -255,14 +255,14 @@ TEST_CASE("sf::Vector2 class template - [system]")
         const sf::Vector2f v(2.4f, 3.0f);
         const sf::Vector2f w(-0.7f, -2.2f);
         
-        CHECK(v.projectedOnto(w) == ApproxVec(1.087430, 3.417636));
+        CHECK(v.projectedOnto(w) == ApproxVec(1.087430f, 3.417636f));
         CHECK(v.projectedOnto(w) == ApproxVec(-1.55347f * w));
 
-        CHECK(w.projectedOnto(v) == ApproxVec(-1.346342, -1.682927));
+        CHECK(w.projectedOnto(v) == ApproxVec(-1.346342f, -1.682927f));
         CHECK(w.projectedOnto(v) == ApproxVec(-0.560976f * v));
 
-        CHECK(v.projectedOnto(sf::Vector2f::UnitX) == ApproxVec(2.4, 0.0));
-        CHECK(v.projectedOnto(sf::Vector2f::UnitY) == ApproxVec(0.0, 3.0));
+        CHECK(v.projectedOnto(sf::Vector2f::UnitX) == ApproxVec(2.4f, 0.0f));
+        CHECK(v.projectedOnto(sf::Vector2f::UnitY) == ApproxVec(0.0f, 3.0f));
     }
 
     SUBCASE("Constexpr support")

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -42,8 +42,8 @@ namespace sf
 // Utilities for approximate equality
 struct ApproxVec
 {
-    ApproxVec(double x, double y)
-        : vector(static_cast<float>(x), static_cast<float>(y)) {}
+    ApproxVec(float x, float y)
+        : vector(x, y) {}
 
     explicit ApproxVec(const sf::Vector2f& v)
         : vector(v) {}
@@ -54,8 +54,8 @@ struct ApproxVec
 // Utilities for approximate equality
 struct ApproxDeg
 {
-    ApproxDeg(double deg)
-        : degrees(static_cast<float>(deg)) {}
+    ApproxDeg(float deg)
+        : degrees(deg) {}
 
     float degrees;
 };


### PR DESCRIPTION
## Description

Both ApproxVec and ApproxDeg accept a double then convert that to a float just to then convert it back to a double. We can save an extra lossy conversion by just accepting a float instead of a double in the first place. I never realized this until #2070 was recently merged which started applying compiler warnings to the unit tests.

On top of that I simplified how we construct the approximate comparison structures for vectors and angles such that we're using strong types to their fullest potential. I kept those as separate commits in case we change our mind about those changes and only use the first.

If accepted, I'd prefer this get merged before #2085 or #2086 as it will cause significant (but easily fixable) conflicts with both. Even just rebasing #2085 on master will require I add a lot of `static_casts` which would then get obviated by this PR. 

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
