### PR TITLE
WIP - Replace font load error handling with exceptions

### DIFF
--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -27,9 +27,7 @@
 ///     sf::Sprite sprite(texture);
 ///
 ///     // Create a graphical text to display
-///     sf::Font font;
-///     if (!font.loadFromFile("arial.ttf"))
-///         return EXIT_FAILURE;
+///     sf::Font font = sf::Font::loadFromFile("arial.ttf");
 ///     sf::Text text("Hello SFML", font, 50);
 ///
 ///     // Load a music to play

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -90,8 +90,7 @@ int main(int argc, char* argv[])
     image.setPosition(sf::Vector2f(screen.size) / 2.f);
     image.setOrigin(sf::Vector2f(texture.getSize()) / 2.f);
 
-    sf::Font font;
-    if (!font.loadFromFile("tuffy.ttf"))
+    sf::Font font = sf::Font::loadFromFile("tuffy.ttf"))
         return EXIT_FAILURE;
 
     sf::Text text("Tap anywhere to move the logo.", font, 64);

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char* argv[])
     image.setPosition(sf::Vector2f(screen.size) / 2.f);
     image.setOrigin(sf::Vector2f(texture.getSize()) / 2.f);
 
-    sf::Font font = sf::Font::loadFromFile("tuffy.ttf"))
+    sf::Font font = sf::Font::loadFromFile("tuffy.ttf"));
         return EXIT_FAILURE;
 
     sf::Text text("Tap anywhere to move the logo.", font, 64);

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -55,19 +55,18 @@ struct SFMLmainWindow
         unsigned int wh = renderWindow.getSize().y;
         sprite.setPosition(sf::Vector2f(ww, wh) / 2.f);
 
-        if (!font.loadFromFile(resPath + "/tuffy.ttf"))
-            NSLog(@"Couldn't load the font");
+        font = sf::Font::loadFromFile(resPath + "/tuffy.ttf")
 
         text.setFillColor(sf::Color::White);
         text.setFont(font);
     }
 
-    sf::RenderWindow renderWindow;
-    sf::Font         font;
-    sf::Text         text;
-    sf::Texture      logo;
-    sf::Sprite       sprite;
-    sf::Color        background;
+    sf::RenderWindow        renderWindow;
+    std::optional<sf::Font> font;
+    sf::Text                text;
+    sf::Texture             logo;
+    sf::Sprite              sprite;
+    sf::Color               background;
 };
 
 // Private stuff

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -55,7 +55,7 @@ struct SFMLmainWindow
         unsigned int wh = renderWindow.getSize().y;
         sprite.setPosition(sf::Vector2f(ww, wh) / 2.f);
 
-        font = sf::Font::loadFromFile(resPath + "/tuffy.ttf")
+        font = sf::Font::loadFromFile(resPath + "/tuffy.ttf");
 
         text.setFillColor(sf::Color::White);
         text.setFont(font);

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -90,9 +90,7 @@ int main()
     sf::RenderWindow window(sf::VideoMode({windowWidth, windowHeight}), "SFML Island", sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
-    sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
-        return EXIT_FAILURE;
+    sf::Font font = sf::Font::loadFromFile("resources/tuffy.ttf");
 
     // Create all of our graphics resources
     sf::Text         hudText;

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -94,9 +94,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the text font
-    sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
-        return EXIT_FAILURE;
+    sf::Font font = sf::Font::loadFromFile("resources/tuffy.ttf");
 
     // Set up our string conversion parameters
     sstr.precision(2);

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -58,9 +58,7 @@ int main()
         sf::Sprite background(backgroundTexture);
 
         // Create some text to draw on top of our OpenGL object
-        sf::Font font;
-        if (!font.loadFromFile(resourcesDir() / "tuffy.ttf"))
-            return EXIT_FAILURE;
+        sf::Font font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf");
 
         sf::Text text("SFML / OpenGL demo", font);
         sf::Text sRgbInstructions("Press space to toggle sRGB conversion", font);

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -354,9 +354,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the application font and pass it to the Effect class
-    sf::Font font;
-    if (!font.loadFromFile("resources/tuffy.ttf"))
-        return EXIT_FAILURE;
+    sf::Font font = sf::Font::loadFromFile("resources/tuffy.ttf");
     Effect::setFont(font);
 
     // Create the effects

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -82,9 +82,7 @@ int main()
     ball.setOrigin({ballRadius / 2.f, ballRadius / 2.f});
 
     // Load the text font
-    sf::Font font;
-    if (!font.loadFromFile(resourcesDir() / "tuffy.ttf"))
-        return EXIT_FAILURE;
+    sf::Font font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf");
 
     // Initialize the pause message
     sf::Text pauseMessage;

--- a/include/SFML/Graphics.hpp
+++ b/include/SFML/Graphics.hpp
@@ -36,6 +36,7 @@
 #include <SFML/Graphics/Font.hpp>
 #include <SFML/Graphics/Glyph.hpp>
 #include <SFML/Graphics/Image.hpp>
+#include <SFML/Graphics/LoadException.hpp>
 #include <SFML/Graphics/PrimitiveType.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/RectangleShape.hpp>

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -68,14 +68,6 @@ public:
 
 public:
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// This constructor defines an empty font
-    ///
-    ////////////////////////////////////////////////////////////
-    Font();
-
-    ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
     ///
     /// \param copy Instance to copy
@@ -123,7 +115,7 @@ public:
     /// \see loadFromMemory, loadFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static Font loadFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the font from a file in memory
@@ -144,7 +136,7 @@ public:
     /// \see loadFromFile, loadFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] static Font loadFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the font from a custom stream
@@ -166,7 +158,7 @@ public:
     /// \see loadFromFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromStream(InputStream& stream);
+    [[nodiscard]] static Font loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the font information
@@ -330,6 +322,14 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor defines an empty font
+    ///
+    ////////////////////////////////////////////////////////////
+    Font();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Structure defining a row of glyphs
     ///
     ////////////////////////////////////////////////////////////
@@ -471,14 +471,8 @@ private:
 ///
 /// Usage example:
 /// \code
-/// // Declare a new font
-/// sf::Font font;
-///
-/// // Load it from a file
-/// if (!font.loadFromFile("arial.ttf"))
-/// {
-///     // error...
-/// }
+/// // Create a new font by loading it from a file
+/// sf::Font font = sf::Font::loadFromFile("arial.ttf");
 ///
 /// // Create a text which uses our font
 /// sf::Text text1;

--- a/include/SFML/Graphics/LoadException.hpp
+++ b/include/SFML/Graphics/LoadException.hpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////
 //
 // SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.
@@ -22,34 +22,35 @@
 //
 ////////////////////////////////////////////////////////////
 
-#pragma once
+#ifndef SFML_LOADEXCEPTION_HPP
+#define SFML_LOADEXCEPTION_HPP
 
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-
-#include <SFML/Config.hpp>
-
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
 #include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
+#include <filesystem>
+#include <sstream>
+#include <string>
+
+namespace sf
+{
+class LoadException final : public Exception
+{
+public:
+    LoadException(const std::string& message);
+    LoadException(const std::filesystem::path& filePath, const std::string& message);
+
+    [[nodiscard]] const char* what() const noexcept override;
+
+private:
+    std::string m_message;
+};
+
+// Inline definition required due to STL type derivation
+#include <SFML/Graphics/LoadException.inl>
+
+} // namespace sf
 
 
-////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
-///
-////////////////////////////////////////////////////////////
+#endif // SFML_LOADEXCEPTION_HPP

--- a/include/SFML/Graphics/LoadException.hpp
+++ b/include/SFML/Graphics/LoadException.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Exception.hpp>
+
 #include <filesystem>
 #include <sstream>
 #include <string>

--- a/include/SFML/Graphics/LoadException.inl
+++ b/include/SFML/Graphics/LoadException.inl
@@ -33,13 +33,12 @@ namespace
 }
 } // namespace
 
-inline LoadException::LoadException(const std::string& message) :
-    m_message(message)
+inline LoadException::LoadException(const std::string& message) : m_message(message)
 {
 }
 
 inline LoadException::LoadException(const std::filesystem::path& filePath, const std::string& message) :
-    m_message(message + "\n" + formatDebugPathInfo(filePath))
+m_message(message + "\n" + formatDebugPathInfo(filePath))
 {
 }
 

--- a/include/SFML/Graphics/LoadException.inl
+++ b/include/SFML/Graphics/LoadException.inl
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////
 //
 // SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.
@@ -22,34 +22,28 @@
 //
 ////////////////////////////////////////////////////////////
 
-#pragma once
+namespace
+{
+[[nodiscard]] std::string formatDebugPathInfo(const std::filesystem::path& path)
+{
+    std::ostringstream stream;
+    stream << "    Provided path: " << path << '\n';
+    stream << "    Absolute path: " << std::filesystem::absolute(path);
+    return stream.str();
+}
+} // namespace
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
+inline LoadException::LoadException(const std::string& message) :
+    m_message(message)
+{
+}
 
-#include <SFML/Config.hpp>
+inline LoadException::LoadException(const std::filesystem::path& filePath, const std::string& message) :
+    m_message(message + "\n" + formatDebugPathInfo(filePath))
+{
+}
 
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
-#include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
-
-
-////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
-///
-////////////////////////////////////////////////////////////
+inline const char* LoadException::what() const noexcept
+{
+    return m_message.c_str();
+}

--- a/include/SFML/System/Exception.hpp
+++ b/include/SFML/System/Exception.hpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////
 //
 // SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.
@@ -22,34 +22,25 @@
 //
 ////////////////////////////////////////////////////////////
 
-#pragma once
+#ifndef SFML_EXCEPTION_HPP
+#define SFML_EXCEPTION_HPP
 
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <exception>
 
-#include <SFML/Config.hpp>
+namespace sf
+{
+class Exception : public std::exception
+{
+public:
+    [[nodiscard]] const char* what() const noexcept override;
+};
 
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
-#include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
+// Inline definition required due to STL type derivation
+#include <SFML/System/Exception.inl>
 
+} // namespace sf
 
-////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
-///
-////////////////////////////////////////////////////////////
+#endif // SFML_EXCEPTION_HPP

--- a/include/SFML/System/Exception.inl
+++ b/include/SFML/System/Exception.inl
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////
 //
 // SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+// Copyright (C) 2007-2022 Laurent Gomila (laurent@sfml-dev.org)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.
@@ -22,34 +22,8 @@
 //
 ////////////////////////////////////////////////////////////
 
-#pragma once
-
 ////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
-
-#include <SFML/Config.hpp>
-
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
-#include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
-
-
-////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
-///
-////////////////////////////////////////////////////////////
+inline const char* Exception::what() const noexcept
+{
+    return "SFML encountered an error";
+}

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SRC
     ${INCROOT}/Image.hpp
     ${SRCROOT}/ImageLoader.cpp
     ${SRCROOT}/ImageLoader.hpp
+    ${INCROOT}/LoadException.hpp
     ${INCROOT}/PrimitiveType.hpp
     ${INCROOT}/Rect.hpp
     ${INCROOT}/Rect.inl

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
     ${INCROOT}/Clock.hpp
     ${SRCROOT}/Err.cpp
     ${INCROOT}/Err.hpp
+    ${INCROOT}/Exception.hpp
     ${INCROOT}/Export.hpp
     ${INCROOT}/InputStream.hpp
     ${INCROOT}/NativeActivity.hpp

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -13,7 +13,7 @@ int main()
 
     // Graphics
     [[maybe_unused]] sf::Color        color;
-    [[maybe_unused]] sf::Font         font;
+    [[maybe_unused]] sf::IntRect      rect;
     [[maybe_unused]] sf::RenderWindow renderWindow;
     [[maybe_unused]] sf::Sprite       sprite;
     [[maybe_unused]] sf::Vertex       vertex;

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -42,11 +42,7 @@ int main(int, char const**)
     sf::Sprite sprite(texture);
 
     // Create a graphical text to display
-    sf::Font font;
-    if (!font.loadFromFile(resourcePath() + "tuffy.ttf"))
-    {
-        return EXIT_FAILURE;
-    }
+    sf::Font font = sf::Font::loadFromFile(resourcePath() + "tuffy.ttf");
     sf::Text text("Hello SFML", font, 50);
     text.setFillColor(sf::Color::Black);
 

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -40,11 +40,7 @@ int main(int argc, char const** argv)
     sf::Sprite sprite(texture);
 
     // Create a graphical text to display
-    sf::Font font;
-    if (!font.loadFromFile("tuffy.ttf"))
-    {
-        return EXIT_FAILURE;
-    }
+    sf::Font font = sf::Font::loadFromFile("tuffy.ttf");
     sf::Text text("Hello SFML", font, 50);
     text.setFillColor(sf::Color::Black);
 


### PR DESCRIPTION
## Description

This is a counter proposal to error handling as demonstrated with #2231 by leveraging exceptions instead of optionals.

For general error handling discussions, please use #2139  
For specific error handling discussions with exceptions, comments are highly appreciated! 🙂 

Longer comment will soon follow on #2139, but some of the advantages I see over optionals:
- Allows for carrying an error message into the user code
- Tried and true concept, you'll find a lot of developers instantly getting exceptions, where optionals may need some more googling
- Keeps the API simple, no need for `->` accessors or other casts
- Handle errors at the layer where you want
- (IDE support for stack traces and pointing to where the error occurred)

Additionally, this also addresses the discussion point about non-default constructability.

## How to test this PR?

**Note:** The simple case presented here doesn't demonstrate the full power of exception handle

```cpp
#include <SFML/Graphics.hpp>
#include <iostream>

int main()
{
    auto window = sf::RenderWindow(sf::VideoMode{{1280u, 720u}}, "Minimal, complete and verifiable example");
    window.setFramerateLimit(144);

    try
    {
        const auto font = sf::Font::loadFromFile("MyFont.ttf");
        auto text = sf::Text{"Hello World", font, 100};

        while (window.isOpen())
        {
            for (auto event = sf::Event{}; window.pollEvent(event);)
            {
                if (event.type == sf::Event::Closed)
                {
                    window.close();
                }
            }

            window.clear();
            window.draw(text);
            window.display();
        }
    }
    catch (sf::LoadException& e)
    {
        std::cout << e.what();
        return -1;
    }
}
```

![image](https://user-images.githubusercontent.com/920861/194765570-0dfb187b-2343-4b29-b95f-17a303b52877.png)
