### PR TITLE
Improve test coverage of existing tests

### DIFF
--- a/test/Graphics/Color.cpp
+++ b/test/Graphics/Color.cpp
@@ -9,95 +9,145 @@ TEST_CASE("sf::Color class - [graphics]")
     {
         SUBCASE("Default constructor")
         {
-            sf::Color c;
-            CHECK(c.r == 0);
-            CHECK(c.g == 0);
-            CHECK(c.b == 0);
-            CHECK(c.a == 255);
+            const sf::Color color;
+            CHECK(color.r == 0);
+            CHECK(color.g == 0);
+            CHECK(color.b == 0);
+            CHECK(color.a == 255);
         }
 
         SUBCASE("(r, g, b) constructor")
         {
-            sf::Color c(1, 2, 3);
-            CHECK(c.r == 1);
-            CHECK(c.g == 2);
-            CHECK(c.b == 3);
-            CHECK(c.a == 255);
+            const sf::Color color(1, 2, 3);
+            CHECK(color.r == 1);
+            CHECK(color.g == 2);
+            CHECK(color.b == 3);
+            CHECK(color.a == 255);
         }
 
         SUBCASE("(r, g, b, a) constructor")
         {
-            sf::Color c(1, 2, 3, 4);
-            CHECK(c.r == 1);
-            CHECK(c.g == 2);
-            CHECK(c.b == 3);
-            CHECK(c.a == 4);
+            const sf::Color color(1, 2, 3, 4);
+            CHECK(color.r == 1);
+            CHECK(color.g == 2);
+            CHECK(color.b == 3);
+            CHECK(color.a == 4);
+        }
+
+        SUBCASE("Int32 constructor")
+        {
+            CHECK(sf::Color(0x00000000) == sf::Color(0, 0, 0, 0));
+            CHECK(sf::Color(0x01020304) == sf::Color(1, 2, 3, 4));
+            CHECK(sf::Color(0xFFFFFFFF) == sf::Color(255, 255, 255, 255));
         }
     }
 
-    SUBCASE("Integer conversions")
+    SUBCASE("toInteger()")
     {
-        sf::Color c(1, 2, 3, 4);
-        sf::Uint32 cInt = c.toInteger();
-
-        sf::Color c2(cInt);
-        CHECK(c2.r == 1);
-        CHECK(c2.g == 2);
-        CHECK(c2.b == 3);
-        CHECK(c2.a == 4);
-    }
-
-    SUBCASE("Comparisons")
-    {
-        sf::Color c(1, 2, 3, 4);
-
-        CHECK(c == c);
-        CHECK(!(c != c));
-
-        sf::Color c2(4, 3, 2, 1);
-
-        CHECK(c2 != c);
-        CHECK(!(c2 == c));
+        CHECK(sf::Color(0, 0, 0, 0).toInteger() == 0x00000000);
+        CHECK(sf::Color(1, 2, 3, 4).toInteger() == 0x01020304);
+        CHECK(sf::Color(255, 255, 255, 255).toInteger() == 0xFFFFFFFF);
     }
 
     SUBCASE("Operations")
     {
-        SUBCASE("Clamped addition")
+        SUBCASE("operator==")
         {
-            sf::Color c(50, 50, 50, 50);
-            CHECK(c + c == sf::Color(100, 100, 100, 100));
+            CHECK(sf::Color() == sf::Color());
+            CHECK(sf::Color(1, 2, 3, 4) == sf::Color(1, 2, 3, 4));
 
-            sf::Color c2(150, 150, 150, 150);
-            CHECK(c2 + c2 == sf::Color(255, 255, 255, 255));
+            CHECK_FALSE(sf::Color(1, 0, 0, 0) == sf::Color(0, 0, 0, 0));
+            CHECK_FALSE(sf::Color(0, 1, 0, 0) == sf::Color(0, 0, 0, 0));
+            CHECK_FALSE(sf::Color(0, 0, 1, 0) == sf::Color(0, 0, 0, 0));
+            CHECK_FALSE(sf::Color(0, 0, 0, 1) == sf::Color(0, 0, 0, 0));
         }
 
-        SUBCASE("Clamped subtraction")
+        SUBCASE("operator!=")
         {
-            sf::Color c(50, 50, 50, 50);
-            sf::Color c2(150, 150, 150, 150);
+            CHECK(sf::Color(1, 0, 0, 0) != sf::Color(0, 0, 0, 0));
+            CHECK(sf::Color(0, 1, 0, 0) != sf::Color(0, 0, 0, 0));
+            CHECK(sf::Color(0, 0, 1, 0) != sf::Color(0, 0, 0, 0));
+            CHECK(sf::Color(0, 0, 0, 1) != sf::Color(0, 0, 0, 0));
 
+            CHECK_FALSE(sf::Color() != sf::Color());
+            CHECK_FALSE(sf::Color(1, 2, 3, 4) != sf::Color(1, 2, 3, 4));
+        }
+
+        SUBCASE("operator+")
+        {
+            CHECK(sf::Color(0, 0, 0, 0) + sf::Color(0, 0, 0, 0) == sf::Color(0, 0, 0, 0));
+            CHECK(sf::Color(50, 50, 50, 50) + sf::Color(50, 50, 50, 50) == sf::Color(100, 100, 100, 100));
+            CHECK(sf::Color(100, 100, 100, 100) + sf::Color(100, 100, 100, 100) == sf::Color(200, 200, 200, 200));
+            CHECK(sf::Color(150, 150, 150, 150) + sf::Color(150, 150, 150, 150) == sf::Color(255, 255, 255, 255));
+            CHECK(sf::Color(255, 255, 255, 255) + sf::Color(255, 255, 255, 255) == sf::Color(255, 255, 255, 255));
+        }
+
+        SUBCASE("operator-")
+        {
+            const sf::Color c(50, 50, 50, 50);
+            const sf::Color c2(150, 150, 150, 150);
             CHECK(c2 - c == sf::Color(100, 100, 100, 100));
             CHECK(c - c2 == sf::Color(0, 0, 0, 0));
         }
 
-        SUBCASE("Modulation")
+        SUBCASE("operator*")
         {
-            sf::Color c(255, 255, 255, 255);
-            sf::Color c2(2, 2, 2, 2);
+            const sf::Color c(255, 255, 255, 255);
+            const sf::Color c2(2, 2, 2, 2);
             CHECK(c * c2 == sf::Color(2, 2, 2, 2));
             CHECK(c2 * c == sf::Color(2, 2, 2, 2));
         }
+
+        SUBCASE("operator+=")
+        {
+            sf::Color color(42, 42, 42, 42);
+            color += sf::Color(1, 1, 1, 1);
+            CHECK(color == sf::Color(43, 43, 43, 43));
+            color += sf::Color(250, 250, 250, 250);
+            CHECK(color == sf::Color(255, 255, 255, 255));
+        }
+
+        SUBCASE("operator-=")
+        {
+            sf::Color color(248, 248, 248, 248);
+            color -= sf::Color(1, 1, 1, 1);
+            CHECK(color == sf::Color(247, 247, 247, 247));
+            color -= sf::Color(250, 250, 250, 250);
+            CHECK(color == sf::Color(0, 0, 0, 0));
+        }
+
+        SUBCASE("operator*=")
+        {
+            sf::Color color(50, 50, 50, 50);
+            color *= sf::Color(20, 20, 20, 20);
+            CHECK(color == sf::Color(3, 3, 3, 3));
+            color *= sf::Color(120, 120, 120, 120);
+            CHECK(color == sf::Color(1, 1, 1, 1));
+        }
+    }
+
+    SUBCASE("Constants")
+    {
+        CHECK(sf::Color::Black == sf::Color(0, 0, 0));
+        CHECK(sf::Color::White == sf::Color(255, 255, 255));
+        CHECK(sf::Color::Red == sf::Color(255, 0, 0));
+        CHECK(sf::Color::Green == sf::Color(0, 255, 0));
+        CHECK(sf::Color::Blue == sf::Color(0, 0, 255));
+        CHECK(sf::Color::Yellow == sf::Color(255, 255, 0));
+        CHECK(sf::Color::Magenta == sf::Color(255, 0, 255));
+        CHECK(sf::Color::Cyan == sf::Color(0, 255, 255));
+        CHECK(sf::Color::Transparent == sf::Color(0, 0, 0, 0));
     }
 
     SUBCASE("Constexpr support")
     {
-        constexpr sf::Color c(1, 2, 3, 4);
-        static_assert(c.r == 1);
-        static_assert(c.g == 2);
-        static_assert(c.b == 3);
-        static_assert(c.a == 4);
+        constexpr sf::Color color(1, 2, 3, 4);
+        static_assert(color.r == 1);
+        static_assert(color.g == 2);
+        static_assert(color.b == 3);
+        static_assert(color.a == 4);
 
-        static_assert(c + c == sf::Color(2, 4, 6, 8));
+        static_assert(color + color == sf::Color(2, 4, 6, 8));
 
         static_assert(sf::Color::Black == sf::Color(0, 0, 0, 255));
     }

--- a/test/Graphics/Rect.cpp
+++ b/test/Graphics/Rect.cpp
@@ -50,24 +50,21 @@ TEST_CASE("sf::Rect class template - [graphics]")
         }
     }
 
-    SUBCASE("Containment")
+    SUBCASE("contains(Vector2)")
     {
-        SUBCASE("contains(Vector2)")
-        {
-            sf::IntRect rectangle({0, 0}, {10, 10});
+        sf::IntRect rectangle({0, 0}, {10, 10});
 
-            CHECK(rectangle.contains(sf::Vector2i(0, 0)) == true);
-            CHECK(rectangle.contains(sf::Vector2i(9, 0)) == true);
-            CHECK(rectangle.contains(sf::Vector2i(0, 9)) == true);
-            CHECK(rectangle.contains(sf::Vector2i(9, 9)) == true);
-            CHECK(rectangle.contains(sf::Vector2i(9, 10)) == false);
-            CHECK(rectangle.contains(sf::Vector2i(10, 9)) == false);
-            CHECK(rectangle.contains(sf::Vector2i(10, 10)) == false);
-            CHECK(rectangle.contains(sf::Vector2i(15, 15)) == false);
-        }
+        CHECK(rectangle.contains(sf::Vector2i(0, 0)) == true);
+        CHECK(rectangle.contains(sf::Vector2i(9, 0)) == true);
+        CHECK(rectangle.contains(sf::Vector2i(0, 9)) == true);
+        CHECK(rectangle.contains(sf::Vector2i(9, 9)) == true);
+        CHECK(rectangle.contains(sf::Vector2i(9, 10)) == false);
+        CHECK(rectangle.contains(sf::Vector2i(10, 9)) == false);
+        CHECK(rectangle.contains(sf::Vector2i(10, 10)) == false);
+        CHECK(rectangle.contains(sf::Vector2i(15, 15)) == false);
     }
 
-    SUBCASE("Intersection")
+    SUBCASE("findIntersection()")
     {
         const sf::IntRect rectangle({0, 0}, {10, 10});
         const sf::IntRect intersectingRectangle({5, 5}, {10, 10});
@@ -84,13 +81,40 @@ TEST_CASE("sf::Rect class template - [graphics]")
         CHECK_FALSE(rectangle.findIntersection(nonIntersectingRectangle));
     }
 
-    SUBCASE("Comparison operations")
+    SUBCASE("getPosition()")
     {
-        sf::IntRect firstRectangle({1, 3}, {2, 5});
-        sf::IntRect secondRectangle({1, 3}, {2, 5});
-        sf::IntRect differentRectangle({3, 1}, {5, 2});
+        CHECK(sf::IntRect({}, {}).getPosition() == sf::Vector2i());
+        CHECK(sf::IntRect({1, 2}, {3, 4}).getPosition() == sf::Vector2i(1, 2));
+    }
 
-        CHECK(firstRectangle == secondRectangle);
-        CHECK(firstRectangle != differentRectangle);
+    SUBCASE("getSize()")
+    {
+        CHECK(sf::IntRect({}, {}).getSize() == sf::Vector2i());
+        CHECK(sf::IntRect({1, 2}, {3, 4}).getSize() == sf::Vector2i(3, 4));
+    }
+
+    SUBCASE("Operators")
+    {
+        SUBCASE("operator==")
+        {
+            CHECK(sf::IntRect() == sf::IntRect());
+            CHECK(sf::IntRect({1, 3}, {2, 5}) == sf::IntRect({1, 3}, {2, 5}));
+
+            CHECK_FALSE(sf::IntRect({1, 0}, {0, 0}) == sf::IntRect({0, 0}, {0, 0}));
+            CHECK_FALSE(sf::IntRect({0, 1}, {0, 0}) == sf::IntRect({0, 0}, {0, 0}));
+            CHECK_FALSE(sf::IntRect({0, 0}, {1, 0}) == sf::IntRect({0, 0}, {0, 0}));
+            CHECK_FALSE(sf::IntRect({0, 0}, {0, 1}) == sf::IntRect({0, 0}, {0, 0}));
+        }
+
+        SUBCASE("operator!=")
+        {
+            CHECK(sf::IntRect({1, 0}, {0, 0}) != sf::IntRect({0, 0}, {0, 0}));
+            CHECK(sf::IntRect({0, 1}, {0, 0}) != sf::IntRect({0, 0}, {0, 0}));
+            CHECK(sf::IntRect({0, 0}, {1, 0}) != sf::IntRect({0, 0}, {0, 0}));
+            CHECK(sf::IntRect({0, 0}, {0, 1}) != sf::IntRect({0, 0}, {0, 0}));
+
+            CHECK_FALSE(sf::IntRect() != sf::IntRect());
+            CHECK_FALSE(sf::IntRect({1, 3}, {2, 5}) != sf::IntRect({1, 3}, {2, 5}));
+        }
     }
 }


### PR DESCRIPTION
## Description

I noticed that a few types had near-100% coverage so this PRs gets those types up to 100% coverage. In some cases it required modest changes to the underlying implementation. 

In the case of
```cpp
if (condition)
{
    return x;
} // Reported as untested code
else
{
    return y;
} 
```
the `else` is necessary and results in code coverage reporting an untested line so it's a win/win to transform it into
```cpp
if (condition)
{
    return x;
}

return y; 
```
which reports no untested code and is easier to read.
## Tasks

* [x] Tested on Linux
* [x]  Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
