### PR TITLE
Simplify approximate comparisons of SFML types

### DIFF
--- a/test/Graphics/CircleShape.cpp
+++ b/test/Graphics/CircleShape.cpp
@@ -19,36 +19,36 @@ TEST_CASE("sf::CircleShape class - [graphics]")
         const sf::CircleShape circle(15.f);
         CHECK(circle.getRadius() == 15.f);
         CHECK(circle.getPointCount() == 30);
-        CHECK(circle.getPoint(0) == ApproxVec2(15, 0));
-        CHECK(circle.getPoint(1) == ApproxVec2(18.118675232f, 0.327785492f));
-        CHECK(circle.getPoint(2) == ApproxVec2(21.101049423f, 1.296817780f));
-        CHECK(circle.getPoint(3) == ApproxVec2(23.816780090f, 2.864745140f));
-        CHECK(circle.getPoint(4) == ApproxVec2(26.147172928f, 4.963042259f));
-        CHECK(circle.getPoint(5) == ApproxVec2(27.990381241f, 7.500000000f));
-        CHECK(circle.getPoint(6) == ApproxVec2(29.265848160f, 10.364745140f));
-        CHECK(circle.getPoint(7) == ApproxVec2(29.917827606f, 13.432072639f));
-        CHECK(circle.getPoint(8) == ApproxVec2(29.917827606f, 16.567928314f));
-        CHECK(circle.getPoint(9) == ApproxVec2(29.265846252f, 19.635257721f));
-        CHECK(circle.getPoint(10) == ApproxVec2(27.990381241f, 22.500000000f));
-        CHECK(circle.getPoint(11) == ApproxVec2(26.147171021f, 25.036960602f));
-        CHECK(circle.getPoint(12) == ApproxVec2(23.816780090f, 27.135253906f));
-        CHECK(circle.getPoint(13) == ApproxVec2(21.101049423f, 28.703182220f));
-        CHECK(circle.getPoint(14) == ApproxVec2(18.118675232f, 29.672214508f));
-        CHECK(circle.getPoint(15) == ApproxVec2(14.999999046f, 30.000000000f));
-        CHECK(circle.getPoint(16) == ApproxVec2(11.881320953f, 29.672214508f));
-        CHECK(circle.getPoint(17) == ApproxVec2(8.898950577f, 28.703182220f));
-        CHECK(circle.getPoint(18) == ApproxVec2(6.183218956f, 27.135253906f));
-        CHECK(circle.getPoint(19) == ApproxVec2(3.852828979f, 25.036960602f));
-        CHECK(circle.getPoint(20) == ApproxVec2(2.009618759f, 22.500000000f));
-        CHECK(circle.getPoint(21) == ApproxVec2(0.734152794f, 19.635255814f));
-        CHECK(circle.getPoint(22) == ApproxVec2(0.082171440f, 16.567928314f));
-        CHECK(circle.getPoint(23) == ApproxVec2(0.082171440f, 13.432073593f));
-        CHECK(circle.getPoint(24) == ApproxVec2(0.734151840f, 10.364746094f));
-        CHECK(circle.getPoint(25) == ApproxVec2(2.009618759f, 7.500000000f));
-        CHECK(circle.getPoint(26) == ApproxVec2(3.852827072f, 4.963040352f));
-        CHECK(circle.getPoint(27) == ApproxVec2(6.183218002f, 2.864748001f));
-        CHECK(circle.getPoint(28) == ApproxVec2(8.898950577f, 1.296818733f));
-        CHECK(circle.getPoint(29) == ApproxVec2(11.881320953f, 0.327786446f));
+        CHECK(circle.getPoint(0) == Approx(sf::Vector2f(15, 0)));
+        CHECK(circle.getPoint(1) == Approx(sf::Vector2f(18.118675232f, 0.327785492f)));
+        CHECK(circle.getPoint(2) == Approx(sf::Vector2f(21.101049423f, 1.296817780f)));
+        CHECK(circle.getPoint(3) == Approx(sf::Vector2f(23.816780090f, 2.864745140f)));
+        CHECK(circle.getPoint(4) == Approx(sf::Vector2f(26.147172928f, 4.963042259f)));
+        CHECK(circle.getPoint(5) == Approx(sf::Vector2f(27.990381241f, 7.500000000f)));
+        CHECK(circle.getPoint(6) == Approx(sf::Vector2f(29.265848160f, 10.364745140f)));
+        CHECK(circle.getPoint(7) == Approx(sf::Vector2f(29.917827606f, 13.432072639f)));
+        CHECK(circle.getPoint(8) == Approx(sf::Vector2f(29.917827606f, 16.567928314f)));
+        CHECK(circle.getPoint(9) == Approx(sf::Vector2f(29.265846252f, 19.635257721f)));
+        CHECK(circle.getPoint(10) == Approx(sf::Vector2f(27.990381241f, 22.500000000f)));
+        CHECK(circle.getPoint(11) == Approx(sf::Vector2f(26.147171021f, 25.036960602f)));
+        CHECK(circle.getPoint(12) == Approx(sf::Vector2f(23.816780090f, 27.135253906f)));
+        CHECK(circle.getPoint(13) == Approx(sf::Vector2f(21.101049423f, 28.703182220f)));
+        CHECK(circle.getPoint(14) == Approx(sf::Vector2f(18.118675232f, 29.672214508f)));
+        CHECK(circle.getPoint(15) == Approx(sf::Vector2f(14.999999046f, 30.000000000f)));
+        CHECK(circle.getPoint(16) == Approx(sf::Vector2f(11.881320953f, 29.672214508f)));
+        CHECK(circle.getPoint(17) == Approx(sf::Vector2f(8.898950577f, 28.703182220f)));
+        CHECK(circle.getPoint(18) == Approx(sf::Vector2f(6.183218956f, 27.135253906f)));
+        CHECK(circle.getPoint(19) == Approx(sf::Vector2f(3.852828979f, 25.036960602f)));
+        CHECK(circle.getPoint(20) == Approx(sf::Vector2f(2.009618759f, 22.500000000f)));
+        CHECK(circle.getPoint(21) == Approx(sf::Vector2f(0.734152794f, 19.635255814f)));
+        CHECK(circle.getPoint(22) == Approx(sf::Vector2f(0.082171440f, 16.567928314f)));
+        CHECK(circle.getPoint(23) == Approx(sf::Vector2f(0.082171440f, 13.432073593f)));
+        CHECK(circle.getPoint(24) == Approx(sf::Vector2f(0.734151840f, 10.364746094f)));
+        CHECK(circle.getPoint(25) == Approx(sf::Vector2f(2.009618759f, 7.500000000f)));
+        CHECK(circle.getPoint(26) == Approx(sf::Vector2f(3.852827072f, 4.963040352f)));
+        CHECK(circle.getPoint(27) == Approx(sf::Vector2f(6.183218002f, 2.864748001f)));
+        CHECK(circle.getPoint(28) == Approx(sf::Vector2f(8.898950577f, 1.296818733f)));
+        CHECK(circle.getPoint(29) == Approx(sf::Vector2f(11.881320953f, 0.327786446f)));
     }
 
     SUBCASE("Radius and point count constructor")
@@ -56,14 +56,14 @@ TEST_CASE("sf::CircleShape class - [graphics]")
         const sf::CircleShape circle(5.f, 8);
         CHECK(circle.getRadius() == 5.f);
         CHECK(circle.getPointCount() == 8);
-        CHECK(circle.getPoint(0) == ApproxVec2(5.000000000f, 0.000000000f));
-        CHECK(circle.getPoint(1) == ApproxVec2(8.535533905f, 1.464465857f));
-        CHECK(circle.getPoint(2) == ApproxVec2(10.000000000f, 5.000000000f));
-        CHECK(circle.getPoint(3) == ApproxVec2(8.535533905f, 8.535533905f));
-        CHECK(circle.getPoint(4) == ApproxVec2(5.000000000f, 10.000000000f));
-        CHECK(circle.getPoint(5) == ApproxVec2(1.464466095f, 8.535533905f));
-        CHECK(circle.getPoint(6) == ApproxVec2(0.000000000f, 4.999999523f));
-        CHECK(circle.getPoint(7) == ApproxVec2(1.464465857f, 1.464466572f));
+        CHECK(circle.getPoint(0) == Approx(sf::Vector2f(5.000000000f, 0.000000000f)));
+        CHECK(circle.getPoint(1) == Approx(sf::Vector2f(8.535533905f, 1.464465857f)));
+        CHECK(circle.getPoint(2) == Approx(sf::Vector2f(10.000000000f, 5.000000000f)));
+        CHECK(circle.getPoint(3) == Approx(sf::Vector2f(8.535533905f, 8.535533905f)));
+        CHECK(circle.getPoint(4) == Approx(sf::Vector2f(5.000000000f, 10.000000000f)));
+        CHECK(circle.getPoint(5) == Approx(sf::Vector2f(1.464466095f, 8.535533905f)));
+        CHECK(circle.getPoint(6) == Approx(sf::Vector2f(0.000000000f, 4.999999523f)));
+        CHECK(circle.getPoint(7) == Approx(sf::Vector2f(1.464465857f, 1.464466572f)));
     }
 
     SUBCASE("Set radius")
@@ -72,12 +72,12 @@ TEST_CASE("sf::CircleShape class - [graphics]")
         circle.setRadius(10.f);
         CHECK(circle.getRadius() == 10.f);
         CHECK(circle.getPointCount() == 6);
-        CHECK(circle.getPoint(0) == ApproxVec2(10.000000000f, 0.000000000f));
-        CHECK(circle.getPoint(1) == ApproxVec2(18.660253525f, 5.000000000f));
-        CHECK(circle.getPoint(2) == ApproxVec2(18.660253525f, 15.000000000f));
-        CHECK(circle.getPoint(3) == ApproxVec2(10.000000000f, 20.000000000f));
-        CHECK(circle.getPoint(4) == ApproxVec2(1.339746475f, 15.000000000f));
-        CHECK(circle.getPoint(5) == ApproxVec2(1.339745522f, 5.000000000f));
+        CHECK(circle.getPoint(0) == Approx(sf::Vector2f(10.000000000f, 0.000000000f)));
+        CHECK(circle.getPoint(1) == Approx(sf::Vector2f(18.660253525f, 5.000000000f)));
+        CHECK(circle.getPoint(2) == Approx(sf::Vector2f(18.660253525f, 15.000000000f)));
+        CHECK(circle.getPoint(3) == Approx(sf::Vector2f(10.000000000f, 20.000000000f)));
+        CHECK(circle.getPoint(4) == Approx(sf::Vector2f(1.339746475f, 15.000000000f)));
+        CHECK(circle.getPoint(5) == Approx(sf::Vector2f(1.339745522f, 5.000000000f)));
     }
 
     SUBCASE("Set point count")
@@ -86,10 +86,10 @@ TEST_CASE("sf::CircleShape class - [graphics]")
         circle.setPointCount(4);
         CHECK(circle.getRadius() == 4.f);
         CHECK(circle.getPointCount() == 4);
-        CHECK(circle.getPoint(0) == ApproxVec2(3.999999762f, 0.000000000f));
-        CHECK(circle.getPoint(1) == ApproxVec2(8.000000000f, 4.000000000f));
-        CHECK(circle.getPoint(2) == ApproxVec2(3.999999762f, 8.000000000f));
-        CHECK(circle.getPoint(3) == ApproxVec2(0.000000000f, 3.999999762f));
+        CHECK(circle.getPoint(0) == Approx(sf::Vector2f(3.999999762f, 0.000000000f)));
+        CHECK(circle.getPoint(1) == Approx(sf::Vector2f(8.000000000f, 4.000000000f)));
+        CHECK(circle.getPoint(2) == Approx(sf::Vector2f(3.999999762f, 8.000000000f)));
+        CHECK(circle.getPoint(3) == Approx(sf::Vector2f(0.000000000f, 3.999999762f)));
     }
 
     SUBCASE("Equilateral triangle")
@@ -97,8 +97,8 @@ TEST_CASE("sf::CircleShape class - [graphics]")
         const sf::CircleShape triangle(2.f, 3);
         CHECK(triangle.getRadius() == 2.f);
         CHECK(triangle.getPointCount() == 3);
-        CHECK(triangle.getPoint(0) == ApproxVec2(1.999999881f, 0.000000000f));
-        CHECK(triangle.getPoint(1) == ApproxVec2(3.732050896f, 3.000000000f));
-        CHECK(triangle.getPoint(2) == ApproxVec2(0.267949224f, 3.000000000f));
+        CHECK(triangle.getPoint(0) == Approx(sf::Vector2f(1.999999881f, 0.000000000f)));
+        CHECK(triangle.getPoint(1) == Approx(sf::Vector2f(3.732050896f, 3.000000000f)));
+        CHECK(triangle.getPoint(2) == Approx(sf::Vector2f(0.267949224f, 3.000000000f)));
     }
 }

--- a/test/Graphics/Shape.cpp
+++ b/test/Graphics/Shape.cpp
@@ -3,8 +3,6 @@
 
 #include <doctest.h>
 
-using doctest::Approx;
-
 class TriangleShape : public sf::Shape
 {
 public:
@@ -93,9 +91,9 @@ TEST_CASE("sf::Shape class - [graphics]")
         triangleShape.move({1, 1});
         triangleShape.rotate(sf::degrees(90));
         CHECK(triangleShape.getLocalBounds() == sf::FloatRect({0, 0}, {2, 3}));
-        CHECK(triangleShape.getGlobalBounds().left == Approx(-2.));
-        CHECK(triangleShape.getGlobalBounds().top == Approx(1.));
-        CHECK(triangleShape.getGlobalBounds().width == Approx(3.));
-        CHECK(triangleShape.getGlobalBounds().height == Approx(2.));
+        CHECK(triangleShape.getGlobalBounds().left == Approx(-2.f));
+        CHECK(triangleShape.getGlobalBounds().top == Approx(1.f));
+        CHECK(triangleShape.getGlobalBounds().width == Approx(3.f));
+        CHECK(triangleShape.getGlobalBounds().height == Approx(2.f));
     }
 }

--- a/test/Graphics/Transform.cpp
+++ b/test/Graphics/Transform.cpp
@@ -6,8 +6,6 @@
 
 #include <doctest.h>
 
-using doctest::Approx;
-
 namespace std
 {
 std::ostream& operator<<(std::ostream& out, const std::vector<float>& vector)
@@ -125,30 +123,18 @@ TEST_CASE("sf::Transform class - [graphics]")
         {
             sf::Transform transform;
             transform.rotate(sf::degrees(90));
-            CHECK(transform.getMatrix()[0] == Approx(0));
-            CHECK(transform.getMatrix()[4] == Approx(-1));
-            CHECK(transform.getMatrix()[12] == Approx(0));
-            CHECK(transform.getMatrix()[1] == Approx(1));
-            CHECK(transform.getMatrix()[5] == Approx(0));
-            CHECK(transform.getMatrix()[13] == Approx(0));
-            CHECK(transform.getMatrix()[3] == Approx(0));
-            CHECK(transform.getMatrix()[7] == Approx(0));
-            CHECK(transform.getMatrix()[15] == Approx(1));
+            CHECK(transform == Approx(sf::Transform(0, -1,  0,
+                                                    1,  0,  0,
+                                                    0,  0,  1)));
         }
 
         SUBCASE("Around custom point")
         {
             sf::Transform transform;
             transform.rotate(sf::degrees(90), {1.0f, 0.0f});
-            CHECK(transform.getMatrix()[0] == Approx(0));
-            CHECK(transform.getMatrix()[4] == Approx(-1));
-            CHECK(transform.getMatrix()[12] == Approx(1));
-            CHECK(transform.getMatrix()[1] == Approx(1));
-            CHECK(transform.getMatrix()[5] == Approx(0));
-            CHECK(transform.getMatrix()[13] == Approx(-1));
-            CHECK(transform.getMatrix()[3] == Approx(0));
-            CHECK(transform.getMatrix()[7] == Approx(0));
-            CHECK(transform.getMatrix()[15] == Approx(1));
+            CHECK(transform == Approx(sf::Transform(0, -1,  1,
+                                                    1,  0, -1,
+                                                    0,  0,  1)));
         }
     }
 

--- a/test/Graphics/Transformable.cpp
+++ b/test/Graphics/Transformable.cpp
@@ -4,8 +4,6 @@
 
 #include <doctest.h>
 
-using doctest::Approx;
-
 TEST_CASE("sf::Transformable class - [graphics]")
 {
     SUBCASE("Construction")
@@ -44,40 +42,40 @@ TEST_CASE("sf::Transformable class - [graphics]")
         transform.rotate(transformable.getRotation(), transformable.getOrigin());
         transform.scale(transformable.getScale(), transformable.getOrigin());
 
-        CHECK(transformable.getTransform().getMatrix()[0] == Approx(static_cast<double>(transform.getMatrix()[0])));
-        CHECK(transformable.getTransform().getMatrix()[1] == Approx(static_cast<double>(transform.getMatrix()[1])));
-        CHECK(transformable.getTransform().getMatrix()[2] == Approx(static_cast<double>(transform.getMatrix()[2])));
-        CHECK(transformable.getTransform().getMatrix()[3] == Approx(static_cast<double>(transform.getMatrix()[3])));
-        CHECK(transformable.getTransform().getMatrix()[4] == Approx(static_cast<double>(transform.getMatrix()[4])));
-        CHECK(transformable.getTransform().getMatrix()[5] == Approx(static_cast<double>(transform.getMatrix()[5])));
-        CHECK(transformable.getTransform().getMatrix()[6] == Approx(static_cast<double>(transform.getMatrix()[6])));
-        CHECK(transformable.getTransform().getMatrix()[7] == Approx(static_cast<double>(transform.getMatrix()[7])));
-        CHECK(transformable.getTransform().getMatrix()[8] == Approx(static_cast<double>(transform.getMatrix()[8])));
-        CHECK(transformable.getTransform().getMatrix()[9] == Approx(static_cast<double>(transform.getMatrix()[9])));
-        CHECK(transformable.getTransform().getMatrix()[10] == Approx(static_cast<double>(transform.getMatrix()[10])));
-        CHECK(transformable.getTransform().getMatrix()[11] == Approx(static_cast<double>(transform.getMatrix()[11])));
-        CHECK(transformable.getTransform().getMatrix()[12] == Approx(static_cast<double>(transform.getMatrix()[12])));
-        CHECK(transformable.getTransform().getMatrix()[13] == Approx(static_cast<double>(transform.getMatrix()[13])));
-        CHECK(transformable.getTransform().getMatrix()[14] == Approx(static_cast<double>(transform.getMatrix()[14])));
-        CHECK(transformable.getTransform().getMatrix()[15] == Approx(static_cast<double>(transform.getMatrix()[15])));
+        CHECK(transformable.getTransform().getMatrix()[0] == Approx(transform.getMatrix()[0]));
+        CHECK(transformable.getTransform().getMatrix()[1] == Approx(transform.getMatrix()[1]));
+        CHECK(transformable.getTransform().getMatrix()[2] == Approx(transform.getMatrix()[2]));
+        CHECK(transformable.getTransform().getMatrix()[3] == Approx(transform.getMatrix()[3]));
+        CHECK(transformable.getTransform().getMatrix()[4] == Approx(transform.getMatrix()[4]));
+        CHECK(transformable.getTransform().getMatrix()[5] == Approx(transform.getMatrix()[5]));
+        CHECK(transformable.getTransform().getMatrix()[6] == Approx(transform.getMatrix()[6]));
+        CHECK(transformable.getTransform().getMatrix()[7] == Approx(transform.getMatrix()[7]));
+        CHECK(transformable.getTransform().getMatrix()[8] == Approx(transform.getMatrix()[8]));
+        CHECK(transformable.getTransform().getMatrix()[9] == Approx(transform.getMatrix()[9]));
+        CHECK(transformable.getTransform().getMatrix()[10] == Approx(transform.getMatrix()[10]));
+        CHECK(transformable.getTransform().getMatrix()[11] == Approx(transform.getMatrix()[11]));
+        CHECK(transformable.getTransform().getMatrix()[12] == Approx(transform.getMatrix()[12]));
+        CHECK(transformable.getTransform().getMatrix()[13] == Approx(transform.getMatrix()[13]));
+        CHECK(transformable.getTransform().getMatrix()[14] == Approx(transform.getMatrix()[14]));
+        CHECK(transformable.getTransform().getMatrix()[15] == Approx(transform.getMatrix()[15]));
 
         const sf::Transform inverse_transform = transform.getInverse();
-        CHECK(transformable.getInverseTransform().getMatrix()[0] == Approx(static_cast<double>(inverse_transform.getMatrix()[0])));
-        CHECK(transformable.getInverseTransform().getMatrix()[1] == Approx(static_cast<double>(inverse_transform.getMatrix()[1])));
-        CHECK(transformable.getInverseTransform().getMatrix()[2] == Approx(static_cast<double>(inverse_transform.getMatrix()[2])));
-        CHECK(transformable.getInverseTransform().getMatrix()[3] == Approx(static_cast<double>(inverse_transform.getMatrix()[3])));
-        CHECK(transformable.getInverseTransform().getMatrix()[4] == Approx(static_cast<double>(inverse_transform.getMatrix()[4])));
-        CHECK(transformable.getInverseTransform().getMatrix()[5] == Approx(static_cast<double>(inverse_transform.getMatrix()[5])));
-        CHECK(transformable.getInverseTransform().getMatrix()[6] == Approx(static_cast<double>(inverse_transform.getMatrix()[6])));
-        CHECK(transformable.getInverseTransform().getMatrix()[7] == Approx(static_cast<double>(inverse_transform.getMatrix()[7])));
-        CHECK(transformable.getInverseTransform().getMatrix()[8] == Approx(static_cast<double>(inverse_transform.getMatrix()[8])));
-        CHECK(transformable.getInverseTransform().getMatrix()[9] == Approx(static_cast<double>(inverse_transform.getMatrix()[9])));
-        CHECK(transformable.getInverseTransform().getMatrix()[10] == Approx(static_cast<double>(inverse_transform.getMatrix()[10])));
-        CHECK(transformable.getInverseTransform().getMatrix()[11] == Approx(static_cast<double>(inverse_transform.getMatrix()[11])));
-        CHECK(transformable.getInverseTransform().getMatrix()[12] == Approx(static_cast<double>(inverse_transform.getMatrix()[12])));
-        CHECK(transformable.getInverseTransform().getMatrix()[13] == Approx(static_cast<double>(inverse_transform.getMatrix()[13])));
-        CHECK(transformable.getInverseTransform().getMatrix()[14] == Approx(static_cast<double>(inverse_transform.getMatrix()[14])));
-        CHECK(transformable.getInverseTransform().getMatrix()[15] == Approx(static_cast<double>(inverse_transform.getMatrix()[15])));
+        CHECK(transformable.getInverseTransform().getMatrix()[0] == Approx(inverse_transform.getMatrix()[0]));
+        CHECK(transformable.getInverseTransform().getMatrix()[1] == Approx(inverse_transform.getMatrix()[1]));
+        CHECK(transformable.getInverseTransform().getMatrix()[2] == Approx(inverse_transform.getMatrix()[2]));
+        CHECK(transformable.getInverseTransform().getMatrix()[3] == Approx(inverse_transform.getMatrix()[3]));
+        CHECK(transformable.getInverseTransform().getMatrix()[4] == Approx(inverse_transform.getMatrix()[4]));
+        CHECK(transformable.getInverseTransform().getMatrix()[5] == Approx(inverse_transform.getMatrix()[5]));
+        CHECK(transformable.getInverseTransform().getMatrix()[6] == Approx(inverse_transform.getMatrix()[6]));
+        CHECK(transformable.getInverseTransform().getMatrix()[7] == Approx(inverse_transform.getMatrix()[7]));
+        CHECK(transformable.getInverseTransform().getMatrix()[8] == Approx(inverse_transform.getMatrix()[8]));
+        CHECK(transformable.getInverseTransform().getMatrix()[9] == Approx(inverse_transform.getMatrix()[9]));
+        CHECK(transformable.getInverseTransform().getMatrix()[10] == Approx(inverse_transform.getMatrix()[10]));
+        CHECK(transformable.getInverseTransform().getMatrix()[11] == Approx(inverse_transform.getMatrix()[11]));
+        CHECK(transformable.getInverseTransform().getMatrix()[12] == Approx(inverse_transform.getMatrix()[12]));
+        CHECK(transformable.getInverseTransform().getMatrix()[13] == Approx(inverse_transform.getMatrix()[13]));
+        CHECK(transformable.getInverseTransform().getMatrix()[14] == Approx(inverse_transform.getMatrix()[14]));
+        CHECK(transformable.getInverseTransform().getMatrix()[15] == Approx(inverse_transform.getMatrix()[15]));
     }
 
     SUBCASE("move()")

--- a/test/System/Angle.cpp
+++ b/test/System/Angle.cpp
@@ -3,8 +3,6 @@
 
 #include <doctest.h>
 
-using doctest::Approx;
-
 TEST_CASE("sf::Angle class - [system]")
 {
     SUBCASE("Construction")
@@ -52,30 +50,30 @@ TEST_CASE("sf::Angle class - [system]")
         {
             const sf::Angle angle = sf::degrees(15);
             CHECK(angle == sf::degrees(15));
-            CHECK(angle.asRadians() == Approx(0.26179939));
+            CHECK(angle.asRadians() == Approx(0.26179939f));
 
             const sf::Angle bigAngle = sf::degrees(1000);
             CHECK(bigAngle == sf::degrees(1000));
-            CHECK(bigAngle.asRadians() == Approx(17.453293));
+            CHECK(bigAngle.asRadians() == Approx(17.453293f));
 
             const sf::Angle bigNegativeAngle = sf::degrees(-4321);
             CHECK(bigNegativeAngle == sf::degrees(-4321));
-            CHECK(bigNegativeAngle.asRadians() == Approx(-75.415677));
+            CHECK(bigNegativeAngle.asRadians() == Approx(-75.415677f));
         }
 
         SUBCASE("radians()")
         {
             const sf::Angle angle = sf::radians(1);
-            CHECK(angle.asDegrees() == Approx(57.2957795));
-            CHECK(angle.asRadians() == Approx(1.0));
+            CHECK(angle.asDegrees() == Approx(57.2957795f));
+            CHECK(angle.asRadians() == Approx(1.f));
 
             const sf::Angle bigAngle = sf::radians(72);
-            CHECK(bigAngle.asDegrees() == Approx(4125.29612));
-            CHECK(bigAngle.asRadians() == Approx(72.0));
+            CHECK(bigAngle.asDegrees() == Approx(4125.29612f));
+            CHECK(bigAngle.asRadians() == Approx(72.f));
 
             const sf::Angle bigNegativeAngle = sf::radians(-200);
-            CHECK(bigNegativeAngle.asDegrees() == Approx(-11459.1559));
-            CHECK(bigNegativeAngle.asRadians() == Approx(-200.0));
+            CHECK(bigNegativeAngle.asDegrees() == Approx(-11459.1559f));
+            CHECK(bigNegativeAngle.asRadians() == Approx(-200.f));
         }
     }
 
@@ -228,7 +226,7 @@ TEST_CASE("sf::Angle class - [system]")
 
             CHECK(sf::Angle::Zero / sf::degrees(1) == 0);
             CHECK(sf::degrees(10) / sf::degrees(10) == 1);
-            CHECK(sf::radians(10) / sf::radians(2) == Approx(5.0));
+            CHECK(sf::radians(10) / sf::radians(2) == Approx(5.f));
         }
 
         SUBCASE("operator/=")

--- a/test/System/Time.cpp
+++ b/test/System/Time.cpp
@@ -3,8 +3,6 @@
 
 #include <doctest.h>
 
-using doctest::Approx;
-
 TEST_CASE("sf::Time class - [system]")
 {
     SUBCASE("Construction")
@@ -163,7 +161,7 @@ TEST_CASE("sf::Time class - [system]")
             CHECK(sf::seconds(1) / static_cast<sf::Int64>(2) == sf::seconds(0.5f));
             CHECK(sf::seconds(42) / static_cast<sf::Int64>(2) == sf::seconds(21));
             CHECK(sf::seconds(1) / sf::seconds(1) == 1.0f);
-            CHECK(sf::milliseconds(10) / sf::microseconds(1) == Approx(10'000.0).epsilon(1e-6));
+            CHECK(sf::milliseconds(10) / sf::microseconds(1) == doctest::Approx(10'000.0).epsilon(1e-6));
         }
 
         SUBCASE("operator/=")

--- a/test/System/Vector2.cpp
+++ b/test/System/Vector2.cpp
@@ -5,7 +5,6 @@
 #include <doctest.h>
 
 using namespace sf::Literals;
-using doctest::Approx;
 
 // Use sf::Vector2i for tests (except for float vector algebra).
 // Test coverage is given, as there are no template specializations.
@@ -40,53 +39,53 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("Length and angle constructor")
         {
-            CHECK(sf::Vector2f(0, sf::degrees(0)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(45)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(90)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(135)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(180)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(270)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(360)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(-90)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(-180)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(-270)) == sf::Vector2f(0, 0));
-            CHECK(sf::Vector2f(0, sf::degrees(-360)) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, 0_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, 45_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, 90_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, 135_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, 180_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, 270_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, 360_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, -90_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, -180_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, -270_deg) == sf::Vector2f(0, 0));
+            CHECK(sf::Vector2f(0, -360_deg) == sf::Vector2f(0, 0));
 
-            CHECK(sf::Vector2f(1, sf::degrees(0)) == sf::Vector2f(1, 0));
-            CHECK(sf::Vector2f(1, sf::degrees(45)) == ApproxVec2(std::sqrt(2.f) / 2.f, std::sqrt(2.f) / 2.f));
-            CHECK(sf::Vector2f(1, sf::degrees(90)) == ApproxVec2(0, 1));
-            CHECK(sf::Vector2f(1, sf::degrees(135)) == ApproxVec2(-std::sqrt(2.f) / 2.f, std::sqrt(2.f) / 2.f));
-            CHECK(sf::Vector2f(1, sf::degrees(180)) == ApproxVec2(-1, 0));
-            CHECK(sf::Vector2f(1, sf::degrees(270)) == ApproxVec2(0, -1));
-            CHECK(sf::Vector2f(1, sf::degrees(360)) == ApproxVec2(1, 0));
-            CHECK(sf::Vector2f(1, sf::degrees(-90)) == ApproxVec2(0, -1));
-            CHECK(sf::Vector2f(1, sf::degrees(-180)) == ApproxVec2(-1, 0));
-            CHECK(sf::Vector2f(1, sf::degrees(-270)) == ApproxVec2(0, 1));
-            CHECK(sf::Vector2f(1, sf::degrees(-360)) == ApproxVec2(1, 0));
+            CHECK(sf::Vector2f(1, 0_deg) == sf::Vector2f(1, 0));
+            CHECK(sf::Vector2f(1, 45_deg) == Approx(sf::Vector2f(std::sqrt(2.f) / 2.f, std::sqrt(2.f) / 2.f)));
+            CHECK(sf::Vector2f(1, 90_deg) == Approx(sf::Vector2f(0, 1)));
+            CHECK(sf::Vector2f(1, 135_deg) == Approx(sf::Vector2f(-std::sqrt(2.f) / 2.f, std::sqrt(2.f) / 2.f)));
+            CHECK(sf::Vector2f(1, 180_deg) == Approx(sf::Vector2f(-1, 0)));
+            CHECK(sf::Vector2f(1, 270_deg) == Approx(sf::Vector2f(0, -1)));
+            CHECK(sf::Vector2f(1, 360_deg) == Approx(sf::Vector2f(1, 0)));
+            CHECK(sf::Vector2f(1, -90_deg) == Approx(sf::Vector2f(0, -1)));
+            CHECK(sf::Vector2f(1, -180_deg) == Approx(sf::Vector2f(-1, 0)));
+            CHECK(sf::Vector2f(1, -270_deg) == Approx(sf::Vector2f(0, 1)));
+            CHECK(sf::Vector2f(1, -360_deg) == Approx(sf::Vector2f(1, 0)));
 
-            CHECK(sf::Vector2f(-1, sf::degrees(0)) == sf::Vector2f(-1, 0));
-            CHECK(sf::Vector2f(-1, sf::degrees(45)) == ApproxVec2(-std::sqrt(2.f) / 2.f, -std::sqrt(2.f) / 2.f));
-            CHECK(sf::Vector2f(-1, sf::degrees(90)) == ApproxVec2(0, -1));
-            CHECK(sf::Vector2f(-1, sf::degrees(135)) == ApproxVec2(std::sqrt(2.f) / 2.f, -std::sqrt(2.f) / 2.f));
-            CHECK(sf::Vector2f(-1, sf::degrees(180)) == ApproxVec2(1, 0));
-            CHECK(sf::Vector2f(-1, sf::degrees(270)) == ApproxVec2(0, 1));
-            CHECK(sf::Vector2f(-1, sf::degrees(360)) == ApproxVec2(-1, 0));
-            CHECK(sf::Vector2f(-1, sf::degrees(-90)) == ApproxVec2(0, 1));
-            CHECK(sf::Vector2f(-1, sf::degrees(-180)) == ApproxVec2(1, 0));
-            CHECK(sf::Vector2f(-1, sf::degrees(-270)) == ApproxVec2(0, -1));
-            CHECK(sf::Vector2f(-1, sf::degrees(-360)) == ApproxVec2(-1, 0));
+            CHECK(sf::Vector2f(-1, 0_deg) == sf::Vector2f(-1, 0));
+            CHECK(sf::Vector2f(-1, 45_deg) == Approx(sf::Vector2f(-std::sqrt(2.f) / 2.f, -std::sqrt(2.f) / 2.f)));
+            CHECK(sf::Vector2f(-1, 90_deg) == Approx(sf::Vector2f(0, -1)));
+            CHECK(sf::Vector2f(-1, 135_deg) == Approx(sf::Vector2f(std::sqrt(2.f) / 2.f, -std::sqrt(2.f) / 2.f)));
+            CHECK(sf::Vector2f(-1, 180_deg) == Approx(sf::Vector2f(1, 0)));
+            CHECK(sf::Vector2f(-1, 270_deg) == Approx(sf::Vector2f(0, 1)));
+            CHECK(sf::Vector2f(-1, 360_deg) == Approx(sf::Vector2f(-1, 0)));
+            CHECK(sf::Vector2f(-1, -90_deg) == Approx(sf::Vector2f(0, 1)));
+            CHECK(sf::Vector2f(-1, -180_deg) == Approx(sf::Vector2f(1, 0)));
+            CHECK(sf::Vector2f(-1, -270_deg) == Approx(sf::Vector2f(0, -1)));
+            CHECK(sf::Vector2f(-1, -360_deg) == Approx(sf::Vector2f(-1, 0)));
 
-            CHECK(sf::Vector2f(4.2f, sf::degrees(0)) == sf::Vector2f(4.2f, 0));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(45)) == ApproxVec2(4.2f * std::sqrt(2.f) / 2.f, 4.2f * std::sqrt(2.f) / 2.f));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(90)) == ApproxVec2(0, 4.2f));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(135)) == ApproxVec2(-4.2f * std::sqrt(2.f) / 2.f, 4.2f * std::sqrt(2.f) / 2.f));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(180)) == ApproxVec2(-4.2f, 0));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(270)) == ApproxVec2(0, -4.2f));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(360)) == ApproxVec2(4.2f, 0));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(-90)) == ApproxVec2(0, -4.2f));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(-180)) == ApproxVec2(-4.2f, 0));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(-270)) == ApproxVec2(0, 4.2f));
-            CHECK(sf::Vector2f(4.2f, sf::degrees(-360)) == ApproxVec2(4.2f, 0));
+            CHECK(sf::Vector2f(4.2f, 0_deg) == sf::Vector2f(4.2f, 0));
+            CHECK(sf::Vector2f(4.2f, 45_deg) == Approx(sf::Vector2f(4.2f * std::sqrt(2.f) / 2.f, 4.2f * std::sqrt(2.f) / 2.f)));
+            CHECK(sf::Vector2f(4.2f, 90_deg) == Approx(sf::Vector2f(0, 4.2f)));
+            CHECK(sf::Vector2f(4.2f, 135_deg) == Approx(sf::Vector2f(-4.2f * std::sqrt(2.f) / 2.f, 4.2f * std::sqrt(2.f) / 2.f)));
+            CHECK(sf::Vector2f(4.2f, 180_deg) == Approx(sf::Vector2f(-4.2f, 0)));
+            CHECK(sf::Vector2f(4.2f, 270_deg) == Approx(sf::Vector2f(0, -4.2f)));
+            CHECK(sf::Vector2f(4.2f, 360_deg) == Approx(sf::Vector2f(4.2f, 0)));
+            CHECK(sf::Vector2f(4.2f, -90_deg) == Approx(sf::Vector2f(0, -4.2f)));
+            CHECK(sf::Vector2f(4.2f, -180_deg) == Approx(sf::Vector2f(-4.2f, 0)));
+            CHECK(sf::Vector2f(4.2f, -270_deg) == Approx(sf::Vector2f(0, 4.2f)));
+            CHECK(sf::Vector2f(4.2f, -360_deg) == Approx(sf::Vector2f(4.2f, 0)));
         }
     }
 
@@ -244,44 +243,44 @@ TEST_CASE("sf::Vector2 class template - [system]")
     {
         const sf::Vector2f v(2.4f, 3.0f);
 
-        CHECK(v.length() == Approx(3.84187));
-        CHECK(v.lengthSq() == Approx(14.7599650969));
-        CHECK(v.normalized() == ApproxVec2(0.624695f, 0.780869f));
+        CHECK(v.length() == Approx(3.84187f));
+        CHECK(v.lengthSq() == Approx(14.7599650969f));
+        CHECK(v.normalized() == Approx(sf::Vector2f(0.624695f, 0.780869f)));
 
         const sf::Vector2f w(-0.7f, -2.2f);
         
-        CHECK(w.length() == Approx(2.30868));
-        CHECK(w.lengthSq() == Approx(5.3300033));
-        CHECK(w.normalized() == ApproxVec2(-0.303204f, -0.952926f));
+        CHECK(w.length() == Approx(2.30868f));
+        CHECK(w.lengthSq() == Approx(5.3300033f));
+        CHECK(w.normalized() == Approx(sf::Vector2f(-0.303204f, -0.952926f)));
     }
 
     SUBCASE("Rotations and angles")
     {
         const sf::Vector2f v(2.4f, 3.0f);
         
-        CHECK(v.angle() == ApproxDeg(51.3402f));
-        CHECK(sf::Vector2f::UnitX.angleTo(v) == ApproxDeg(51.3402f));
-        CHECK(sf::Vector2f::UnitY.angleTo(v) == ApproxDeg(-38.6598f));
+        CHECK(v.angle() == Approx(51.3402_deg));
+        CHECK(sf::Vector2f::UnitX.angleTo(v) == Approx(51.3402_deg));
+        CHECK(sf::Vector2f::UnitY.angleTo(v) == Approx(-38.6598_deg));
 
         const sf::Vector2f w(-0.7f, -2.2f);
 
-        CHECK(w.angle() == ApproxDeg(-107.65f));
-        CHECK(sf::Vector2f::UnitX.angleTo(w) == ApproxDeg(-107.65f));
-        CHECK(sf::Vector2f::UnitY.angleTo(w) == ApproxDeg(162.35f));
+        CHECK(w.angle() == Approx(-107.65_deg));
+        CHECK(sf::Vector2f::UnitX.angleTo(w) == Approx(-107.65_deg));
+        CHECK(sf::Vector2f::UnitY.angleTo(w) == Approx(162.35_deg));
 
-        CHECK(v.angleTo(w) == ApproxDeg(-158.9902f));
-        CHECK(w.angleTo(v) == ApproxDeg(158.9902f));
+        CHECK(v.angleTo(w) == Approx(-158.9902_deg));
+        CHECK(w.angleTo(v) == Approx(158.9902_deg));
 
         const float ratio = w.length() / v.length();
-        CHECK(v.rotatedBy(-158.9902_deg) * ratio  == ApproxVec2(w));
-        CHECK(w.rotatedBy(158.9902_deg) / ratio == ApproxVec2(v));
+        CHECK(v.rotatedBy(-158.9902_deg) * ratio  == Approx(w));
+        CHECK(w.rotatedBy(158.9902_deg) / ratio == Approx(v));
 
         CHECK(v.perpendicular() == sf::Vector2f(-3.0f, 2.4f));
         CHECK(v.perpendicular().perpendicular().perpendicular().perpendicular() == v);
 
-        CHECK(v.rotatedBy(90_deg) == ApproxVec2(-3.0f, 2.4f));
-        CHECK(v.rotatedBy(27.14_deg) == ApproxVec2(0.767248f, 3.76448f));
-        CHECK(v.rotatedBy(-36.11_deg) == ApproxVec2(3.70694f, 1.00925f));
+        CHECK(v.rotatedBy(90_deg) == Approx(sf::Vector2f(-3.0f, 2.4f)));
+        CHECK(v.rotatedBy(27.14_deg) == Approx(sf::Vector2f(0.767248f, 3.76448f)));
+        CHECK(v.rotatedBy(-36.11_deg) == Approx(sf::Vector2f(3.70694f, 1.00925f)));
     }
     
     SUBCASE("Products and quotients")
@@ -289,16 +288,16 @@ TEST_CASE("sf::Vector2 class template - [system]")
         const sf::Vector2f v(2.4f, 3.0f);
         const sf::Vector2f w(-0.7f, -2.2f);
 
-        CHECK(v.dot(w) == Approx(-8.28));
-        CHECK(w.dot(v) == Approx(-8.28));
+        CHECK(v.dot(w) == Approx(-8.28f));
+        CHECK(w.dot(v) == Approx(-8.28f));
 
-        CHECK(v.cross(w) == Approx(-3.18));
-        CHECK(w.cross(v) == Approx(+3.18));
+        CHECK(v.cross(w) == Approx(-3.18f));
+        CHECK(w.cross(v) == Approx(+3.18f));
         
-        CHECK(v.cwiseMul(w) == ApproxVec2(-1.68f, -6.6f));
-        CHECK(w.cwiseMul(v) == ApproxVec2(-1.68f, -6.6f));
-        CHECK(v.cwiseDiv(w) == ApproxVec2(-3.428571f, -1.363636f));
-        CHECK(w.cwiseDiv(v) == ApproxVec2(-0.291666f, -0.733333f));
+        CHECK(v.cwiseMul(w) == Approx(sf::Vector2f(-1.68f, -6.6f)));
+        CHECK(w.cwiseMul(v) == Approx(sf::Vector2f(-1.68f, -6.6f)));
+        CHECK(v.cwiseDiv(w) == Approx(sf::Vector2f(-3.428571f, -1.363636f)));
+        CHECK(w.cwiseDiv(v) == Approx(sf::Vector2f(-0.291666f, -0.733333f)));
     }
     
     SUBCASE("Projection")
@@ -306,14 +305,14 @@ TEST_CASE("sf::Vector2 class template - [system]")
         const sf::Vector2f v(2.4f, 3.0f);
         const sf::Vector2f w(-0.7f, -2.2f);
         
-        CHECK(v.projectedOnto(w) == ApproxVec2(1.087430f, 3.417636f));
-        CHECK(v.projectedOnto(w) == ApproxVec2(-1.55347f * w));
+        CHECK(v.projectedOnto(w) == Approx(sf::Vector2f(1.087430f, 3.417636f)));
+        CHECK(v.projectedOnto(w) == Approx(sf::Vector2f(-1.55347f * w)));
 
-        CHECK(w.projectedOnto(v) == ApproxVec2(-1.346342f, -1.682927f));
-        CHECK(w.projectedOnto(v) == ApproxVec2(-0.560976f * v));
+        CHECK(w.projectedOnto(v) == Approx(sf::Vector2f(-1.346342f, -1.682927f)));
+        CHECK(w.projectedOnto(v) == Approx(sf::Vector2f(-0.560976f * v)));
 
-        CHECK(v.projectedOnto(sf::Vector2f::UnitX) == ApproxVec2(2.4f, 0.0f));
-        CHECK(v.projectedOnto(sf::Vector2f::UnitY) == ApproxVec2(0.0f, 3.0f));
+        CHECK(v.projectedOnto(sf::Vector2f::UnitX) == Approx(sf::Vector2f(2.4f, 0.0f)));
+        CHECK(v.projectedOnto(sf::Vector2f::UnitY) == Approx(sf::Vector2f(0.0f, 3.0f)));
     }
 
     SUBCASE("Constexpr support")

--- a/test/System/Vector3.cpp
+++ b/test/System/Vector3.cpp
@@ -4,8 +4,6 @@
 
 #include <doctest.h>
 
-using doctest::Approx;
-
 // Use sf::Vector3i for tests (except for float vector algebra).
 // Test coverage is given, as there are no template specializations.
 
@@ -206,9 +204,9 @@ TEST_CASE("sf::Vector3 class template - [system]")
     {
         const sf::Vector3f v(2.4f, 3.0f, 5.2f);
 
-        CHECK(v.length() == Approx(6.46529));
-        CHECK(v.lengthSq() == Approx(41.79997));
-        CHECK(v.normalized() == ApproxVec3(0.37121f, 0.46401f, 0.80429f));
+        CHECK(v.length() == Approx(6.46529f));
+        CHECK(v.lengthSq() == Approx(41.79997f));
+        CHECK(v.normalized() == Approx(sf::Vector3f(0.37121f, 0.46401f, 0.80429f)));
     }
 
     SUBCASE("Products and quotients")
@@ -216,16 +214,16 @@ TEST_CASE("sf::Vector3 class template - [system]")
         const sf::Vector3f v(2.4f, 3.0f, 5.2f);
         const sf::Vector3f w(-0.7f, -2.2f, -4.8f);
 
-        CHECK(v.dot(w) == Approx(-33.24));
-        CHECK(w.dot(v) == Approx(-33.24));
+        CHECK(v.dot(w) == Approx(-33.24f));
+        CHECK(w.dot(v) == Approx(-33.24f));
 
-        CHECK(v.cross(w) == ApproxVec3(-2.96f, 7.88f, -3.18f));
-        CHECK(w.cross(v) == ApproxVec3(2.96f, -7.88f, 3.18f));
+        CHECK(v.cross(w) == Approx(sf::Vector3f(-2.96f, 7.88f, -3.18f)));
+        CHECK(w.cross(v) == Approx(sf::Vector3f(2.96f, -7.88f, 3.18f)));
 
-        CHECK(v.cwiseMul(w) == ApproxVec3(-1.68f, -6.6f, -24.96f));
-        CHECK(w.cwiseMul(v) == ApproxVec3(-1.68f, -6.6f, -24.96f));
-        CHECK(v.cwiseDiv(w) == ApproxVec3(-3.428571f, -1.363636f, -1.0833333f));
-        CHECK(w.cwiseDiv(v) == ApproxVec3(-0.291666f, -0.733333f, -0.9230769f));
+        CHECK(v.cwiseMul(w) == Approx(sf::Vector3f(-1.68f, -6.6f, -24.96f)));
+        CHECK(w.cwiseMul(v) == Approx(sf::Vector3f(-1.68f, -6.6f, -24.96f)));
+        CHECK(v.cwiseDiv(w) == Approx(sf::Vector3f(-3.428571f, -1.363636f, -1.0833333f)));
+        CHECK(w.cwiseDiv(v) == Approx(sf::Vector3f(-0.291666f, -0.733333f, -0.9230769f)));
     }
 
     SUBCASE("Constexpr support")

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -1,4 +1,5 @@
-// Note: No need to increase compile time by including TestUtilities/Graphics.hpp
+#include "GraphicsUtil.hpp"
+
 #include <SFML/Graphics/BlendMode.hpp>
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Transform.hpp>
@@ -36,4 +37,17 @@ namespace sf
 
         return os;
     }
+}
+
+bool operator==(const sf::Transform& lhs, const Approx<sf::Transform>& rhs)
+{
+    return lhs.getMatrix()[0]  == Approx(rhs.value.getMatrix()[0])
+        && lhs.getMatrix()[4]  == Approx(rhs.value.getMatrix()[4])
+        && lhs.getMatrix()[12] == Approx(rhs.value.getMatrix()[12])
+        && lhs.getMatrix()[1]  == Approx(rhs.value.getMatrix()[1])
+        && lhs.getMatrix()[5]  == Approx(rhs.value.getMatrix()[5])
+        && lhs.getMatrix()[13] == Approx(rhs.value.getMatrix()[13])
+        && lhs.getMatrix()[3]  == Approx(rhs.value.getMatrix()[3])
+        && lhs.getMatrix()[7]  == Approx(rhs.value.getMatrix()[7])
+        && lhs.getMatrix()[15] == Approx(rhs.value.getMatrix()[15]);
 }

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -33,4 +33,6 @@ namespace sf
     }
 }
 
+bool operator==(const sf::Transform& lhs, const Approx<sf::Transform>& rhs);
+
 #endif // SFML_TESTUTILITIES_GRAPHICS_HPP

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -35,37 +35,24 @@ namespace sf
     }
 }
 
-bool operator==(const sf::Vector2f& lhs, const ApproxVec2& rhs)
+bool operator==(const float& lhs, const Approx<float>& rhs)
 {
-    return static_cast<double>((lhs - rhs.vector).length()) == doctest::Approx(0.0);
+    return static_cast<double>(lhs) == doctest::Approx(static_cast<double>(rhs.value));
 }
 
-bool operator==(const sf::Vector3f& lhs, const ApproxVec3& rhs)
+bool operator==(const sf::Vector2f& lhs, const Approx<sf::Vector2f>& rhs)
 {
-    return static_cast<double>((lhs - rhs.vector).length()) == doctest::Approx(0.0);
+    return (lhs - rhs.value).length() == Approx(0.f);
 }
 
-bool operator==(const sf::Angle& lhs, const ApproxDeg& rhs)
+bool operator==(const sf::Vector3f& lhs, const Approx<sf::Vector3f>& rhs)
 {
-    return static_cast<double>(lhs.asDegrees()) == doctest::Approx(static_cast<double>(rhs.degrees));
+    return (lhs - rhs.value).length() == Approx(0.f);
 }
 
-std::ostream& operator <<(std::ostream& os, const ApproxVec2& approx)
+bool operator==(const sf::Angle& lhs, const Approx<sf::Angle>& rhs)
 {
-    os << approx.vector;
-    return os;
-}
-
-std::ostream& operator <<(std::ostream& os, const ApproxVec3& approx)
-{
-    os << approx.vector;
-    return os;
-}
-
-std::ostream& operator <<(std::ostream& os, const ApproxDeg& approx)
-{
-    os << sf::degrees(approx.degrees);
-    return os;
+    return lhs.asDegrees() == Approx(rhs.value.asDegrees());
 }
 
 namespace sf::Testing

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -41,45 +41,28 @@ namespace sf
     }
 }
 
-// Utilities for approximate equality
-struct ApproxVec2
+////////////////////////////////////////////////////////////
+/// Class template for creating custom approximate comparisons.
+/// To register a new type, simply implement a custom operator==
+/// overload for that type.
+////////////////////////////////////////////////////////////
+template <typename T>
+struct Approx
 {
-    ApproxVec2(float x, float y)
-        : vector(x, y) {}
-
-    explicit ApproxVec2(const sf::Vector2f& v)
-        : vector(v) {}
-
-    sf::Vector2f vector;
+    explicit Approx(const T& t) : value(t) {}
+    const T& value;
 };
 
-struct ApproxVec3
+bool operator==(const float& lhs, const Approx<float>& rhs);
+bool operator==(const sf::Vector2f& lhs, const Approx<sf::Vector2f>& rhs);
+bool operator==(const sf::Vector3f& lhs, const Approx<sf::Vector3f>& rhs);
+bool operator==(const sf::Angle& lhs, const Approx<sf::Angle>& rhs);
+
+template <typename T>
+std::ostream& operator <<(std::ostream& os, const Approx<T>& approx)
 {
-    ApproxVec3(float x, float y, float z)
-        : vector(x, y, z) {}
-
-    explicit ApproxVec3(const sf::Vector3f& v)
-        : vector(v) {}
-
-    sf::Vector3f vector;
-};
-
-// Utilities for approximate equality
-struct ApproxDeg
-{
-    ApproxDeg(float deg)
-        : degrees(deg) {}
-
-    float degrees;
-};
-
-bool operator==(const sf::Vector2f& lhs, const ApproxVec2& rhs);
-bool operator==(const sf::Vector3f& lhs, const ApproxVec3& rhs);
-bool operator==(const sf::Angle& lhs, const ApproxDeg& rhs);
-
-std::ostream& operator <<(std::ostream& os, const ApproxVec2& approx);
-std::ostream& operator <<(std::ostream& os, const ApproxVec3& approx);
-std::ostream& operator <<(std::ostream& os, const ApproxDeg& approx);
+    return os << approx.value;
+}
 
 namespace sf::Testing
 {


### PR DESCRIPTION
## Description

With the help of @kimci86 I refactored how we handle approximate comparisons with the goal of making our test utilities more generic which reduces code size and more clean by removing the need for so many `static_cast`s. Along the way I added some extra utilities for approximate comparisons of `sf::Transform` since those tests were pretty verbose. 

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
