### PR TITLE
Fix incorrect cast when parsing FTP connection port

### DIFF
--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -558,7 +558,7 @@ Ftp::Response Ftp::DataChannel::open(Ftp::TransferMode mode)
             }
 
             // Reconstruct connection port and address
-            unsigned short port = static_cast<Uint8>(data[4] * 256) + data[5];
+            unsigned short port = static_cast<Uint16>(data[4] * 256 + data[5]);
             IpAddress address(data[0],
                               data[1],
                               data[2],


### PR DESCRIPTION
## Description

This commit fixes a regression introduced in eb19331e52e8165d0b1ae83c070b94827b8bd7ad as part of PR #1846.

## How to test this PR?

- Start a local FTP server. I used [pyftpdlib](https://pypi.org/project/pyftpdlib/).
  ```bash
  pip3 install --user pyftpdlib
  python3 -m pyftpdlib -u user -P pass
   ```
- Edit SFML's example program `ftp` to use port 2121 (pyftpdlib's default port).
  Note I am not using port 21 to avoid having to run the server as root.
  ```diff
  diff --git a/examples/ftp/Ftp.cpp b/examples/ftp/Ftp.cpp
  index e4de8adc..469937a9 100644
  --- a/examples/ftp/Ftp.cpp
  +++ b/examples/ftp/Ftp.cpp
  @@ -36,7 +36,7 @@ int main()
 
       // Connect to the server
       sf::Ftp server;
  -    sf::Ftp::Response connectResponse = server.connect(address);
  +    sf::Ftp::Response connectResponse = server.connect(address, 2121);
       std::cout << connectResponse << std::endl;
       if (!connectResponse.isOk())
           return EXIT_FAILURE;
  ```
- Compile and run SFML's example program `ftp`.

Without the patch, the example program cannot gather the content of the server's working directory.
With the patch, it can :)
