### PR TITLE
Reduce the scope of helper class

### DIFF
--- a/test/System/FileInputStream.cpp
+++ b/test/System/FileInputStream.cpp
@@ -1,9 +1,61 @@
 #include <SFML/System/FileInputStream.hpp>
-#include "SystemUtil.hpp"
+#include <cassert>
+#include <fstream>
+#include <sstream>
 #include <string_view>
 #include <utility>
 
 #include <doctest.h>
+    
+static std::string getTemporaryFilePath()
+{
+    static int counter = 0;
+
+    std::ostringstream oss;
+    oss << "sfmltemp" << counter << ".tmp";
+    ++counter;
+
+    std::filesystem::path result;
+    result /= std::filesystem::temp_directory_path();
+    result /= oss.str();
+
+    return result.string();
+}
+
+class TemporaryFile
+{
+private:
+    std::string m_path;
+
+public:
+    // Create a temporary file with a randomly generated path, containing 'contents'.
+    TemporaryFile(const std::string& contents)
+        : m_path(getTemporaryFilePath())
+    {
+        std::ofstream ofs(m_path);
+        assert(ofs);
+
+        ofs << contents;
+        assert(ofs);
+    }
+
+    // Close and delete the generated file.
+    ~TemporaryFile()
+    {
+        [[maybe_unused]] const bool removed = std::filesystem::remove(m_path);
+        assert(removed);
+    }
+
+    // Prevent copies.
+    TemporaryFile(const TemporaryFile&) = delete;
+    TemporaryFile& operator=(const TemporaryFile&) = delete;
+
+    // Return the randomly generated path.
+    const std::string& getPath() const
+    {
+        return m_path;
+    }
+};
 
 TEST_CASE("sf::FileInputStream class - [system]")
 {
@@ -20,7 +72,7 @@ TEST_CASE("sf::FileInputStream class - [system]")
     {
         const std::string fileContents = "hello world";
 
-        sf::Testing::TemporaryFile tmpFile(fileContents);
+        TemporaryFile tmpFile(fileContents);
         sf::FileInputStream fis;
 
         REQUIRE(fis.open(tmpFile.getPath()));

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -5,13 +5,6 @@
 #include <SFML/System/Time.hpp>
 
 #include <doctest.h> // for Approx
-#include <cassert>
-#include <filesystem>
-#include <fstream>
-#include <iomanip>
-#include <limits>
-#include <ostream>
-#include <sstream>
 
 namespace sf
 {
@@ -53,43 +46,4 @@ bool operator==(const sf::Vector3f& lhs, const Approx<sf::Vector3f>& rhs)
 bool operator==(const sf::Angle& lhs, const Approx<sf::Angle>& rhs)
 {
     return lhs.asDegrees() == Approx(rhs.value.asDegrees());
-}
-
-namespace sf::Testing
-{
-    static std::string getTemporaryFilePath()
-    {
-        static int counter = 0;
-
-        std::ostringstream oss;
-        oss << "sfmltemp" << counter << ".tmp";
-        ++counter;
-
-        std::filesystem::path result;
-        result /= std::filesystem::temp_directory_path();
-        result /= oss.str();
-
-        return result.string();
-    }
-
-    TemporaryFile::TemporaryFile(const std::string& contents)
-        : m_path(getTemporaryFilePath())
-    {
-        std::ofstream ofs(m_path);
-        assert(ofs);
-
-        ofs << contents;
-        assert(ofs);
-    }
-
-    TemporaryFile::~TemporaryFile()
-    {
-        [[maybe_unused]] const bool removed = std::filesystem::remove(m_path);
-        assert(removed);
-    }
-
-    const std::string& TemporaryFile::getPath() const
-    {
-        return m_path;
-    }
 }

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -12,8 +12,6 @@
 #include <iomanip>
 #include <limits>
 #include <ostream>
-#include <sstream>
-#include <string>
 
 // String conversions for doctest framework
 namespace sf
@@ -63,29 +61,6 @@ template <typename T>
 std::ostream& operator <<(std::ostream& os, const Approx<T>& approx)
 {
     return os << approx.value;
-}
-
-namespace sf::Testing
-{
-    class TemporaryFile
-    {
-    private:
-        std::string m_path;
-
-    public:
-        // Create a temporary file with a randomly generated path, containing 'contents'.
-        TemporaryFile(const std::string& contents);
-
-        // Close and delete the generated file.
-        ~TemporaryFile();
-
-        // Prevent copies.
-        TemporaryFile(const TemporaryFile&) = delete;
-        TemporaryFile& operator=(const TemporaryFile&) = delete;
-
-        // Return the randomly generated path.
-        const std::string& getPath() const;
-    };
 }
 
 #endif // SFML_TESTUTILITIES_SYSTEM_HPP


### PR DESCRIPTION
## Description

`TemporaryFile` is only used in 1 .cpp file so it doesn't need to be part of SystemUtil. This also let me remove a few headers from SystemUtil.hpp which should result in a modest compile time improvement. 

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
