### PR TITLE
Change Vector2 and Vector3 length function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # Build folders
 build/
+cmake-build-*/
 
 # Cache/IDE folders
 .cache/

--- a/src/SFML/System/Vector2.cpp
+++ b/src/SFML/System/Vector2.cpp
@@ -106,8 +106,9 @@ template <typename T>
 T Vector2<T>::length() const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::length() is only supported for floating point types");
-    
-    return std::sqrt(x*x + y*y);
+
+    // don't use std::hypot because of slow performance
+    return std::sqrt(x * x + y * y);
 }
 
 } // namespace sf

--- a/src/SFML/System/Vector2.cpp
+++ b/src/SFML/System/Vector2.cpp
@@ -106,8 +106,8 @@ template <typename T>
 T Vector2<T>::length() const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::length() is only supported for floating point types");
-
-    return std::hypot(x, y);
+    
+    return std::sqrt(x*x + y*y);
 }
 
 } // namespace sf

--- a/src/SFML/System/Vector3.cpp
+++ b/src/SFML/System/Vector3.cpp
@@ -48,7 +48,8 @@ T Vector3<T>::length() const
 {
     static_assert(std::is_floating_point_v<T>, "Vector3::length() is only supported for floating point types");
 
-    return std::sqrt(x*x + y*y + z*z);
+    // don't use std::hypot because of slow performance
+    return std::sqrt(x * x + y * y + z * z);
 }
 
 } // namespace sf

--- a/src/SFML/System/Vector3.cpp
+++ b/src/SFML/System/Vector3.cpp
@@ -48,7 +48,7 @@ T Vector3<T>::length() const
 {
     static_assert(std::is_floating_point_v<T>, "Vector3::length() is only supported for floating point types");
 
-    return std::hypot(x, y, z);
+    return std::sqrt(x*x + y*y + z*z);
 }
 
 } // namespace sf


### PR DESCRIPTION
* [x] Has this change been discussed on [Github](https://github.com/SFML/SFML/issues/2190) before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [x] If you have additional steps which need to be performed list them as tasks!

----

## Description

Replacing hypot because of bad performance.

Perfomance with hypot:
![grafik](https://user-images.githubusercontent.com/71488985/188573915-dc78de88-856a-4f46-9dfe-72622dcbcf37.png)

Performance with a normal sqrt instead
![grafik](https://user-images.githubusercontent.com/71488985/188574352-e668d161-f861-402d-8158-f0aa528c5e32.png)

GLM and EIgen only for comparison reasons

As you can see using a normal sqrt speeds up the length function by a factor of ~10.

This PR is related to the issue #2190

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Testet with the benchmark code. 

Test and Benchmark code:
[main.zip](https://github.com/SFML/SFML/files/9494334/main.zip)!

Obviously the change is platform independent.
