### PR TITLE
Test install interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,13 @@ jobs:
         files: ./build/coverage.out
         fail_ci_if_error: true
 
+    - name: Test Install Interface
+      if: matrix.platform.name != 'Android' && matrix.config.name != 'Frameworks' && matrix.config.name != 'iOS' && matrix.config.name != 'Static DRM'
+      shell: bash
+      run: |
+        cmake -S $GITHUB_WORKSPACE/test/install -B $GITHUB_WORKSPACE/test/install/build -DSFML_ROOT=$GITHUB_WORKSPACE/install -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
+        cmake --build $GITHUB_WORKSPACE/test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+
   format:
     name: Formatting on ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,8 @@ FetchContent_MakeAvailable(doctest)
 list(APPEND CMAKE_MODULE_PATH ${doctest_SOURCE_DIR}/scripts/cmake)
 include(doctest)
 
+add_subdirectory(install)
+
 add_library(sfml-test-main STATIC
     DoctestMain.cpp
     TestUtilities/SystemUtil.hpp

--- a/test/install/CMakeLists.txt
+++ b/test/install/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.16)
+project(test-sfml-install CXX)
+
+# This skips the find_package call when building via add_subdirectory since that will fail under those circumstances
+# It's a CMake 3.16-compatible replacement to PROJECT_IS_TOP_LEVEL
+# https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    if(NOT BUILD_SHARED_LIBS)
+        set(SFML_STATIC_LIBRARIES TRUE)
+    endif()
+    find_package(SFML 3.0.0 EXACT CONFIG REQUIRED COMPONENTS Graphics Network Audio)
+endif()
+
+add_executable(test-sfml-install Install.cpp)
+target_link_libraries(test-sfml-install PRIVATE SFML::Graphics SFML::Network SFML::Audio)

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -1,0 +1,37 @@
+#include <SFML/Audio.hpp>
+#include <SFML/Graphics.hpp>
+#include <SFML/Network.hpp>
+
+// Instantiate some types from each module to test for linker issues. This program is not meant be ran.
+int main()
+{
+    // Audio
+    sf::InputSoundFile input_sound_file;
+    sf::Listener       listener;
+    sf::Music          music;
+    sf::Sound          sound;
+
+    // Graphics
+    sf::Color        color;
+    sf::Font         font;
+    sf::RenderWindow render_window;
+    sf::Sprite       sprite;
+    sf::Vertex       vertex;
+
+    // Network
+    sf::Ftp       ftp;
+    sf::Http      http;
+    sf::Packet    packet;
+    sf::UdpSocket udp_socket;
+
+    // System
+    sf::Angle           angle;
+    sf::FileInputStream file_input_stream;
+    sf::String          string;
+    sf::Time            time;
+
+    // Window
+    sf::Context   context;
+    sf::VideoMode video_mode;
+    sf::Window    window;
+}


### PR DESCRIPTION
## Description

This PR adds tests for the package install interface. I chose to skip the platforms that are either too hard to test or have a broken install interface. The project that is consuming the install interface does little more than find the package and build its headers. This seems to be sufficient.

These tests will better enable some fixes to install code and CMake changes that result in more generated files which we must ensure get installed correctly. I'm happy with how little code ended up being necessary to implement these.