### PR TITLE
Clean up various uses of `(void)`

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -645,7 +645,7 @@ Out Utf<32>::toUtf32(In begin, In end, Out output)
 
 ////////////////////////////////////////////////////////////
 template <typename In>
-Uint32 Utf<32>::decodeAnsi(In input, const std::locale& locale)
+Uint32 Utf<32>::decodeAnsi(In input, [[maybe_unused]] const std::locale& locale)
 {
     // On Windows, GCC's standard library (glibc++) has almost
     // no support for Unicode stuff. As a consequence, in this
@@ -655,8 +655,6 @@ Uint32 Utf<32>::decodeAnsi(In input, const std::locale& locale)
     #if defined(SFML_SYSTEM_WINDOWS) &&                       /* if Windows ... */                          \
        (defined(__GLIBCPP__) || defined (__GLIBCXX__)) &&     /* ... and standard library is glibc++ ... */ \
       !(defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)) /* ... and STLPort is not used on top of it */
-
-        (void)locale; // to avoid warnings
 
         wchar_t character = 0;
         mbtowc(&character, &input, 1);
@@ -690,7 +688,7 @@ Uint32 Utf<32>::decodeWide(In input)
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<32>::encodeAnsi(Uint32 codepoint, Out output, char replacement, const std::locale& locale)
+Out Utf<32>::encodeAnsi(Uint32 codepoint, Out output, char replacement, [[maybe_unused]] const std::locale& locale)
 {
     // On Windows, gcc's standard library (glibc++) has almost
     // no support for Unicode stuff. As a consequence, in this
@@ -700,8 +698,6 @@ Out Utf<32>::encodeAnsi(Uint32 codepoint, Out output, char replacement, const st
     #if defined(SFML_SYSTEM_WINDOWS) &&                       /* if Windows ... */                          \
        (defined(__GLIBCPP__) || defined (__GLIBCXX__)) &&     /* ... and standard library is glibc++ ... */ \
       !(defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)) /* ... and STLPort is not used on top of it */
-
-        (void)locale; // to avoid warnings
 
         char character = 0;
         if (wctomb(&character, static_cast<wchar_t>(codepoint)) >= 0)

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -206,11 +206,10 @@ bool VertexBuffer::update(const Vertex* vertices, std::size_t vertexCount, unsig
 
 
 ////////////////////////////////////////////////////////////
-bool VertexBuffer::update(const VertexBuffer& vertexBuffer)
+bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
 {
 #ifdef SFML_OPENGL_ES
 
-    (void) vertexBuffer;
     return false;
 
 #else

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -245,9 +245,8 @@ void getScreenSizeInPixels(ANativeActivity* activity, int* width, int* height)
 
 
 ////////////////////////////////////////////////////////////
-static void onStart(ANativeActivity* activity)
+static void onStart(ANativeActivity* /* activity */)
 {
-    (void) activity;
 }
 
 
@@ -285,9 +284,8 @@ static void onPause(ANativeActivity* activity)
 
 
 ////////////////////////////////////////////////////////////
-static void onStop(ANativeActivity* activity)
+static void onStop(ANativeActivity* /* activity */)
 {
-    (void) activity;
 }
 
 
@@ -340,8 +338,6 @@ static void onDestroy(ANativeActivity* activity)
 ////////////////////////////////////////////////////////////
 static void onNativeWindowCreated(ANativeActivity* activity, ANativeWindow* window)
 {
-    (void) window;
-
     sf::priv::ActivityStates* states = sf::priv::retrieveStates(activity);
     std::scoped_lock lock(states->mutex);
 
@@ -365,10 +361,8 @@ static void onNativeWindowCreated(ANativeActivity* activity, ANativeWindow* wind
 
 
 ////////////////////////////////////////////////////////////
-static void onNativeWindowDestroyed(ANativeActivity* activity, ANativeWindow* window)
+static void onNativeWindowDestroyed(ANativeActivity* activity, ANativeWindow* /* window */)
 {
-    (void) window;
-
     sf::priv::ActivityStates* states = sf::priv::retrieveStates(activity);
     std::scoped_lock lock(states->mutex);
 
@@ -392,18 +386,14 @@ static void onNativeWindowDestroyed(ANativeActivity* activity, ANativeWindow* wi
 
 
 ////////////////////////////////////////////////////////////
-static void onNativeWindowRedrawNeeded(ANativeActivity* activity, ANativeWindow* window)
+static void onNativeWindowRedrawNeeded(ANativeActivity* /* activity */, ANativeWindow* /* window */)
 {
-    (void) activity;
-    (void) window;
 }
 
 
 ////////////////////////////////////////////////////////////
-static void onNativeWindowResized(ANativeActivity* activity, ANativeWindow* window)
+static void onNativeWindowResized(ANativeActivity* /* activity */, ANativeWindow* /* window */)
 {
-    (void) activity;
-    (void) window;
 }
 
 
@@ -442,18 +432,14 @@ static void onInputQueueDestroyed(ANativeActivity* activity, AInputQueue* queue)
 
 
 ////////////////////////////////////////////////////////////
-static void onWindowFocusChanged(ANativeActivity* activity, int focused)
+static void onWindowFocusChanged(ANativeActivity* /* activity */, int /* focused */)
 {
-    (void) activity;
-    (void) focused;
 }
 
 
 ////////////////////////////////////////////////////////////
-static void onContentRectChanged(ANativeActivity* activity, const ARect* rect)
+static void onContentRectChanged(ANativeActivity* activity, const ARect* /* rect */)
 {
-    (void) rect;
-
     // Retrieve our activity states from the activity instance
     sf::priv::ActivityStates* states = sf::priv::retrieveStates(activity);
     std::scoped_lock lock(states->mutex);
@@ -472,16 +458,14 @@ static void onContentRectChanged(ANativeActivity* activity, const ARect* rect)
 
 
 ////////////////////////////////////////////////////////////
-static void onConfigurationChanged(ANativeActivity* activity)
+static void onConfigurationChanged(ANativeActivity* /* activity */)
 {
-    (void) activity;
 }
 
 
 ////////////////////////////////////////////////////////////
-static void* onSaveInstanceState(ANativeActivity* activity, size_t* outLen)
+static void* onSaveInstanceState(ANativeActivity* /* activity */, size_t* outLen)
 {
-    (void) activity;
     *outLen = 0;
 
     return nullptr;
@@ -489,9 +473,8 @@ static void* onSaveInstanceState(ANativeActivity* activity, size_t* outLen)
 
 
 ////////////////////////////////////////////////////////////
-static void onLowMemory(ANativeActivity* activity)
+static void onLowMemory(ANativeActivity* /* activity */)
 {
-    (void) activity;
 }
 
 

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -48,12 +48,9 @@ namespace
     EGLDisplay display = EGL_NO_DISPLAY;
     int waitingForFlip = 0;
 
-    static void pageFlipHandler(int fd, unsigned int frame,
-        unsigned int sec, unsigned int usec, void* data)
+    static void pageFlipHandler(int /* fd */, unsigned int /* frame */,
+        unsigned int /* sec */, unsigned int /* usec */, void* data)
     {
-        // suppress unused param warning
-        (void)fd, (void)frame, (void)sec, (void)usec;
-
         int* temp = static_cast<int*>(data);
         *temp = 0;
     }

--- a/src/SFML/Window/DRM/InputImplUDev.cpp
+++ b/src/SFML/Window/DRM/InputImplUDev.cpp
@@ -79,7 +79,7 @@ namespace
     bool shiftDown() { return (keyMap[sf::Keyboard::LShift] || keyMap[sf::Keyboard::RShift]); }
     bool systemDown() { return (keyMap[sf::Keyboard::LSystem] || keyMap[sf::Keyboard::RSystem]); }
 
-    void uninitFileDescriptors(void)
+    void uninitFileDescriptors()
     {
         for (std::vector<int>::iterator itr = fileDescriptors.begin(); itr != fileDescriptors.end(); ++itr)
             close(*itr);

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -132,7 +132,7 @@ m_config  (nullptr)
 
 
 ////////////////////////////////////////////////////////////
-EglContext::EglContext(EglContext* shared, const ContextSettings& settings, const WindowImpl& owner, unsigned int bitsPerPixel) :
+EglContext::EglContext(EglContext* shared, const ContextSettings& settings, [[maybe_unused]] const WindowImpl& owner, unsigned int bitsPerPixel) :
 m_display (EGL_NO_DISPLAY),
 m_context (EGL_NO_CONTEXT),
 m_surface (EGL_NO_SURFACE),
@@ -164,8 +164,7 @@ m_config  (nullptr)
     // Create EGL surface (except on Android because the window is created
     // asynchronously, its activity manager will call it for us)
     createSurface(owner.getSystemHandle());
-#else
-    (void) owner;
+
 #endif
 }
 

--- a/src/SFML/Window/OSX/SFKeyboardModifiersHelper.h
+++ b/src/SFML/Window/OSX/SFKeyboardModifiersHelper.h
@@ -49,7 +49,7 @@ namespace sf {
 /// It needs to be called before any event, e.g. in the window constructor.
 ///
 ////////////////////////////////////////////////////////////
-void initialiseKeyboardHelper(void);
+void initialiseKeyboardHelper();
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
+++ b/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
@@ -123,7 +123,7 @@ void processLeftRightModifiers(NSUInteger modifiers,
 
 
 ////////////////////////////////////////////////////////
-void initialiseKeyboardHelper(void)
+void initialiseKeyboardHelper()
 {
     if (isStateInitialized) return;
 

--- a/src/SFML/Window/OSX/WindowImplCocoa.hpp
+++ b/src/SFML/Window/OSX/WindowImplCocoa.hpp
@@ -106,7 +106,7 @@ public:
     /// Send the event to SFML WindowImpl class.
     ///
     ////////////////////////////////////////////////////////////
-    void windowClosed(void);
+    void windowClosed();
 
     ////////////////////////////////////////////////////////////
     /// \brief Window Resized Event - called by the cocoa window object
@@ -124,7 +124,7 @@ public:
     /// Send the event to SFML WindowImpl class.
     ///
     ////////////////////////////////////////////////////////////
-    void windowLostFocus(void);
+    void windowLostFocus();
 
     ////////////////////////////////////////////////////////////
     /// \brief Window Get Focus Event - called by the cocoa window object
@@ -132,7 +132,7 @@ public:
     /// Send the event to SFML WindowImpl class.
     ///
     ////////////////////////////////////////////////////////////
-    void windowGainedFocus(void);
+    void windowGainedFocus();
 
     ////////////////////////////////////////////////////////////
     /// \brief Mouse Down Event - called by the cocoa view object
@@ -188,7 +188,7 @@ public:
     /// Send the event to SFML WindowImpl class.
     ///
     ////////////////////////////////////////////////////////////
-    void mouseMovedIn(void);
+    void mouseMovedIn();
 
     ////////////////////////////////////////////////////////////
     /// \brief Mouse Out Event - called by the cocoa view object
@@ -196,7 +196,7 @@ public:
     /// Send the event to SFML WindowImpl class.
     ///
     ////////////////////////////////////////////////////////////
-    void mouseMovedOut(void);
+    void mouseMovedOut();
 
     ////////////////////////////////////////////////////////////
     /// \brief Key Down Event - called by the cocoa view object
@@ -245,7 +245,7 @@ public:
     /// Also ensure NSApp is constructed.
     ///
     ////////////////////////////////////////////////////////////
-    static void setUpProcess(void);
+    static void setUpProcess();
 
 public:
 

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -172,7 +172,7 @@ void WindowImplCocoa::applyContext(NSOpenGLContextRef context) const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::setUpProcess(void)
+void WindowImplCocoa::setUpProcess()
 {
     AutoreleasePool pool;
     static bool isTheProcessSetAsApplication = false;
@@ -209,7 +209,7 @@ void WindowImplCocoa::setUpProcess(void)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::windowClosed(void)
+void WindowImplCocoa::windowClosed()
 {
     Event event;
     event.type = Event::Closed;
@@ -232,7 +232,7 @@ void WindowImplCocoa::windowResized(const Vector2u& size)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::windowLostFocus(void)
+void WindowImplCocoa::windowLostFocus()
 {
     if (!m_showCursor && [m_delegate isMouseInside])
         showMouseCursor(); // Make sure the cursor is visible
@@ -245,7 +245,7 @@ void WindowImplCocoa::windowLostFocus(void)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::windowGainedFocus(void)
+void WindowImplCocoa::windowGainedFocus()
 {
     if (!m_showCursor && [m_delegate isMouseInside])
         hideMouseCursor(); // Restore user's setting
@@ -323,7 +323,7 @@ void WindowImplCocoa::mouseWheelScrolledAt(float deltaX, float deltaY, int x, in
 }
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::mouseMovedIn(void)
+void WindowImplCocoa::mouseMovedIn()
 {
     if (!m_showCursor)
         hideMouseCursor(); // Restore user's setting
@@ -335,7 +335,7 @@ void WindowImplCocoa::mouseMovedIn(void)
 }
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::mouseMovedOut(void)
+void WindowImplCocoa::mouseMovedOut()
 {
     if (!m_showCursor)
         showMouseCursor(); // Make sure the cursor is visible

--- a/src/SFML/Window/Vulkan.cpp
+++ b/src/SFML/Window/Vulkan.cpp
@@ -55,11 +55,10 @@ using VulkanImplType = sf::priv::VulkanImplWin32;
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-bool Vulkan::isAvailable(bool requireGraphics)
+bool Vulkan::isAvailable([[maybe_unused]] bool requireGraphics)
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
-    (void) requireGraphics;
     return false;
 
 #else
@@ -71,11 +70,10 @@ bool Vulkan::isAvailable(bool requireGraphics)
 
 
 ////////////////////////////////////////////////////////////
-VulkanFunctionPointer Vulkan::getFunction(const char* name)
+VulkanFunctionPointer Vulkan::getFunction([[maybe_unused]] const char* name)
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
-    (void) name;
     return nullptr;
 
 #else

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -295,13 +295,10 @@ void WindowImpl::processSensorEvents()
 
 
 ////////////////////////////////////////////////////////////
-bool WindowImpl::createVulkanSurface(const VkInstance& instance, VkSurfaceKHR& surface, const VkAllocationCallbacks* allocator)
+bool WindowImpl::createVulkanSurface([[maybe_unused]] const VkInstance& instance, [[maybe_unused]] VkSurfaceKHR& surface, [[maybe_unused]] const VkAllocationCallbacks* allocator)
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
-    (void) instance;
-    (void) surface;
-    (void) allocator;
     return false;
 
 #else

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/ResourcePath.hpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/ResourcePath.hpp
@@ -38,6 +38,6 @@
 /// with the main bundle or an empty string is there is no bundle.
 ///
 ////////////////////////////////////////////////////////////
-std::filesystem::path resourcePath(void);
+std::filesystem::path resourcePath();
 
 #endif

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/ResourcePath.mm
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/ResourcePath.mm
@@ -31,7 +31,7 @@
 #include <filesystem>
 
 ////////////////////////////////////////////////////////////
-std::filesystem::path resourcePath(void)
+std::filesystem::path resourcePath()
 {
     NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 


### PR DESCRIPTION
## Description

`(void)` is used for function parameter that are sometimes used, function parameters that are never used, and functions which accept zero parameters. This PR cleans up the usage of `(void)` to improve readability and consistency throughout the codebase.
 
## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
