### PR TITLE
Simplify how vectors are deallocated

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -527,7 +527,7 @@ void Font::cleanup()
 
     // Reset members
     m_pages.clear();
-    std::vector<Uint8>().swap(m_pixelBuffer);
+    m_pixelBuffer = {};
 }
 
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -66,7 +66,7 @@ void Image::create(const Vector2u& size, const Color& color)
     else
     {
         // Dump the pixel buffer
-        std::vector<Uint8>().swap(m_pixels);
+        m_pixels = {};
 
         // Assign the new size
         m_size.x = 0;
@@ -92,7 +92,7 @@ void Image::create(const Vector2u& size, const Uint8* pixels)
     else
     {
         // Dump the pixel buffer
-        std::vector<Uint8>().swap(m_pixels);
+        m_pixels = {};
 
         // Assign the new size
         m_size.x = 0;


### PR DESCRIPTION
## Description

After discussion in Discord, I came to learn that this "swap with empty temporary" pattern was a way to clear _and deallocate_ a vector. This PR maintains that behavior but uses the more expressive C++11 syntax for default initializing a variable. 

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
