### PR TITLE
Limit the scope of event object

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -32,8 +32,7 @@ int main()
 
     while (window.isOpen())
     {
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             if (event.type == sf::Event::Closed)
                 window.close();

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,8 +37,7 @@ int main()
 
     while (window.isOpen())
     {
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             if (event.type == sf::Event::Closed)
                 window.close();

--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -44,8 +44,7 @@
 ///     while (window.isOpen())
 ///     {
 ///         // Process events
-///         sf::Event event;
-///         while (window.pollEvent(event))
+///         for (sf::Event event; window.pollEvent(event);)
 ///         {
 ///             // Close window: exit
 ///             if (event.type == sf::Event::Closed)

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -109,9 +109,7 @@ int main(int argc, char *argv[])
 
     while (window.isOpen())
     {
-        sf::Event event;
-
-        while (active ? window.pollEvent(event) : window.waitEvent(event))
+        for (sf::Event event; active ? window.pollEvent(event) : window.waitEvent(event);)
         {
             switch (event.type)
             {

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -183,8 +183,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             // Window closed or escape key pressed: exit
             if ((event.type == sf::Event::Closed) ||

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -165,8 +165,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             // Window closed or escape key pressed: exit
             if ((event.type == sf::Event::Closed) ||

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -197,8 +197,7 @@ int main()
         while (window.isOpen())
         {
             // Process events
-            sf::Event event;
-            while (window.pollEvent(event))
+            for (sf::Event event; window.pollEvent(event);)
             {
                 // Close window: exit
                 if (event.type == sf::Event::Closed)

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -406,8 +406,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             // Close window: exit
             if (event.type == sf::Event::Closed)

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -111,8 +111,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             // Window closed or escape key pressed: exit
             if ((event.type == sf::Event::Closed) ||

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -2463,8 +2463,7 @@ public:
         while (window.isOpen())
         {
             // Process events
-            sf::Event event;
-            while (window.pollEvent(event))
+            for (sf::Event event; window.pollEvent(event);)
             {
                 // Close window: exit
                 if (event.type == sf::Event::Closed)

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -136,8 +136,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             // Close window: exit
             if (event.type == sf::Event::Closed)

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -203,8 +203,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    sf::Event event;
-///    while (window.pollEvent(event))
+///    for (sf::Event event; window.pollEvent(event);)
 ///    {
 ///        // Request for closing the window
 ///        if (event.type == sf::Event::Closed)

--- a/include/SFML/Window/Clipboard.hpp
+++ b/include/SFML/Window/Clipboard.hpp
@@ -97,8 +97,7 @@ public:
 /// sf::String string = sf::Clipboard::getString();
 ///
 /// // or use it in the event loop
-/// sf::Event event;
-/// while(window.pollEvent(event))
+/// for (sf::Event event; window.pollEvent(event);)
 /// {
 ///     if(event.type == sf::Event::Closed)
 ///         window.close();

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -246,8 +246,7 @@ public:
 ///
 /// Usage example:
 /// \code
-/// sf::Event event;
-/// while (window.pollEvent(event))
+/// for (sf::Event event; window.pollEvent(event);)
 /// {
 ///     // Request for closing the window
 ///     if (event.type == sf::Event::Closed)

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -336,8 +336,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    sf::Event event;
-///    while (window.pollEvent(event))
+///    for (sf::Event event; window.pollEvent(event);)
 ///    {
 ///        // Request for closing the window
 ///        if (event.type == sf::Event::Closed)

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -165,8 +165,7 @@ public:
     /// thus you should always call this function in a loop
     /// to make sure that you process every pending event.
     /// \code
-    /// sf::Event event;
-    /// while (window.pollEvent(event))
+    /// for (sf::Event event; window.pollEvent(event);)
     /// {
     ///    // process event...
     /// }
@@ -514,8 +513,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    sf::Event event;
-///    while (window.pollEvent(event))
+///    for (sf::Event event; window.pollEvent(event);)
 ///    {
 ///        // Request for closing the window
 ///        if (event.type == sf::Event::Closed)

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -60,8 +60,7 @@ int main(int, char const**)
     while (window.isOpen())
     {
         // Process events
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             // Close window: exit
             if (event.type == sf::Event::Closed) {

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -58,8 +58,7 @@ int main(int argc, char const** argv)
     while (window.isOpen())
     {
         // Process events
-        sf::Event event;
-        while (window.pollEvent(event))
+        for (sf::Event event; window.pollEvent(event);)
         {
             // Close window: exit
             if (event.type == sf::Event::Closed) {


### PR DESCRIPTION
## Description

Thanks to @eXpl0it3r for this neat little trick to limit the scope of the `sf::Event` object. I figured it was worth making this sweeping change to all event loops in the library so that anyone copy-pasting code gets slightly better code than before. I even changed the issue and PR templates.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
