### PR TITLE
Fix corelation between text setOutlineThickness() and getLocalBounds()

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -500,19 +500,8 @@ void Text::ensureGeometryUpdate() const
         {
             const Glyph& glyph = m_font->getGlyph(curChar, m_characterSize, isBold, m_outlineThickness);
 
-            float left   = glyph.bounds.left;
-            float top    = glyph.bounds.top;
-            float right  = glyph.bounds.left + glyph.bounds.width;
-            float bottom = glyph.bounds.top  + glyph.bounds.height;
-
             // Add the outline glyph to the vertices
             addGlyphQuad(m_outlineVertices, Vector2f(x, y), m_outlineColor, glyph, italicShear);
-
-            // Update the current bounds with the outlined glyph bounds
-            minX = std::min(minX, x + left   - italicShear * bottom);
-            maxX = std::max(maxX, x + right  - italicShear * top);
-            minY = std::min(minY, y + top);
-            maxY = std::max(maxY, y + bottom);
         }
 
         // Extract the current glyph's description
@@ -521,22 +510,29 @@ void Text::ensureGeometryUpdate() const
         // Add the glyph to the vertices
         addGlyphQuad(m_vertices, Vector2f(x, y), m_fillColor, glyph, italicShear);
 
-        // Update the current bounds with the non outlined glyph bounds
-        if (m_outlineThickness == 0)
-        {
-            float left   = glyph.bounds.left;
-            float top    = glyph.bounds.top;
-            float right  = glyph.bounds.left + glyph.bounds.width;
-            float bottom = glyph.bounds.top  + glyph.bounds.height;
+        // Update the current bounds
+        float left   = glyph.bounds.left;
+        float top    = glyph.bounds.top;
+        float right  = glyph.bounds.left + glyph.bounds.width;
+        float bottom = glyph.bounds.top + glyph.bounds.height;
 
-            minX = std::min(minX, x + left  - italicShear * bottom);
-            maxX = std::max(maxX, x + right - italicShear * top);
-            minY = std::min(minY, y + top);
-            maxY = std::max(maxY, y + bottom);
-        }
+        minX = std::min(minX, x + left - italicShear * bottom);
+        maxX = std::max(maxX, x + right - italicShear * top);
+        minY = std::min(minY, y + top);
+        maxY = std::max(maxY, y + bottom);
 
         // Advance to the next character
         x += glyph.advance + letterSpacing;
+    }
+
+    // If we're using outline, update the current bounds
+    if (m_outlineThickness != 0)
+    {
+        float outline = std::abs(std::ceil(m_outlineThickness));
+        minX -= outline;
+        maxX += outline;
+        minY -= outline;
+        maxY += outline;
     }
 
     // If we're using the underlined style, add the last line


### PR DESCRIPTION
This fixes text crawling explained in issue [#2129](https://github.com/SFML/SFML/issues/2129)

Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [X] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [X] Have you provided some example/test code for your changes?

----

## Description

Please describe your pull request.

This PR is related to the issue [#2129](https://github.com/SFML/SFML/issues/2129)

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Example code provided in the issue linked above