### PR TITLE
Unify float literal usage in tests

### DIFF
--- a/test/Graphics/CircleShape.cpp
+++ b/test/Graphics/CircleShape.cpp
@@ -8,7 +8,7 @@ TEST_CASE("sf::CircleShape class - [graphics]")
     SUBCASE("Default constructor")
     {
         const sf::CircleShape circle;
-        CHECK(circle.getRadius() == 0);
+        CHECK(circle.getRadius() == 0.f);
         CHECK(circle.getPointCount() == 30);
         for (std::size_t i = 0; i < circle.getPointCount(); ++i)
             CHECK(circle.getPoint(i) == sf::Vector2f(0, 0));

--- a/test/Graphics/Glyph.cpp
+++ b/test/Graphics/Glyph.cpp
@@ -8,7 +8,7 @@ TEST_CASE("sf::Glyph class - [graphics]")
     SUBCASE("Construction")
     {
         const sf::Glyph glyph;
-        CHECK(glyph.advance == 0);
+        CHECK(glyph.advance == 0.f);
         CHECK(glyph.lsbDelta == 0);
         CHECK(glyph.rsbDelta == 0);
         CHECK(glyph.bounds == sf::FloatRect());

--- a/test/Graphics/Rect.cpp
+++ b/test/Graphics/Rect.cpp
@@ -40,7 +40,7 @@ TEST_CASE("sf::Rect class template - [graphics]")
 
         SUBCASE("Conversion constructor")
         {
-            sf::FloatRect sourceRectangle({1.0f, 2.0f}, {3.0f, 4.0f});
+            sf::FloatRect sourceRectangle({1.f, 2.f}, {3.f, 4.f});
             sf::IntRect rectangle(sourceRectangle);
 
             CHECK(rectangle.left == static_cast<int>(sourceRectangle.left));

--- a/test/Graphics/RectangleShape.cpp
+++ b/test/Graphics/RectangleShape.cpp
@@ -8,29 +8,29 @@ TEST_CASE("sf::RectangleShape class - [graphics]")
     SUBCASE("Default constructor")
     {
         const sf::RectangleShape rectangle;
-        CHECK(rectangle.getSize() == sf::Vector2f(0, 0));
+        CHECK(rectangle.getSize() == sf::Vector2f(0.f, 0.f));
         CHECK(rectangle.getPointCount() == 4);
-        CHECK(rectangle.getPoint(0) == sf::Vector2f(0, 0));
-        CHECK(rectangle.getPoint(1) == sf::Vector2f(0, 0));
-        CHECK(rectangle.getPoint(2) == sf::Vector2f(0, 0));
-        CHECK(rectangle.getPoint(3) == sf::Vector2f(0, 0));
+        CHECK(rectangle.getPoint(0) == sf::Vector2f(0.f, 0.f));
+        CHECK(rectangle.getPoint(1) == sf::Vector2f(0.f, 0.f));
+        CHECK(rectangle.getPoint(2) == sf::Vector2f(0.f, 0.f));
+        CHECK(rectangle.getPoint(3) == sf::Vector2f(0.f, 0.f));
     }
 
     SUBCASE("Size constructor")
     {
-        const sf::RectangleShape rectangle({9, 8});
-        CHECK(rectangle.getSize() == sf::Vector2f(9, 8));
+        const sf::RectangleShape rectangle({9.f, 8.f});
+        CHECK(rectangle.getSize() == sf::Vector2f(9.f, 8.f));
         CHECK(rectangle.getPointCount() == 4);
-        CHECK(rectangle.getPoint(0) == sf::Vector2f(0, 0));
-        CHECK(rectangle.getPoint(1) == sf::Vector2f(9, 0));
-        CHECK(rectangle.getPoint(2) == sf::Vector2f(9, 8));
-        CHECK(rectangle.getPoint(3) == sf::Vector2f(0, 8));
+        CHECK(rectangle.getPoint(0) == sf::Vector2f(0.f, 0.f));
+        CHECK(rectangle.getPoint(1) == sf::Vector2f(9.f, 0.f));
+        CHECK(rectangle.getPoint(2) == sf::Vector2f(9.f, 8.f));
+        CHECK(rectangle.getPoint(3) == sf::Vector2f(0.f, 8.f));
     }
 
     SUBCASE("Set size")
     {
-        sf::RectangleShape rectangle({7, 6});
-        rectangle.setSize({5, 4});
-        CHECK(rectangle.getSize() == sf::Vector2f(5, 4));
+        sf::RectangleShape rectangle({7.f, 6.f});
+        rectangle.setSize({5.f, 4.f});
+        CHECK(rectangle.getSize() == sf::Vector2f(5.f, 4.f));
     }
 }

--- a/test/Graphics/RenderStates.cpp
+++ b/test/Graphics/RenderStates.cpp
@@ -29,7 +29,7 @@ TEST_CASE("sf::RenderStates class - [graphics]")
 
         SUBCASE("Transform constructor")
         {
-            const sf::Transform transform(10, 9, 8, 7, 6, 5, 4, 3, 2);
+            const sf::Transform transform(10.f, 9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f);
             const sf::RenderStates renderStates(transform);
             CHECK(renderStates.blendMode == sf::BlendMode());
             CHECK(renderStates.transform == transform);
@@ -61,7 +61,7 @@ TEST_CASE("sf::RenderStates class - [graphics]")
         {
             const sf::BlendMode blendMode(sf::BlendMode::One, sf::BlendMode::SrcColor, sf::BlendMode::ReverseSubtract,
                                           sf::BlendMode::OneMinusDstAlpha, sf::BlendMode::DstAlpha, sf::BlendMode::Max);
-            const sf::Transform transform(10, 2, 3, 4, 50, 40, 30, 20, 10);
+            const sf::Transform transform(10.f, 2.f, 3.f, 4.f, 50.f, 40.f, 30.f, 20.f, 10.f);
             const sf::RenderStates renderStates(blendMode, transform, nullptr, nullptr);
             CHECK(renderStates.blendMode == blendMode);
             CHECK(renderStates.transform == transform);

--- a/test/Graphics/Shape.cpp
+++ b/test/Graphics/Shape.cpp
@@ -22,8 +22,8 @@ public:
         switch (index)
         {
             default:
-            case 0: return sf::Vector2f(m_size.x / 2, 0);
-            case 1: return sf::Vector2f(0, m_size.y);
+            case 0: return sf::Vector2f(m_size.x / 2.f, 0.f);
+            case 1: return sf::Vector2f(0.f, m_size.y);
             case 2: return sf::Vector2f(m_size.x, m_size.y);
         }
     }
@@ -36,12 +36,12 @@ TEST_CASE("sf::Shape class - [graphics]")
 {
     SUBCASE("Default constructor")
     {
-        const TriangleShape triangleShape({0, 0});
+        const TriangleShape triangleShape({0.f, 0.f});
         CHECK(triangleShape.getTexture() == nullptr);
         CHECK(triangleShape.getTextureRect() == sf::IntRect());
         CHECK(triangleShape.getFillColor() == sf::Color::White);
         CHECK(triangleShape.getOutlineColor() == sf::Color::White);
-        CHECK(triangleShape.getOutlineThickness() == 0.0f);
+        CHECK(triangleShape.getOutlineThickness() == 0.f);
         CHECK(triangleShape.getLocalBounds() == sf::FloatRect());
         CHECK(triangleShape.getGlobalBounds() == sf::FloatRect());
     }
@@ -76,21 +76,21 @@ TEST_CASE("sf::Shape class - [graphics]")
 
     SUBCASE("Virtual functions: getPoint, getPointCount")
     {
-        const TriangleShape triangleShape({2, 2});
+        const TriangleShape triangleShape({2.f, 2.f});
         CHECK(triangleShape.getPointCount() == 3);
-        CHECK(triangleShape.getPoint(0) == sf::Vector2f(1, 0));
-        CHECK(triangleShape.getPoint(1) == sf::Vector2f(0, 2));
-        CHECK(triangleShape.getPoint(2) == sf::Vector2f(2, 2));
+        CHECK(triangleShape.getPoint(0) == sf::Vector2f(1.f, 0.f));
+        CHECK(triangleShape.getPoint(1) == sf::Vector2f(0.f, 2.f));
+        CHECK(triangleShape.getPoint(2) == sf::Vector2f(2.f, 2.f));
     }
 
     SUBCASE("Get bounds")
     {
         TriangleShape triangleShape({2, 3});
-        CHECK(triangleShape.getLocalBounds() == sf::FloatRect({0, 0}, {2, 3}));
-        CHECK(triangleShape.getGlobalBounds() == sf::FloatRect({0, 0}, {2, 3}));
-        triangleShape.move({1, 1});
+        CHECK(triangleShape.getLocalBounds() == sf::FloatRect({0.f, 0.f}, {2.f, 3.f}));
+        CHECK(triangleShape.getGlobalBounds() == sf::FloatRect({0.f, 0.f}, {2.f, 3.f}));
+        triangleShape.move({1.f, 1.f});
         triangleShape.rotate(sf::degrees(90));
-        CHECK(triangleShape.getLocalBounds() == sf::FloatRect({0, 0}, {2, 3}));
+        CHECK(triangleShape.getLocalBounds() == sf::FloatRect({0.f, 0.f}, {2.f, 3.f}));
         CHECK(triangleShape.getGlobalBounds().left == Approx(-2.f));
         CHECK(triangleShape.getGlobalBounds().top == Approx(1.f));
         CHECK(triangleShape.getGlobalBounds().width == Approx(3.f));

--- a/test/Graphics/Transform.cpp
+++ b/test/Graphics/Transform.cpp
@@ -29,63 +29,63 @@ TEST_CASE("sf::Transform class - [graphics]")
 
         SUBCASE("3x3 matrix constructor")
         {
-            const sf::Transform transform(10.0f, 11.0f, 12.0f,
-                                          13.0f, 14.0f, 15.0f,
-                                          16.0f, 17.0f, 18.0f);
+            const sf::Transform transform(10.f, 11.f, 12.f,
+                                          13.f, 14.f, 15.f,
+                                          16.f, 17.f, 18.f);
             const std::vector<float> matrix(transform.getMatrix(), transform.getMatrix() + 16);
-            CHECK(matrix == std::vector<float>{10.0f, 13.0f, 0.0f, 16.0f,
-                                               11.0f, 14.0f, 0.0f, 17.0f,
-                                                0.0f,  0.0f, 1.0f,  0.0f,
-                                               12.0f, 15.0f, 0.0f, 18.0f});
+            CHECK(matrix == std::vector<float>{10.f, 13.f, 0.f, 16.f,
+                                               11.f, 14.f, 0.f, 17.f,
+                                                0.f,  0.f, 1.f,  0.f,
+                                               12.f, 15.f, 0.f, 18.f});
         }
     }
 
     SUBCASE("Identity matrix")
     {
         const std::vector<float> matrix(sf::Transform::Identity.getMatrix(), sf::Transform::Identity.getMatrix() + 16);
-        CHECK(matrix == std::vector<float>{1.0f, 0.0f, 0.0f, 0.0f,
-                                           0.0f, 1.0f, 0.0f, 0.0f,
-                                           0.0f, 0.0f, 1.0f, 0.0f,
-                                           0.0f, 0.0f, 0.0f, 1.0f});
+        CHECK(matrix == std::vector<float>{1.f, 0.f, 0.f, 0.f,
+                                           0.f, 1.f, 0.f, 0.f,
+                                           0.f, 0.f, 1.f, 0.f,
+                                           0.f, 0.f, 0.f, 1.f});
     }
 
     SUBCASE("getInverse()")
     {
         CHECK(sf::Transform::Identity.getInverse() == sf::Transform::Identity);
-        CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f).getInverse() == sf::Transform::Identity);
-        CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f).getInverse() == sf::Transform(0.375f, -0.5f, 0.875f, -1.0f, 1.0f, -1.0f, 0.875f, -0.5f, 0.375f));
+        CHECK(sf::Transform(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f).getInverse() == sf::Transform::Identity);
+        CHECK(sf::Transform(1.f, 2.f, 3.f, 4.f, 5.f, 4.f, 3.f, 2.f, 1.f).getInverse() == sf::Transform(0.375f, -0.5f, 0.875f, -1.f, 1.f, -1.f, 0.875f, -0.5f, 0.375f));
     }
 
     SUBCASE("transformPoint()")
     {
-        CHECK(sf::Transform::Identity.transformPoint({-10.0f, -10.0f}) == sf::Vector2f(-10.0f, -10.0f));
-        CHECK(sf::Transform::Identity.transformPoint({-1.0f, -1.0f}) == sf::Vector2f(-1.0f, -1.0f));
-        CHECK(sf::Transform::Identity.transformPoint({-1.0f, 0.0f}) == sf::Vector2f(-1.0f, 0.0f));
-        CHECK(sf::Transform::Identity.transformPoint({0.0f, 0.0f}) == sf::Vector2f(0.0f, 0.0f));
-        CHECK(sf::Transform::Identity.transformPoint({0.0f, 1.0f}) == sf::Vector2f(0.0f, 1.0f));
-        CHECK(sf::Transform::Identity.transformPoint({1.0f, 1.0f}) == sf::Vector2f(1.0f, 1.0f));
-        CHECK(sf::Transform::Identity.transformPoint({10.0f, 10.0f}) == sf::Vector2f(10.0f, 10.0f));
+        CHECK(sf::Transform::Identity.transformPoint({-10.f, -10.f}) == sf::Vector2f(-10.f, -10.f));
+        CHECK(sf::Transform::Identity.transformPoint({-1.f, -1.f}) == sf::Vector2f(-1.f, -1.f));
+        CHECK(sf::Transform::Identity.transformPoint({-1.f, 0.f}) == sf::Vector2f(-1.f, 0.f));
+        CHECK(sf::Transform::Identity.transformPoint({0.f, 0.f}) == sf::Vector2f(0.f, 0.f));
+        CHECK(sf::Transform::Identity.transformPoint({0.f, 1.f}) == sf::Vector2f(0.f, 1.f));
+        CHECK(sf::Transform::Identity.transformPoint({1.f, 1.f}) == sf::Vector2f(1.f, 1.f));
+        CHECK(sf::Transform::Identity.transformPoint({10.f, 10.f}) == sf::Vector2f(10.f, 10.f));
 
-        const sf::Transform transform(1.0f, 2.0f, 3.0f,
-                                      4.0f, 5.0f, 4.0f,
-                                      3.0f, 2.0f, 1.0f);
-        CHECK(transform.transformPoint({-1.0f, -1.0f}) == sf::Vector2f(0.0f, -5.0f));
-        CHECK(transform.transformPoint({0.0f, 0.0f}) == sf::Vector2f(3.0f, 4.0f));
-        CHECK(transform.transformPoint({1.0f, 1.0f}) == sf::Vector2f(6.0f, 13.0f));
+        const sf::Transform transform(1.f, 2.f, 3.f,
+                                      4.f, 5.f, 4.f,
+                                      3.f, 2.f, 1.f);
+        CHECK(transform.transformPoint({-1.f, -1.f}) == sf::Vector2f(0.f, -5.f));
+        CHECK(transform.transformPoint({0.f, 0.f}) == sf::Vector2f(3.f, 4.f));
+        CHECK(transform.transformPoint({1.f, 1.f}) == sf::Vector2f(6.f, 13.f));
     }
 
     SUBCASE("transformRect()")
     {
-        CHECK(sf::Transform::Identity.transformRect({{-200.0f, -200.0f}, {-100.0f, -100.0f}}) == sf::FloatRect({-300.0f, -300.0f}, {100.0f, 100.0f}));
-        CHECK(sf::Transform::Identity.transformRect({{0.0f, 0.0f}, {0.0f, 0.0f}}) == sf::FloatRect({0.0f, 0.0f}, {0.0f, 0.0f}));
-        CHECK(sf::Transform::Identity.transformRect({{100.0f, 100.0f}, {200.0f, 200.0f}}) == sf::FloatRect({100.0f, 100.0f}, {200.0f, 200.0f}));
+        CHECK(sf::Transform::Identity.transformRect({{-200.f, -200.f}, {-100.f, -100.f}}) == sf::FloatRect({-300.f, -300.f}, {100.f, 100.f}));
+        CHECK(sf::Transform::Identity.transformRect({{0.f, 0.f}, {0.f, 0.f}}) == sf::FloatRect({0.f, 0.f}, {0.f, 0.f}));
+        CHECK(sf::Transform::Identity.transformRect({{100.f, 100.f}, {200.f, 200.f}}) == sf::FloatRect({100.f, 100.f}, {200.f, 200.f}));
 
-        const sf::Transform transform(1.0f, 2.0f, 3.0f,
-                                      4.0f, 5.0f, 4.0f,
-                                      3.0f, 2.0f, 1.0f);
-        CHECK(transform.transformRect({{-100.0f, -100.0f}, {200.0f, 200.0f}}) == sf::FloatRect({-297.0f, -896.0f}, {600.0f, 1800.0f}));
-        CHECK(transform.transformRect({{0.0f, 0.0f}, {0.0f, 0.0f}}) == sf::FloatRect({3.0f, 4.0f}, {0.0f, 0.0f}));
-        CHECK(transform.transformRect({{100.0f, 100.0f}, {200.0f, 200.0f}}) == sf::FloatRect({303.0f, 904.0f}, {600.0f, 1800.0f}));
+        const sf::Transform transform(1.f, 2.f, 3.f,
+                                      4.f, 5.f, 4.f,
+                                      3.f, 2.f, 1.f);
+        CHECK(transform.transformRect({{-100.f, -100.f}, {200.f, 200.f}}) == sf::FloatRect({-297.f, -896.f}, {600.f, 1800.f}));
+        CHECK(transform.transformRect({{0.f, 0.f}, {0.f, 0.f}}) == sf::FloatRect({3.f, 4.f}, {0.f, 0.f}));
+        CHECK(transform.transformRect({{100.f, 100.f}, {200.f, 200.f}}) == sf::FloatRect({303.f, 904.f}, {600.f, 1800.f}));
     }
 
     SUBCASE("combine()")
@@ -94,27 +94,27 @@ TEST_CASE("sf::Transform class - [graphics]")
         CHECK(identity.combine(sf::Transform::Identity) == sf::Transform::Identity);
         CHECK(identity.combine(sf::Transform::Identity).combine(sf::Transform::Identity) == sf::Transform::Identity);
 
-        sf::Transform transform(1.0f, 2.0f, 3.0f,
-                                4.0f, 5.0f, 4.0f,
-                                3.0f, 2.0f, 1.0f);
+        sf::Transform transform(1.f, 2.f, 3.f,
+                                4.f, 5.f, 4.f,
+                                3.f, 2.f, 1.f);
         CHECK(identity.combine(transform) == transform);
         CHECK(transform.combine(sf::Transform::Identity) == transform);
-        CHECK(transform.combine(transform) == sf::Transform(18.0f, 18.0f, 14.0f,
-                                                            36.0f, 41.0f, 36.0f,
-                                                            14.0f, 18.0f, 18.0f));
-        CHECK(transform.combine(sf::Transform(10.0f,  2.0f,  3.0f,
-                                               4.0f, 50.0f, 40.0f,
-                                              30.0f, 20.0f, 10.0f))
-            == sf::Transform( 672.0f, 1216.0f,  914.0f,
-                             1604.0f, 2842.0f, 2108.0f,
-                              752.0f, 1288.0f,  942.0f));
+        CHECK(transform.combine(transform) == sf::Transform(18.f, 18.f, 14.f,
+                                                            36.f, 41.f, 36.f,
+                                                            14.f, 18.f, 18.f));
+        CHECK(transform.combine(sf::Transform(10.f,  2.f,  3.f,
+                                               4.f, 50.f, 40.f,
+                                              30.f, 20.f, 10.f))
+            == sf::Transform( 672.f, 1216.f,  914.f,
+                             1604.f, 2842.f, 2108.f,
+                              752.f, 1288.f,  942.f));
     }
 
     SUBCASE("translate()")
     {
-        sf::Transform transform(9, 8, 7, 6, 5, 4, 3, 2, 1);
-        CHECK(transform.translate({10.0f, 20.0f}) == sf::Transform(9, 8, 257, 6, 5, 164, 3, 2, 71));
-        CHECK(transform.translate({10.0f, 20.0f}) == sf::Transform(9, 8, 507, 6, 5, 324, 3, 2, 141));
+        sf::Transform transform(9.f, 8.f, 7.f, 6.f, 5.f, 4.f, 3.f, 2.f, 1.f);
+        CHECK(transform.translate({10.f, 20.f}) == sf::Transform(9.f, 8.f, 257.f, 6.f, 5.f, 164.f, 3.f, 2.f, 71.f));
+        CHECK(transform.translate({10.f, 20.f}) == sf::Transform(9.f, 8.f, 507.f, 6.f, 5.f, 324.f, 3.f, 2.f, 141.f));
     }
 
     SUBCASE("rotate()")
@@ -123,18 +123,18 @@ TEST_CASE("sf::Transform class - [graphics]")
         {
             sf::Transform transform;
             transform.rotate(sf::degrees(90));
-            CHECK(transform == Approx(sf::Transform(0, -1,  0,
-                                                    1,  0,  0,
-                                                    0,  0,  1)));
+            CHECK(transform == Approx(sf::Transform(0.f, -1.f,  0.f,
+                                                    1.f,  0.f,  0.f,
+                                                    0.f,  0.f,  1.f)));
         }
 
         SUBCASE("Around custom point")
         {
             sf::Transform transform;
-            transform.rotate(sf::degrees(90), {1.0f, 0.0f});
-            CHECK(transform == Approx(sf::Transform(0, -1,  1,
-                                                    1,  0, -1,
-                                                    0,  0,  1)));
+            transform.rotate(sf::degrees(90), {1.f, 0.f});
+            CHECK(transform == Approx(sf::Transform(0.f, -1.f,  1.f,
+                                                    1.f,  0.f, -1.f,
+                                                    0.f,  0.f,  1.f)));
         }
     }
 
@@ -142,17 +142,17 @@ TEST_CASE("sf::Transform class - [graphics]")
     {
         SUBCASE("About origin")
         {
-            sf::Transform transform(1, 2, 3, 4, 5, 4, 3, 2, 1);
-            CHECK(transform.scale({2.0f, 4.0f}) == sf::Transform(2, 8, 3, 8, 20, 4, 6, 8, 1));
-            CHECK(transform.scale({0.0f, 0.0f}) == sf::Transform(0, 0, 3, 0, 0, 4, 0, 0, 1));
-            CHECK(transform.scale({10.0f, 10.0f}) == sf::Transform(0, 0, 3, 0, 0, 4, 0, 0, 1));
+            sf::Transform transform(1.f, 2.f, 3.f, 4.f, 5.f, 4.f, 3.f, 2.f, 1.f);
+            CHECK(transform.scale({2.f, 4.f}) == sf::Transform(2.f, 8.f, 3.f, 8.f, 20.f, 4.f, 6.f, 8.f, 1.f));
+            CHECK(transform.scale({0.f, 0.f}) == sf::Transform(0.f, 0.f, 3.f, 0.f, 0.f, 4.f, 0.f, 0.f, 1.f));
+            CHECK(transform.scale({10.f, 10.f}) == sf::Transform(0.f, 0.f, 3.f, 0.f, 0.f, 4.f, 0.f, 0.f, 1.f));
         }
 
         SUBCASE("About custom point")
         {
-            sf::Transform transform(1, 2, 3, 4, 5, 4, 3, 2, 1);
-            CHECK(transform.scale({1.0f, 2.0f}, {1.0f, 0.0f}) == sf::Transform(1, 4, 3, 4, 10, 4, 3, 4, 1));
-            CHECK(transform.scale({0.0f, 0.0f}, {1.0f, 0.0f}) == sf::Transform(0, 0, 4, 0, 0, 8, 0, 0, 4));
+            sf::Transform transform(1.f, 2.f, 3.f, 4.f, 5.f, 4.f, 3.f, 2.f, 1.f);
+            CHECK(transform.scale({1.f, 2.f}, {1.f, 0.f}) == sf::Transform(1.f, 4.f, 3.f, 4.f, 10.f, 4.f, 3.f, 4.f, 1.f));
+            CHECK(transform.scale({0.f, 0.f}, {1.f, 0.f}) == sf::Transform(0.f, 0.f, 4.f, 0.f, 0.f, 8.f, 0.f, 0.f, 4.f));
         }
     }
 
@@ -163,89 +163,89 @@ TEST_CASE("sf::Transform class - [graphics]")
             CHECK(sf::Transform::Identity * sf::Transform::Identity == sf::Transform::Identity);
             CHECK(sf::Transform::Identity * sf::Transform::Identity * sf::Transform::Identity == sf::Transform::Identity);
 
-            const sf::Transform transform(1.0f, 2.0f, 3.0f,
-                                          4.0f, 5.0f, 4.0f,
-                                          3.0f, 2.0f, 1.0f);
+            const sf::Transform transform(1.f, 2.f, 3.f,
+                                          4.f, 5.f, 4.f,
+                                          3.f, 2.f, 1.f);
             CHECK(sf::Transform::Identity * transform == transform);
             CHECK(transform * sf::Transform::Identity == transform);
-            CHECK(transform * transform == sf::Transform(18.0f, 18.0f, 14.0f,
-                                                         36.0f, 41.0f, 36.0f,
-                                                         14.0f, 18.0f, 18.0f));
-            CHECK(transform * sf::Transform(10.0f,  2.0f,  3.0f,
-                                             4.0f, 50.0f, 40.0f,
-                                            30.0f, 20.0f, 10.0f)
-                == sf::Transform(108.0f, 162.0f, 113.0f,
-                                 180.0f, 338.0f, 252.0f,
-                                  68.0f, 126.0f,  99.0f));
+            CHECK(transform * transform == sf::Transform(18.f, 18.f, 14.f,
+                                                         36.f, 41.f, 36.f,
+                                                         14.f, 18.f, 18.f));
+            CHECK(transform * sf::Transform(10.f,  2.f,  3.f,
+                                             4.f, 50.f, 40.f,
+                                            30.f, 20.f, 10.f)
+                == sf::Transform(108.f, 162.f, 113.f,
+                                 180.f, 338.f, 252.f,
+                                  68.f, 126.f,  99.f));
         }
 
         SUBCASE("operator*=")
         {
-            sf::Transform transform(1.0f, 2.0f, 3.0f,
-                                    4.0f, 5.0f, 4.0f,
-                                    3.0f, 2.0f, 1.0f);
+            sf::Transform transform(1.f, 2.f, 3.f,
+                                    4.f, 5.f, 4.f,
+                                    3.f, 2.f, 1.f);
             transform *= sf::Transform::Identity;
-            CHECK(transform == sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f));
+            CHECK(transform == sf::Transform(1.f, 2.f, 3.f, 4.f, 5.f, 4.f, 3.f, 2.f, 1.f));
             transform *= transform;
-            CHECK(transform == sf::Transform(18.0f, 18.0f, 14.0f,
-                                             36.0f, 41.0f, 36.0f,
-                                             14.0f, 18.0f, 18.0f));
-            transform *= sf::Transform(10.0f,  2.0f,  3.0f,
-                                        4.0f, 50.0f, 40.0f,
-                                       30.0f, 20.0f, 10.0f);
-            CHECK(transform == sf::Transform( 672.0f, 1216.0f,  914.0f,
-                                             1604.0f, 2842.0f, 2108.0f,
-                                              752.0f, 1288.0f,  942.0f));
+            CHECK(transform == sf::Transform(18.f, 18.f, 14.f,
+                                             36.f, 41.f, 36.f,
+                                             14.f, 18.f, 18.f));
+            transform *= sf::Transform(10.f,  2.f,  3.f,
+                                        4.f, 50.f, 40.f,
+                                       30.f, 20.f, 10.f);
+            CHECK(transform == sf::Transform( 672.f, 1216.f,  914.f,
+                                             1604.f, 2842.f, 2108.f,
+                                              752.f, 1288.f,  942.f));
         }
 
         SUBCASE("operator* with vector")
         {
-            CHECK(sf::Transform::Identity * sf::Vector2f(-10.0f, -10.0f) == sf::Vector2f(-10.0f, -10.0f));
-            CHECK(sf::Transform::Identity * sf::Vector2f(-1.0f, -1.0f) == sf::Vector2f(-1.0f, -1.0f));
-            CHECK(sf::Transform::Identity * sf::Vector2f(-1.0f, 0.0f) == sf::Vector2f(-1.0f, 0.0f));
-            CHECK(sf::Transform::Identity * sf::Vector2f(0.0f, 0.0f) == sf::Vector2f(0.0f, 0.0f));
-            CHECK(sf::Transform::Identity * sf::Vector2f(0.0f, 1.0f) == sf::Vector2f(0.0f, 1.0f));
-            CHECK(sf::Transform::Identity * sf::Vector2f(1.0f, 1.0f) == sf::Vector2f(1.0f, 1.0f));
-            CHECK(sf::Transform::Identity * sf::Vector2f(10.0f, 10.0f) == sf::Vector2f(10.0f, 10.0f));
+            CHECK(sf::Transform::Identity * sf::Vector2f(-10.f, -10.f) == sf::Vector2f(-10.f, -10.f));
+            CHECK(sf::Transform::Identity * sf::Vector2f(-1.f, -1.f) == sf::Vector2f(-1.f, -1.f));
+            CHECK(sf::Transform::Identity * sf::Vector2f(-1.f, 0.f) == sf::Vector2f(-1.f, 0.f));
+            CHECK(sf::Transform::Identity * sf::Vector2f(0.f, 0.f) == sf::Vector2f(0.f, 0.f));
+            CHECK(sf::Transform::Identity * sf::Vector2f(0.f, 1.f) == sf::Vector2f(0.f, 1.f));
+            CHECK(sf::Transform::Identity * sf::Vector2f(1.f, 1.f) == sf::Vector2f(1.f, 1.f));
+            CHECK(sf::Transform::Identity * sf::Vector2f(10.f, 10.f) == sf::Vector2f(10.f, 10.f));
 
-            const sf::Transform transform(1.0f, 2.0f, 3.0f,
-                                          4.0f, 5.0f, 4.0f,
-                                          3.0f, 2.0f, 1.0f);
-            CHECK(transform * sf::Vector2f(-1.0f, -1.0f) == sf::Vector2f(0.0f, -5.0f));
-            CHECK(transform * sf::Vector2f(0.0f, 0.0f) == sf::Vector2f(3.0f, 4.0f));
-            CHECK(transform * sf::Vector2f(1.0f, 1.0f) == sf::Vector2f(6.0f, 13.0f));
+            const sf::Transform transform(1.f, 2.f, 3.f,
+                                          4.f, 5.f, 4.f,
+                                          3.f, 2.f, 1.f);
+            CHECK(transform * sf::Vector2f(-1.f, -1.f) == sf::Vector2f(0.f, -5.f));
+            CHECK(transform * sf::Vector2f(0.f, 0.f) == sf::Vector2f(3.f, 4.f));
+            CHECK(transform * sf::Vector2f(1.f, 1.f) == sf::Vector2f(6.f, 13.f));
         }
 
         SUBCASE("operator==")
         {
             CHECK(sf::Transform::Identity == sf::Transform::Identity);
             CHECK(sf::Transform() == sf::Transform());
-            CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0) == sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
+            CHECK(sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f) == sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
             CHECK(sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f)
                == sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
-            CHECK(sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f)
-               == sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
+            CHECK(sf::Transform(1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f)
+               == sf::Transform(1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f));
         }
 
         SUBCASE("operator!=")
         {
             CHECK_FALSE(sf::Transform::Identity != sf::Transform::Identity);
             CHECK_FALSE(sf::Transform() != sf::Transform());
-            CHECK_FALSE(sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
+            CHECK_FALSE(sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
             CHECK_FALSE(sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f)
                      != sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
-            CHECK_FALSE(sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f)
-                     != sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
+            CHECK_FALSE(sf::Transform(1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f)
+                     != sf::Transform(1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f, 1000.f));
 
-            CHECK(sf::Transform(1, 0, 0, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 1, 0, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 0, 1, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 0, 0, 1, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 0, 0, 0, 1, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 0, 0, 0, 0, 1, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 1, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 0, 1, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 1) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
+            CHECK(sf::Transform(1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
+            CHECK(sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f) != sf::Transform(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f));
         }
     }
 }

--- a/test/Graphics/Transformable.cpp
+++ b/test/Graphics/Transformable.cpp
@@ -9,10 +9,10 @@ TEST_CASE("sf::Transformable class - [graphics]")
     SUBCASE("Construction")
     {
         const sf::Transformable transformable;
-        CHECK(transformable.getPosition() == sf::Vector2f(0, 0));
+        CHECK(transformable.getPosition() == sf::Vector2f(0.f, 0.f));
         CHECK(transformable.getRotation() == sf::Angle::Zero);
-        CHECK(transformable.getScale() == sf::Vector2f(1, 1));
-        CHECK(transformable.getOrigin() == sf::Vector2f(0, 0));
+        CHECK(transformable.getScale() == sf::Vector2f(1.f, 1.f));
+        CHECK(transformable.getOrigin() == sf::Vector2f(0.f, 0.f));
         CHECK(transformable.getTransform() == sf::Transform());
         CHECK(transformable.getInverseTransform() == sf::Transform());
     }
@@ -21,8 +21,8 @@ TEST_CASE("sf::Transformable class - [graphics]")
     {
         sf::Transformable transformable;
 
-        transformable.setPosition({3, 4});
-        CHECK(transformable.getPosition() == sf::Vector2f(3, 4));
+        transformable.setPosition({3.f, 4.f});
+        CHECK(transformable.getPosition() == sf::Vector2f(3.f, 4.f));
 
         transformable.setRotation(sf::degrees(3.14f));
         CHECK(transformable.getRotation() == sf::degrees(3.14f));
@@ -31,11 +31,11 @@ TEST_CASE("sf::Transformable class - [graphics]")
         transformable.setRotation(sf::degrees(-72));
         CHECK(transformable.getRotation() == sf::degrees(288));
 
-        transformable.setScale({5, 6});
-        CHECK(transformable.getScale() == sf::Vector2f(5, 6));
+        transformable.setScale({5.f, 6.f});
+        CHECK(transformable.getScale() == sf::Vector2f(5.f, 6.f));
 
-        transformable.setOrigin({7, 8});
-        CHECK(transformable.getOrigin() == sf::Vector2f(7, 8));
+        transformable.setOrigin({7.f, 8.f});
+        CHECK(transformable.getOrigin() == sf::Vector2f(7.f, 8.f));
 
         sf::Transform transform;
         transform.translate(transformable.getPosition() - transformable.getOrigin());
@@ -81,11 +81,11 @@ TEST_CASE("sf::Transformable class - [graphics]")
     SUBCASE("move()")
     {
         sf::Transformable transformable;
-        CHECK(transformable.getPosition() == sf::Vector2f(0, 0));
-        transformable.move({9, 10});
-        CHECK(transformable.getPosition() == sf::Vector2f(9, 10));
-        transformable.move({-15, 2});
-        CHECK(transformable.getPosition() == sf::Vector2f(-6, 12));
+        CHECK(transformable.getPosition() == sf::Vector2f(0.f, 0.f));
+        transformable.move({9.f, 10.f});
+        CHECK(transformable.getPosition() == sf::Vector2f(9.f, 10.f));
+        transformable.move({-15.f, 2.f});
+        CHECK(transformable.getPosition() == sf::Vector2f(-6.f, 12.f));
     }
 
     SUBCASE("rotate()")
@@ -107,12 +107,12 @@ TEST_CASE("sf::Transformable class - [graphics]")
     SUBCASE("scale()")
     {
         sf::Transformable transformable;
-        CHECK(transformable.getScale() == sf::Vector2f(1, 1));
-        transformable.scale({2, 3});
-        CHECK(transformable.getScale() == sf::Vector2f(2, 3));
-        transformable.scale({2, 1});
-        CHECK(transformable.getScale() == sf::Vector2f(4, 3));
-        transformable.scale({-1, -1});
-        CHECK(transformable.getScale() == sf::Vector2f(-4, -3));
+        CHECK(transformable.getScale() == sf::Vector2f(1.f, 1.f));
+        transformable.scale({2.f, 3.f});
+        CHECK(transformable.getScale() == sf::Vector2f(2.f, 3.f));
+        transformable.scale({2.f, 1.f});
+        CHECK(transformable.getScale() == sf::Vector2f(4.f, 3.f));
+        transformable.scale({-1.f, -1.f});
+        CHECK(transformable.getScale() == sf::Vector2f(-4.f, -3.f));
     }
 }

--- a/test/Graphics/Vertex.cpp
+++ b/test/Graphics/Vertex.cpp
@@ -10,49 +10,49 @@ TEST_CASE("sf::Vertex class - [graphics]")
         SUBCASE("Default constructor")
         {
             const sf::Vertex vertex;
-            CHECK(vertex.position == sf::Vector2f(0.0f, 0.0f));
+            CHECK(vertex.position == sf::Vector2f(0.f, 0.f));
             CHECK(vertex.color == sf::Color(255, 255, 255));
-            CHECK(vertex.texCoords == sf::Vector2f(0.0f, 0.0f));
+            CHECK(vertex.texCoords == sf::Vector2f(0.f, 0.f));
         }
 
         SUBCASE("Position constructor")
         {
-            const sf::Vertex vertex({1, 2});
-            CHECK(vertex.position == sf::Vector2f(1.0f, 2.0f));
+            const sf::Vertex vertex({1.f, 2.f});
+            CHECK(vertex.position == sf::Vector2f(1.f, 2.f));
             CHECK(vertex.color == sf::Color(255, 255, 255));
-            CHECK(vertex.texCoords == sf::Vector2f(0.0f, 0.0f));
+            CHECK(vertex.texCoords == sf::Vector2f(0.f, 0.f));
         }
 
         SUBCASE("Position and color constructor")
         {
-            const sf::Vertex vertex({1, 2}, {3, 4, 5, 6});
-            CHECK(vertex.position == sf::Vector2f(1.0f, 2.0f));
+            const sf::Vertex vertex({1.f, 2.f}, {3, 4, 5, 6});
+            CHECK(vertex.position == sf::Vector2f(1.f, 2.f));
             CHECK(vertex.color == sf::Color(3, 4, 5, 6));
-            CHECK(vertex.texCoords == sf::Vector2f(0.0f, 0.0f));
+            CHECK(vertex.texCoords == sf::Vector2f(0.f, 0.f));
         }
 
         SUBCASE("Position and coords constructor")
         {
-            const sf::Vertex vertex({1, 2}, {3, 4});
-            CHECK(vertex.position == sf::Vector2f(1.0f, 2.0f));
+            const sf::Vertex vertex({1.f, 2.f}, {3.f, 4.f});
+            CHECK(vertex.position == sf::Vector2f(1.f, 2.f));
             CHECK(vertex.color == sf::Color(255, 255, 255));
-            CHECK(vertex.texCoords == sf::Vector2f(3.0f, 4.0f));
+            CHECK(vertex.texCoords == sf::Vector2f(3.f, 4.f));
         }
 
         SUBCASE("Position, color, and coords constructor")
         {
-            const sf::Vertex vertex({1, 2}, {3, 4, 5, 6}, {7, 8});
-            CHECK(vertex.position == sf::Vector2f(1.0f, 2.0f));
+            const sf::Vertex vertex({1.f, 2.f}, {3, 4, 5, 6}, {7.f, 8.f});
+            CHECK(vertex.position == sf::Vector2f(1.f, 2.f));
             CHECK(vertex.color == sf::Color(3, 4, 5, 6));
-            CHECK(vertex.texCoords == sf::Vector2f(7.0f, 8.0f));
+            CHECK(vertex.texCoords == sf::Vector2f(7.f, 8.f));
         }
     }
 
     SUBCASE("Constexpr support")
     {
-        constexpr sf::Vertex vertex({1, 2}, {3, 4, 5, 6}, {7, 8});
-        static_assert(vertex.position == sf::Vector2f(1.0f, 2.0f));
+        constexpr sf::Vertex vertex({1.f, 2.f}, {3, 4, 5, 6}, {7.f, 8.f});
+        static_assert(vertex.position == sf::Vector2f(1.f, 2.f));
         static_assert(vertex.color == sf::Color(3, 4, 5, 6));
-        static_assert(vertex.texCoords == sf::Vector2f(7.0f, 8.0f));
+        static_assert(vertex.texCoords == sf::Vector2f(7.f, 8.f));
     }
 }

--- a/test/Graphics/VertexArray.cpp
+++ b/test/Graphics/VertexArray.cpp
@@ -12,7 +12,7 @@ TEST_CASE("sf::VertexArray class - [graphics]")
             const sf::VertexArray vertexArray;
             CHECK(vertexArray.getVertexCount() == 0);
             CHECK(vertexArray.getPrimitiveType() == sf::PrimitiveType::Points);
-            CHECK(vertexArray.getBounds() == sf::FloatRect({0, 0}, {0, 0}));
+            CHECK(vertexArray.getBounds() == sf::FloatRect({0.f, 0.f}, {0.f, 0.f}));
         }
 
         SUBCASE("Explicit constructor with default argument")
@@ -20,7 +20,7 @@ TEST_CASE("sf::VertexArray class - [graphics]")
             const sf::VertexArray vertexArray(sf::PrimitiveType::Lines);
             CHECK(vertexArray.getVertexCount() == 0);
             CHECK(vertexArray.getPrimitiveType() == sf::PrimitiveType::Lines);
-            CHECK(vertexArray.getBounds() == sf::FloatRect({0, 0}, {0, 0}));
+            CHECK(vertexArray.getBounds() == sf::FloatRect({0.f, 0.f}, {0.f, 0.f}));
         }
 
         SUBCASE("Explicit constructor")
@@ -28,7 +28,7 @@ TEST_CASE("sf::VertexArray class - [graphics]")
             const sf::VertexArray vertexArray(sf::PrimitiveType::Lines, 10);
             CHECK(vertexArray.getVertexCount() == 10);
             CHECK(vertexArray.getPrimitiveType() == sf::PrimitiveType::Lines);
-            CHECK(vertexArray.getBounds() == sf::FloatRect({0, 0}, {0, 0}));
+            CHECK(vertexArray.getBounds() == sf::FloatRect({0.f, 0.f}, {0.f, 0.f}));
             for (std::size_t i = 0; i < vertexArray.getVertexCount(); ++i)
             {
                 CHECK(vertexArray[i].position == sf::Vertex().position);
@@ -62,7 +62,7 @@ TEST_CASE("sf::VertexArray class - [graphics]")
     SUBCASE("Append to array")
     {
         sf::VertexArray vertexArray;
-        const sf::Vertex vertex({1, 2}, {3, 4, 5, 6}, {7, 8});
+        const sf::Vertex vertex({1.f, 2.f}, {3, 4, 5, 6}, {7.f, 8.f});
         vertexArray.append(vertex);
         CHECK(vertexArray.getVertexCount() == 1);
         CHECK(vertexArray[0].position == vertex.position);
@@ -74,7 +74,7 @@ TEST_CASE("sf::VertexArray class - [graphics]")
     {
         sf::VertexArray vertexArray;
         vertexArray.resize(10);
-        const sf::Vertex otherVertex({2, 3}, {4, 5, 6, 7}, {8, 9});
+        const sf::Vertex otherVertex({2.f, 3.f}, {4, 5, 6, 7}, {8.f, 9.f});
         vertexArray[9] = otherVertex;
         CHECK(vertexArray[9].position == otherVertex.position);
         CHECK(vertexArray[9].color == otherVertex.color);
@@ -91,14 +91,14 @@ TEST_CASE("sf::VertexArray class - [graphics]")
     SUBCASE("Get bounds")
     {
         sf::VertexArray vertexArray;
-        vertexArray.append(sf::Vertex({1, 1}));
-        vertexArray.append(sf::Vertex({2, 2}));
-        CHECK(vertexArray.getBounds() == sf::FloatRect({1, 1}, {1, 1}));
-        vertexArray[0] = sf::Vertex({0, 0});
-        CHECK(vertexArray.getBounds() == sf::FloatRect({0, 0}, {2, 2}));
-        vertexArray[0] = sf::Vertex({5, 5});
-        CHECK(vertexArray.getBounds() == sf::FloatRect({2, 2}, {3, 3}));
-        vertexArray.append(sf::Vertex({10, 10}));
-        CHECK(vertexArray.getBounds() == sf::FloatRect({2, 2}, {8, 8}));
+        vertexArray.append(sf::Vertex({1.f, 1.f}));
+        vertexArray.append(sf::Vertex({2.f, 2.f}));
+        CHECK(vertexArray.getBounds() == sf::FloatRect({1.f, 1.f}, {1.f, 1.f}));
+        vertexArray[0] = sf::Vertex({0.f, 0.f});
+        CHECK(vertexArray.getBounds() == sf::FloatRect({0.f, 0.f}, {2.f, 2.f}));
+        vertexArray[0] = sf::Vertex({5.f, 5.f});
+        CHECK(vertexArray.getBounds() == sf::FloatRect({2.f, 2.f}, {3.f, 3.f}));
+        vertexArray.append(sf::Vertex({10.f, 10.f}));
+        CHECK(vertexArray.getBounds() == sf::FloatRect({2.f, 2.f}, {8.f, 8.f}));
     }
 }

--- a/test/Graphics/View.cpp
+++ b/test/Graphics/View.cpp
@@ -10,34 +10,34 @@ TEST_CASE("sf::View class - [graphics]")
         SUBCASE("Default constructor")
         {
             const sf::View view;
-            CHECK(view.getCenter() == sf::Vector2f(500, 500));
-            CHECK(view.getSize() == sf::Vector2f(1000, 1000));
+            CHECK(view.getCenter() == sf::Vector2f(500.f, 500.f));
+            CHECK(view.getSize() == sf::Vector2f(1000.f, 1000.f));
             CHECK(view.getRotation() == sf::Angle::Zero);
-            CHECK(view.getViewport() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(view.getTransform() == sf::Transform(0.002f, 0, -1, 0, -0.002f, 1, 0, 0, 1));
-            CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 500, 0, -500, 500, 0, 0, 1)));
+            CHECK(view.getViewport() == sf::FloatRect({0.f, 0.f}, {1.f, 1.f}));
+            CHECK(view.getTransform() == sf::Transform(0.002f, 0.f, -1.f, 0.f, -0.002f, 1.f, 0.f, 0.f, 1.f));
+            CHECK(view.getInverseTransform() == Approx(sf::Transform(500.f, 0.f, 500.f, 0.f, -500.f, 500.f, 0.f, 0.f, 1.f)));
         }
 
         SUBCASE("Rectangle constructor")
         {
-            const sf::View view(sf::FloatRect({10, 20}, {400, 600}));
-            CHECK(view.getCenter() == sf::Vector2f(210, 320));
-            CHECK(view.getSize() == sf::Vector2f(400, 600));
+            const sf::View view(sf::FloatRect({10.f, 20.f}, {400.f, 600.f}));
+            CHECK(view.getCenter() == sf::Vector2f(210.f, 320.f));
+            CHECK(view.getSize() == sf::Vector2f(400.f, 600.f));
             CHECK(view.getRotation() == sf::Angle::Zero);
-            CHECK(view.getViewport() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(view.getTransform() == Approx(sf::Transform(0.005f, 0, -1.05f, 0, -0.00333333f, 1.06667f, 0, 0, 1)));
-            CHECK(view.getInverseTransform() == Approx(sf::Transform(200, 0, 210, 0, -300, 320, 0, 0, 1)));
+            CHECK(view.getViewport() == sf::FloatRect({0.f, 0.f}, {1.f, 1.f}));
+            CHECK(view.getTransform() == Approx(sf::Transform(0.005f, 0.f, -1.05f, 0.f, -0.00333333f, 1.06667f, 0.f, 0.f, 1.f)));
+            CHECK(view.getInverseTransform() == Approx(sf::Transform(200.f, 0.f, 210.f, 0.f, -300.f, 320.f, 0.f, 0.f, 1.f)));
         }
 
         SUBCASE("Center + size constructor")
         {
-            const sf::View view({520, 960}, {1080, 1920});
-            CHECK(view.getCenter() == sf::Vector2f(520, 960));
-            CHECK(view.getSize() == sf::Vector2f(1080, 1920));
+            const sf::View view({520.f, 960.f}, {1080.f, 1920.f});
+            CHECK(view.getCenter() == sf::Vector2f(520.f, 960.f));
+            CHECK(view.getSize() == sf::Vector2f(1080.f, 1920.f));
             CHECK(view.getRotation() == sf::Angle::Zero);
-            CHECK(view.getViewport() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(view.getTransform() == Approx(sf::Transform(0.00185185f, 0, -0.962963f, 0, -0.00104167f, 1, 0, 0, 1)));
-            CHECK(view.getInverseTransform() == Approx(sf::Transform(540, 0, 520, 0, -960, 960, 0, 0, 1)));
+            CHECK(view.getViewport() == sf::FloatRect({0.f, 0.f}, {1.f, 1.f}));
+            CHECK(view.getTransform() == Approx(sf::Transform(0.00185185f, 0.f, -0.962963f, 0.f, -0.00104167f, 1.f, 0.f, 0.f, 1.f)));
+            CHECK(view.getInverseTransform() == Approx(sf::Transform(540.f, 0.f, 520.f, 0.f, -960.f, 960.f, 0.f, 0.f, 1.f)));
         }
     }
 
@@ -46,17 +46,17 @@ TEST_CASE("sf::View class - [graphics]")
         sf::View view;
         view.setCenter({3.14f, 4.2f});
         CHECK(view.getCenter() == sf::Vector2f(3.14f, 4.2f));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -0.00628f, 0, -0.002f, 0.0084f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 3.14f, 0, -500, 4.2f, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0.f, -0.00628f, 0.f, -0.002f, 0.0084f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0.f, 3.14f, 0.f, -500, 4.2f, 0.f, 0.f, 1.f)));
     }
 
     SUBCASE("Set/get size")
     {
         sf::View view;
-        view.setSize({600, 900});
-        CHECK(view.getSize() == sf::Vector2f(600, 900));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.00333333f, 0, -1.66667f, 0, -0.00222222f, 1.11111f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(300, 0, 500, 0, -450, 500, 0, 0, 1)));
+        view.setSize({600.f, 900.f});
+        CHECK(view.getSize() == sf::Vector2f(600.f, 900.f));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.00333333f, 0.f, -1.66667f, 0.f, -0.00222222f, 1.11111f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(300.f, 0.f, 500.f, 0.f, -450.f, 500.f, 0.f, 0.f, 1.f)));
     }
 
     SUBCASE("Set/get rotation")
@@ -64,47 +64,47 @@ TEST_CASE("sf::View class - [graphics]")
         sf::View view;
         view.setRotation(sf::degrees(-345));
         CHECK(view.getRotation() == sf::degrees(15));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.00193185f, 0.000517638f, -1.22474f, 0.000517638f, -0.00193185f, 0.707107f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(482.963f, 129.41f, 500, 129.41f, -482.963f, 500, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.00193185f, 0.000517638f, -1.22474f, 0.000517638f, -0.00193185f, 0.707107f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(482.963f, 129.41f, 500.f, 129.41f, -482.963f, 500.f, 0.f, 0.f, 1.f)));
         view.setRotation(sf::degrees(400));
         CHECK(view.getRotation() == sf::degrees(40));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.00153209f, 0.00128558f, -1.40883f, 0.00128558f, -0.00153209f, 0.123257f, 0, 0, 1 )));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(383.022f, 321.394f, 500, 321.394f, -383.022f, 500, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.00153209f, 0.00128558f, -1.40883f, 0.00128558f, -0.00153209f, 0.123257f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(383.022f, 321.394f, 500.f, 321.394f, -383.022f, 500.f, 0.f, 0.f, 1.f)));
     }
 
     SUBCASE("Set/get viewport")
     {
         sf::View view;
-        view.setViewport({{150, 250}, {500, 750}});
-        CHECK(view.getViewport() == sf::FloatRect({150, 250}, {500, 750}));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -1, 0, -0.002f, 1, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 500, 0, -500, 500, 0, 0, 1)));
+        view.setViewport({{150.f, 250.f}, {500.f, 750.f}});
+        CHECK(view.getViewport() == sf::FloatRect({150.f, 250.f}, {500.f, 750.f}));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0.f, -1.f, 0.f, -0.002f, 1.f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(500.f, 0.f, 500.f, 0.f, -500.f, 500.f, 0.f, 0.f, 1.f)));
     }
 
     SUBCASE("reset()")
     {
         sf::View view;
         view.setCenter({3.14f, 4.2f});
-        view.setSize({600, 900});
+        view.setSize({600.f, 900.f});
         view.setRotation(sf::degrees(15));
-        view.setViewport({{150, 250}, {500, 750}});
-        view.reset({{1, 2}, {3, 4}});
-        CHECK(view.getCenter() == sf::Vector2f(2.5f, 4));
-        CHECK(view.getSize() == sf::Vector2f(3, 4));
+        view.setViewport({{150.f, 250.f}, {500.f, 750.f}});
+        view.reset({{1.f, 2.f}, {3.f, 4.f}});
+        CHECK(view.getCenter() == sf::Vector2f(2.5f, 4.f));
+        CHECK(view.getSize() == sf::Vector2f(3.f, 4.f));
         CHECK(view.getRotation() == sf::Angle::Zero);
-        CHECK(view.getViewport() == sf::FloatRect({150, 250}, {500, 750}));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.666667f, 0, -1.66667f, 0, -0.5f, 2, 0, 0, 1 )));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(1.5f, 0, 2.5f, 0, -2, 4, 0, 0, 1)));
+        CHECK(view.getViewport() == sf::FloatRect({150.f, 250.f}, {500.f, 750.f}));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.666667f, 0.f, -1.66667f, 0.f, -0.5f, 2.f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(1.5f, 0.f, 2.5f, 0.f, -2.f, 4.f, 0.f, 0.f, 1.f)));
     }
 
     SUBCASE("move()")
     {
         sf::View view;
-        view.setCenter({25, 25});
-        view.move({15, 25});
-        CHECK(view.getCenter() == sf::Vector2f(40, 50));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -0.08f, 0, -0.002f, 0.1f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 40, 0, -500, 50, 0, 0, 1)));
+        view.setCenter({25.f, 25.f});
+        view.move({15.f, 25.f});
+        CHECK(view.getCenter() == sf::Vector2f(40.f, 50.f));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0.f, -0.08f, 0.f, -0.002f, 0.1f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(500.f, 0.f, 40.f, 0.f, -500.f, 50.f, 0.f, 0.f, 1.f)));
     }
 
     SUBCASE("rotate()")
@@ -113,17 +113,17 @@ TEST_CASE("sf::View class - [graphics]")
         view.setRotation(sf::degrees(45));
         view.rotate(sf::degrees(-15));
         CHECK(view.getRotation() == sf::degrees(30));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.00173205f, 0.001f, -1.36603f, 0.001f, -0.00173205f, 0.366025f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(433.013f, 250, 500, 250, -433.013f, 500, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.00173205f, 0.001f, -1.36603f, 0.001f, -0.00173205f, 0.366025f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(433.013f, 250.f, 500.f, 250.f, -433.013f, 500.f, 0.f, 0.f, 1.f)));
     }
 
     SUBCASE("zoom()")
     {
         sf::View view;
-        view.setSize({25, 25});
-        view.zoom(4);
-        CHECK(view.getSize() == sf::Vector2f(100, 100));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.02f, 0, -10, 0, -0.02f, 10, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(50, 0, 500, 0, -50, 500, 0, 0, 1)));
+        view.setSize({25.f, 25.f});
+        view.zoom(4.f);
+        CHECK(view.getSize() == sf::Vector2f(100.f, 100.f));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.02f, 0.f, -10.f, 0.f, -0.02f, 10.f, 0.f, 0.f, 1.f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(50.f, 0.f, 500.f, 0.f, -50.f, 500.f, 0.f, 0.f, 1.f)));
     }
 }

--- a/test/System/Angle.cpp
+++ b/test/System/Angle.cpp
@@ -204,11 +204,11 @@ TEST_CASE("sf::Angle class - [system]")
         {
             CHECK(sf::radians(0) * 10 == sf::Angle::Zero);
             CHECK(sf::degrees(10) * 2.5f == sf::degrees(25));
-            CHECK(sf::degrees(100) * 10.0f == sf::degrees(1000));
+            CHECK(sf::degrees(100) * 10.f == sf::degrees(1000));
 
             CHECK(10 * sf::radians(0) == sf::Angle::Zero);
             CHECK(2.5f * sf::degrees(10) == sf::degrees(25));
-            CHECK(10.0f * sf::degrees(100) == sf::degrees(1000));
+            CHECK(10.f * sf::degrees(100) == sf::degrees(1000));
         }
 
         SUBCASE("operator*=")

--- a/test/System/Time.cpp
+++ b/test/System/Time.cpp
@@ -10,7 +10,7 @@ TEST_CASE("sf::Time class - [system]")
         SUBCASE("Default constructor")
         {
             const sf::Time time;
-            CHECK(time.asSeconds() == 0.0f);
+            CHECK(time.asSeconds() == 0.f);
             CHECK(time.asMilliseconds() == 0);
             CHECK(time.asMicroseconds() == 0);
         }
@@ -18,11 +18,11 @@ TEST_CASE("sf::Time class - [system]")
         SUBCASE("Construct from seconds")
         {
             const sf::Time time = sf::seconds(123);
-            CHECK(time.asSeconds() == 123.0f);
+            CHECK(time.asSeconds() == 123.f);
             CHECK(time.asMilliseconds() == 123'000);
             CHECK(time.asMicroseconds() == 123'000'000);
 
-            CHECK(sf::seconds(1'000.0f).asMicroseconds() == 1'000'000'000);
+            CHECK(sf::seconds(1'000.f).asMicroseconds() == 1'000'000'000);
             CHECK(sf::seconds(0.0000009f).asMicroseconds() == 0);
             CHECK(sf::seconds(0.0000001f).asMicroseconds() == 0);
             CHECK(sf::seconds(0.00000001f).asMicroseconds() == 0);
@@ -31,7 +31,7 @@ TEST_CASE("sf::Time class - [system]")
             CHECK(sf::seconds(-0.00000001f).asMicroseconds() == 0);
             CHECK(sf::seconds(-0.0000001f).asMicroseconds() == 0);
             CHECK(sf::seconds(-0.0000009f).asMicroseconds() == 0);
-            CHECK(sf::seconds(-1'000.0f).asMicroseconds() == -1'000'000'000);
+            CHECK(sf::seconds(-1'000.f).asMicroseconds() == -1'000'000'000);
         }
 
         SUBCASE("Construct from milliseconds")
@@ -53,7 +53,7 @@ TEST_CASE("sf::Time class - [system]")
 
     SUBCASE("Zero time")
     {
-        CHECK(sf::Time::Zero.asSeconds() == 0.0f);
+        CHECK(sf::Time::Zero.asSeconds() == 0.f);
         CHECK(sf::Time::Zero.asMilliseconds() == 0);
         CHECK(sf::Time::Zero.asMicroseconds() == 0);
     }
@@ -135,11 +135,11 @@ TEST_CASE("sf::Time class - [system]")
 
         SUBCASE("operator*")
         {
-            CHECK(sf::seconds(1) * 2.0f == sf::seconds(2));
+            CHECK(sf::seconds(1) * 2.f == sf::seconds(2));
             CHECK(sf::seconds(12) * 0.5f == sf::seconds(6));
             CHECK(sf::seconds(1) * static_cast<sf::Int64>(2) == sf::seconds(2));
             CHECK(sf::seconds(42) * static_cast<sf::Int64>(2) == sf::seconds(84));
-            CHECK(2.0f * sf::seconds(1) == sf::seconds(2));
+            CHECK(2.f * sf::seconds(1) == sf::seconds(2));
             CHECK(0.5f * sf::seconds(12) == sf::seconds(6));
             CHECK(static_cast<sf::Int64>(2) * sf::seconds(1) == sf::seconds(2));
             CHECK(static_cast<sf::Int64>(2) * sf::seconds(42) == sf::seconds(84));
@@ -156,11 +156,11 @@ TEST_CASE("sf::Time class - [system]")
 
         SUBCASE("operator/")
         {
-            CHECK(sf::seconds(1) / 2.0f == sf::seconds(0.5f));
+            CHECK(sf::seconds(1) / 2.f == sf::seconds(0.5f));
             CHECK(sf::seconds(12) / 0.5f == sf::seconds(24));
             CHECK(sf::seconds(1) / static_cast<sf::Int64>(2) == sf::seconds(0.5f));
             CHECK(sf::seconds(42) / static_cast<sf::Int64>(2) == sf::seconds(21));
-            CHECK(sf::seconds(1) / sf::seconds(1) == 1.0f);
+            CHECK(sf::seconds(1) / sf::seconds(1) == 1.f);
             CHECK(sf::milliseconds(10) / sf::microseconds(1) == doctest::Approx(10'000.0).epsilon(1e-6));
         }
 

--- a/test/System/Vector2.cpp
+++ b/test/System/Vector2.cpp
@@ -30,7 +30,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
         SUBCASE("Conversion constructor")
         {
-            const sf::Vector2f sourceVector(1.0f, 2.0f);
+            const sf::Vector2f sourceVector(1.f, 2.f);
             const sf::Vector2i vector(sourceVector);
 
             CHECK(vector.x == static_cast<int>(sourceVector.x));
@@ -241,7 +241,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
     SUBCASE("Length and normalization")
     {
-        const sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f v(2.4f, 3.f);
 
         CHECK(v.length() == Approx(3.84187f));
         CHECK(v.lengthSq() == Approx(14.7599650969f));
@@ -256,7 +256,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
 
     SUBCASE("Rotations and angles")
     {
-        const sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f v(2.4f, 3.f);
         
         CHECK(v.angle() == Approx(51.3402_deg));
         CHECK(sf::Vector2f::UnitX.angleTo(v) == Approx(51.3402_deg));
@@ -275,17 +275,17 @@ TEST_CASE("sf::Vector2 class template - [system]")
         CHECK(v.rotatedBy(-158.9902_deg) * ratio  == Approx(w));
         CHECK(w.rotatedBy(158.9902_deg) / ratio == Approx(v));
 
-        CHECK(v.perpendicular() == sf::Vector2f(-3.0f, 2.4f));
+        CHECK(v.perpendicular() == sf::Vector2f(-3.f, 2.4f));
         CHECK(v.perpendicular().perpendicular().perpendicular().perpendicular() == v);
 
-        CHECK(v.rotatedBy(90_deg) == Approx(sf::Vector2f(-3.0f, 2.4f)));
+        CHECK(v.rotatedBy(90_deg) == Approx(sf::Vector2f(-3.f, 2.4f)));
         CHECK(v.rotatedBy(27.14_deg) == Approx(sf::Vector2f(0.767248f, 3.76448f)));
         CHECK(v.rotatedBy(-36.11_deg) == Approx(sf::Vector2f(3.70694f, 1.00925f)));
     }
     
     SUBCASE("Products and quotients")
     {
-        const sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f v(2.4f, 3.f);
         const sf::Vector2f w(-0.7f, -2.2f);
 
         CHECK(v.dot(w) == Approx(-8.28f));
@@ -302,7 +302,7 @@ TEST_CASE("sf::Vector2 class template - [system]")
     
     SUBCASE("Projection")
     {
-        const sf::Vector2f v(2.4f, 3.0f);
+        const sf::Vector2f v(2.4f, 3.f);
         const sf::Vector2f w(-0.7f, -2.2f);
         
         CHECK(v.projectedOnto(w) == Approx(sf::Vector2f(1.087430f, 3.417636f)));
@@ -311,8 +311,8 @@ TEST_CASE("sf::Vector2 class template - [system]")
         CHECK(w.projectedOnto(v) == Approx(sf::Vector2f(-1.346342f, -1.682927f)));
         CHECK(w.projectedOnto(v) == Approx(sf::Vector2f(-0.560976f * v)));
 
-        CHECK(v.projectedOnto(sf::Vector2f::UnitX) == Approx(sf::Vector2f(2.4f, 0.0f)));
-        CHECK(v.projectedOnto(sf::Vector2f::UnitY) == Approx(sf::Vector2f(0.0f, 3.0f)));
+        CHECK(v.projectedOnto(sf::Vector2f::UnitX) == Approx(sf::Vector2f(2.4f, 0.f)));
+        CHECK(v.projectedOnto(sf::Vector2f::UnitY) == Approx(sf::Vector2f(0.f, 3.f)));
     }
 
     SUBCASE("Constexpr support")

--- a/test/System/Vector3.cpp
+++ b/test/System/Vector3.cpp
@@ -29,7 +29,7 @@ TEST_CASE("sf::Vector3 class template - [system]")
 
         SUBCASE("Conversion constructor")
         {
-            sf::Vector3f sourceVector(1.0f, 2.0f, 3.0f);
+            sf::Vector3f sourceVector(1.f, 2.f, 3.f);
             sf::Vector3i vector(sourceVector);
 
             CHECK(vector.x == static_cast<int>(sourceVector.x));
@@ -202,7 +202,7 @@ TEST_CASE("sf::Vector3 class template - [system]")
 
     SUBCASE("Length and normalization")
     {
-        const sf::Vector3f v(2.4f, 3.0f, 5.2f);
+        const sf::Vector3f v(2.4f, 3.f, 5.2f);
 
         CHECK(v.length() == Approx(6.46529f));
         CHECK(v.lengthSq() == Approx(41.79997f));
@@ -211,7 +211,7 @@ TEST_CASE("sf::Vector3 class template - [system]")
 
     SUBCASE("Products and quotients")
     {
-        const sf::Vector3f v(2.4f, 3.0f, 5.2f);
+        const sf::Vector3f v(2.4f, 3.f, 5.2f);
         const sf::Vector3f w(-0.7f, -2.2f, -4.8f);
 
         CHECK(v.dot(w) == Approx(-33.24f));


### PR DESCRIPTION
## Description

The inconsistent use of numeric literals is 100% the fault of whoever has been writing all these unit tests so run `git blame` and yell at that idiot. Unifying how we use literals also has the knock-on effect of removing tons of code (as measured by character count) which has readability gains. For anyone curious about the `int` -> `float` conversion, this is 100% safe because these `int` literals are known by the compiler to convert losslessly to `float`s so there's no correctness lost in this PR.

The best way to look at this PR is me going back and cleaning up inconsistencies in my own code from the last few months.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
