### PR TITLE
WIP - safer 'std::optional'-based 'sf::Image' API

### DIFF
--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -1833,13 +1833,15 @@ public:
     void setupTextureImage()
     {
         // Load the image data
-        sf::Image imageData;
+        std::optional<sf::Image> maybeImageData = sf::Image::loadFromFile("resources/logo.png");
 
-        if (!imageData.loadFromFile("resources/logo.png"))
+        if (!maybeImageData.has_value())
         {
             vulkanAvailable = false;
             return;
         }
+
+        sf::Image& imageData = *maybeImageData;
 
         // Create a staging buffer to transfer the data with
         VkDeviceSize imageSize = imageData.getSize().x * imageData.getSize().y * 4;

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -33,6 +33,7 @@
 #include <SFML/Graphics/Rect.hpp>
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -49,13 +50,22 @@ class SFML_GRAPHICS_API Image
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Deleted default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Image() = delete;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Create the image and fill it with a unique color
+    ///
+    /// If \a size has any zero component, an unset optional is
+    /// returned.
     ///
     /// \param size  Width and height of the image
     /// \param color Fill color
     ///
     ////////////////////////////////////////////////////////////
-    void create(const Vector2u& size, const Color& color = Color(0, 0, 0));
+    [[nodiscard]] static std::optional<Image> create(const Vector2u& size, const Color& color = Color(0, 0, 0));
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the image from an array of pixels
@@ -63,13 +73,15 @@ public:
     /// The \a pixel array is assumed to contain 32-bits RGBA pixels,
     /// and have the given \a width and \a height. If not, this is
     /// an undefined behavior.
-    /// If \a pixels is null, an empty image is created.
+    ///
+    /// If \a pixels is null or \a size has any zero component, an
+    /// unset optional is returned.
     ///
     /// \param size   Width and height of the image
     /// \param pixels Array of pixels to copy to the image
     ///
     ////////////////////////////////////////////////////////////
-    void create(const Vector2u& size, const std::uint8_t* pixels);
+    [[nodiscard]] static std::optional<Image> create(const Vector2u& size, const std::uint8_t* pixels);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the image from a file on disk
@@ -77,16 +89,17 @@ public:
     /// The supported image formats are bmp, png, tga, jpg, gif,
     /// psd, hdr, pic and pnm. Some format options are not supported,
     /// like jpeg with arithmetic coding or ASCII pnm.
-    /// If this function fails, the image is left unchanged.
+    ///
+    /// If this function fails, an unset optional is returned.
     ///
     /// \param filename Path of the image file to load
     ///
-    /// \return True if loading was successful
+    /// \return A set optional if loading was successful
     ///
     /// \see loadFromMemory, loadFromStream, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<Image> loadFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the image from a file in memory
@@ -94,17 +107,18 @@ public:
     /// The supported image formats are bmp, png, tga, jpg, gif,
     /// psd, hdr, pic and pnm. Some format options are not supported,
     /// like jpeg with arithmetic coding or ASCII pnm.
-    /// If this function fails, the image is left unchanged.
+    ///
+    /// If this function fails, an unset optional is returned.
     ///
     /// \param data Pointer to the file data in memory
     /// \param size Size of the data to load, in bytes
     ///
-    /// \return True if loading was successful
+    /// \return A set optional if loading was successful
     ///
     /// \see loadFromFile, loadFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t size);
+    [[nodiscard]] static std::optional<Image> loadFromMemory(const void* data, std::size_t size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the image from a custom stream
@@ -112,16 +126,17 @@ public:
     /// The supported image formats are bmp, png, tga, jpg, gif,
     /// psd, hdr, pic and pnm. Some format options are not supported,
     /// like jpeg with arithmetic coding or ASCII pnm.
-    /// If this function fails, the image is left unchanged.
+    ///
+    /// If this function fails, an unset optional is returned.
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return True if loading was successful
+    /// \return A set optional if loading was successful
     ///
     /// \see loadFromFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromStream(InputStream& stream);
+    [[nodiscard]] static std::optional<Image> loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the image to a file on disk
@@ -275,6 +290,15 @@ public:
     void flipVertically();
 
 private:
+    ////////////////////////////////////////////////////////////
+    /// \brief Create an image from \a size and \a pixels
+    ///
+    /// This constructor is private as the intended user API is
+    /// through static member functions returning optionals.
+    ///
+    ////////////////////////////////////////////////////////////
+    Image(Vector2u size, std::vector<std::uint8_t>&& pixels);
+
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -33,6 +33,7 @@
 #include <SFML/Window/GlResource.hpp>
 
 #include <filesystem>
+#include <optional>
 
 
 namespace sf
@@ -101,8 +102,7 @@ public:
     ///
     /// This function is a shortcut for the following code:
     /// \code
-    /// sf::Image image;
-    /// image.loadFromFile(filename);
+    /// const std:optional<sf::Image> image = sf::Image::loadFromFile(data, size);
     /// texture.loadFromImage(image, area);
     /// \endcode
     ///
@@ -132,8 +132,7 @@ public:
     ///
     /// This function is a shortcut for the following code:
     /// \code
-    /// sf::Image image;
-    /// image.loadFromMemory(data, size);
+    /// const std:optional<sf::Image> image = sf::Image::loadFromMemory(data, size);
     /// texture.loadFromImage(image, area);
     /// \endcode
     ///
@@ -164,8 +163,7 @@ public:
     ///
     /// This function is a shortcut for the following code:
     /// \code
-    /// sf::Image image;
-    /// image.loadFromStream(stream);
+    /// const std:optional<sf::Image> image = sf::Image::loadFromStream(stream);
     /// texture.loadFromImage(image, area);
     /// \endcode
     ///
@@ -235,7 +233,7 @@ public:
     /// \see loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    Image copyToImage() const;
+    std::optional<Image> copyToImage() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the whole texture from an array of pixels

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -41,6 +41,7 @@
 #include FT_OUTLINE_H
 #include FT_BITMAP_H
 #include FT_STROKER_H
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -680,7 +681,8 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
                 for (unsigned int x = padding; x < width - padding; ++x)
                 {
                     // The color channels remain white, just fill the alpha channel
-                    std::size_t index            = x + y * width;
+                    const std::size_t index = x + y * width;
+
                     m_pixelBuffer[index * 4 + 3] = ((pixels[(x - padding) / 8]) & (1 << (7 - ((x - padding) % 8)))) ? 255 : 0;
                 }
                 pixels += bitmap.pitch;
@@ -837,8 +839,9 @@ bool Font::setCurrentSize(unsigned int characterSize) const
 Font::Page::Page(bool smooth) : nextRow(3)
 {
     // Make sure that the texture is initialized by default
-    sf::Image image;
-    image.create({128, 128}, Color(255, 255, 255, 0));
+    std::optional<Image> maybeImage = Image::create({128, 128}, Color(255, 255, 255, 0));
+    assert(maybeImage.has_value());
+    Image& image = *maybeImage;
 
     // Reserve a 2x2 white square for texturing underlines
     for (unsigned int x = 0; x < 2; ++x)

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -218,24 +218,24 @@ bool Texture::create(const Vector2u& size)
 ////////////////////////////////////////////////////////////
 bool Texture::loadFromFile(const std::filesystem::path& filename, const IntRect& area)
 {
-    Image image;
-    return image.loadFromFile(filename) && loadFromImage(image, area);
+    const std::optional<Image> maybeImage = Image::loadFromFile(filename);
+    return maybeImage.has_value() && loadFromImage(*maybeImage, area);
 }
 
 
 ////////////////////////////////////////////////////////////
 bool Texture::loadFromMemory(const void* data, std::size_t size, const IntRect& area)
 {
-    Image image;
-    return image.loadFromMemory(data, size) && loadFromImage(image, area);
+    const std::optional<Image> maybeImage = Image::loadFromMemory(data, size);
+    return maybeImage.has_value() && loadFromImage(*maybeImage, area);
 }
 
 
 ////////////////////////////////////////////////////////////
 bool Texture::loadFromStream(InputStream& stream, const IntRect& area)
 {
-    Image image;
-    return image.loadFromStream(stream) && loadFromImage(image, area);
+    const std::optional<Image> maybeImage = Image::loadFromStream(stream);
+    return maybeImage.has_value() && loadFromImage(*maybeImage, area);
 }
 
 
@@ -319,11 +319,11 @@ Vector2u Texture::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-Image Texture::copyToImage() const
+std::optional<Image> Texture::copyToImage() const
 {
     // Easy case: empty texture
     if (!m_texture)
-        return Image();
+        return std::nullopt;
 
     TransientContextLock lock;
 
@@ -393,10 +393,7 @@ Image Texture::copyToImage() const
 #endif // SFML_OPENGL_ES
 
     // Create the image
-    Image image;
-    image.create(m_size, pixels.data());
-
-    return image;
+    return Image::create(m_size, pixels.data());
 }
 
 
@@ -559,7 +556,8 @@ void Texture::update(const Texture& texture, const Vector2u& dest)
 
 #endif // SFML_OPENGL_ES
 
-    update(texture.copyToImage(), dest);
+    if (const std::optional<Image> maybeCopy = texture.copyToImage(); maybeCopy.has_value())
+        update(*maybeCopy, dest);
 }
 
 

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -13,19 +13,11 @@ static_assert(std::is_nothrow_move_assignable_v<sf::Image>);
 
 TEST_CASE("[Graphics] sf::Image")
 {
-    SUBCASE("Default constructor")
-    {
-        const sf::Image image;
-        CHECK(image.getSize() == sf::Vector2u());
-        CHECK(image.getPixelsPtr() == nullptr);
-    }
-
     SUBCASE("Create")
     {
         SUBCASE("create(Vector2)")
         {
-            sf::Image image;
-            image.create(sf::Vector2u(10, 10));
+            const sf::Image image = sf::Image::create(sf::Vector2u(10, 10)).value();
             CHECK(image.getSize() == sf::Vector2u(10, 10));
             CHECK(image.getPixelsPtr() != nullptr);
 
@@ -40,8 +32,7 @@ TEST_CASE("[Graphics] sf::Image")
 
         SUBCASE("create(Vector2, Color)")
         {
-            sf::Image image;
-            image.create(sf::Vector2u(10, 10), sf::Color::Red);
+            const sf::Image image = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Red).value();
 
             CHECK(image.getSize() == sf::Vector2u(10, 10));
             CHECK(image.getPixelsPtr() != nullptr);
@@ -67,8 +58,7 @@ TEST_CASE("[Graphics] sf::Image")
                 pixels[i + 3] = 255; // a
             }
 
-            sf::Image image;
-            image.create(sf::Vector2u(10, 10), pixels.data());
+            const sf::Image image = sf::Image::create(sf::Vector2u(10, 10), pixels.data()).value();
 
             CHECK(image.getSize() == sf::Vector2u(10, 10));
             CHECK(image.getPixelsPtr() != nullptr);
@@ -85,9 +75,7 @@ TEST_CASE("[Graphics] sf::Image")
 
     SUBCASE("Set/get pixel")
     {
-        sf::Image image;
-
-        image.create(sf::Vector2u(10, 10), sf::Color::Green);
+        sf::Image image = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Green).value();
         CHECK(image.getPixel(sf::Vector2u(2, 2)) == sf::Color::Green);
 
         image.setPixel(sf::Vector2u(2, 2), sf::Color::Blue);
@@ -98,11 +86,9 @@ TEST_CASE("[Graphics] sf::Image")
     {
         SUBCASE("Copy (Image, Vector2u)")
         {
-            sf::Image image1;
-            image1.create(sf::Vector2u(10, 10), sf::Color::Blue);
+            const sf::Image image1 = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Blue).value();
 
-            sf::Image image2;
-            image2.create(sf::Vector2u(10, 10));
+            sf::Image image2 = sf::Image::create(sf::Vector2u(10, 10)).value();
             CHECK(image2.copy(image1, sf::Vector2u(0, 0)));
 
             for (std::uint32_t i = 0; i < 10; ++i)
@@ -116,11 +102,9 @@ TEST_CASE("[Graphics] sf::Image")
 
         SUBCASE("Copy (Image, Vector2u, IntRect)")
         {
-            sf::Image image1;
-            image1.create(sf::Vector2u(5, 5), sf::Color::Blue);
+            const sf::Image image1 = sf::Image::create(sf::Vector2u(5, 5), sf::Color::Blue).value();
 
-            sf::Image image2;
-            image2.create(sf::Vector2u(10, 10));
+            sf::Image image2 = sf::Image::create(sf::Vector2u(10, 10)).value();
             CHECK(image2.copy(image1, sf::Vector2u(0, 0), sf::IntRect(sf::Vector2i(0, 0), sf::Vector2i(5, 5))));
 
             for (std::uint32_t i = 0; i < 10; ++i)
@@ -150,11 +134,9 @@ TEST_CASE("[Graphics] sf::Image")
                 ((source.b * source.a) + (((dest.b * dest.a) * (255 - source.a))) / 255) / a);
             const sf::Color composite(r, g, b, a);
 
-            sf::Image image1;
-            image1.create(sf::Vector2u(10, 10), dest);
+            sf::Image image1 = sf::Image::create(sf::Vector2u(10, 10), dest).value();
 
-            sf::Image image2;
-            image2.create(sf::Vector2u(10, 10), source);
+            const sf::Image image2 = sf::Image::create(sf::Vector2u(10, 10), source).value();
             CHECK(image1.copy(image2, sf::Vector2u(0, 0), sf::IntRect(sf::Vector2i(0, 0), sf::Vector2i(10, 10)), true));
 
             for (std::uint32_t i = 0; i < 10; ++i)
@@ -166,31 +148,11 @@ TEST_CASE("[Graphics] sf::Image")
             }
         }
 
-        SUBCASE("Copy (Empty image)")
-        {
-            sf::Image image1;
-            sf::Image image2;
-
-            image2.create(sf::Vector2u(10, 10), sf::Color::Red);
-            CHECK(!image2.copy(image1, sf::Vector2u(0, 0), sf::IntRect(sf::Vector2i(0, 0), sf::Vector2i(9, 9))));
-
-            for (std::uint32_t i = 0; i < 10; ++i)
-            {
-                for (std::uint32_t j = 0; j < 10; ++j)
-                {
-                    CHECK(image2.getPixel(sf::Vector2u(i, j)) == sf::Color::Red);
-                }
-            }
-        }
-
         SUBCASE("Copy (Out of bounds sourceRect)")
         {
-            sf::Image image1;
-            image1.create(sf::Vector2u(5, 5), sf::Color::Blue);
+            const sf::Image image1 = sf::Image::create(sf::Vector2u(5, 5), sf::Color::Blue).value();
+            sf::Image       image2 = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Red).value();
 
-            sf::Image image2;
-
-            image2.create(sf::Vector2u(10, 10), sf::Color::Red);
             CHECK(!image2.copy(image1, sf::Vector2u(0, 0), sf::IntRect(sf::Vector2i(5, 5), sf::Vector2i(9, 9))));
 
             for (std::uint32_t i = 0; i < 10; ++i)
@@ -207,8 +169,7 @@ TEST_CASE("[Graphics] sf::Image")
     {
         SUBCASE("createMaskFromColor(Color)")
         {
-            sf::Image image;
-            image.create(sf::Vector2u(10, 10), sf::Color::Blue);
+            sf::Image image = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Blue).value();
             image.createMaskFromColor(sf::Color::Blue);
 
             for (std::uint32_t i = 0; i < 10; ++i)
@@ -222,8 +183,7 @@ TEST_CASE("[Graphics] sf::Image")
 
         SUBCASE("createMaskFromColor(Color, std::uint8_t)")
         {
-            sf::Image image;
-            image.create(sf::Vector2u(10, 10), sf::Color::Blue);
+            sf::Image image = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Blue).value();
             image.createMaskFromColor(sf::Color::Blue, 100);
 
             for (std::uint32_t i = 0; i < 10; ++i)
@@ -238,8 +198,7 @@ TEST_CASE("[Graphics] sf::Image")
 
     SUBCASE("Flip horizontally")
     {
-        sf::Image image;
-        image.create(sf::Vector2u(10, 10), sf::Color::Red);
+        sf::Image image = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Red).value();
         image.setPixel(sf::Vector2u(0, 0), sf::Color::Green);
         image.flipHorizontally();
 
@@ -248,8 +207,7 @@ TEST_CASE("[Graphics] sf::Image")
 
     SUBCASE("Flip vertically")
     {
-        sf::Image image;
-        image.create(sf::Vector2u(10, 10), sf::Color::Red);
+        sf::Image image = sf::Image::create(sf::Vector2u(10, 10), sf::Color::Red).value();
         image.setPixel(sf::Vector2u(0, 0), sf::Color::Green);
         image.flipVertically();
 


### PR DESCRIPTION
This WIP PR changes the API of `sf::Image` to something similar to `sf::IpAddress`, where the "empty state" is not representable anymore, and any creation has to go through a `static` member function returning an `std::optional<sf::Image>`. 

Main benefits:
- Any existing `sf::Image` is in a valid state, with some valid data (except if it has been moved-from).
- It is now possible to have `const` objects of type `sf::Image`, as the initialization is done in a non-mutating manner.
- A set of run-time defects is now caught at compile-time.

Thoughts?