### PR TITLE
Clarify Image::copy implementation

### DIFF
--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -317,16 +317,16 @@ private:
 ///
 /// // Create a 20x20 image filled with black color
 /// sf::Image image;
-/// image.create(20, 20, sf::Color::Black);
+/// image.create({20, 20}, sf::Color::Black);
 ///
-/// // Copy image1 on image2 at position (10, 10)
-/// if (!image.copy(background, 10, 10))
+/// // Copy background on image at position (10, 10)
+/// if (!image.copy(background, {10, 10}))
 ///     return -1;
 ///
 /// // Make the top-left pixel transparent
-/// sf::Color color = image.getPixel(0, 0);
+/// sf::Color color = image.getPixel({0, 0});
 /// color.a = 0;
-/// image.setPixel(0, 0, color);
+/// image.setPixel({0, 0}, color);
 ///
 /// // Save the image to a file
 /// if (!image.saveToFile("result.png"))

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -199,7 +199,7 @@ public:
     /// Note that this function can fail if either image is invalid
     /// (i.e. zero-sized width or height), or if \a sourceRect is
     /// not within the boundaries of the \a source parameter, or
-    /// if the destination area is invalid (i.e. negative coordinates).
+    /// if the destination area is out of the boundaries of this image.
     ///
     /// On failure, the destination image is left unchanged.
     ///


### PR DESCRIPTION
## Description

As discussed in the recent `sf::Image` PR https://github.com/SFML/SFML/pull/2117#pullrequestreview-1014201329, I thought the `Image::copy` implementation was at least confusing if not buggy, so here is I hope a cleaner version.

@Bambo-Borris @vittorioromeo What do you think?

## How to test this PR?

- Unit tests on CI
