### PR TITLE
Add tests for `sf::MemoryInputStream`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(SYSTEM_SRC
     System/Clock.cpp
     System/Err.cpp
     System/FileInputStream.cpp
+    System/MemoryInputStream.cpp
     System/Time.cpp
     System/Vector2.cpp
     System/Vector3.cpp

--- a/test/System/MemoryInputStream.cpp
+++ b/test/System/MemoryInputStream.cpp
@@ -1,0 +1,33 @@
+#include <SFML/System/MemoryInputStream.hpp>
+#include <string_view>
+#include <ostream>
+
+#include <doctest.h>
+
+TEST_CASE("sf::MemoryInputStream class - [system]")
+{
+    SUBCASE("Empty stream")
+    {
+        sf::MemoryInputStream mis;
+
+        CHECK(mis.read(nullptr, 0) == -1);
+        CHECK(mis.seek(0) == -1);
+        CHECK(mis.tell() == -1);
+        CHECK(mis.getSize() == -1);
+    }
+
+    SUBCASE("Open memory stream")
+    {
+        using namespace std::literals::string_view_literals;
+        constexpr auto memoryContents = "hello world"sv;
+        sf::MemoryInputStream mis;
+        mis.open(memoryContents.data(), sizeof(char) * memoryContents.size());
+
+        char buffer[32];
+        CHECK(mis.read(buffer, 5) == 5);
+        CHECK(std::string_view(buffer, 5) == std::string_view(memoryContents.data(), 5));
+        CHECK(mis.seek(10) == 10);
+        CHECK(mis.tell() == 10);
+        CHECK(mis.getSize() == 11);
+    }
+}


### PR DESCRIPTION
## Description

`sf::FileInputStream` tests were already covered but noticed `sf::MemoryInputStream` tests were missing. Hoping these tests provide adequate coverage. 

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?
CI runs the tests! 
