### PR TITLE
Fix SoundStream::play to restart the sound if it was played before

### DIFF
--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -136,6 +136,15 @@ void SoundStream::play()
         // If the sound is playing, stop it and continue as if it was stopped
         stop();
     }
+    else if (!isStreaming)
+    {
+        // Either the streaming thread has never been launched or it has been launched and has reached its end.
+        // - If it has reached its end, we have to restart the sound from the beginning.
+        // - If it has never been launched, it is not necessary to move to the beginning, but it is not harmful.
+        // To check if the sound has never been launched would require additional complexity
+        // which we can avoid by moving to the beginning in both cases.
+        onSeek(Time::Zero);
+    }
 
     // Start updating the stream in a separate thread to avoid blocking the application
     m_isStreaming = true;


### PR DESCRIPTION
## Description

This is similar to the fix I contributed in #2037 for master branch but this time for 2.6.x branch. I did not realize at first a part of the bug was also present in 2.6.x branch.

The bug is that calling `SoundStream::play` after the sound was played in full a first time does not restart the sound. The expected behavior according to this method documentation is to restart the sound.

The fix is a little different from #2037 because we use `sf::Thread` which does not provide a `joinable` method like `std::thread` does in master.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Running the `voip` example program.