### PR TITLE
Return of the Testing PRs (`sf::Packet`)

### DIFF
--- a/test/Network/Packet.cpp
+++ b/test/Network/Packet.cpp
@@ -2,20 +2,62 @@
 
 #include <doctest/doctest.h>
 
+#include <array>
 #include <limits>
 
-#define CHECK_PACKET_STREAM_OPERATORS(expected) \
-    do                                          \
-    {                                           \
-        sf::Packet packet;                      \
-        packet << expected;                     \
-        decltype(expected) received;            \
-        packet >> received;                     \
-        CHECK(expected == received);            \
+#define CHECK_PACKET_STREAM_OPERATORS(expected)              \
+    do                                                       \
+    {                                                        \
+        sf::Packet packet;                                   \
+        packet << expected;                                  \
+        CHECK(packet.getReadPosition() == 0);                \
+        CHECK(packet.getData() != nullptr);                  \
+        CHECK(packet.getDataSize() == sizeof(expected));     \
+        CHECK(!packet.endOfPacket());                        \
+        CHECK(static_cast<bool>(packet));                    \
+                                                             \
+        decltype(expected) received;                         \
+        packet >> received;                                  \
+        CHECK(packet.getReadPosition() == sizeof(expected)); \
+        CHECK(packet.getData() != nullptr);                  \
+        CHECK(packet.getDataSize() == sizeof(expected));     \
+        CHECK(packet.endOfPacket());                         \
+        CHECK(static_cast<bool>(packet));                    \
+        CHECK(expected == received);                         \
     } while (false)
 
 TEST_CASE("sf::Packet class - [network]")
 {
+    SUBCASE("Default constructor")
+    {
+        const sf::Packet packet;
+        CHECK(packet.getReadPosition() == 0);
+        CHECK(packet.getData() == nullptr);
+        CHECK(packet.getDataSize() == 0);
+        CHECK(packet.endOfPacket());
+        CHECK(static_cast<bool>(packet));
+    }
+
+    SUBCASE("Append and clear")
+    {
+        constexpr std::array data = {1, 2, 3, 4, 5, 6};
+
+        sf::Packet packet;
+        packet.append(data.data(), data.size());
+        CHECK(packet.getReadPosition() == 0);
+        CHECK(packet.getData() != nullptr);
+        CHECK(packet.getDataSize() == data.size());
+        CHECK(!packet.endOfPacket());
+        CHECK(static_cast<bool>(packet));
+
+        packet.clear();
+        CHECK(packet.getReadPosition() == 0);
+        CHECK(packet.getData() == nullptr);
+        CHECK(packet.getDataSize() == 0);
+        CHECK(packet.endOfPacket());
+        CHECK(static_cast<bool>(packet));
+    }
+
     SUBCASE("Stream operators")
     {
         SUBCASE("std::int8_t")

--- a/test/Network/Packet.cpp
+++ b/test/Network/Packet.cpp
@@ -4,15 +4,15 @@
 
 #include <limits>
 
-template <typename IntegerType>
-static void testPacketStreamOperators(IntegerType expected)
-{
-    sf::Packet packet;
-    packet << expected;
-    IntegerType received;
-    packet >> received;
-    CHECK(expected == received);
-}
+#define CHECK_PACKET_STREAM_OPERATORS(expected) \
+    do                                          \
+    {                                           \
+        sf::Packet packet;                      \
+        packet << expected;                     \
+        decltype(expected) received;            \
+        packet >> received;                     \
+        CHECK(expected == received);            \
+    } while (false)
 
 TEST_CASE("sf::Packet class - [network]")
 {
@@ -20,34 +20,34 @@ TEST_CASE("sf::Packet class - [network]")
     {
         SUBCASE("std::int8_t")
         {
-            testPacketStreamOperators(std::int8_t(0));
-            testPacketStreamOperators(std::int8_t(1));
-            testPacketStreamOperators(std::numeric_limits<std::int8_t>::min());
-            testPacketStreamOperators(std::numeric_limits<std::int8_t>::max());
+            CHECK_PACKET_STREAM_OPERATORS(std::int8_t(0));
+            CHECK_PACKET_STREAM_OPERATORS(std::int8_t(1));
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int8_t>::min());
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int8_t>::max());
         }
 
         SUBCASE("std::int16_t")
         {
-            testPacketStreamOperators(std::int16_t(0));
-            testPacketStreamOperators(std::int16_t(1));
-            testPacketStreamOperators(std::numeric_limits<std::int16_t>::min());
-            testPacketStreamOperators(std::numeric_limits<std::int16_t>::max());
+            CHECK_PACKET_STREAM_OPERATORS(std::int16_t(0));
+            CHECK_PACKET_STREAM_OPERATORS(std::int16_t(1));
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int16_t>::min());
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int16_t>::max());
         }
 
         SUBCASE("std::int32_t")
         {
-            testPacketStreamOperators(std::int32_t(0));
-            testPacketStreamOperators(std::int32_t(1));
-            testPacketStreamOperators(std::numeric_limits<std::int32_t>::min());
-            testPacketStreamOperators(std::numeric_limits<std::int32_t>::max());
+            CHECK_PACKET_STREAM_OPERATORS(std::int32_t(0));
+            CHECK_PACKET_STREAM_OPERATORS(std::int32_t(1));
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int32_t>::min());
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int32_t>::max());
         }
 
         SUBCASE("std::int64_t")
         {
-            testPacketStreamOperators(std::int64_t(0));
-            testPacketStreamOperators(std::int64_t(1));
-            testPacketStreamOperators(std::numeric_limits<std::int64_t>::min());
-            testPacketStreamOperators(std::numeric_limits<std::int64_t>::max());
+            CHECK_PACKET_STREAM_OPERATORS(std::int64_t(0));
+            CHECK_PACKET_STREAM_OPERATORS(std::int64_t(1));
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int64_t>::min());
+            CHECK_PACKET_STREAM_OPERATORS(std::numeric_limits<std::int64_t>::max());
         }
     }
 }

--- a/test/Network/Packet.cpp
+++ b/test/Network/Packet.cpp
@@ -1,4 +1,4 @@
-#include <SFML/Network.hpp>
+#include <SFML/Network/Packet.hpp>
 
 #include <doctest/doctest.h>
 


### PR DESCRIPTION
## Description

I thought the `sf::Packet` tests were lacking so I shored them up to bring them up to the standard of all the other unit tests.
