### PR TITLE
Disable warnings as errors for clang-cl builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         platform:
         - { name: Windows VS2019, os: windows-2019 }
         - { name: Windows VS2022, os: windows-2022 }
+        - { name: Windows VS2022 Clang, os: windows-2022, flags: -T ClangCL }
         - { name: Linux GCC,      os: ubuntu-latest  }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: MacOS XCode,    os: macos-latest   }

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -68,7 +68,13 @@ function(set_file_warnings)
         # -Wimplicit-fallthrough # warn when a missing break causes control flow to continue at the next case in a switch statement (disabled until better compiler support for explicit fallthrough is available)
         ${NON_ANDROID_CLANG_AND_GCC_WARNINGS}
     )
-
+    
+    # For now if we're using MSVC-like clang interface on Windows
+    # we'll disable warnings as errors 
+    if(SFML_OS_WINDOWS AND SFML_COMPILER_CLANG_CL)
+        set(WARNINGS_AS_ERRORS FALSE)
+    endif()
+    
     if(WARNINGS_AS_ERRORS)
         set(CLANG_AND_GCC_WARNINGS ${CLANG_AND_GCC_WARNINGS} -Werror)
         set(MSVC_WARNINGS ${MSVC_WARNINGS} /WX)

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -107,6 +107,11 @@ if(MSVC)
     elseif(MSVC_VERSION LESS_EQUAL 1939)
         set(SFML_MSVC_VERSION 17)
     endif()
+	
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		set(SFML_COMPILER_CLANG_CL 1)
+	endif()
+	
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(SFML_COMPILER_CLANG 1)
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [X] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

As highlighted in https://github.com/SFML/SFML/issues/2046 the 2.6.x & master branches both produce compile errors when using either clang++ or clang-cl. This PR supresses some warnings which are not supported by clang-cl, and also disables `/WX` due to an issue where dependencies from `extlib/` were being compiled with `/WX` when they shouldn't have been. This would cause the CI to fail due to `/WX`, so this option has been temporarily disabled for Windows + clang-cl builds. 

For CI logs showing the issue with the clang-cl + `/WX` see [here](https://github.com/SFML/SFML/actions/runs/2327878406)

This does **not** resolve the compiler errors that originate from using clang++ on Windows (the GNU-like interface). Though I intend to add a follow up PR which will fix the clang++ build and add the necessary CI to confirm it's working. 

This PR is related to the issue #

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Compile with clang-cl on Windows.
