### PR TITLE
Assorted Small Build Simplifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,6 @@ endmacro()
 # determine whether to create a debug or release build
 sfml_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
 
-if (NOT CMAKE_VERSION VERSION_LESS 3.9)
-    cmake_policy(SET CMP0068 NEW)
-endif()
-
 if(NOT CMAKE_OSX_SYSROOT)
     # query the path to the default SDK, will fail on non-macOS, but it's okay.
     execute_process(COMMAND xcodebuild -sdk macosx -version Path

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,6 @@ endmacro()
 # determine whether to create a debug or release build
 sfml_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
 
-# Suppress Mac OS X RPATH warnings and adopt new related behaviors
-cmake_policy(SET CMP0042 NEW)
 if (NOT CMAKE_VERSION VERSION_LESS 3.9)
     cmake_policy(SET CMP0068 NEW)
 endif()

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -171,11 +171,10 @@ macro(sfml_add_library module)
         endif()
     endif()
 
-    # if using gcc or clang on a non-Windows platform, we must hide public symbols by default
-    # (exported ones are explicitly marked)
-    if(NOT SFML_OS_WINDOWS AND (SFML_COMPILER_GCC OR SFML_COMPILER_CLANG))
-        set_target_properties(${target} PROPERTIES COMPILE_FLAGS -fvisibility=hidden)
-    endif()
+    # ensure public symbols are hidden by default (exported ones are explicitly marked)
+    set_target_properties(${target} PROPERTIES
+                          CXX_VISIBILITY_PRESET hidden
+                          VISIBILITY_INLINES_HIDDEN YES)
 
     # build frameworks or dylibs
     if(SFML_OS_MACOSX AND BUILD_SHARED_LIBS AND NOT THIS_STATIC)


### PR DESCRIPTION
## Description

The commits are mostly self explanatory but in short, I remove unnecessarily setting two CMake policies and modernize how we hide symbols to be more cross platform.

The CMake docs linked in the extended message explain how these two policies are no longer necessary as long as your minimum CMake version is greater than 3.0 and 3.9 respectively. Because we now require 3.15 we can rely on the default value of those policies instead of having to explicitly specify new behavior. The new way to enable visibility flags can be validated by configuring with `-DCMAKE_EXPORT_COMPILE_COMMANDS` and see how all library targets continue to get built with `-fvisibility=hidden` and `-fvisibility-inlines-hidden`.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
