### PR TITLE
Fix minor inconsistency in type cast in voip example

### DIFF
--- a/examples/voip/Server.cpp
+++ b/examples/voip/Server.cpp
@@ -85,7 +85,7 @@ private:
         // (don't forget that we run in two separate threads)
         {
             sf::Lock lock(m_mutex);
-            m_tempBuffer.assign(m_samples.begin() + static_cast<std::vector<sf::Int64>::difference_type>(m_offset), m_samples.end());
+            m_tempBuffer.assign(m_samples.begin() + static_cast<std::vector<sf::Int16>::difference_type>(m_offset), m_samples.end());
         }
 
         // Fill audio data to pass to the stream


### PR DESCRIPTION
because m_samples is a vector of Int16 values.

That's it for today. Thank you.