### PR TITLE
Add tests for `sf::RenderStates`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(GRAPHICS_SRC
     Graphics/Rect.cpp
     Graphics/RectangleShape.cpp
     Graphics/Shape.cpp
+    Graphics/RenderStates.cpp
     Graphics/Transform.cpp
     Graphics/Transformable.cpp
     Graphics/Vertex.cpp

--- a/test/Graphics/RenderStates.cpp
+++ b/test/Graphics/RenderStates.cpp
@@ -1,0 +1,80 @@
+#include <SFML/Graphics/RenderStates.hpp>
+#include "GraphicsUtil.hpp"
+
+#include <doctest.h>
+
+TEST_CASE("sf::RenderStates class - [graphics]")
+{
+    SUBCASE("Construction")
+    {
+        SUBCASE("Default constructor")
+        {
+            const sf::RenderStates renderStates;
+            CHECK(renderStates.blendMode == sf::BlendMode());
+            CHECK(renderStates.transform == sf::Transform());
+            CHECK(renderStates.texture == nullptr);
+            CHECK(renderStates.shader == nullptr);
+        }
+
+        SUBCASE("BlendMode constructor")
+        {
+            const sf::BlendMode blendMode(sf::BlendMode::Zero, sf::BlendMode::SrcColor, sf::BlendMode::ReverseSubtract,
+                                          sf::BlendMode::OneMinusDstAlpha, sf::BlendMode::DstAlpha, sf::BlendMode::Max);
+            const sf::RenderStates renderStates(blendMode);
+            CHECK(renderStates.blendMode == blendMode);
+            CHECK(renderStates.transform == sf::Transform());
+            CHECK(renderStates.texture == nullptr);
+            CHECK(renderStates.shader == nullptr);
+        }
+
+        SUBCASE("Transform constructor")
+        {
+            const sf::Transform transform(10, 9, 8, 7, 6, 5, 4, 3, 2);
+            const sf::RenderStates renderStates(transform);
+            CHECK(renderStates.blendMode == sf::BlendMode());
+            CHECK(renderStates.transform == transform);
+            CHECK(renderStates.texture == nullptr);
+            CHECK(renderStates.shader == nullptr);
+        }
+
+        SUBCASE("Texture constructor")
+        {
+            const sf::Texture* texture = nullptr;
+            const sf::RenderStates renderStates(texture);
+            CHECK(renderStates.blendMode == sf::BlendMode());
+            CHECK(renderStates.transform == sf::Transform());
+            CHECK(renderStates.texture == texture);
+            CHECK(renderStates.shader == nullptr);
+        }
+
+        SUBCASE("Shader constructor")
+        {
+            const sf::Shader* shader = nullptr;
+            const sf::RenderStates renderStates(shader);
+            CHECK(renderStates.blendMode == sf::BlendMode());
+            CHECK(renderStates.transform == sf::Transform());
+            CHECK(renderStates.texture == nullptr);
+            CHECK(renderStates.shader == shader);
+        }
+
+        SUBCASE("Verbose constructor")
+        {
+            const sf::BlendMode blendMode(sf::BlendMode::One, sf::BlendMode::SrcColor, sf::BlendMode::ReverseSubtract,
+                                          sf::BlendMode::OneMinusDstAlpha, sf::BlendMode::DstAlpha, sf::BlendMode::Max);
+            const sf::Transform transform(10, 2, 3, 4, 50, 40, 30, 20, 10);
+            const sf::RenderStates renderStates(blendMode, transform, nullptr, nullptr);
+            CHECK(renderStates.blendMode == blendMode);
+            CHECK(renderStates.transform == transform);
+            CHECK(renderStates.texture == nullptr);
+            CHECK(renderStates.shader == nullptr);
+        }
+    }
+
+    SUBCASE("Default constant")
+    {
+        CHECK(sf::RenderStates::Default.blendMode == sf::BlendMode());
+        CHECK(sf::RenderStates::Default.transform == sf::Transform());
+        CHECK(sf::RenderStates::Default.texture == nullptr);
+        CHECK(sf::RenderStates::Default.shader == nullptr); 
+    }
+}


### PR DESCRIPTION
## Description

Graphics module tests continue with another simple constructor-only type. Sadly we can't use anything but `nullptr` for `sf::Texture` and `sf::Shader` because the Linux CI jobs will fail.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
