### PR TITLE
Fix typo in variable name in Unix/JoystickImpl.cpp

### DIFF
--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -234,12 +234,12 @@ namespace
                 // If not mapped before, map it now
                 if (record == joystickList.end())
                 {
-                    JoystickRecord nweRecord;
-                    nweRecord.deviceNode = devnode;
-                    nweRecord.systemPath = syspath;
-                    nweRecord.plugged    = true;
+                    JoystickRecord newRecord;
+                    newRecord.deviceNode = devnode;
+                    newRecord.systemPath = syspath;
+                    newRecord.plugged    = true;
 
-                    joystickList.push_back(nweRecord);
+                    joystickList.push_back(newRecord);
                 }
             }
 


### PR DESCRIPTION
Hacktoberfest, here I come ! 