### PR TITLE
Include InputStream.hpp directly in SoundFileReaderMp3.cpp

### DIFF
--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -46,7 +46,7 @@
 #undef MINIMP3_NO_STDIO
 
 #include <SFML/Audio/SoundFileReaderMp3.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
+#include <SFML/System/InputStream.hpp>
 #include <SFML/System/Err.hpp>
 #include <algorithm>
 #include <cstring>


### PR DESCRIPTION
instead of indirect inclusion through MemoryInputStream.hpp

Thank you for respecting my OCD.