### PR TITLE
Remove unused `<string>` include from `Texture.hpp`

### DIFF
--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -32,7 +32,6 @@
 #include <SFML/Window/GlResource.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <filesystem>
-#include <string>
 
 
 namespace sf


### PR DESCRIPTION
Self-explanatory.