### PR TITLE
Update .gitignore for Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build/
 .cache/
 .vscode/
 .idea/
+.vs/


### PR DESCRIPTION
This is a small PR that adds `.vs/` to the `.gitignore`. It should help people working with Visual Studio.