### PR TITLE
Modernize examples

### DIFF
--- a/examples/X11/CMakeLists.txt
+++ b/examples/X11/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/X11)
-
 # all source files
-set(SRC ${SRCROOT}/X11.cpp)
+set(SRC X11.cpp)
 
 # define the X11 target
 sfml_add_example(X11Example GUI_APP

--- a/examples/X11/X11.cpp
+++ b/examples/X11/X11.cpp
@@ -8,6 +8,7 @@
 #include <gl.h>
 
 #include <X11/Xlib.h>
+#include <array>
 #include <iostream>
 #include <cmath>
 #include <cstdlib>
@@ -93,7 +94,7 @@
     glRotatef(elapsedTime * 18.f, 0.f, 0.f, 1.f);
 
     // Define a 3D cube (6 faces made of 2 triangles composed by 3 vertices)
-    static const GLfloat cube[] =
+    constexpr std::array<GLfloat, 216> cube =
     {
         // positions    // colors
         -50, -50, -50,  1, 1, 0,
@@ -140,8 +141,8 @@
     };
 
     // Draw the cube
-    glVertexPointer(3, GL_FLOAT, 6 * sizeof(GLfloat), cube);
-    glColorPointer(3, GL_FLOAT, 6 * sizeof(GLfloat), cube + 3);
+    glVertexPointer(3, GL_FLOAT, 6 * sizeof(GLfloat), cube.data());
+    glColorPointer(3, GL_FLOAT, 6 * sizeof(GLfloat), cube.data() + 3);
     glDrawArrays(GL_TRIANGLES, 0, 36);
 
     return true;

--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/cocoa)
-
 # Usage: compile_xib(INPUT path/to/file.xib OUTPUT path/to/file.nib)
 function(compile_xib)
     cmake_parse_arguments(THIS "" "INPUT;OUTPUT" "" ${ARGN})
@@ -30,22 +27,22 @@ function(compile_xib)
 endfunction()
 
 # all source files
-set(SRC ${SRCROOT}/CocoaAppDelegate.h
-        ${SRCROOT}/CocoaAppDelegate.mm
-        ${SRCROOT}/NSString+stdstring.h
-        ${SRCROOT}/NSString+stdstring.mm
-        ${SRCROOT}/main.m)
+set(SRC CocoaAppDelegate.h
+        CocoaAppDelegate.mm
+        NSString+stdstring.h
+        NSString+stdstring.mm
+        main.m)
 
-compile_xib(INPUT "${SRCROOT}/MainMenu.xib" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib")
+compile_xib(INPUT "MainMenu.xib" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib")
 
 # all resource files
-set(RESOURCES ${SRCROOT}/resources/icon.icns
-              ${SRCROOT}/resources/tuffy.ttf
-              ${SRCROOT}/resources/logo.png
-              ${SRCROOT}/resources/blue.png
-              ${SRCROOT}/resources/green.png
-              ${SRCROOT}/resources/red.png
-              ${SRCROOT}/resources/Credits.rtf
+set(RESOURCES resources/icon.icns
+              resources/tuffy.ttf
+              resources/logo.png
+              resources/blue.png
+              resources/green.png
+              resources/red.png
+              resources/Credits.rtf
               ${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib)
 set_source_files_properties(${RESOURCES} PROPERTIES
                             MACOSX_PACKAGE_LOCATION Resources)
@@ -57,5 +54,5 @@ sfml_add_example(cocoa
                  DEPENDS SFML::System SFML::Window SFML::Graphics)
 set_target_properties(cocoa PROPERTIES
                       MACOSX_BUNDLE TRUE
-                      MACOSX_BUNDLE_INFO_PLIST ${SRCROOT}/resources/Cocoa-Info.plist)
+                      MACOSX_BUNDLE_INFO_PLIST resources/Cocoa-Info.plist)
 target_link_libraries(cocoa PRIVATE "-framework Cocoa" "-framework Foundation" SFML::Graphics)

--- a/examples/ftp/CMakeLists.txt
+++ b/examples/ftp/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/ftp)
-
 # all source files
-set(SRC ${SRCROOT}/Ftp.cpp)
+set(SRC Ftp.cpp)
 
 # define the ftp target
 sfml_add_example(ftp

--- a/examples/island/CMakeLists.txt
+++ b/examples/island/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/island)
-
 # all source files
-set(SRC ${SRCROOT}/Island.cpp)
+set(SRC Island.cpp)
 
 # define the island target
 sfml_add_example(island GUI_APP

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -8,6 +8,7 @@
 #include <SFML/Graphics.hpp>
 
 #include <algorithm>
+#include <array>
 #include <deque>
 #include <iostream>
 #include <mutex>
@@ -161,8 +162,8 @@ int main()
     statusText.setPosition({(windowWidth - statusText.getLocalBounds().width) / 2.f, (windowHeight - statusText.getLocalBounds().height) / 2.f});
 
     // Set up an array of pointers to our settings for arrow navigation
-    Setting settings[] =
-    {
+    constexpr std::array<Setting, 9> settings =
+    {{
         {"perlinFrequency",     &perlinFrequency},
         {"perlinFrequencyBase", &perlinFrequencyBase},
         {"heightBase",          &heightBase},
@@ -172,10 +173,9 @@ int main()
         {"heightFactor",        &heightFactor},
         {"heightFlatten",       &heightFlatten},
         {"lightFactor",         &lightFactor}
-    };
+    }};
 
-    const int settingCount = 9;
-    int currentSetting = 0;
+    std::size_t currentSetting = 0;
 
     std::ostringstream osstr;
     sf::Clock clock;
@@ -199,8 +199,8 @@ int main()
                 switch (event.key.code)
                 {
                     case sf::Keyboard::Enter: generateTerrain(terrainStagingBuffer.data()); break;
-                    case sf::Keyboard::Down:  currentSetting = (currentSetting + 1) % settingCount; break;
-                    case sf::Keyboard::Up:    currentSetting = (currentSetting + settingCount - 1) % settingCount; break;
+                    case sf::Keyboard::Down:  currentSetting = (currentSetting + 1) % settings.size(); break;
+                    case sf::Keyboard::Up:    currentSetting = (currentSetting + settings.size() - 1) % settings.size(); break;
                     case sf::Keyboard::Left:  *(settings[currentSetting].value) -= 0.1f; break;
                     case sf::Keyboard::Right: *(settings[currentSetting].value) += 0.1f; break;
                     default: break;
@@ -244,7 +244,7 @@ int main()
                   << "perlinOctaves:  " << perlinOctaves << "\n\n"
                   << "Use the arrow keys to change the values.\nUse the return key to regenerate the terrain.\n\n";
 
-            for (int i = 0; i < settingCount; ++i)
+            for (std::size_t i = 0; i < settings.size(); ++i)
                 osstr << ((i == currentSetting) ? ">>  " : "       ") << settings[i].name << ":  " << *(settings[i].value) << '\n';
 
             hudText.setString(osstr.str());

--- a/examples/joystick/CMakeLists.txt
+++ b/examples/joystick/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/joystick)
-
 # all source files
-set(SRC ${SRCROOT}/Joystick.cpp)
+set(SRC Joystick.cpp)
 
 # define the joystick target
 sfml_add_example(joystick GUI_APP

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -4,6 +4,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics.hpp>
 #include <algorithm>
+#include <array>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -23,7 +24,7 @@ namespace
     float threshold = 0.1f;
 
     // Axes labels in as C strings
-    const char* axislabels[] = {"X", "Y", "Z", "R", "U", "V", "PovX", "PovY"};
+    constexpr std::array axislabels = {"X", "Y", "Z", "R", "U", "V", "PovX", "PovY"};
 
     // Helper to set text entries to a specified value
     template<typename T>

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/opengl)
-
 # all source files
-set(SRC ${SRCROOT}/OpenGL.cpp)
+set(SRC OpenGL.cpp)
 
 if (SFML_OS_IOS)
     set(RESOURCES

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -3,6 +3,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics.hpp>
+#include <array>
 #include <iostream>
 #include <cstdlib>
 
@@ -124,7 +125,7 @@ int main()
         sf::Texture::bind(&texture);
 
         // Define a 3D cube (6 faces made of 2 triangles composed by 3 vertices)
-        static const GLfloat cube[] =
+        constexpr std::array<GLfloat, 180> cube =
         {
             // positions    // texture coordinates
             -20, -20, -20,  0, 0,
@@ -173,8 +174,8 @@ int main()
         // Enable position and texture coordinates vertex components
         glEnableClientState(GL_VERTEX_ARRAY);
         glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-        glVertexPointer(3, GL_FLOAT, 5 * sizeof(GLfloat), cube);
-        glTexCoordPointer(2, GL_FLOAT, 5 * sizeof(GLfloat), cube + 3);
+        glVertexPointer(3, GL_FLOAT, 5 * sizeof(GLfloat), cube.data());
+        glTexCoordPointer(2, GL_FLOAT, 5 * sizeof(GLfloat), cube.data() + 3);
 
         // Disable normal and color vertex components
         glDisableClientState(GL_NORMAL_ARRAY);

--- a/examples/shader/CMakeLists.txt
+++ b/examples/shader/CMakeLists.txt
@@ -1,10 +1,6 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/shader)
-
 # all source files
-set(SRC
-    ${SRCROOT}/Effect.hpp
-    ${SRCROOT}/Shader.cpp)
+set(SRC Effect.hpp
+        Shader.cpp)
 
 # define the shader target
 sfml_add_example(shader GUI_APP

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -4,8 +4,14 @@
 ////////////////////////////////////////////////////////////
 #include "Effect.hpp"
 #include <array>
-#include <cmath>
+#include <random>
 
+
+namespace
+{
+    std::random_device rd;
+    std::mt19937 rng(rd());
+}
 
 const sf::Font* Effect::s_font = nullptr;
 
@@ -135,15 +141,19 @@ public:
 
     bool onLoad() override
     {
+        std::uniform_real_distribution<float> x_distribution(0, 800);
+        std::uniform_real_distribution<float> y_distribution(0, 600);
+        std::uniform_int_distribution<sf::Uint16> color_distribution(0, 255);
+
         // Create the points
         m_points.setPrimitiveType(sf::Points);
         for (int i = 0; i < 40000; ++i)
         {
-            auto x = static_cast<float>(std::rand() % 800);
-            auto y = static_cast<float>(std::rand() % 600);
-            auto r = static_cast<sf::Uint8>(std::rand() % 255);
-            auto g = static_cast<sf::Uint8>(std::rand() % 255);
-            auto b = static_cast<sf::Uint8>(std::rand() % 255);
+            auto x = x_distribution(rng);
+            auto y = y_distribution(rng);
+            auto r = static_cast<sf::Uint8>(color_distribution(rng));
+            auto g = static_cast<sf::Uint8>(color_distribution(rng));
+            auto b = static_cast<sf::Uint8>(color_distribution(rng));
             m_points.append(sf::Vertex(sf::Vector2f(x, y), sf::Color(r, g, b)));
         }
 

--- a/examples/sockets/CMakeLists.txt
+++ b/examples/sockets/CMakeLists.txt
@@ -1,10 +1,7 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sockets)
-
 # all source files
-set(SRC ${SRCROOT}/Sockets.cpp
-        ${SRCROOT}/TCP.cpp
-        ${SRCROOT}/UDP.cpp)
+set(SRC Sockets.cpp
+        TCP.cpp
+        UDP.cpp)
 
 # define the sockets target
 sfml_add_example(sockets

--- a/examples/sound/CMakeLists.txt
+++ b/examples/sound/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sound)
-
 # all source files
-set(SRC ${SRCROOT}/Sound.cpp)
+set(SRC Sound.cpp)
 
 # define the sound target
 sfml_add_example(sound

--- a/examples/sound_capture/CMakeLists.txt
+++ b/examples/sound_capture/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/sound_capture)
-
 # all source files
-set(SRC ${SRCROOT}/SoundCapture.cpp)
+set(SRC SoundCapture.cpp)
 
 # define the sound-capture target
 sfml_add_example(sound-capture

--- a/examples/tennis/CMakeLists.txt
+++ b/examples/tennis/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/tennis)
-
 # all source files
-set(SRC ${SRCROOT}/Tennis.cpp)
+set(SRC Tennis.cpp)
 if (SFML_OS_IOS)
     set(RESOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/resources/ball.wav

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -4,9 +4,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics.hpp>
 #include <SFML/Audio.hpp>
-#include <cmath>
-#include <ctime>
-#include <cstdlib>
+#include <random>
 
 #ifdef SFML_SYSTEM_IOS
 #include <SFML/Main.hpp>
@@ -29,7 +27,8 @@ std::filesystem::path resourcesDir()
 ////////////////////////////////////////////////////////////
 int main()
 {
-    std::srand(static_cast<unsigned int>(std::time(nullptr)));
+    std::random_device rd;
+    std::mt19937 rng(rd());
 
     // Define some constants
     const float gameWidth = 800;
@@ -140,7 +139,7 @@ int main()
                     do
                     {
                         // Make sure the ball initial angle is not too much vertical
-                        ballAngle = sf::degrees(static_cast<float>(std::rand() % 360));
+                        ballAngle = sf::degrees(std::uniform_real_distribution<float>(0, 360)(rng));
                     }
                     while (std::abs(std::cos(ballAngle.asRadians())) < 0.7f);
                 }
@@ -231,6 +230,8 @@ int main()
                 ball.setPosition({ball.getPosition().x, gameHeight - ballRadius - 0.1f});
             }
 
+            std::uniform_real_distribution<float> dist(0, 20);
+
             // Check the collisions between the ball and the paddles
             // Left Paddle
             if (ball.getPosition().x - ballRadius < leftPaddle.getPosition().x + paddleSize.x / 2 &&
@@ -239,9 +240,9 @@ int main()
                 ball.getPosition().y - ballRadius <= leftPaddle.getPosition().y + paddleSize.y / 2)
             {
                 if (ball.getPosition().y > leftPaddle.getPosition().y)
-                    ballAngle = sf::degrees(180) - ballAngle + sf::degrees(static_cast<float>(std::rand() % 20));
+                    ballAngle = sf::degrees(180) - ballAngle + sf::degrees(dist(rng));
                 else
-                    ballAngle = sf::degrees(180) - ballAngle - sf::degrees(static_cast<float>(std::rand() % 20));
+                    ballAngle = sf::degrees(180) - ballAngle - sf::degrees(dist(rng));
 
                 ballSound.play();
                 ball.setPosition({leftPaddle.getPosition().x + ballRadius + paddleSize.x / 2 + 0.1f, ball.getPosition().y});
@@ -254,9 +255,9 @@ int main()
                 ball.getPosition().y - ballRadius <= rightPaddle.getPosition().y + paddleSize.y / 2)
             {
                 if (ball.getPosition().y > rightPaddle.getPosition().y)
-                    ballAngle = sf::degrees(180) - ballAngle + sf::degrees(static_cast<float>(std::rand() % 20));
+                    ballAngle = sf::degrees(180) - ballAngle + sf::degrees(dist(rng));
                 else
-                    ballAngle = sf::degrees(180) - ballAngle - sf::degrees(static_cast<float>(std::rand() % 20));
+                    ballAngle = sf::degrees(180) - ballAngle - sf::degrees(dist(rng));
 
                 ballSound.play();
                 ball.setPosition({rightPaddle.getPosition().x - ballRadius - paddleSize.x / 2 - 0.1f, ball.getPosition().y});

--- a/examples/voip/CMakeLists.txt
+++ b/examples/voip/CMakeLists.txt
@@ -1,10 +1,7 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/voip)
-
 # all source files
-set(SRC ${SRCROOT}/VoIP.cpp
-        ${SRCROOT}/Client.cpp
-        ${SRCROOT}/Server.cpp)
+set(SRC VoIP.cpp
+        Client.cpp
+        Server.cpp)
 
 # define the voip target
 sfml_add_example(voip

--- a/examples/vulkan/CMakeLists.txt
+++ b/examples/vulkan/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/vulkan)
-
 # all source files
-set(SRC ${SRCROOT}/Vulkan.cpp)
+set(SRC Vulkan.cpp)
 
 # define the window target
 sfml_add_example(vulkan GUI_APP

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -9,6 +9,7 @@
 #include <SFML/Graphics.hpp>
 
 #include <SFML/Window.hpp>
+#include <array>
 #include <iostream>
 #include <limits>
 #include <vector>
@@ -1370,7 +1371,7 @@ public:
     // Create our vertex buffer and upload its data
     void setupVertexBuffer()
     {
-        float vertexData[] = {
+        constexpr std::array vertexData = {
             // X      Y      Z     R     G     B     A     U     V
             -0.5f, -0.5f,  0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f,
              0.5f, -0.5f,  0.5f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
@@ -1432,7 +1433,7 @@ public:
         }
 
         // Copy the vertex data into the buffer
-        std::memcpy(ptr, vertexData, sizeof(vertexData));
+        std::memcpy(ptr, vertexData.data(), sizeof(vertexData));
 
         // Unmap the buffer
         vkUnmapMemory(device, stagingBufferMemory);
@@ -1464,7 +1465,7 @@ public:
     // Create our index buffer and upload its data
     void setupIndexBuffer()
     {
-        uint16_t indexData[] = {
+        constexpr std::array<std::uint16_t, 36> indexData = {
             0,  1,  2,
             2,  3,  0,
 
@@ -1513,7 +1514,7 @@ public:
         }
 
         // Copy the index data into the buffer
-        std::memcpy(ptr, indexData, sizeof(indexData));
+        std::memcpy(ptr, indexData.data(), sizeof(indexData));
 
         // Unmap the buffer
         vkUnmapMemory(device, stagingBufferMemory);

--- a/examples/win32/CMakeLists.txt
+++ b/examples/win32/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/win32)
-
 # all source files
-set(SRC ${SRCROOT}/Win32.cpp)
+set(SRC Win32.cpp)
 
 # define the win32 target
 sfml_add_example(win32 GUI_APP

--- a/examples/window/CMakeLists.txt
+++ b/examples/window/CMakeLists.txt
@@ -1,8 +1,5 @@
-
-set(SRCROOT ${PROJECT_SOURCE_DIR}/examples/window)
-
 # all source files
-set(SRC ${SRCROOT}/Window.cpp)
+set(SRC Window.cpp)
 
 # define the window target
 sfml_add_example(window GUI_APP

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -11,6 +11,7 @@
 #include <SFML/Main.hpp>
 #endif
 
+#include <array>
 #include <iostream>
 #include <cstdlib>
 
@@ -73,7 +74,7 @@ int main()
 #endif
 
     // Define a 3D cube (6 faces made of 2 triangles composed by 3 vertices)
-    GLfloat cube[] =
+    constexpr std::array<GLfloat, 252> cube =
     {
         // positions    // colors (r, g, b, a)
         -50, -50, -50,  0, 0, 1, 1,
@@ -122,8 +123,8 @@ int main()
     // Enable position and color vertex components
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_COLOR_ARRAY);
-    glVertexPointer(3, GL_FLOAT, 7 * sizeof(GLfloat), cube);
-    glColorPointer(4, GL_FLOAT, 7 * sizeof(GLfloat), cube + 3);
+    glVertexPointer(3, GL_FLOAT, 7 * sizeof(GLfloat), cube.data());
+    glColorPointer(4, GL_FLOAT, 7 * sizeof(GLfloat), cube.data() + 3);
 
     // Disable normal and texture coordinates vertex components
     glDisableClientState(GL_NORMAL_ARRAY);


### PR DESCRIPTION
## Description

Chipping away at some of the C++17 items mentioned [here](https://github.com/SFML/SFML/wiki/SD%3A-CPP-17-Support#filesystem-api). I also found an easy way to simplify the CMake code for all the examples that should help improve readability and maintainability.

I ran the Tennis, Island, and Shader examples on macOS and could not observe any different behavior.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
