### PR TITLE
Treat each test case as a unique test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,9 @@ if(SFML_OS_MACOSX)
     set(XCODE_TEMPLATES_ARCH "\$(NATIVE_ARCH_ACTUAL)")
 endif()
 
+# set the output directory for SFML DLLs and executables
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+
 # enable project folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -330,17 +330,7 @@ function(sfml_add_test target SOURCES DEPENDS)
     endif()
 
     # Add the test
-    add_test(${target} ${target})
-
-    # If building shared libs on windows we must copy the dependencies into the folder
-    if (WIN32 AND BUILD_SHARED_LIBS)
-        foreach (DEPENDENCY ${DEPENDS})
-            add_custom_command(TARGET ${target} PRE_BUILD
-                                COMMAND ${CMAKE_COMMAND} -E copy
-                                $<TARGET_FILE:${DEPENDENCY}>
-                                $<TARGET_FILE_DIR:${target}>)
-        endforeach()
-    endif()
+    doctest_discover_tests(${target})
 endfunction()
 
 # Create an interface library for an external dependency. This virtual target can provide

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,8 @@ FetchContent_Declare(doctest
     GIT_TAG v2.4.9
 )
 FetchContent_MakeAvailable(doctest)
+list(APPEND CMAKE_MODULE_PATH ${doctest_SOURCE_DIR}/scripts/cmake)
+include(doctest)
 
 add_library(sfml-test-main STATIC
     DoctestMain.cpp
@@ -76,30 +78,18 @@ set(AUDIO_SRC
 )
 sfml_add_test(test-sfml-audio "${AUDIO_SRC}" SFML::Audio)
 
+if(SFML_OS_WINDOWS AND NOT SFML_USE_SYSTEM_DEPS)
+    add_custom_command(
+        TARGET test-sfml-audio
+        COMMENT "Copy OpenAL DLL"
+        PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/extlibs/bin/$<IF:$<BOOL:${ARCH_64BITS}>,x64,x86>/openal32.dll $<TARGET_FILE_DIR:test-sfml-audio>
+    )
+endif()
+
 # Automatically run the tests at the end of the build
 add_custom_target(runtests ALL
                   DEPENDS test-sfml-system test-sfml-window test-sfml-graphics test-sfml-network test-sfml-audio
 )
-
-if(SFML_OS_WINDOWS AND NOT SFML_USE_SYSTEM_DEPS)
-    # Copy the binaries of SFML dependencies
-    list(APPEND BINARIES
-        "openal32.dll"
-    )
-
-    foreach (BINARY ${BINARIES})
-        if(ARCH_32BITS)
-            list(APPEND BINARY_PATHS "${PROJECT_SOURCE_DIR}/extlibs/bin/x86/${BINARY}")
-        elseif(ARCH_64BITS)
-            list(APPEND BINARY_PATHS "${PROJECT_SOURCE_DIR}/extlibs/bin/x64/${BINARY}")
-        endif()
-    endforeach()
-
-    add_custom_command(TARGET runtests
-                       COMMENT "Copy binaries"
-                       POST_BUILD COMMAND "${CMAKE_COMMAND}" -E copy ${BINARY_PATHS} "$<TARGET_FILE_DIR:test-sfml-system>"
-    )
-endif()
 
 if(SFML_ENABLE_COVERAGE AND SFML_COMPILER_MSVC)
     # Try to find and use OpenCppCoverage for coverage reporting when building with MSVC


### PR DESCRIPTION
## Description

The use of `doctest_discover_tests` converts each `TEST_CASE` entry into a unique CTest test. This means in practice that each test .cpp file gets run as a test by itself. This has huge benefits in terms of legibility when tests fail. It's now much more obvious precisely what test failed instead of simply seeing something in the Graphics module failed and having to jump straight into the console logs.

One side effect of this change was needing to build all DLLs and executables into the same directory within the binary directory. I tried hard to avoid needing to do this but could find no other option. The reason we need to do this is that `doctest_discover_tests` actually runs the test executable itself to query it for all the test cases it contains. It then uses that information to generate all the CMake `add_test` calls. I actually quite like this though. Consolidating the location of DLLs in particular means less hassle for Windows users who can now more easily run the example programs or simply find those DLLs so they can copy them elsewhere as needed. This also let us simplify some of the `sfml_add_test` code which was a nice side effect.

---

Before
```
Test project /Users/thrasher/Projects/sfml/build
    Start 1: test-sfml-system
1/5 Test #1: test-sfml-system .................   Passed    0.01 sec
    Start 2: test-sfml-window
2/5 Test #2: test-sfml-window .................   Passed    0.01 sec
    Start 3: test-sfml-graphics
3/5 Test #3: test-sfml-graphics ...............   Passed    0.01 sec
    Start 4: test-sfml-network
4/5 Test #4: test-sfml-network ................   Passed    0.28 sec
    Start 5: test-sfml-audio
5/5 Test #5: test-sfml-audio ..................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 5
```

After
```
Test project /Users/thrasher/Projects/sfml/build
      Start  1: sf::Angle class - [system]
 1/28 Test  #1: sf::Angle class - [system] ...............   Passed    0.00 sec
      Start  2: sf::Clock class - [system]
 2/28 Test  #2: sf::Clock class - [system] ...............   Passed    0.01 sec
      Start  3: SFML/Config.hpp
 3/28 Test  #3: SFML/Config.hpp ..........................   Passed    0.00 sec
      Start  4: sf::err - [system]
 4/28 Test  #4: sf::err - [system] .......................   Passed    0.00 sec
      Start  5: sf::FileInputStream class - [system]
 5/28 Test  #5: sf::FileInputStream class - [system] .....   Passed    0.00 sec
      Start  6: sf::MemoryInputStream class - [system]
 6/28 Test  #6: sf::MemoryInputStream class - [system] ...   Passed    0.00 sec
      Start  7: sf::Time class - [system]
 7/28 Test  #7: sf::Time class - [system] ................   Passed    0.00 sec
      Start  8: sf::Vector2 class template - [system]
 8/28 Test  #8: sf::Vector2 class template - [system] ....   Passed    0.00 sec
      Start  9: sf::Vector3 class template - [system]
 9/28 Test  #9: sf::Vector3 class template - [system] ....   Passed    0.00 sec
      Start 10: sf::ContextSettings class - [window]
10/28 Test #10: sf::ContextSettings class - [window] .....   Passed    0.01 sec
      Start 11: sf::VideoMode class - [window]
11/28 Test #11: sf::VideoMode class - [window] ...........   Passed    0.01 sec
      Start 12: sf::BlendMode class - [graphics]
12/28 Test #12: sf::BlendMode class - [graphics] .........   Passed    0.01 sec
      Start 13: sf::CircleShape class - [graphics]
13/28 Test #13: sf::CircleShape class - [graphics] .......   Passed    0.01 sec
      Start 14: sf::Color class - [graphics]
14/28 Test #14: sf::Color class - [graphics] .............   Passed    0.01 sec
      Start 15: sf::ConvexShape class - [graphics]
15/28 Test #15: sf::ConvexShape class - [graphics] .......   Passed    0.01 sec
      Start 16: sf::Glyph class - [graphics]
16/28 Test #16: sf::Glyph class - [graphics] .............   Passed    0.01 sec
      Start 17: sf::Image - [graphics]
17/28 Test #17: sf::Image - [graphics] ...................   Passed    0.01 sec
      Start 18: sf::Rect class template - [graphics]
18/28 Test #18: sf::Rect class template - [graphics] .....   Passed    0.01 sec
      Start 19: sf::RectangleShape class - [graphics]
19/28 Test #19: sf::RectangleShape class - [graphics] ....   Passed    0.01 sec
      Start 20: sf::RenderStates class - [graphics]
20/28 Test #20: sf::RenderStates class - [graphics] ......   Passed    0.01 sec
      Start 21: sf::Shape class - [graphics]
21/28 Test #21: sf::Shape class - [graphics] .............   Passed    0.01 sec
      Start 22: sf::Transform class - [graphics]
22/28 Test #22: sf::Transform class - [graphics] .........   Passed    0.01 sec
      Start 23: sf::Transformable class - [graphics]
23/28 Test #23: sf::Transformable class - [graphics] .....   Passed    0.01 sec
      Start 24: sf::Vertex class - [graphics]
24/28 Test #24: sf::Vertex class - [graphics] ............   Passed    0.01 sec
      Start 25: sf::VertexArray class - [graphics]
25/28 Test #25: sf::VertexArray class - [graphics] .......   Passed    0.01 sec
      Start 26: sf::View class - [graphics]
26/28 Test #26: sf::View class - [graphics] ..............   Passed    0.01 sec
      Start 27: sf::IpAddress class - [network]
27/28 Test #27: sf::IpAddress class - [network] ..........   Passed    0.28 sec
      Start 28: sf::Packet class - [network]
28/28 Test #28: sf::Packet class - [network] .............   Passed    0.01 sec

100% tests passed, 0 tests failed out of 28
```