### PR TITLE
SFML/Graphics/Text.cpp: Compare utf32-characters to utf32 character literals consistently

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -323,7 +323,7 @@ Vector2f Text::findCharacterPos(std::size_t index) const
 
     // Precompute the variables needed by the algorithm
     bool  isBold          = m_style & Bold;
-    float whitespaceWidth = m_font->getGlyph(L' ', m_characterSize, isBold).advance;
+    float whitespaceWidth = m_font->getGlyph(U' ', m_characterSize, isBold).advance;
     float letterSpacing   = ( whitespaceWidth / 3.f ) * ( m_letterSpacingFactor - 1.f );
     whitespaceWidth      += letterSpacing;
     float lineSpacing     = m_font->getLineSpacing(m_characterSize) * m_lineSpacingFactor;
@@ -342,9 +342,9 @@ Vector2f Text::findCharacterPos(std::size_t index) const
         // Handle special characters
         switch (curChar)
         {
-            case ' ':  position.x += whitespaceWidth;             continue;
-            case '\t': position.x += whitespaceWidth * 4;         continue;
-            case '\n': position.y += lineSpacing; position.x = 0; continue;
+            case U' ':  position.x += whitespaceWidth;             continue;
+            case U'\t': position.x += whitespaceWidth * 4;         continue;
+            case U'\n': position.y += lineSpacing; position.x = 0; continue;
         }
 
         // For regular characters, add the advance offset of the glyph
@@ -431,11 +431,11 @@ void Text::ensureGeometryUpdate() const
     // Compute the location of the strike through dynamically
     // We use the center point of the lowercase 'x' glyph as the reference
     // We reuse the underline thickness as the thickness of the strike through as well
-    FloatRect xBounds = m_font->getGlyph(L'x', m_characterSize, isBold).bounds;
+    FloatRect xBounds = m_font->getGlyph(U'x', m_characterSize, isBold).bounds;
     float strikeThroughOffset = xBounds.top + xBounds.height / 2.f;
 
     // Precompute the variables needed by the algorithm
-    float whitespaceWidth = m_font->getGlyph(L' ', m_characterSize, isBold).advance;
+    float whitespaceWidth = m_font->getGlyph(U' ', m_characterSize, isBold).advance;
     float letterSpacing   = ( whitespaceWidth / 3.f ) * ( m_letterSpacingFactor - 1.f );
     whitespaceWidth      += letterSpacing;
     float lineSpacing     = m_font->getLineSpacing(m_characterSize) * m_lineSpacingFactor;
@@ -453,14 +453,14 @@ void Text::ensureGeometryUpdate() const
         Uint32 curChar = m_string[i];
 
         // Skip the \r char to avoid weird graphical issues
-        if (curChar == L'\r')
+        if (curChar == U'\r')
             continue;
 
         // Apply the kerning offset
         x += m_font->getKerning(prevChar, curChar, m_characterSize, isBold);
 
         // If we're using the underlined style and there's a new line, draw a line
-        if (isUnderlined && (curChar == L'\n' && prevChar != L'\n'))
+        if (isUnderlined && (curChar == U'\n' && prevChar != U'\n'))
         {
             addLine(m_vertices, x, y, m_fillColor, underlineOffset, underlineThickness);
 
@@ -469,7 +469,7 @@ void Text::ensureGeometryUpdate() const
         }
 
         // If we're using the strike through style and there's a new line, draw a line across all characters
-        if (isStrikeThrough && (curChar == L'\n' && prevChar != L'\n'))
+        if (isStrikeThrough && (curChar == U'\n' && prevChar != U'\n'))
         {
             addLine(m_vertices, x, y, m_fillColor, strikeThroughOffset, underlineThickness);
 
@@ -480,7 +480,7 @@ void Text::ensureGeometryUpdate() const
         prevChar = curChar;
 
         // Handle special characters
-        if ((curChar == L' ') || (curChar == L'\n') || (curChar == L'\t'))
+        if ((curChar == U' ') || (curChar == U'\n') || (curChar == U'\t'))
         {
             // Update the current bounds (min coordinates)
             minX = std::min(minX, x);
@@ -488,9 +488,9 @@ void Text::ensureGeometryUpdate() const
 
             switch (curChar)
             {
-                case L' ':  x += whitespaceWidth;     break;
-                case L'\t': x += whitespaceWidth * 4; break;
-                case L'\n': y += lineSpacing; x = 0;  break;
+                case U' ':  x += whitespaceWidth;     break;
+                case U'\t': x += whitespaceWidth * 4; break;
+                case U'\n': y += lineSpacing; x = 0;  break;
             }
 
             // Update the current bounds (max coordinates)


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [X] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Please describe your pull request.

As discussed during [https://github.com/SFML/SFML/pull/2107](https://github.com/SFML/SFML/pull/2107), here's a pull-request replacing L-literals with U-literals, when comparing towards sf::Uint32-character literals (from sf::String). I tried searching for other cases requiring a similar fix, but I wasn't able to find any. I'm not too familiar withthis codebase, so I might've missed some, though.

This PR is related to the issue #
[https://github.com/SFML/SFML/pull/2107](https://github.com/SFML/SFML/pull/2107)

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

This can be tested, simply by creating and drawing sf::text-objects in a simple project.
Test specifically '\n', '\t ', '\r' and ' ' in this project, as well as a "Hello World". It shouldn't appear any different than before. Test that it compiles for all the platforms this is supposed to be compiled for in sfml 3.0.