### PR TITLE
Simplify how warnings are ignored on Apple platforms

### DIFF
--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -32,13 +32,7 @@
 #define GREEN @"Green"
 #define RED   @"Red"
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 // Our PIMPL
 struct SFMLmainWindow

--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -33,11 +33,7 @@
 #include <utility>
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace

--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -33,13 +33,8 @@
 #include <filesystem>
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 #include <al.h>
@@ -100,9 +95,5 @@ ALenum alGetLastErrorImpl();
 #endif // SFML_ALCHECK_HPP
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#endif
 #endif

--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -34,11 +34,7 @@
 #include <ostream>
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -36,11 +36,7 @@
 #include <ostream>
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace sf

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -30,11 +30,7 @@
 #include <SFML/Audio/SoundBuffer.hpp>
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace sf

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -38,11 +38,7 @@
 #include <ostream>
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace sf

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -40,11 +40,7 @@
 #endif
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -29,11 +29,7 @@
 #include <SFML/Audio/SoundSource.hpp>
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace sf

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -40,11 +40,7 @@
 #endif
 
 #if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 #endif
 
 namespace sf

--- a/src/SFML/Window/Android/SensorImpl.cpp
+++ b/src/SFML/Window/Android/SensorImpl.cpp
@@ -30,9 +30,7 @@
 
 #include <android/looper.h>
 
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
+#if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 

--- a/src/SFML/Window/OSX/CursorImpl.mm
+++ b/src/SFML/Window/OSX/CursorImpl.mm
@@ -109,8 +109,8 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::SizeBottom:      newCursor = [NSCursor resizeUpDownCursor];        break;
 
         // These cursor types are undocumented, may not be available on some platforms
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundeclared-selector"
         case Cursor::SizeTopRight:
         case Cursor::SizeBottomLeft:
         case Cursor::SizeBottomLeftTopRight:
@@ -126,7 +126,7 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::Help:
             newCursor = loadFromSelector(@selector(_helpCursor));
             break;
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
     }
     // clang-format on
 

--- a/src/SFML/Window/OSX/SFApplication.m
+++ b/src/SFML/Window/OSX/SFApplication.m
@@ -28,13 +28,7 @@
 ////////////////////////////////////////////////////////////
 #import <SFML/Window/OSX/SFApplication.h>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFApplicationDelegate.m
+++ b/src/SFML/Window/OSX/SFApplicationDelegate.m
@@ -28,13 +28,7 @@
 ////////////////////////////////////////////////////////////
 #import <SFML/Window/OSX/SFApplicationDelegate.h>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 ////////////////////////////////////////////////////////////
 @implementation SFApplicationDelegate

--- a/src/SFML/Window/OSX/SFContext.mm
+++ b/src/SFML/Window/OSX/SFContext.mm
@@ -35,13 +35,7 @@
 #include <ostream>
 #include <stdint.h>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 namespace sf
 {

--- a/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
+++ b/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
@@ -29,13 +29,7 @@
 #import <SFML/Window/OSX/SFKeyboardModifiersHelper.h>
 #include <SFML/Window/OSX/WindowImplCocoa.hpp>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFOpenGLView+keyboard.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView+keyboard.mm
@@ -31,13 +31,7 @@
 #import <SFML/Window/OSX/SFOpenGLView+keyboard_priv.h>
 #include <SFML/Window/OSX/WindowImplCocoa.hpp>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 ////////////////////////////////////////////////////////////
 /// In this file, we implement keyboard handling for SFOpenGLView

--- a/src/SFML/Window/OSX/SFOpenGLView+mouse.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView+mouse.mm
@@ -32,13 +32,7 @@
 
 #include <cmath>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFOpenGLView.h
+++ b/src/SFML/Window/OSX/SFOpenGLView.h
@@ -28,15 +28,8 @@
 ////////////////////////////////////////////////////////////
 #import <AppKit/AppKit.h>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 namespace sf
 {
@@ -212,10 +205,4 @@ class WindowImplCocoa;
 
 @end
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#endif
-#endif

--- a/src/SFML/Window/OSX/SFOpenGLView.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView.mm
@@ -32,13 +32,7 @@
 #import <SFML/Window/OSX/SFSilentResponder.h>
 #include <SFML/Window/OSX/WindowImplCocoa.hpp>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/OSX/SFViewController.mm
+++ b/src/SFML/Window/OSX/SFViewController.mm
@@ -34,13 +34,7 @@
 
 #include <ostream>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 @implementation SFViewController
 

--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -43,13 +43,7 @@
 #include <algorithm>
 #include <ostream>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 ////////////////////////////////////////////////////////////
 /// SFBlackView is a simple view filled with black, nothing more

--- a/src/SFML/Window/OSX/WindowImplCocoa.hpp
+++ b/src/SFML/Window/OSX/WindowImplCocoa.hpp
@@ -32,15 +32,8 @@
 #include <SFML/Window/Event.hpp>
 #include <SFML/Window/WindowImpl.hpp>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 ////////////////////////////////////////////////////////////
 /// Predefine OBJ-C classes
@@ -379,12 +372,6 @@ private:
 
 } // namespace sf
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#endif
-#endif
 
 #endif // SFML_WINDOWIMPLCOCOA_HPP

--- a/src/SFML/Window/OSX/WindowImplDelegateProtocol.h
+++ b/src/SFML/Window/OSX/WindowImplDelegateProtocol.h
@@ -32,15 +32,8 @@
 
 #import <AppKit/AppKit.h>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 namespace sf
 {
@@ -246,10 +239,4 @@ class WindowImplCocoa;
 
 @end
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#endif
-#endif

--- a/src/SFML/Window/OSX/cg_sf_conversion.mm
+++ b/src/SFML/Window/OSX/cg_sf_conversion.mm
@@ -30,13 +30,7 @@
 #import <SFML/Window/OSX/Scaling.h>
 #include <SFML/Window/OSX/cg_sf_conversion.hpp>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 namespace sf
 {

--- a/src/SFML/Window/iOS/EaglContext.hpp
+++ b/src/SFML/Window/iOS/EaglContext.hpp
@@ -35,15 +35,8 @@
 
 #include <glad/gl.h>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 SFML_DECLARE_OBJC_CLASS(EAGLContext);
 SFML_DECLARE_OBJC_CLASS(SFView);
@@ -178,12 +171,6 @@ private:
 
 } // namespace sf
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#endif
-#endif
 
 #endif // SFML_EAGLCONTEXT_HPP

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -39,13 +39,7 @@
 #include <ostream>
 
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 
 namespace

--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -176,25 +176,12 @@ std::vector<sf::Vector2i> touchPositions;
     if (!self.sfWindow)
         return false;
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif
-#endif
 
     UIViewController* rootViewController = [((__bridge UIWindow*)(self.sfWindow->getSystemHandle())) rootViewController];
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#endif
-#endif
 
     if (!rootViewController || ![rootViewController shouldAutorotate])
         return false;

--- a/src/SFML/Window/iOS/SFView.mm
+++ b/src/SFML/Window/iOS/SFView.mm
@@ -32,13 +32,7 @@
 #include <QuartzCore/CAEAGLLayer.h>
 #include <cstring>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 @interface SFView ()
 

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -34,13 +34,7 @@
 
 #include <UIKit/UIKit.h>
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#endif
 
 namespace sf
 {
@@ -109,25 +103,12 @@ void WindowImplUIKit::processEvents()
 ////////////////////////////////////////////////////////////
 WindowHandle WindowImplUIKit::getSystemHandle() const
 {
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wold-style-cast"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-#endif
-#endif
 
     return (__bridge WindowHandle)m_window;
 
-#if defined(__APPLE__)
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
-#endif
-#endif
 }
 
 


### PR DESCRIPTION
## Description

GCC can't build SFML on Apple platforms so it's a given that within Apple-specific code, Clang is being used. Furthermore within files that are only compiled on Apple platforms, there is no need to use the preprocessor to check whether Apple is the current platform. That much is implied within those files.

## Tasks

* [x] Tested on Linux
* [x] Tested on Windows
* [x] Tested on macOS
* [x] Tested on iOS
* [x] Tested on Android
