### PR TITLE
Allow implicit construction of `sf::VideoMode`

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,7 +27,7 @@ Tell us how to reproduce this issue. Please provide a [minimal, complete and ver
 
 int main()
 {
-    sf::RenderWindow window(sf::VideoMode(1280, 720), "Minimal, complete and verifiable example");
+    sf::RenderWindow window({{1280, 720}}, "Minimal, complete and verifiable example");
     window.setFramerateLimit(60);
 
     while (window.isOpen())

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ Describe how to best test these changes. Please provide a [minimal, complete and
 
 int main()
 {
-    sf::RenderWindow window(sf::VideoMode(1280, 720), "Minimal, complete and verifiable example");
+    sf::RenderWindow window({{1280, 720}}, "Minimal, complete and verifiable example");
     window.setFramerateLimit(60);
 
     while (window.isOpen())

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -88,7 +88,7 @@ void generateTerrain(sf::Vertex* vertexBuffer);
 int main()
 {
     // Create the window of the application
-    sf::RenderWindow window(sf::VideoMode({windowWidth, windowHeight}), "SFML Island",
+    sf::RenderWindow window({{windowWidth, windowHeight}}, "SFML Island",
                             sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -88,7 +88,7 @@ namespace
 int main()
 {
     // Create the window of the application
-    sf::RenderWindow window(sf::VideoMode({400, 775}), "Joystick", sf::Style::Close);
+    sf::RenderWindow window({{400, 775}}, "Joystick", sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
     // Load the text font

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -46,7 +46,7 @@ int main()
         contextSettings.sRgbCapable = sRgb;
 
         // Create the main window
-        sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML graphics with OpenGL", sf::Style::Default, contextSettings);
+        sf::RenderWindow window({{800, 600}}, "SFML graphics with OpenGL", sf::Style::Default, contextSettings);
         window.setVerticalSyncEnabled(true);
 
         // Create a sprite for the background

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -362,7 +362,7 @@ private:
 int main()
 {
     // Create the main window
-    sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML Shader",
+    sf::RenderWindow window({{800, 600}}, "SFML Shader",
                             sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -37,7 +37,7 @@ int main()
     float ballRadius = 10.f;
 
     // Create the window of the application
-    sf::RenderWindow window(sf::VideoMode({static_cast<unsigned int>(gameWidth), static_cast<unsigned int>(gameHeight)}, 32), "SFML Tennis",
+    sf::RenderWindow window({{static_cast<unsigned int>(gameWidth), static_cast<unsigned int>(gameHeight)}, 32}, "SFML Tennis",
                             sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -28,7 +28,7 @@ int main()
     contextSettings.depthBits = 24;
 
     // Create the main window
-    sf::Window window(sf::VideoMode({640, 480}), "SFML window with OpenGL", sf::Style::Default, contextSettings);
+    sf::Window window({{640, 480}}, "SFML window with OpenGL", sf::Style::Default, contextSettings);
 
     // Make it the active window for OpenGL calls
     if (!window.setActive())

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -258,7 +258,7 @@ private:
 ///
 /// \code
 /// // Create a new render-window
-/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+/// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // Create a new render-texture
 /// sf::RenderTexture texture;

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -194,7 +194,7 @@ private:
 ///
 /// \code
 /// // Declare and create a new render-window
-/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+/// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // Limit the framerate to 60 frames per second (this step is optional)
 /// window.setFramerateLimit(60);
@@ -229,7 +229,7 @@ private:
 ///
 /// \code
 /// // Create the render window
-/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML OpenGL");
+/// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML OpenGL");
 ///
 /// // Create a sprite and a text to display
 /// sf::Sprite sprite;

--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -58,7 +58,7 @@ public:
     /// \param modeBitsPerPixel Pixel depths in bits per pixel
     ///
     ////////////////////////////////////////////////////////////
-    explicit VideoMode(const Vector2u& modeSize, unsigned int modeBitsPerPixel = 32);
+    VideoMode(const Vector2u& modeSize, unsigned int modeBitsPerPixel = 32);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current desktop video mode
@@ -221,7 +221,7 @@ SFML_WINDOW_API bool operator >=(const VideoMode& left, const VideoMode& right);
 ///
 /// // Create a window with the same pixel depth as the desktop
 /// sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
-/// window.create(sf::VideoMode(1024, 768, desktop.bitsPerPixel), "SFML window");
+/// window.create(sf::VideoMode({1024, 768}, desktop.bitsPerPixel), "SFML window");
 /// \endcode
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -327,7 +327,7 @@ private:
 /// Usage example:
 /// \code
 /// // Declare and create a new window
-/// sf::Window window(sf::VideoMode(800, 600), "SFML window");
+/// sf::Window window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // Limit the framerate to 60 frames per second (this step is optional)
 /// window.setFramerateLimit(60);

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -507,7 +507,7 @@ private:
 /// Usage example:
 /// \code
 /// // Declare and create a new window
-/// sf::WindowBase window(sf::VideoMode(800, 600), "SFML window");
+/// sf::WindowBase window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // The main loop - ends as soon as the window is closed
 /// while (window.isOpen())


### PR DESCRIPTION
## Description

In #2055 I marked `sf::VideoMode::VideoMode` as explicit because a 2 parameter constructor became a 1 parameter constructor and I blindly followed the "mark converting constructors as `explicit`" advice. We've since received feedback about how annoying this is. In hindsight this change isn't helpful and simply requires users write excessively verbose code so this PR rolls that back.

This PR also fixes a number of incorrect docs which still reference the old `float, float` constructor.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
