### PR TITLE
Xcode fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
         - { name: Windows VS2022, os: windows-2022 }
         - { name: Linux GCC,      os: ubuntu-latest }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++, gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
-        - { name: MacOS XCode,    os: macos-latest }
+        - { name: MacOS,          os: macos-latest }
+        - { name: MacOS Xcode,    os: macos-latest, flags: -GXcode }
         config:
         - { name: Shared, flags: -DBUILD_SHARED_LIBS=TRUE }
         - { name: Static, flags: -DBUILD_SHARED_LIBS=FALSE }
@@ -30,9 +31,9 @@ jobs:
         - platform: { name: Windows VS2022, os: windows-2022 }
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
           type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
-        - platform: { name: MacOS XCode, os: macos-latest }
+        - platform: { name: MacOS, os: macos-latest }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }
-        - platform: { name: MacOS XCode, os: macos-latest }
+        - platform: { name: MacOS, os: macos-latest }
           config: { name: iOS, flags: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/cmake/toolchains/iOS.toolchain.cmake -DIOS_PLATFORM=SIMULATOR }
         - platform: { name: Android, os: ubuntu-latest }
           config: { name: x86, flags: -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r23b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }

--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -35,7 +35,7 @@ set(SRC CocoaAppDelegate.h
         NSString+stdstring.mm
         main.m)
 
-compile_xib(INPUT "MainMenu.xib" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib")
+compile_xib(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/MainMenu.xib" OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/MainMenu.nib")
 
 # all resource files
 set(RESOURCES resources/icon.icns
@@ -56,5 +56,5 @@ sfml_add_example(cocoa
                  DEPENDS SFML::System SFML::Window SFML::Graphics)
 set_target_properties(cocoa PROPERTIES
                       MACOSX_BUNDLE TRUE
-                      MACOSX_BUNDLE_INFO_PLIST resources/Cocoa-Info.plist)
+                      MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/resources/Cocoa-Info.plist)
 target_link_libraries(cocoa PRIVATE "-framework Cocoa" "-framework Foundation" SFML::Graphics)

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -199,7 +199,7 @@ struct SFMLmainWindow
     if (self.initialized)
     {
         float angle = [sender floatValue];
-        self.mainWindow->sprite.setRotation(angle);
+        self.mainWindow->sprite.setRotation(sf::degrees(angle));
     }
 }
 


### PR DESCRIPTION
## Description

Despite the name the Xcode jobs in the GitHub actions CI don't really use the Xcode generator, and it turns out there are some issues with it where absolute paths are expected, and a conversation from `float` to `sf::Angle`.

This adds tests for the Xcode generator and fixes those issues
