### PR TITLE
Cleanup tests

### DIFF
--- a/test/Graphics/BlendMode.cpp
+++ b/test/Graphics/BlendMode.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::BlendMode class - [graphics]")
+TEST_CASE("[Graphics] sf::BlendMode")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/CircleShape.cpp
+++ b/test/Graphics/CircleShape.cpp
@@ -4,7 +4,7 @@
 
 #include <SystemUtil.hpp>
 
-TEST_CASE("sf::CircleShape class - [graphics]")
+TEST_CASE("[Graphics] sf::CircleShape")
 {
     SUBCASE("Default constructor")
     {

--- a/test/Graphics/Color.cpp
+++ b/test/Graphics/Color.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::Color class - [graphics]")
+TEST_CASE("[Graphics] sf::Color")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/ConvexShape.cpp
+++ b/test/Graphics/ConvexShape.cpp
@@ -4,7 +4,7 @@
 
 #include <SystemUtil.hpp>
 
-TEST_CASE("sf::ConvexShape class - [graphics]")
+TEST_CASE("[Graphics] sf::ConvexShape")
 {
     SUBCASE("Default constructor")
     {

--- a/test/Graphics/Glyph.cpp
+++ b/test/Graphics/Glyph.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::Glyph class - [graphics]")
+TEST_CASE("[Graphics] sf::Glyph")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/Image.cpp
+++ b/test/Graphics/Image.cpp
@@ -5,7 +5,7 @@
 #include <GraphicsUtil.hpp>
 #include <array>
 
-TEST_CASE("sf::Image - [graphics]")
+TEST_CASE("[Graphics] sf::Image")
 {
     SUBCASE("Default constructor")
     {

--- a/test/Graphics/Rect.cpp
+++ b/test/Graphics/Rect.cpp
@@ -5,7 +5,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::Rect class template - [graphics]")
+TEST_CASE("[Graphics] sf::Rect")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/RectangleShape.cpp
+++ b/test/Graphics/RectangleShape.cpp
@@ -4,7 +4,7 @@
 
 #include <SystemUtil.hpp>
 
-TEST_CASE("sf::RectangleShape class - [graphics]")
+TEST_CASE("[Graphics] sf::RectangleShape")
 {
     SUBCASE("Default constructor")
     {

--- a/test/Graphics/RenderStates.cpp
+++ b/test/Graphics/RenderStates.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::RenderStates class - [graphics]")
+TEST_CASE("[Graphics] sf::RenderStates")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/Shape.cpp
+++ b/test/Graphics/Shape.cpp
@@ -35,7 +35,7 @@ private:
     sf::Vector2f m_size;
 };
 
-TEST_CASE("sf::Shape class - [graphics]")
+TEST_CASE("[Graphics] sf::Shape")
 {
     SUBCASE("Default constructor")
     {

--- a/test/Graphics/Transform.cpp
+++ b/test/Graphics/Transform.cpp
@@ -25,7 +25,7 @@ struct StringMaker<std::vector<float>>
 };
 } // namespace doctest
 
-TEST_CASE("sf::Transform class - [graphics]")
+TEST_CASE("[Graphics] sf::Transform")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/Transformable.cpp
+++ b/test/Graphics/Transformable.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::Transformable class - [graphics]")
+TEST_CASE("[Graphics] sf::Transformable")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/Vertex.cpp
+++ b/test/Graphics/Vertex.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::Vertex class - [graphics]")
+TEST_CASE("[Graphics] sf::Vertex")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/VertexArray.cpp
+++ b/test/Graphics/VertexArray.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::VertexArray class - [graphics]")
+TEST_CASE("[Graphics] sf::VertexArray")
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/View.cpp
+++ b/test/Graphics/View.cpp
@@ -4,7 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 
-TEST_CASE("sf::View class - [graphics]")
+TEST_CASE("[Graphics] sf::View")
 {
     SUBCASE("Construction")
     {

--- a/test/Network/IpAddress.cpp
+++ b/test/Network/IpAddress.cpp
@@ -8,7 +8,7 @@
 using namespace std::string_literals;
 using namespace std::string_view_literals;
 
-TEST_CASE("sf::IpAddress class - [network]")
+TEST_CASE("[Network] sf::IpAddress")
 {
     SUBCASE("Construction")
     {

--- a/test/Network/Packet.cpp
+++ b/test/Network/Packet.cpp
@@ -26,7 +26,7 @@
         CHECK(expected == received);                         \
     } while (false)
 
-TEST_CASE("sf::Packet class - [network]")
+TEST_CASE("[Network] sf::Packet")
 {
     SUBCASE("Default constructor")
     {

--- a/test/System/Angle.cpp
+++ b/test/System/Angle.cpp
@@ -4,7 +4,7 @@
 
 #include <SystemUtil.hpp>
 
-TEST_CASE("sf::Angle class - [system]")
+TEST_CASE("[System] sf::Angle")
 {
     SUBCASE("Construction")
     {

--- a/test/System/Clock.cpp
+++ b/test/System/Clock.cpp
@@ -6,7 +6,7 @@
 #include <SystemUtil.hpp>
 #include <thread>
 
-TEST_CASE("sf::Clock class - [system]")
+TEST_CASE("[System] sf::Clock")
 {
     SUBCASE("getElapsedTime()")
     {

--- a/test/System/Config.cpp
+++ b/test/System/Config.cpp
@@ -2,7 +2,7 @@
 
 #include <doctest/doctest.h>
 
-TEST_CASE("SFML/Config.hpp")
+TEST_CASE("[System] SFML/Config.hpp")
 {
     SUBCASE("Version macros")
     {

--- a/test/System/Err.cpp
+++ b/test/System/Err.cpp
@@ -4,7 +4,7 @@
 
 #include <sstream>
 
-TEST_CASE("sf::err - [system]")
+TEST_CASE("[System] sf::err")
 {
     SUBCASE("Overflow default buffer")
     {

--- a/test/System/FileInputStream.cpp
+++ b/test/System/FileInputStream.cpp
@@ -58,7 +58,7 @@ public:
     }
 };
 
-TEST_CASE("sf::FileInputStream class - [system]")
+TEST_CASE("[System] sf::FileInputStream")
 {
     SUBCASE("Empty stream")
     {

--- a/test/System/MemoryInputStream.cpp
+++ b/test/System/MemoryInputStream.cpp
@@ -5,7 +5,7 @@
 #include <ostream>
 #include <string_view>
 
-TEST_CASE("sf::MemoryInputStream class - [system]")
+TEST_CASE("[System] sf::MemoryInputStream")
 {
     SUBCASE("Empty stream")
     {

--- a/test/System/Time.cpp
+++ b/test/System/Time.cpp
@@ -19,7 +19,7 @@ struct StringMaker<std::chrono::duration<Rep, Period>>
 };
 } // namespace doctest
 
-TEST_CASE("sf::Time class - [system]")
+TEST_CASE("[System] sf::Time")
 {
     SUBCASE("Construction")
     {

--- a/test/System/Vector2.cpp
+++ b/test/System/Vector2.cpp
@@ -12,7 +12,7 @@ using namespace sf::Literals;
 // Test coverage is given, as there are no template specializations.
 
 
-TEST_CASE("sf::Vector2 class template - [system]")
+TEST_CASE("[System] sf::Vector2")
 {
     SUBCASE("Construction")
     {

--- a/test/System/Vector2.cpp
+++ b/test/System/Vector2.cpp
@@ -18,14 +18,14 @@ TEST_CASE("[System] sf::Vector2")
     {
         SUBCASE("Default constructor")
         {
-            sf::Vector2i vector;
+            const sf::Vector2i vector;
             CHECK(vector.x == 0);
             CHECK(vector.y == 0);
         }
 
         SUBCASE("(x, y) coordinate constructor")
         {
-            sf::Vector2i vector(1, 2);
+            const sf::Vector2i vector(1, 2);
             CHECK(vector.x == 1);
             CHECK(vector.y == 2);
         }
@@ -146,7 +146,7 @@ TEST_CASE("[System] sf::Vector2")
     SUBCASE("Arithmetic operations between vector and scalar value")
     {
         sf::Vector2i vector(26, 12);
-        int          scalar = 2;
+        const int    scalar = 2;
 
         SUBCASE("vector * scalar")
         {

--- a/test/System/Vector3.cpp
+++ b/test/System/Vector3.cpp
@@ -8,7 +8,7 @@
 // Use sf::Vector3i for tests (except for float vector algebra).
 // Test coverage is given, as there are no template specializations.
 
-TEST_CASE("sf::Vector3 class template - [system]")
+TEST_CASE("[System] sf::Vector3")
 {
     SUBCASE("Construction")
     {

--- a/test/System/Vector3.cpp
+++ b/test/System/Vector3.cpp
@@ -14,7 +14,7 @@ TEST_CASE("[System] sf::Vector3")
     {
         SUBCASE("Default constructor")
         {
-            sf::Vector3i vector;
+            const sf::Vector3i vector;
             CHECK(vector.x == 0);
             CHECK(vector.y == 0);
             CHECK(vector.z == 0);
@@ -22,7 +22,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SUBCASE("(x, y, z) coordinate constructor")
         {
-            sf::Vector3i vector(1, 2, 3);
+            const sf::Vector3i vector(1, 2, 3);
             CHECK(vector.x == 1);
             CHECK(vector.y == 2);
             CHECK(vector.z == 3);
@@ -30,8 +30,8 @@ TEST_CASE("[System] sf::Vector3")
 
         SUBCASE("Conversion constructor")
         {
-            sf::Vector3f sourceVector(1.0f, 2.0f, 3.0f);
-            sf::Vector3i vector(sourceVector);
+            const sf::Vector3f sourceVector(1.0f, 2.0f, 3.0f);
+            const sf::Vector3i vector(sourceVector);
 
             CHECK(vector.x == static_cast<int>(sourceVector.x));
             CHECK(vector.y == static_cast<int>(sourceVector.y));
@@ -43,8 +43,8 @@ TEST_CASE("[System] sf::Vector3")
     {
         SUBCASE("-vector")
         {
-            sf::Vector3i vector(1, 2, 3);
-            sf::Vector3i negatedVector = -vector;
+            const sf::Vector3i vector(1, 2, 3);
+            const sf::Vector3i negatedVector = -vector;
 
             CHECK(negatedVector.x == -1);
             CHECK(negatedVector.y == -2);
@@ -54,8 +54,8 @@ TEST_CASE("[System] sf::Vector3")
 
     SUBCASE("Arithmetic operations between two vectors")
     {
-        sf::Vector3i firstVector(2, 5, 6);
-        sf::Vector3i secondVector(8, 3, 7);
+        sf::Vector3i       firstVector(2, 5, 6);
+        const sf::Vector3i secondVector(8, 3, 7);
 
         SUBCASE("vector += vector")
         {
@@ -77,7 +77,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SUBCASE("vector + vector")
         {
-            sf::Vector3i result = firstVector + secondVector;
+            const sf::Vector3i result = firstVector + secondVector;
 
             CHECK(result.x == 10);
             CHECK(result.y == 8);
@@ -86,7 +86,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SUBCASE("vector - vector")
         {
-            sf::Vector3i result = firstVector - secondVector;
+            const sf::Vector3i result = firstVector - secondVector;
 
             CHECK(result.x == -6);
             CHECK(result.y == 2);
@@ -97,7 +97,7 @@ TEST_CASE("[System] sf::Vector3")
     SUBCASE("Arithmetic operations between vector and scalar value")
     {
         sf::Vector3i vector(26, 12, 6);
-        int          scalar = 2;
+        const int    scalar = 2;
 
         SUBCASE("vector * scalar")
         {
@@ -147,9 +147,9 @@ TEST_CASE("[System] sf::Vector3")
 
     SUBCASE("Comparison operations (two equal and one different vector)")
     {
-        sf::Vector3i firstEqualVector(1, 5, 6);
-        sf::Vector3i secondEqualVector(1, 5, 6);
-        sf::Vector3i differentVector(6, 9, 7);
+        const sf::Vector3i firstEqualVector(1, 5, 6);
+        const sf::Vector3i secondEqualVector(1, 5, 6);
+        const sf::Vector3i differentVector(6, 9, 7);
 
         SUBCASE("vector == vector")
         {

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -9,19 +9,16 @@ namespace sf
 {
 std::ostream& operator<<(std::ostream& os, const BlendMode& blendMode)
 {
-    os << "( " << blendMode.colorSrcFactor << ", " << blendMode.colorDstFactor << ", " << blendMode.colorEquation << ", "
-       << blendMode.alphaSrcFactor << ", " << blendMode.alphaDstFactor << ", " << blendMode.alphaEquation << " )";
-
-    return os;
+    return os << "( " << blendMode.colorSrcFactor << ", " << blendMode.colorDstFactor << ", " << blendMode.colorEquation
+              << ", " << blendMode.alphaSrcFactor << ", " << blendMode.alphaDstFactor << ", " << blendMode.alphaEquation
+              << " )";
 }
 
 std::ostream& operator<<(std::ostream& os, const Color& color)
 {
-    os << "0x" << std::hex << color.toInteger() << std::dec << " (r=" << static_cast<int>(color.r)
-       << ", g=" << static_cast<int>(color.g) << ", b=" << static_cast<int>(color.b)
-       << ", a=" << static_cast<int>(color.a) << ")";
-
-    return os;
+    return os << "0x" << std::hex << color.toInteger() << std::dec << " (r=" << static_cast<int>(color.r)
+              << ", g=" << static_cast<int>(color.g) << ", b=" << static_cast<int>(color.b)
+              << ", a=" << static_cast<int>(color.a) << ")";
 }
 
 std::ostream& operator<<(std::ostream& os, const Transform& transform)
@@ -30,7 +27,6 @@ std::ostream& operator<<(std::ostream& os, const Transform& transform)
     os << matrix[0] << ", " << matrix[4] << ", " << matrix[12] << ", ";
     os << matrix[1] << ", " << matrix[5] << ", " << matrix[13] << ", ";
     os << matrix[3] << ", " << matrix[7] << ", " << matrix[15];
-
     return os;
 }
 } // namespace sf

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -7,7 +7,7 @@
 
 namespace sf
 {
-std::ostream& operator<<(std::ostream& os, const sf::BlendMode& blendMode)
+std::ostream& operator<<(std::ostream& os, const BlendMode& blendMode)
 {
     os << "( " << blendMode.colorSrcFactor << ", " << blendMode.colorDstFactor << ", " << blendMode.colorEquation << ", "
        << blendMode.alphaSrcFactor << ", " << blendMode.alphaDstFactor << ", " << blendMode.alphaEquation << " )";
@@ -15,7 +15,7 @@ std::ostream& operator<<(std::ostream& os, const sf::BlendMode& blendMode)
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const sf::Color& color)
+std::ostream& operator<<(std::ostream& os, const Color& color)
 {
     os << "0x" << std::hex << color.toInteger() << std::dec << " (r=" << static_cast<int>(color.r)
        << ", g=" << static_cast<int>(color.g) << ", b=" << static_cast<int>(color.b)
@@ -24,7 +24,7 @@ std::ostream& operator<<(std::ostream& os, const sf::Color& color)
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const sf::Transform& transform)
+std::ostream& operator<<(std::ostream& os, const Transform& transform)
 {
     const auto& matrix = transform.getMatrix();
     os << matrix[0] << ", " << matrix[4] << ", " << matrix[12] << ", ";

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -23,7 +23,7 @@ std::ostream& operator<<(std::ostream& os, const Color& color);
 std::ostream& operator<<(std::ostream& os, const Transform& transform);
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const sf::Rect<T>& rect)
+std::ostream& operator<<(std::ostream& os, const Rect<T>& rect)
 {
     const auto flags = os.flags();
     os << std::fixed << std::setprecision(std::numeric_limits<T>::max_digits10);

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -8,20 +8,20 @@
 
 namespace sf
 {
-std::ostream& operator<<(std::ostream& os, const sf::Angle& angle)
+std::ostream& operator<<(std::ostream& os, const Angle& angle)
 {
     os << std::fixed << std::setprecision(std::numeric_limits<float>::max_digits10);
     os << angle.asDegrees() << " deg";
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const sf::String& string)
+std::ostream& operator<<(std::ostream& os, const String& string)
 {
     os << string.toAnsiString();
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, sf::Time time)
+std::ostream& operator<<(std::ostream& os, Time time)
 {
     os << time.asMicroseconds() << "us";
     return os;

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -11,20 +11,17 @@ namespace sf
 std::ostream& operator<<(std::ostream& os, const Angle& angle)
 {
     os << std::fixed << std::setprecision(std::numeric_limits<float>::max_digits10);
-    os << angle.asDegrees() << " deg";
-    return os;
+    return os << angle.asDegrees() << " deg";
 }
 
 std::ostream& operator<<(std::ostream& os, const String& string)
 {
-    os << string.toAnsiString();
-    return os;
+    return os << string.toAnsiString();
 }
 
 std::ostream& operator<<(std::ostream& os, Time time)
 {
-    os << time.asMicroseconds() << "us";
-    return os;
+    return os << time.asMicroseconds() << "us";
 }
 } // namespace sf
 

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -20,12 +20,12 @@ class Angle;
 class String;
 class Time;
 
-std::ostream& operator<<(std::ostream& os, const sf::Angle& angle);
-std::ostream& operator<<(std::ostream& os, const sf::String& string);
-std::ostream& operator<<(std::ostream& os, sf::Time time);
+std::ostream& operator<<(std::ostream& os, const Angle& angle);
+std::ostream& operator<<(std::ostream& os, const String& string);
+std::ostream& operator<<(std::ostream& os, Time time);
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const sf::Vector2<T>& vector)
+std::ostream& operator<<(std::ostream& os, const Vector2<T>& vector)
 {
     os << std::fixed << std::setprecision(std::numeric_limits<T>::max_digits10);
     os << "(" << vector.x << ", " << vector.y << ")";
@@ -33,7 +33,7 @@ std::ostream& operator<<(std::ostream& os, const sf::Vector2<T>& vector)
 }
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const sf::Vector3<T>& vector)
+std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector)
 {
     os << "(" << vector.x << ", " << vector.y << ", " << vector.z << ")";
     return os;

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -28,15 +28,13 @@ template <typename T>
 std::ostream& operator<<(std::ostream& os, const Vector2<T>& vector)
 {
     os << std::fixed << std::setprecision(std::numeric_limits<T>::max_digits10);
-    os << "(" << vector.x << ", " << vector.y << ")";
-    return os;
+    return os << "(" << vector.x << ", " << vector.y << ")";
 }
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector)
 {
-    os << "(" << vector.x << ", " << vector.y << ", " << vector.z << ")";
-    return os;
+    return os << "(" << vector.x << ", " << vector.y << ", " << vector.z << ")";
 }
 } // namespace sf
 

--- a/test/TestUtilities/WindowUtil.cpp
+++ b/test/TestUtilities/WindowUtil.cpp
@@ -5,7 +5,7 @@
 
 namespace sf
 {
-std::ostream& operator<<(std::ostream& os, const sf::VideoMode& videoMode)
+std::ostream& operator<<(std::ostream& os, const VideoMode& videoMode)
 {
     os << videoMode.size.x << "x" << videoMode.size.y << "x" << videoMode.bitsPerPixel;
     return os;

--- a/test/TestUtilities/WindowUtil.cpp
+++ b/test/TestUtilities/WindowUtil.cpp
@@ -7,7 +7,6 @@ namespace sf
 {
 std::ostream& operator<<(std::ostream& os, const VideoMode& videoMode)
 {
-    os << videoMode.size.x << "x" << videoMode.size.y << "x" << videoMode.bitsPerPixel;
-    return os;
+    return os << videoMode.size.x << "x" << videoMode.size.y << "x" << videoMode.bitsPerPixel;
 }
 } // namespace sf

--- a/test/TestUtilities/WindowUtil.hpp
+++ b/test/TestUtilities/WindowUtil.hpp
@@ -13,7 +13,7 @@ namespace sf
 {
 class VideoMode;
 
-std::ostream& operator<<(std::ostream& os, const sf::VideoMode& videoMode);
+std::ostream& operator<<(std::ostream& os, const VideoMode& videoMode);
 } // namespace sf
 
 #endif // SFML_TESTUTILITIES_WINDOW_HPP

--- a/test/Window/ContextSettings.cpp
+++ b/test/Window/ContextSettings.cpp
@@ -2,7 +2,7 @@
 
 #include <doctest/doctest.h>
 
-TEST_CASE("sf::ContextSettings class - [window]")
+TEST_CASE("[Window] sf::ContextSettings")
 {
     SUBCASE("Construction")
     {

--- a/test/Window/VideoMode.cpp
+++ b/test/Window/VideoMode.cpp
@@ -4,7 +4,7 @@
 
 #include <WindowUtil.hpp>
 
-TEST_CASE("sf::VideoMode class - [window]")
+TEST_CASE("[Window] sf::VideoMode")
 {
     SUBCASE("Construction")
     {


### PR DESCRIPTION
## Description

Here are some assorted cleanups to the tests I've been accumulated for a couple months. No drastic changes are made. The biggest change is renaming all the tests cases. Here's a before and after for what the test output looks like. I think it's a lot easier to parse now.

Before
```
Run tests
Test project /Users/thrasher/Projects/sfml/build/test
      Start  1: sf::Angle class - [system]
 1/28 Test  #1: sf::Angle class - [system] ...............   Passed    0.00 sec
      Start  2: sf::Clock class - [system]
 2/28 Test  #2: sf::Clock class - [system] ...............   Passed    0.01 sec
      Start  3: SFML/Config.hpp
 3/28 Test  #3: SFML/Config.hpp ..........................   Passed    0.00 sec
      Start  4: sf::err - [system]
 4/28 Test  #4: sf::err - [system] .......................   Passed    0.00 sec
      Start  5: sf::FileInputStream class - [system]
 5/28 Test  #5: sf::FileInputStream class - [system] .....   Passed    0.00 sec
      Start  6: sf::MemoryInputStream class - [system]
 6/28 Test  #6: sf::MemoryInputStream class - [system] ...   Passed    0.00 sec
      Start  7: sf::Time class - [system]
 7/28 Test  #7: sf::Time class - [system] ................   Passed    0.00 sec
      Start  8: sf::Vector2 class template - [system]
 8/28 Test  #8: sf::Vector2 class template - [system] ....   Passed    0.00 sec
      Start  9: sf::Vector3 class template - [system]
 9/28 Test  #9: sf::Vector3 class template - [system] ....   Passed    0.00 sec
      Start 10: sf::ContextSettings class - [window]
10/28 Test #10: sf::ContextSettings class - [window] .....   Passed    0.01 sec
      Start 11: sf::VideoMode class - [window]
11/28 Test #11: sf::VideoMode class - [window] ...........   Passed    0.01 sec
      Start 12: sf::BlendMode class - [graphics]
12/28 Test #12: sf::BlendMode class - [graphics] .........   Passed    0.01 sec
      Start 13: sf::CircleShape class - [graphics]
13/28 Test #13: sf::CircleShape class - [graphics] .......   Passed    0.01 sec
      Start 14: sf::Color class - [graphics]
14/28 Test #14: sf::Color class - [graphics] .............   Passed    0.01 sec
      Start 15: sf::ConvexShape class - [graphics]
15/28 Test #15: sf::ConvexShape class - [graphics] .......   Passed    0.01 sec
      Start 16: sf::Glyph class - [graphics]
16/28 Test #16: sf::Glyph class - [graphics] .............   Passed    0.01 sec
      Start 17: sf::Image - [graphics]
17/28 Test #17: sf::Image - [graphics] ...................   Passed    0.01 sec
      Start 18: sf::Rect class template - [graphics]
18/28 Test #18: sf::Rect class template - [graphics] .....   Passed    0.01 sec
      Start 19: sf::RectangleShape class - [graphics]
19/28 Test #19: sf::RectangleShape class - [graphics] ....   Passed    0.01 sec
      Start 20: sf::RenderStates class - [graphics]
20/28 Test #20: sf::RenderStates class - [graphics] ......   Passed    0.01 sec
      Start 21: sf::Shape class - [graphics]
21/28 Test #21: sf::Shape class - [graphics] .............   Passed    0.01 sec
      Start 22: sf::Transform class - [graphics]
22/28 Test #22: sf::Transform class - [graphics] .........   Passed    0.01 sec
      Start 23: sf::Transformable class - [graphics]
23/28 Test #23: sf::Transformable class - [graphics] .....   Passed    0.01 sec
      Start 24: sf::Vertex class - [graphics]
24/28 Test #24: sf::Vertex class - [graphics] ............   Passed    0.01 sec
      Start 25: sf::VertexArray class - [graphics]
25/28 Test #25: sf::VertexArray class - [graphics] .......   Passed    0.01 sec
      Start 26: sf::View class - [graphics]
26/28 Test #26: sf::View class - [graphics] ..............   Passed    0.01 sec
      Start 27: sf::IpAddress class - [network]
27/28 Test #27: sf::IpAddress class - [network] ..........   Passed    0.28 sec
      Start 28: sf::Packet class - [network]
28/28 Test #28: sf::Packet class - [network] .............   Passed    0.00 sec
```

After
```
Run tests
Test project /Users/thrasher/Projects/sfml/build/test
      Start  1: [System] sf::Angle
 1/28 Test  #1: [System] sf::Angle ...............   Passed    0.00 sec
      Start  2: [System] sf::Clock
 2/28 Test  #2: [System] sf::Clock ...............   Passed    0.01 sec
      Start  3: SFML/Config.hpp
 3/28 Test  #3: SFML/Config.hpp ..................   Passed    0.00 sec
      Start  4: [System] sf::err
 4/28 Test  #4: [System] sf::err .................   Passed    0.00 sec
      Start  5: [System] sf::FileInputStream
 5/28 Test  #5: [System] sf::FileInputStream .....   Passed    0.00 sec
      Start  6: [System] sf::MemoryInputStream
 6/28 Test  #6: [System] sf::MemoryInputStream ...   Passed    0.00 sec
      Start  7: [System] sf::Time
 7/28 Test  #7: [System] sf::Time ................   Passed    0.00 sec
      Start  8: [System] sf::Vector2
 8/28 Test  #8: [System] sf::Vector2 .............   Passed    0.00 sec
      Start  9: [System] sf::Vector3
 9/28 Test  #9: [System] sf::Vector3 .............   Passed    0.00 sec
      Start 10: [Window] sf::ContextSettings
10/28 Test #10: [Window] sf::ContextSettings .....   Passed    0.01 sec
      Start 11: [Window] sf::VideoMode
11/28 Test #11: [Window] sf::VideoMode ...........   Passed    0.01 sec
      Start 12: [Graphics] sf::BlendMode
12/28 Test #12: [Graphics] sf::BlendMode .........   Passed    0.01 sec
      Start 13: [Graphics] sf::CircleShape
13/28 Test #13: [Graphics] sf::CircleShape .......   Passed    0.01 sec
      Start 14: [Graphics] sf::Color
14/28 Test #14: [Graphics] sf::Color .............   Passed    0.01 sec
      Start 15: [Graphics] sf::ConvexShape
15/28 Test #15: [Graphics] sf::ConvexShape .......   Passed    0.01 sec
      Start 16: [Graphics] sf::Glyph
16/28 Test #16: [Graphics] sf::Glyph .............   Passed    0.01 sec
      Start 17: [Graphics] sf::Image
17/28 Test #17: [Graphics] sf::Image .............   Passed    0.01 sec
      Start 18: [Graphics] sf::Rect
18/28 Test #18: [Graphics] sf::Rect ..............   Passed    0.01 sec
      Start 19: [Graphics] sf::RectangleShape
19/28 Test #19: [Graphics] sf::RectangleShape ....   Passed    0.01 sec
      Start 20: [Graphics] sf::RenderStates
20/28 Test #20: [Graphics] sf::RenderStates ......   Passed    0.01 sec
      Start 21: [Graphics] sf::Shape
21/28 Test #21: [Graphics] sf::Shape .............   Passed    0.01 sec
      Start 22: [Graphics] sf::Transform
22/28 Test #22: [Graphics] sf::Transform .........   Passed    0.01 sec
      Start 23: [Graphics] sf::Transformable
23/28 Test #23: [Graphics] sf::Transformable .....   Passed    0.01 sec
      Start 24: [Graphics] sf::Vertex
24/28 Test #24: [Graphics] sf::Vertex ............   Passed    0.01 sec
      Start 25: [Graphics] sf::VertexArray
25/28 Test #25: [Graphics] sf::VertexArray .......   Passed    0.01 sec
      Start 26: [Graphics] sf::View
26/28 Test #26: [Graphics] sf::View ..............   Passed    0.01 sec
      Start 27: [Network] sf::IpAddress
27/28 Test #27: [Network] sf::IpAddress ..........   Passed    0.50 sec
      Start 28: [Network] sf::Packet
28/28 Test #28: [Network] sf::Packet .............   Passed    0.01 sec
```

---


I also have a commit that [simplifies how code coverage is applied](https://github.com/ChrisThrasher/SFML/commit/4c017a82e88dab855163b9d61fd05503a715ff0e) in case someone wants to check that out. I may add that this PR but chose to omit it for now so any discussion about it wouldn't delay reviewing the simpler stuff.