### PR TITLE
Use `std::size_t`

### DIFF
--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -1611,7 +1611,7 @@ public:
     void setupUniformBuffers()
     {
         // Create a uniform buffer for every frame that might be in flight to prevent clobbering
-        for (size_t i = 0; i < swapchainImages.size(); ++i)
+        for (std::size_t i = 0; i < swapchainImages.size(); ++i)
         {
             uniformBuffers.push_back(0);
             uniformBuffersMemory.push_back(0);

--- a/src/SFML/Audio/SoundFileReaderOgg.cpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.cpp
@@ -36,7 +36,7 @@
 
 namespace
 {
-size_t read(void* ptr, size_t size, size_t nmemb, void* data)
+std::size_t read(void* ptr, std::size_t size, std::size_t nmemb, void* data)
 {
     auto* stream = static_cast<sf::InputStream*>(data);
     return static_cast<std::size_t>(stream->read(ptr, static_cast<sf::Int64>(size * nmemb)));

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -474,7 +474,7 @@ static void onConfigurationChanged(ANativeActivity* /* activity */)
 
 
 ////////////////////////////////////////////////////////////
-static void* onSaveInstanceState(ANativeActivity* /* activity */, size_t* outLen)
+static void* onSaveInstanceState(ANativeActivity* /* activity */, std::size_t* outLen)
 {
     *outLen = 0;
 
@@ -489,7 +489,7 @@ static void onLowMemory(ANativeActivity* /* activity */)
 
 
 ////////////////////////////////////////////////////////////
-JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_t savedStateSize)
+JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, std::size_t savedStateSize)
 {
     // Create an activity states (will keep us in the know, about events we care)
     auto* states = new sf::priv::ActivityStates;

--- a/src/SFML/Main/SFMLActivity.cpp
+++ b/src/SFML/Main/SFMLActivity.cpp
@@ -38,7 +38,7 @@
 
 namespace
 {
-using activityOnCreatePointer = void (*)(ANativeActivity*, void*, size_t);
+using activityOnCreatePointer = void (*)(ANativeActivity*, void*, std::size_t);
 }
 
 const char* getLibraryName(JNIEnv* lJNIEnv, jobject& objectActivityInfo)
@@ -71,8 +71,8 @@ const char* getLibraryName(JNIEnv* lJNIEnv, jobject& objectActivityInfo)
     }
 
     // Convert the application name to a C++ string and return it
-    const size_t applicationNameLength = static_cast<size_t>(lJNIEnv->GetStringUTFLength(valueString));
-    const char*  applicationName       = lJNIEnv->GetStringUTFChars(valueString, nullptr);
+    const std::size_t applicationNameLength = static_cast<std::size_t>(lJNIEnv->GetStringUTFLength(valueString));
+    const char*       applicationName       = lJNIEnv->GetStringUTFChars(valueString, nullptr);
 
     if (applicationNameLength >= 256)
     {
@@ -80,7 +80,7 @@ const char* getLibraryName(JNIEnv* lJNIEnv, jobject& objectActivityInfo)
         exit(1);
     }
 
-    strncpy(name, applicationName, static_cast<size_t>(applicationNameLength));
+    strncpy(name, applicationName, static_cast<std::size_t>(applicationNameLength));
     name[applicationNameLength] = '\0';
     lJNIEnv->ReleaseStringUTFChars(valueString, applicationName);
 
@@ -132,7 +132,7 @@ void* loadLibrary(const char* libraryName, JNIEnv* lJNIEnv, jobject& ObjectActiv
     return handle;
 }
 
-void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, size_t savedStateSize)
+void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, std::size_t savedStateSize)
 {
     // Before we can load a library, we need to find out its location. As
     // we're powerless here in C/C++, we need the JNI interface to communicate

--- a/src/SFML/Network/Unix/SocketImpl.hpp
+++ b/src/SFML/Network/Unix/SocketImpl.hpp
@@ -55,7 +55,7 @@ public:
     // Types
     ////////////////////////////////////////////////////////////
     using AddrLength = socklen_t;
-    using Size       = size_t;
+    using Size       = std::size_t;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create an internal sockaddr_in address

--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -67,8 +67,8 @@ struct ActivityStates
     EGLDisplay  display;
     EglContext* context;
 
-    void*  savedState;
-    size_t savedStateSize;
+    void*       savedState;
+    std::size_t savedStateSize;
 
     std::recursive_mutex mutex;
 

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -61,7 +61,7 @@ Int64 ResourceStream::read(void* data, Int64 size)
 {
     if (m_file)
     {
-        return AAsset_read(m_file, data, static_cast<size_t>(size));
+        return AAsset_read(m_file, data, static_cast<std::size_t>(size));
     }
     else
     {

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -476,9 +476,9 @@ int WindowImplAndroid::processMotionEvent(AInputEvent* _event, ActivityStates& s
     else if (static_cast<Uint32>(device) & AINPUT_SOURCE_TOUCHSCREEN)
         event.type = Event::TouchMoved;
 
-    size_t pointerCount = AMotionEvent_getPointerCount(_event);
+    std::size_t pointerCount = AMotionEvent_getPointerCount(_event);
 
-    for (size_t p = 0; p < pointerCount; ++p)
+    for (std::size_t p = 0; p < pointerCount; ++p)
     {
         int32_t id = AMotionEvent_getPointerId(_event, p);
 
@@ -516,8 +516,8 @@ int WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* _event, Act
     int32_t device = AInputEvent_getSource(_event);
     int32_t action = AMotionEvent_getAction(_event);
 
-    size_t  index = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
-    int32_t id    = AMotionEvent_getPointerId(_event, index);
+    std::size_t index = (action & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
+    int32_t     id    = AMotionEvent_getPointerId(_event, index);
 
     int x = static_cast<int>(AMotionEvent_getX(_event, index));
     int y = static_cast<int>(AMotionEvent_getY(_event, index));

--- a/src/SFML/Window/DRM/InputImplUDev.cpp
+++ b/src/SFML/Window/DRM/InputImplUDev.cpp
@@ -315,8 +315,8 @@ void pushEvent(sf::Event& event)
 TouchSlot& atSlot(int idx)
 {
     if (idx >= static_cast<int>(touchSlots.size()))
-        touchSlots.resize(static_cast<size_t>(idx + 1));
-    return touchSlots.at(static_cast<size_t>(idx));
+        touchSlots.resize(static_cast<std::size_t>(idx + 1));
+    return touchSlots.at(static_cast<std::size_t>(idx));
 }
 
 void processSlots()

--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -228,7 +228,7 @@ bool JoystickImpl::open(unsigned int index)
 
             // Then allocate a buffer for data retrieval
             m_length = hid_report_size(m_desc, hid_input, m_id);
-            m_buffer.resize(static_cast<size_t>(m_length));
+            m_buffer.resize(static_cast<std::size_t>(m_length));
 
             m_state.connected = true;
 
@@ -300,7 +300,7 @@ Joystick::Identification JoystickImpl::getIdentification() const
 ////////////////////////////////////////////////////////////
 JoystickState JoystickImpl::JoystickImpl::update()
 {
-    while (read(m_file, m_buffer.data(), static_cast<size_t>(m_length)) == m_length)
+    while (read(m_file, m_buffer.data(), static_cast<std::size_t>(m_length)) == m_length)
     {
         hid_data_t data = hid_start_parse(m_desc, 1 << hid_input, m_id);
 

--- a/src/SFML/Window/OSX/cg_sf_conversion.hpp
+++ b/src/SFML/Window/OSX/cg_sf_conversion.hpp
@@ -44,7 +44,7 @@ namespace priv
 /// to represent video mode. Instead it uses a CGDisplayMode opaque type.
 ///
 ////////////////////////////////////////////////////////////
-size_t modeBitsPerPixel(CGDisplayModeRef mode);
+std::size_t modeBitsPerPixel(CGDisplayModeRef mode);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get bpp for all OS X version
@@ -53,7 +53,7 @@ size_t modeBitsPerPixel(CGDisplayModeRef mode);
 /// display bits per pixel information for a given display id.
 ///
 ////////////////////////////////////////////////////////////
-size_t displayBitsPerPixel(CGDirectDisplayID displayId);
+std::size_t displayBitsPerPixel(CGDirectDisplayID displayId);
 
 ////////////////////////////////////////////////////////////
 /// \brief Convert a Quartz video mode into a sf::VideoMode object

--- a/src/SFML/Window/OSX/cg_sf_conversion.mm
+++ b/src/SFML/Window/OSX/cg_sf_conversion.mm
@@ -38,9 +38,9 @@ namespace priv
 {
 
 ////////////////////////////////////////////////////////////
-size_t modeBitsPerPixel(CGDisplayModeRef mode)
+std::size_t modeBitsPerPixel(CGDisplayModeRef mode)
 {
-    size_t bpp = 0; // no match
+    std::size_t bpp = 0; // no match
 
     // Compare encoding.
     CFStringRef pixEnc = CGDisplayModeCopyPixelEncoding(mode);
@@ -59,13 +59,13 @@ size_t modeBitsPerPixel(CGDisplayModeRef mode)
 
 
 ////////////////////////////////////////////////////////////
-size_t displayBitsPerPixel(CGDirectDisplayID displayId)
+std::size_t displayBitsPerPixel(CGDirectDisplayID displayId)
 {
     // Get the display mode.
     CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
 
     // Get bpp for the mode.
-    const size_t bpp = modeBitsPerPixel(mode);
+    const std::size_t bpp = modeBitsPerPixel(mode);
 
     // Clean up Memory.
     CGDisplayModeRelease(mode);

--- a/src/SFML/Window/Win32/ClipboardImpl.cpp
+++ b/src/SFML/Window/Win32/ClipboardImpl.cpp
@@ -87,8 +87,8 @@ void ClipboardImpl::setString(const String& text)
     }
 
     // Create a Win32-compatible string
-    size_t string_size   = (text.getSize() + 1) * sizeof(WCHAR);
-    HANDLE string_handle = GlobalAlloc(GMEM_MOVEABLE, string_size);
+    std::size_t string_size   = (text.getSize() + 1) * sizeof(WCHAR);
+    HANDLE      string_handle = GlobalAlloc(GMEM_MOVEABLE, string_size);
 
     if (string_handle)
     {

--- a/test/Graphics/Transform.cpp
+++ b/test/Graphics/Transform.cpp
@@ -17,7 +17,7 @@ struct StringMaker<std::vector<float>>
     {
         assert(!vector.empty());
         doctest::String out = "{ ";
-        for (size_t i = 0; i + 1 < vector.size(); ++i)
+        for (std::size_t i = 0; i + 1 < vector.size(); ++i)
             out += toString(vector[i]) + ", ";
         out += toString(vector.back()) + " }";
         return out;


### PR DESCRIPTION
## Description

Found a few places using `size_t` instead of `std::size_t` so I went through a did an exhaustive search for everywhere else using the shorter form so that the whole codebase is now consistent about using the more verbose option.
