### PR TITLE
Replace 'TcpSocket::send' local buffer with data member

### DIFF
--- a/include/SFML/Network/TcpSocket.hpp
+++ b/include/SFML/Network/TcpSocket.hpp
@@ -228,7 +228,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    PendingPacket m_pendingPacket; //!< Temporary data of the packet currently being received
+    PendingPacket     m_pendingPacket;     //!< Temporary data of the packet currently being received
+    std::vector<char> m_blockToSendBuffer; //!< Buffer used to prepare data being sent from the socket
 };
 
 } // namespace sf

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -324,15 +324,15 @@ Socket::Status TcpSocket::send(Packet& packet)
     Uint32 packetSize = htonl(static_cast<Uint32>(size));
 
     // Allocate memory for the data block to send
-    std::vector<char> blockToSend(sizeof(packetSize) + size);
+    m_blockToSendBuffer.resize(sizeof(packetSize) + size);
 
     // Copy the packet size and data into the block to send
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wnull-dereference" // False positive.
-    std::memcpy(blockToSend.data(), &packetSize, sizeof(packetSize));
+    std::memcpy(m_blockToSendBuffer.data(), &packetSize, sizeof(packetSize));
     #pragma GCC diagnostic pop
     if (size > 0)
-        std::memcpy(blockToSend.data() + sizeof(packetSize), data, size);
+        std::memcpy(m_blockToSendBuffer.data() + sizeof(packetSize), data, size);
 
     // These warnings are ignored here for portability, as even on Windows the
     // signature of `send` might change depending on whether Win32 or MinGW is
@@ -343,7 +343,7 @@ Socket::Status TcpSocket::send(Packet& packet)
     #pragma GCC diagnostic ignored "-Wsign-conversion"
     // Send the data block
     std::size_t sent;
-    Status status = send(blockToSend.data() + packet.m_sendPos, static_cast<priv::SocketImpl::Size>(blockToSend.size() - packet.m_sendPos), sent);
+    Status status = send(m_blockToSendBuffer.data() + packet.m_sendPos, static_cast<priv::SocketImpl::Size>(m_blockToSendBuffer.size() - packet.m_sendPos), sent);
     #pragma GCC diagnostic pop
     #pragma GCC diagnostic pop
 


### PR DESCRIPTION
As the title says, this PR replaces a local `blockToSend` variable that resulted in a dynamic memory allocation on every call to `sf::TcpSocket::send` with a data member that can be reused between multiple calls. It aims to be a run-time performance optimization and to reduce the number of dynamic allocations.

**This PR is untested.** I would like to hear some thoughts on the change, and want to know if I am missing something *(is there a reason why it was not a data member before?)* and the best way to test it.

The only possible case where this change might break something is if `sf::TcpSocket::send` is meant to be concurrently called by multiple threads at the same time. Is that our expectation for this API? Seems unlikely...