### PR TITLE
Apply compiler warnings to test utilities

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(sfml-test-main STATIC
 target_include_directories(sfml-test-main SYSTEM PUBLIC "${PROJECT_SOURCE_DIR}/extlibs/headers")
 target_include_directories(sfml-test-main PUBLIC TestUtilities)
 target_link_libraries(sfml-test-main PUBLIC SFML::System)
+set_target_warnings(sfml-test-main)
 
 SET(SYSTEM_SRC
     System/Angle.cpp

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -37,12 +37,12 @@ namespace sf
 
 bool operator==(const sf::Vector2f& lhs, const ApproxVec& rhs)
 {
-    return (lhs - rhs.vector).length() == doctest::Approx(0.0);
+    return static_cast<double>((lhs - rhs.vector).length()) == doctest::Approx(0.0);
 }
 
 bool operator==(const sf::Angle& lhs, const ApproxDeg& rhs)
 {
-    return lhs.asDegrees() == doctest::Approx(rhs.degrees);
+    return static_cast<double>(lhs.asDegrees()) == doctest::Approx(static_cast<double>(rhs.degrees));
 }
 
 std::ostream& operator <<(std::ostream& os, const ApproxVec& approx)


### PR DESCRIPTION
## Description

This was an oversight. Because `sfml-test-main` isn't made via a macro, it was overlooked that we weren't applying compiler warnings to these source files. Thanks to @JonnyPtn for spotting this.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
