### PR TITLE
Add tests for SFML/Config.hpp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set_target_warnings(sfml-test-main)
 SET(SYSTEM_SRC
     System/Angle.cpp
     System/Clock.cpp
+    System/Config.cpp
     System/Err.cpp
     System/FileInputStream.cpp
     System/MemoryInputStream.cpp
@@ -32,6 +33,12 @@ SET(SYSTEM_SRC
     System/Vector3.cpp
 )
 sfml_add_test(test-sfml-system "${SYSTEM_SRC}" SFML::System)
+target_compile_definitions(test-sfml-system PRIVATE
+    EXPECTED_SFML_VERSION_MAJOR=${SFML_VERSION_MAJOR}
+    EXPECTED_SFML_VERSION_MINOR=${SFML_VERSION_MINOR}
+    EXPECTED_SFML_VERSION_PATCH=${SFML_VERSION_PATCH}
+    EXPECTED_SFML_VERSION_IS_RELEASE=$<IF:$<BOOL:${VERSION_IS_RELEASE}>,true,false>
+)
 
 SET(WINDOW_SRC
     Window/ContextSettings.cpp

--- a/test/System/Config.cpp
+++ b/test/System/Config.cpp
@@ -1,0 +1,29 @@
+#include <SFML/Config.hpp>
+
+#include <doctest/doctest.h>
+
+TEST_CASE("SFML/Config.hpp")
+{
+    SUBCASE("Version macros")
+    {
+        CHECK(SFML_VERSION_MAJOR == EXPECTED_SFML_VERSION_MAJOR);
+        CHECK(SFML_VERSION_MINOR == EXPECTED_SFML_VERSION_MINOR);
+        CHECK(SFML_VERSION_PATCH == EXPECTED_SFML_VERSION_PATCH);
+        CHECK(SFML_VERSION_IS_RELEASE == EXPECTED_SFML_VERSION_IS_RELEASE);
+    }
+
+    SUBCASE("Fixed width types")
+    {
+        CHECK(sizeof(sf::Int8) == 1);
+        CHECK(sizeof(sf::Uint8) == 1);
+
+        CHECK(sizeof(sf::Int16) == 2);
+        CHECK(sizeof(sf::Uint16) == 2);
+
+        CHECK(sizeof(sf::Int32) == 4);
+        CHECK(sizeof(sf::Uint32) == 4);
+
+        CHECK(sizeof(sf::Int64) == 8);
+        CHECK(sizeof(sf::Uint64) == 8);
+    }
+}


### PR DESCRIPTION
## Description

I just realized that there are some things in Config.hpp that can easily be tested. These are rather trivial tests but the more the merrier, right? It's easy to say "why bother testing this?" but it's hard to draw fine line between "too trivial to justify testing" and "complex enough to justify testing" so I'd rather we err on the side of testing all code which can be tested this easily. 

I tried to test more code in this header but most of it lives behind platform-specific preprocessor switches and I'm not sure how we'd test that without basically recreating the entire contents of the header in these tests.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
