### PR TITLE
Copy OpenAL DLL into runtime directory alongside other DLLs and EXEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,9 @@ if(SFML_OS_MACOSX)
     set(XCODE_TEMPLATES_ARCH "\$(NATIVE_ARCH_ACTUAL)")
 endif()
 
+# set the output directory for SFML DLLs and executables
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+
 # enable project folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -311,17 +311,7 @@ function(sfml_add_test target SOURCES DEPENDS)
     endif()
     
     # Add the test
-    add_test(${target} ${target})
-
-    # If building shared libs on windows we must copy the dependencies into the folder
-    if (WIN32 AND BUILD_SHARED_LIBS)
-        foreach (DEPENDENCY ${DEPENDS})
-            add_custom_command(TARGET ${target} PRE_BUILD
-                                COMMAND ${CMAKE_COMMAND} -E copy
-                                $<TARGET_FILE:${DEPENDENCY}>
-                                $<TARGET_FILE_DIR:${target}>)
-        endforeach()
-    endif()
+    add_test(NAME ${target} COMMAND ${target})
 endfunction()
 
 # Create an interface library for an external dependency. This virtual target can provide

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -93,3 +93,11 @@ endif()
 target_link_libraries(sfml-audio
                       PUBLIC sfml-system
                       PRIVATE VORBIS FLAC)
+
+if(SFML_OS_WINDOWS AND NOT SFML_USE_SYSTEM_DEPS)
+    add_custom_command(
+        TARGET sfml-audio
+        COMMENT "Copy OpenAL DLL"
+        PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/extlibs/bin/$<IF:$<BOOL:${ARCH_64BITS}>,x64,x86>/openal32.dll ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/openal32.dll
+    )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,5 +48,5 @@ add_custom_target(runtests ALL
 
 add_custom_command(TARGET runtests
                    COMMENT "Run tests"
-                   POST_BUILD COMMAND ctest ARGS --output-on-failure
+                   POST_BUILD COMMAND ctest ARGS --output-on-failure -C $<CONFIG>
 )


### PR DESCRIPTION
## Description

Backporting changes from master that ensure all DLLs get put in the same place which make them easy to copy out and makes it easier to run unit tests and example programs on DLL platforms. I'd tried to exactly match what's already in `master` so that a future back merge goes as smoothly as possible.