### PR TITLE
Fix incorrect cast when loading 16-bit samples from WAV file

### DIFF
--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -50,7 +50,7 @@ namespace
         if (static_cast<std::size_t>(stream.read(bytes, static_cast<sf::Int64>(sizeof(bytes)))) != sizeof(bytes))
             return false;
 
-        value = static_cast<sf::Uint8>(bytes[0] | (bytes[1] << 8));
+        value = static_cast<sf::Int16>(bytes[0] | (bytes[1] << 8));
 
         return true;
     }


### PR DESCRIPTION
## Description

This commit fixes a regression introduced in c74694c3b20640de3403214bc27e10c17d752dcb as part of PR #1846.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

- Convert the file `examples/sound/resources/killdeer.wav` to 16-bit WAV file using audacity for example.
- Run the "sound" example program.

Without he fix, you can hear a faint noise. With the fix, you can hear the expected sound.
