### PR TITLE
Fix compilation on Linux with SFML_OPENGL_ES option

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -91,18 +91,9 @@ if(SFML_OS_WINDOWS)
     # make sure that we use the Unicode version of the Win API functions
     add_definitions(-DUNICODE -D_UNICODE)
 elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
-    if(SFML_OPENGL_ES)
-        set(PLATFORM_SRC
-            ${PLATFORM_SRC}
-            ${SRCROOT}/EGLCheck.cpp
-            ${SRCROOT}/EGLCheck.hpp
-            ${SRCROOT}/EglContext.cpp
-            ${SRCROOT}/EglContext.hpp
-        )
-    elseif(SFML_USE_DRM)
+    if(SFML_USE_DRM)
         add_definitions(-DSFML_USE_DRM)
         set(PLATFORM_SRC
-            ${PLATFORM_SRC}
             ${SRCROOT}/EGLCheck.cpp
             ${SRCROOT}/EGLCheck.hpp
             ${SRCROOT}/DRM/CursorImpl.hpp
@@ -121,7 +112,6 @@ elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
         )
     else()
         set(PLATFORM_SRC
-            ${PLATFORM_SRC}
             ${SRCROOT}/Unix/CursorImpl.hpp
             ${SRCROOT}/Unix/CursorImpl.cpp
             ${SRCROOT}/Unix/ClipboardImpl.hpp
@@ -132,14 +122,27 @@ elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
             ${SRCROOT}/Unix/SensorImpl.hpp
             ${SRCROOT}/Unix/Display.cpp
             ${SRCROOT}/Unix/Display.hpp
-            ${SRCROOT}/Unix/GlxContext.cpp
-            ${SRCROOT}/Unix/GlxContext.hpp
             ${SRCROOT}/Unix/VideoModeImpl.cpp
             ${SRCROOT}/Unix/VulkanImplX11.cpp
             ${SRCROOT}/Unix/VulkanImplX11.hpp
             ${SRCROOT}/Unix/WindowImplX11.cpp
             ${SRCROOT}/Unix/WindowImplX11.hpp
         )
+        if(SFML_OPENGL_ES)
+            set(PLATFORM_SRC
+                ${PLATFORM_SRC}
+                ${SRCROOT}/EGLCheck.cpp
+                ${SRCROOT}/EGLCheck.hpp
+                ${SRCROOT}/EglContext.cpp
+                ${SRCROOT}/EglContext.hpp
+            )
+        else()
+             set(PLATFORM_SRC
+                ${PLATFORM_SRC}
+                ${SRCROOT}/Unix/GlxContext.cpp
+                ${SRCROOT}/Unix/GlxContext.hpp
+            )
+        endif()
     endif()
     if(SFML_OS_LINUX)
         set(PLATFORM_SRC

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -28,7 +28,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/DRM/DRMContext.hpp>
 #include <SFML/Window/DRM/WindowImplDRM.hpp>
-#include <SFML/OpenGL.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Sleep.hpp>
 #include <cerrno>

--- a/src/SFML/Window/DRM/DRMContext.hpp
+++ b/src/SFML/Window/DRM/DRMContext.hpp
@@ -33,7 +33,6 @@
 #include <SFML/Window/EGLCheck.hpp>
 #include <SFML/Window/GlContext.hpp>
 #include <SFML/Window/VideoMode.hpp>
-#include <SFML/OpenGL.hpp>
 #include <drm-common.h>
 #include <glad/egl.h>
 #include <gbm.h>

--- a/src/SFML/Window/EglContext.hpp
+++ b/src/SFML/Window/EglContext.hpp
@@ -36,6 +36,7 @@
 #include <glad/egl.h>
 #if defined(SFML_SYSTEM_LINUX) && !defined(SFML_USE_DRM)
     #include <X11/Xlib.h>
+    #include <X11/Xutil.h>
 #endif
 
 namespace sf

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -59,15 +59,15 @@
 
 #elif defined(SFML_SYSTEM_LINUX) || defined(SFML_SYSTEM_FREEBSD) || defined(SFML_SYSTEM_OPENBSD) || defined(SFML_SYSTEM_NETBSD)
 
-    #if defined(SFML_OPENGL_ES)
-
-        #include <SFML/Window/EglContext.hpp>
-        typedef sf::priv::EglContext ContextType;
-
-    #elif defined(SFML_USE_DRM)
+    #if defined(SFML_USE_DRM)
 
         #include <SFML/Window/DRM/DRMContext.hpp>
         typedef sf::priv::DRMContext ContextType;
+
+    #elif defined(SFML_OPENGL_ES)
+
+        #include <SFML/Window/EglContext.hpp>
+        typedef sf::priv::EglContext ContextType;
 
     #else
 


### PR DESCRIPTION
## Description

Last night in #2157, I introduced without realizing some nonsense in the Window/CMakeLists.txt file.
I hoped CI would catch this kind of mistakes but there is no check with SFML_OPENGL_ES option enabled.

This PR makes it possible to build SFML on Linux with any combination of SFML_USE_DRM and SFML_OPENGL_ES as it was before #2157.

## How to test this PR?

```
cmake -B build -DCMAKE_BUILD_TYPE=Debug -DWARNINGS_AS_ERRORS=False
cmake -B build -DSFML_USE_DRM=False -DSFML_OPENGL_ES=False && cmake --build build
cmake -B build -DSFML_USE_DRM=True  -DSFML_OPENGL_ES=False && cmake --build build
cmake -B build -DSFML_USE_DRM=False -DSFML_OPENGL_ES=True  && cmake --build build
cmake -B build -DSFML_USE_DRM=True  -DSFML_OPENGL_ES=True  && cmake --build build
```

I had to disable WARNINGS_AS_ERRORS because some OpenGL ES specific parts trigger warnings, but that is a different topic.

Tested on Ubuntu and Raspbian.