### PR TITLE
Include '<utility>' for 'std::exchange'

### DIFF
--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -29,6 +29,7 @@
 #include <SFML/System/Err.hpp>
 #include <string>
 #include <ostream>
+#include <utility>
 
 #if defined(__APPLE__)
     #if defined(__clang__)


### PR DESCRIPTION
This should fix compilation on the latest version of MSYS2, which fails due to `std::exchange` being used without `<utility>` being included.