### PR TITLE
WIP - safer 'std::optional'-based 'sf::Font' API 

### DIFF
--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -90,11 +90,8 @@ int main(int argc, char* argv[])
     image.setPosition(sf::Vector2f(screen.size) / 2.f);
     image.setOrigin(sf::Vector2f(texture.getSize()) / 2.f);
 
-    std::optional<sf::Font> font = sf::Font::loadFromFile("tuffy.ttf");
-    if (!font.has_value())
-        return EXIT_FAILURE;
-
-    sf::Text text("Tap anywhere to move the logo.", *font, 64);
+    sf::Font font = sf::Font::loadFromFile("tuffy.ttf").value();
+    sf::Text text("Tap anywhere to move the logo.", font, 64);
     text.setFillColor(sf::Color::Black);
     text.setPosition({10, 10});
 

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -90,11 +90,11 @@ int main(int argc, char* argv[])
     image.setPosition(sf::Vector2f(screen.size) / 2.f);
     image.setOrigin(sf::Vector2f(texture.getSize()) / 2.f);
 
-    sf::Font font;
-    if (!font.loadFromFile("tuffy.ttf"))
+    std::optional<sf::Font> font = sf::Font::loadFromFile("tuffy.ttf");
+    if (!font.has_value())
         return EXIT_FAILURE;
 
-    sf::Text text("Tap anywhere to move the logo.", font, 64);
+    sf::Text text("Tap anywhere to move the logo.", *font, 64);
     text.setFillColor(sf::Color::Black);
     text.setPosition({10, 10});
 

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -4,6 +4,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics.hpp>
 
+#include "SFML/Graphics/Font.hpp"
+
 #define STB_PERLIN_IMPLEMENTATION
 #include <stb_perlin.h>
 
@@ -90,9 +92,7 @@ int main()
     sf::RenderWindow window(sf::VideoMode({windowWidth, windowHeight}), "SFML Island", sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
-    std::optional<sf::Font> font = sf::Font::loadFromFile("resources/tuffy.ttf");
-    if (!font.has_value())
-        return EXIT_FAILURE;
+    sf::Font font = sf::Font::loadFromFile("resources/tuffy.ttf").value();
 
     // Create all of our graphics resources
     sf::Text         hudText;
@@ -102,13 +102,13 @@ int main()
     sf::VertexBuffer terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Static);
 
     // Set up our text drawables
-    statusText.setFont(*font);
+    statusText.setFont(font);
     statusText.setCharacterSize(28);
     statusText.setFillColor(sf::Color::White);
     statusText.setOutlineColor(sf::Color::Black);
     statusText.setOutlineThickness(2.0f);
 
-    hudText.setFont(*font);
+    hudText.setFont(font);
     hudText.setCharacterSize(14);
     hudText.setFillColor(sf::Color::White);
     hudText.setOutlineColor(sf::Color::Black);

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -4,8 +4,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics.hpp>
 
-#include "SFML/Graphics/Font.hpp"
-
 #define STB_PERLIN_IMPLEMENTATION
 #include <stb_perlin.h>
 

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -90,8 +90,8 @@ int main()
     sf::RenderWindow window(sf::VideoMode({windowWidth, windowHeight}), "SFML Island", sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
-    sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
+    std::optional<sf::Font> font = sf::Font::loadFromFile("resources/tuffy.ttf");
+    if (!font.has_value())
         return EXIT_FAILURE;
 
     // Create all of our graphics resources
@@ -102,13 +102,13 @@ int main()
     sf::VertexBuffer terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Static);
 
     // Set up our text drawables
-    statusText.setFont(font);
+    statusText.setFont(*font);
     statusText.setCharacterSize(28);
     statusText.setFillColor(sf::Color::White);
     statusText.setOutlineColor(sf::Color::Black);
     statusText.setOutlineThickness(2.0f);
 
-    hudText.setFont(font);
+    hudText.setFont(*font);
     hudText.setCharacterSize(14);
     hudText.setFillColor(sf::Color::White);
     hudText.setOutlineColor(sf::Color::Black);

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -94,9 +94,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the text font
-    std::optional<sf::Font> font = sf::Font::loadFromFile("resources/tuffy.ttf");
-    if (!font.has_value())
-        return EXIT_FAILURE;
+    sf::Font font = sf::Font::loadFromFile("resources/tuffy.ttf").value();
 
     // Set up our string conversion parameters
     sstr.precision(2);
@@ -113,8 +111,8 @@ int main()
     sstr.str("");
     sstr << threshold << "  (Change with up/down arrow keys)";
 
-    texts["Threshold"].label.setPosition({5.f, 5.f + 2 * font->getLineSpacing(14)});
-    texts["Threshold"].value.setPosition({80.f, 5.f + 2 * font->getLineSpacing(14)});
+    texts["Threshold"].label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
+    texts["Threshold"].value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
 
     texts["Threshold"].label.setString("Threshold:");
     texts["Threshold"].value.setString(sstr.str());
@@ -124,10 +122,10 @@ int main()
     {
         JoystickObject& object = texts[axislabels[i]];
 
-        object.label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font->getLineSpacing(14))});
+        object.label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
         object.label.setString(std::string(axislabels[i]) + ":");
 
-        object.value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font->getLineSpacing(14))});
+        object.value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
         object.value.setString("N/A");
     }
 
@@ -138,21 +136,21 @@ int main()
         JoystickObject& object = texts[sstr.str()];
 
         object.label.setPosition(
-            {5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font->getLineSpacing(14))});
+            {5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
         object.label.setString(sstr.str() + ":");
 
         object.value.setPosition(
-            {80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font->getLineSpacing(14))});
+            {80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
         object.value.setString("N/A");
     }
 
     for (auto& [label, joystickObject] : texts)
     {
-        joystickObject.label.setFont(*font);
+        joystickObject.label.setFont(font);
         joystickObject.label.setCharacterSize(14);
         joystickObject.label.setFillColor(sf::Color::White);
 
-        joystickObject.value.setFont(*font);
+        joystickObject.value.setFont(font);
         joystickObject.value.setCharacterSize(14);
         joystickObject.value.setFillColor(sf::Color::White);
     }

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -94,8 +94,8 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the text font
-    sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
+    std::optional<sf::Font> font = sf::Font::loadFromFile("resources/tuffy.ttf");
+    if (!font.has_value())
         return EXIT_FAILURE;
 
     // Set up our string conversion parameters
@@ -113,8 +113,8 @@ int main()
     sstr.str("");
     sstr << threshold << "  (Change with up/down arrow keys)";
 
-    texts["Threshold"].label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
-    texts["Threshold"].value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
+    texts["Threshold"].label.setPosition({5.f, 5.f + 2 * font->getLineSpacing(14)});
+    texts["Threshold"].value.setPosition({80.f, 5.f + 2 * font->getLineSpacing(14)});
 
     texts["Threshold"].label.setString("Threshold:");
     texts["Threshold"].value.setString(sstr.str());
@@ -124,10 +124,10 @@ int main()
     {
         JoystickObject& object = texts[axislabels[i]];
 
-        object.label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
+        object.label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font->getLineSpacing(14))});
         object.label.setString(std::string(axislabels[i]) + ":");
 
-        object.value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
+        object.value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font->getLineSpacing(14))});
         object.value.setString("N/A");
     }
 
@@ -138,21 +138,21 @@ int main()
         JoystickObject& object = texts[sstr.str()];
 
         object.label.setPosition(
-            {5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
+            {5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font->getLineSpacing(14))});
         object.label.setString(sstr.str() + ":");
 
         object.value.setPosition(
-            {80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
+            {80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font->getLineSpacing(14))});
         object.value.setString("N/A");
     }
 
     for (auto& [label, joystickObject] : texts)
     {
-        joystickObject.label.setFont(font);
+        joystickObject.label.setFont(*font);
         joystickObject.label.setCharacterSize(14);
         joystickObject.label.setFillColor(sf::Color::White);
 
-        joystickObject.value.setFont(font);
+        joystickObject.value.setFont(*font);
         joystickObject.value.setCharacterSize(14);
         joystickObject.value.setFillColor(sf::Color::White);
     }

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -58,13 +58,11 @@ int main()
         sf::Sprite background(backgroundTexture);
 
         // Create some text to draw on top of our OpenGL object
-        std::optional<sf::Font> font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf");
-        if (!font.has_value())
-            return EXIT_FAILURE;
+        sf::Font font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf").value();
 
-        sf::Text text("SFML / OpenGL demo", *font);
-        sf::Text sRgbInstructions("Press space to toggle sRGB conversion", *font);
-        sf::Text mipmapInstructions("Press return to toggle mipmapping", *font);
+        sf::Text text("SFML / OpenGL demo", font);
+        sf::Text sRgbInstructions("Press space to toggle sRGB conversion", font);
+        sf::Text mipmapInstructions("Press return to toggle mipmapping", font);
         text.setFillColor(sf::Color(255, 255, 255, 170));
         sRgbInstructions.setFillColor(sf::Color(255, 255, 255, 170));
         mipmapInstructions.setFillColor(sf::Color(255, 255, 255, 170));

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -58,13 +58,13 @@ int main()
         sf::Sprite background(backgroundTexture);
 
         // Create some text to draw on top of our OpenGL object
-        sf::Font font;
-        if (!font.loadFromFile(resourcesDir() / "tuffy.ttf"))
+        std::optional<sf::Font> font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf");
+        if (!font.has_value())
             return EXIT_FAILURE;
 
-        sf::Text text("SFML / OpenGL demo", font);
-        sf::Text sRgbInstructions("Press space to toggle sRGB conversion", font);
-        sf::Text mipmapInstructions("Press return to toggle mipmapping", font);
+        sf::Text text("SFML / OpenGL demo", *font);
+        sf::Text sRgbInstructions("Press space to toggle sRGB conversion", *font);
+        sf::Text mipmapInstructions("Press return to toggle mipmapping", *font);
         text.setFillColor(sf::Color(255, 255, 255, 170));
         sRgbInstructions.setFillColor(sf::Color(255, 255, 255, 170));
         mipmapInstructions.setFillColor(sf::Color(255, 255, 255, 170));

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -354,10 +354,11 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the application font and pass it to the Effect class
-    sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
+    std::optional<sf::Font> font = sf::Font::loadFromFile("resources/tuffy.ttf");
+    if (!font.has_value())
         return EXIT_FAILURE;
-    Effect::setFont(font);
+
+    Effect::setFont(*font);
 
     // Create the effects
     Pixelate   pixelateEffect;
@@ -383,12 +384,12 @@ int main()
     textBackground.setColor(sf::Color(255, 255, 255, 200));
 
     // Create the description text
-    sf::Text description("Current effect: " + effects[current]->getName(), font, 20);
+    sf::Text description("Current effect: " + effects[current]->getName(), *font, 20);
     description.setPosition({10.f, 530.f});
     description.setFillColor(sf::Color(80, 80, 80));
 
     // Create the instructions text
-    sf::Text instructions("Press left and right arrows to change the current shader", font, 20);
+    sf::Text instructions("Press left and right arrows to change the current shader", *font, 20);
     instructions.setPosition({280.f, 555.f});
     instructions.setFillColor(sf::Color(80, 80, 80));
 

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -354,11 +354,8 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the application font and pass it to the Effect class
-    std::optional<sf::Font> font = sf::Font::loadFromFile("resources/tuffy.ttf");
-    if (!font.has_value())
-        return EXIT_FAILURE;
-
-    Effect::setFont(*font);
+    sf::Font font = sf::Font::loadFromFile("resources/tuffy.ttf").value();
+    Effect::setFont(font);
 
     // Create the effects
     Pixelate   pixelateEffect;
@@ -384,12 +381,12 @@ int main()
     textBackground.setColor(sf::Color(255, 255, 255, 200));
 
     // Create the description text
-    sf::Text description("Current effect: " + effects[current]->getName(), *font, 20);
+    sf::Text description("Current effect: " + effects[current]->getName(), font, 20);
     description.setPosition({10.f, 530.f});
     description.setFillColor(sf::Color(80, 80, 80));
 
     // Create the instructions text
-    sf::Text instructions("Press left and right arrows to change the current shader", *font, 20);
+    sf::Text instructions("Press left and right arrows to change the current shader", font, 20);
     instructions.setPosition({280.f, 555.f});
     instructions.setFillColor(sf::Color(80, 80, 80));
 

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -82,13 +82,13 @@ int main()
     ball.setOrigin({ballRadius / 2.f, ballRadius / 2.f});
 
     // Load the text font
-    sf::Font font;
-    if (!font.loadFromFile(resourcesDir() / "tuffy.ttf"))
+    std::optional<sf::Font> font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf");
+    if (!font.has_value())
         return EXIT_FAILURE;
 
     // Initialize the pause message
     sf::Text pauseMessage;
-    pauseMessage.setFont(font);
+    pauseMessage.setFont(*font);
     pauseMessage.setCharacterSize(40);
     pauseMessage.setPosition({170.f, 200.f});
     pauseMessage.setFillColor(sf::Color::White);

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -82,13 +82,11 @@ int main()
     ball.setOrigin({ballRadius / 2.f, ballRadius / 2.f});
 
     // Load the text font
-    std::optional<sf::Font> font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf");
-    if (!font.has_value())
-        return EXIT_FAILURE;
+    sf::Font font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf").value();
 
     // Initialize the pause message
     sf::Text pauseMessage;
-    pauseMessage.setFont(*font);
+    pauseMessage.setFont(font);
     pauseMessage.setCharacterSize(40);
     pauseMessage.setPosition({170.f, 200.f});
     pauseMessage.setFillColor(sf::Color::White);

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -116,7 +116,7 @@ public:
     /// \see loadFromMemory, loadFromStream
     ///
     ////////////////////////////////////////////////////////////
-    static std::optional<Font> loadFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<Font> loadFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the font from a file in memory
@@ -137,7 +137,7 @@ public:
     /// \see loadFromFile, loadFromStream
     ///
     ////////////////////////////////////////////////////////////
-    static std::optional<Font> loadFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] static std::optional<Font> loadFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the font from a custom stream
@@ -159,7 +159,7 @@ public:
     /// \see loadFromFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    static std::optional<Font> loadFromStream(InputStream& stream);
+    [[nodiscard]] static std::optional<Font> loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the font information

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -34,6 +34,7 @@
 #include <SFML/Graphics/Texture.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -67,14 +68,6 @@ public:
     };
 
 public:
-    ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// This constructor defines an empty font
-    ///
-    ////////////////////////////////////////////////////////////
-    Font();
-
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
     ///
@@ -123,7 +116,7 @@ public:
     /// \see loadFromMemory, loadFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename);
+    static std::optional<Font> loadFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the font from a file in memory
@@ -144,7 +137,7 @@ public:
     /// \see loadFromFile, loadFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t sizeInBytes);
+    static std::optional<Font> loadFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the font from a custom stream
@@ -166,7 +159,7 @@ public:
     /// \see loadFromFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromStream(InputStream& stream);
+    static std::optional<Font> loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the font information
@@ -329,6 +322,14 @@ public:
     Font& operator=(const Font& right);
 
 private:
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor defines an empty font
+    ///
+    ////////////////////////////////////////////////////////////
+    Font();
+
     ////////////////////////////////////////////////////////////
     /// \brief Structure defining a row of glyphs
     ///

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -201,8 +201,8 @@ std::optional<Font> Font::loadFromFile(const std::filesystem::path& filename)
 #else
 
     Font result;
-    m_stream = std::make_unique<priv::ResourceStream>(filename);
-    return loadFromStream(*m_stream);
+    result.m_stream = std::make_unique<priv::ResourceStream>(filename);
+    return loadFromStream(*result.m_stream);
 
 #endif
 }

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -13,7 +13,7 @@ int main()
 
     // Graphics
     [[maybe_unused]] sf::Color        color;
-    [[maybe_unused]] sf::Font         font;
+    [[maybe_unused]] sf::IntRect      rect;
     [[maybe_unused]] sf::RenderWindow renderWindow;
     [[maybe_unused]] sf::Sprite       sprite;
     [[maybe_unused]] sf::Vertex       vertex;

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -40,12 +40,11 @@ int main(int argc, char const** argv)
     sf::Sprite sprite(texture);
 
     // Create a graphical text to display
-    sf::Font font;
-    if (!font.loadFromFile("tuffy.ttf"))
-    {
+    std::optional<sf::Font> font = sf::Font::loadFromFile("tuffy.ttf");
+    if (!font.has_value())
         return EXIT_FAILURE;
-    }
-    sf::Text text("Hello SFML", font, 50);
+
+    sf::Text text("Hello SFML", *font, 50);
     text.setFillColor(sf::Color::Black);
 
     // Load a music to play

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -40,11 +40,8 @@ int main(int argc, char const** argv)
     sf::Sprite sprite(texture);
 
     // Create a graphical text to display
-    std::optional<sf::Font> font = sf::Font::loadFromFile("tuffy.ttf");
-    if (!font.has_value())
-        return EXIT_FAILURE;
-
-    sf::Text text("Hello SFML", *font, 50);
+    sf::Font font = sf::Font::loadFromFile("tuffy.ttf").value();
+    sf::Text text("Hello SFML", font, 50);
     text.setFillColor(sf::Color::Black);
 
     // Load a music to play


### PR DESCRIPTION
Same as #2228, but for `sf::Font`.