### PR TITLE
Remove MSVC compiler warnings override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
-
-# customize the compiler options CMake uses to initialize variables with
-set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerOptionsOverride.cmake")
+cmake_minimum_required(VERSION 3.15)
 
 # define a macro that helps defining an option
 macro(sfml_set_option var default type docstring)

--- a/cmake/CompilerOptionsOverride.cmake
+++ b/cmake/CompilerOptionsOverride.cmake
@@ -1,5 +1,0 @@
-if(MSVC)
-	# remove default warning level from CMAKE_CXX_FLAGS_INIT
-	string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT}")
-	string(REGEX REPLACE "/W[0-4]" "" CMAKE_C_FLAGS_INIT "${CMAKE_C_FLAGS_INIT}")
-endif()


### PR DESCRIPTION
## Description

These overrides existed to prevent MSVC errors related to duplicate compiler warnings. Because we required a version of CMake older 3.15, CMake would add `/W3` as a default compiler flag when using MSVC. We then add `/W4` in addition to that. Modern CMake versions seem to deduplicate these warnings but older versions did not.

The easist fix is to raise the minimum CMake version to 3.15 which changes the default behavior to no longer add `/W3` without being explicitly specified. See the below link for more information about this behavior change.

https://cmake.org/cmake/help/latest/policy/CMP0092.html

The upgrade to a higher minimum CMake version was inevitable. Currently we're still using 3.8 like SFML 2 requires. As CMake advances, default behaviors get improved but you can't take advantage of them until your `cmake_minimum_required` is raised because CMake wants to make sure backwards compatibility is maintained. 3.15 is a great version to require. Ideally I think 3.16 is best because it's the highest we can go without breaking support for Ubuntu 20 LTS. I'm aware we could ask users to install a new CMake version but for many that's enough to make them give up on SFML so I'd rather not make them do that unless we have a particularly good reason. 

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
