### PR TITLE
Fix Visual Studio 2019 complaints regarding the int64_t type not being in the std namespace

### DIFF
--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -31,6 +31,7 @@
 #include <SFML/System/Export.hpp>
 
 #include <chrono>
+#include <cstdint>
 
 
 namespace sf


### PR DESCRIPTION
This resolves the issue that I logged here:
https://github.com/SFML/SFML/issues/2211
