### PR TITLE
bugfix for #2100: null-dereference in GCC 12.1.0

### DIFF
--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -261,7 +261,10 @@ void Http::Response::parse(const std::string& data)
             std::istreambuf_iterator<char> it(in);
             std::istreambuf_iterator<char> itEnd;
             for (std::size_t i = 0; ((i < length) && (it != itEnd)); i++)
-                m_body.push_back(*it++);
+            {
+                m_body.push_back(*it);
+                ++it;
+            }
         }
 
         // Drop the rest of the line (chunk-extension)


### PR DESCRIPTION
## bugfix for #2100: null-dereference in GCC 12.1.0

This PR is related to the issue #2100

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

See issue #2100 
