### PR TITLE
Time out test for public IP address

### DIFF
--- a/test/Network/IpAddress.cpp
+++ b/test/Network/IpAddress.cpp
@@ -72,9 +72,11 @@ TEST_CASE("sf::IpAddress class - [network]")
         SUBCASE("getPublicAddress")
         {
             const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getPublicAddress(sf::seconds(1));
-            REQUIRE(ipAddress.has_value());
-            CHECK(ipAddress->toString() != "0.0.0.0");
-            CHECK(ipAddress->toInteger() != 0);
+            if (ipAddress.has_value())
+            {
+                CHECK(ipAddress->toString() != "0.0.0.0");
+                CHECK(ipAddress->toInteger() != 0);
+            }
         }
     }
 

--- a/test/Network/IpAddress.cpp
+++ b/test/Network/IpAddress.cpp
@@ -71,7 +71,7 @@ TEST_CASE("sf::IpAddress class - [network]")
 
         SUBCASE("getPublicAddress")
         {
-            const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getPublicAddress();
+            const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getPublicAddress(sf::seconds(1));
             REQUIRE(ipAddress.has_value());
             CHECK(ipAddress->toString() != "0.0.0.0");
             CHECK(ipAddress->toInteger() != 0);


### PR DESCRIPTION
## Description

On poor network connections, the call to getPublicAddress may hang indefinitely. If it is to succeed, let's require that it succeed without a reasonable time frame to put an upper limit on how long tests take to run.

While I'm at it, I'm also letting this test pass even if nullopt is returned because that behavior is part of the contract of this API. Otherwise this test is requiring that a stable network connection is present meaning your tests would fail on an airplane for no good reason.