### PR TITLE
Fixes for Windows scancode implementation

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -334,7 +334,7 @@ public:
             LaunchMail,         //!< Keyboard Launch Mail key
             LaunchMediaSelect,  //!< Keyboard Launch Media Select key
 
-            ScancodeCount           //!< Keep last -- the total number of scancodes
+            ScancodeCount       //!< Keep last -- the total number of scancodes
         };
     };
 

--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -178,6 +178,16 @@ public:
     ////////////////////////////////////////////////////////////
     struct Scan
     {
+        // TODO: replace with enum class in SFML 3.
+        // Clang warns us rightfully that Scancode names shadow Key names.
+        // A safer solution would be to use a C++11 scoped enumeration (enum class),
+        // but it is not possible in SFML 2 which uses C++03.
+        // For now, we just ignore those warnings.
+        #if defined(__clang__)
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wshadow"
+        #endif
+
         enum Scancode
         {
             Unknown = -1,       //!< Represents any scancode not present in this enum
@@ -336,6 +346,10 @@ public:
 
             ScancodeCount       //!< Keep last -- the total number of scancodes
         };
+
+        #if defined(__clang__)
+            #pragma clang diagnostic pop
+        #endif
     };
 
     typedef Scan::Scancode Scancode;

--- a/src/SFML/Window/Android/InputImpl.cpp
+++ b/src/SFML/Window/Android/InputImpl.cpp
@@ -58,7 +58,7 @@ Keyboard::Key InputImpl::localize(Keyboard::Scancode /* code */)
 Keyboard::Scancode InputImpl::delocalize(Keyboard::Key /* key */)
 {
     // Not applicable
-    return Keyboard::ScanUnknown;
+    return Keyboard::Scan::Unknown;
 }
 
 String InputImpl::getDescription(Keyboard::Scancode /* code */)

--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -500,7 +500,7 @@ void ensureMapping()
         {
             scancode = translateKeyCode(display, static_cast<KeyCode>(keycode));
 
-            if (scancode != sf::Keyboard::ScanUnknown && scancodeToKeycode[scancode] == NullKeyCode)
+            if (scancode != sf::Keyboard::Scan::Unknown && scancodeToKeycode[scancode] == NullKeyCode)
                 scancodeToKeycode[scancode] = static_cast<KeyCode>(keycode);
 
             keycodeToScancode[keycode] = scancode;
@@ -554,7 +554,7 @@ KeyCode keyToKeyCode(sf::Keyboard::Key key)
 
     // Fallback for when XKeysymToKeycode cannot tell the KeyCode for XK_Alt_R
     if (key == sf::Keyboard::RAlt)
-        return scancodeToKeycode[sf::Keyboard::ScanRAlt];
+        return scancodeToKeycode[sf::Keyboard::Scan::RAlt];
 
     return NullKeyCode;
 }

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -565,7 +565,8 @@ void InputImpl::ensureMappings()
         Keyboard::Scancode scan = static_cast<Keyboard::Scancode>(i);
         UINT virtualKey = sfScanToVirtualKey(scan);
         Keyboard::Key key = virtualKeyToSfKey(virtualKey);
-        m_keyToScancodeMapping[key] = scan;
+        if (key != Keyboard::Unknown && m_keyToScancodeMapping[key] == Keyboard::Scan::Unknown)
+            m_keyToScancodeMapping[key] = scan;
         m_scancodeToKeyMapping[scan] = key;
     }
 

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -374,7 +374,7 @@ WORD sfScanToWinScan(Keyboard::Scancode code)
 
         case Keyboard::Scan::NumpadDivide:   return 0xE035;
         case Keyboard::Scan::NumpadMultiply: return 0x37;
-        case Keyboard::Scan::NumpadMinus:    return 0xA4;
+        case Keyboard::Scan::NumpadMinus:    return 0x4A;
         case Keyboard::Scan::NumpadPlus:     return 0x4E;
         case Keyboard::Scan::NumpadEqual:    return 0x7E;
         case Keyboard::Scan::NumpadEnter:    return 0xE01C;

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -459,6 +459,7 @@ WORD sfScanToWinScanExtended(Keyboard::Scancode code)
         case Keyboard::Scan::Up:                 return 72  | 0xE100;
         case Keyboard::Scan::NumLock:            return 69  | 0xE100;
         case Keyboard::Scan::NumpadEnter:        return 28  | 0xE100;
+        case Keyboard::Scan::NumpadDivide:       return 53  | 0xE100;
         case Keyboard::Scan::Help:               return 97  | 0xE100;
         case Keyboard::Scan::Menu:               return 93  | 0xE100;
         case Keyboard::Scan::Select:             return 30  | 0xE100;


### PR DESCRIPTION
## Description

This PR is related to the issue #1235.

- It makes CI pass by locally disabling some warnings and finishing to rename Scancode values.
- It provides some fixes for the scancode feature implementation on Windows:
    + `delocalize(Key::Enter)` is now `Scan::Enter` instead of `Scan::NumpadEnter`.
    + Better description for `Scan::NumpadMinus` and `Scan::NumpadDivide`.

I made many small commit to describe my changes but they can be squashed.

There are still remaining oddities that I couldn't manage to fix. See: https://github.com/SFML/SFML/pull/1235#issuecomment-991954851.

Tested using [SFML-Input](https://github.com/eXpl0it3r/SFML-Input/) on Windows 10 with QWERTY (UK) and AZERTY (FR) keyboards.
