### PR TITLE
Hide examples, tests, and documentation from projects consuming SFML via `add_subdirectory`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,21 +53,11 @@ else()
     endif()
 endif()
 
-# add an option for building the examples
-if(NOT SFML_OS_ANDROID)
-    sfml_set_option(SFML_BUILD_EXAMPLES FALSE BOOL "TRUE to build the SFML examples, FALSE to ignore them")
-else()
-    set(SFML_BUILD_EXAMPLES FALSE)
-endif()
-
 # add options to select which modules to build
 sfml_set_option(SFML_BUILD_WINDOW TRUE BOOL "TRUE to build SFML's Window module. This setting is ignored, if the graphics module is built.")
 sfml_set_option(SFML_BUILD_GRAPHICS TRUE BOOL "TRUE to build SFML's Graphics module.")
 sfml_set_option(SFML_BUILD_AUDIO TRUE BOOL "TRUE to build SFML's Audio module.")
 sfml_set_option(SFML_BUILD_NETWORK TRUE BOOL "TRUE to build SFML's Network module.")
-
-# add an option for building the API documentation
-sfml_set_option(SFML_BUILD_DOC FALSE BOOL "TRUE to generate the API documentation, FALSE to ignore it")
 
 if(SFML_BUILD_WINDOW)
     # add an option for choosing the OpenGL implementation
@@ -78,12 +68,6 @@ if(SFML_BUILD_WINDOW)
         sfml_set_option(SFML_USE_DRM FALSE BOOL "TRUE to use DRM windowing backend")
     endif()
 endif()
-
-# add an option for building the test suite
-sfml_set_option(SFML_BUILD_TEST_SUITE FALSE BOOL "TRUE to build the SFML test suite, FALSE to ignore it")
-
-# add an option for enabling coverage reporting
-sfml_set_option(SFML_ENABLE_COVERAGE FALSE BOOL "TRUE to enable coverage reporting, FALSE to ignore it")
 
 # macOS specific options
 if(SFML_OS_MACOSX)
@@ -247,22 +231,6 @@ set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
 
 # add the subdirectories
 add_subdirectory(src/SFML)
-if(SFML_BUILD_EXAMPLES)
-    add_subdirectory(examples)
-endif()
-if(SFML_BUILD_DOC)
-    add_subdirectory(doc)
-endif()
-if(SFML_BUILD_TEST_SUITE)
-    if(SFML_OS_IOS)
-        message( WARNING "Unit testing not supported on iOS")
-    elseif(SFML_BUILD_WINDOW AND SFML_BUILD_GRAPHICS AND SFML_BUILD_NETWORK AND SFML_BUILD_AUDIO)
-        enable_testing()
-        add_subdirectory(test)
-    else()
-        message(WARNING "Cannot build unit testing unless all modules are enabled")
-    endif()
-endif()
 
 # on Linux and BSD-like OS, install pkg-config files by default
 set(SFML_INSTALL_PKGCONFIG_DEFAULT FALSE)
@@ -533,8 +501,45 @@ set(CPACK_NSIS_INSTALLER_MUI_ICON_CODE "!define MUI_WELCOMEFINISHPAGE_BITMAP \\\
 
 include(CPack)
 
-if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+# configure extras by default when building SFML directly, otherwise hide them
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    set(SFML_CONFIGURE_EXTRAS_DEFAULT TRUE)
+else()
+    set(SFML_CONFIGURE_EXTRAS_DEFAULT FALSE)
+endif()
+sfml_set_option(SFML_CONFIGURE_EXTRAS ${SFML_CONFIGURE_EXTRAS_DEFAULT} BOOL "TRUE to configure extras, FALSE to ignore them")
+
+if(NOT SFML_CONFIGURE_EXTRAS)
     return()
+endif()
+
+# add an option for building the API documentation
+sfml_set_option(SFML_BUILD_DOC FALSE BOOL "TRUE to generate the API documentation, FALSE to ignore it")
+if(SFML_BUILD_DOC)
+    add_subdirectory(doc)
+endif()
+
+# add an option for building the examples
+sfml_set_option(SFML_BUILD_EXAMPLES FALSE BOOL "TRUE to build the SFML examples, FALSE to ignore them")
+if(SFML_BUILD_EXAMPLES AND NOT SFML_OS_ANDROID)
+    add_subdirectory(examples)
+endif()
+
+# add an option for building the test suite
+sfml_set_option(SFML_BUILD_TEST_SUITE FALSE BOOL "TRUE to build the SFML test suite, FALSE to ignore it")
+
+# add an option for enabling coverage reporting
+sfml_set_option(SFML_ENABLE_COVERAGE FALSE BOOL "TRUE to enable coverage reporting, FALSE to ignore it")
+
+if(SFML_BUILD_TEST_SUITE)
+    if(SFML_OS_IOS)
+        message(WARNING "Unit testing not supported on iOS")
+    elseif(SFML_BUILD_WINDOW AND SFML_BUILD_GRAPHICS AND SFML_BUILD_NETWORK AND SFML_BUILD_AUDIO)
+        enable_testing()
+        add_subdirectory(test)
+    else()
+        message(WARNING "Cannot build unit testing unless all modules are enabled")
+    endif()
 endif()
 
 sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires version 12, 13, or 14")


### PR DESCRIPTION
## Description

Currently projects like the official CMake template inherit some SFML cache variables like `SFML_BUILD_TEST_SUITE`. Here's a screenshot from a project of mine that uses `FetchContent` to build the `master` branch.

<img width="507" alt="Screen Shot 2022-10-09 at 10 41 07 PM" src="https://user-images.githubusercontent.com/39244355/194800226-28a05e0e-1dbb-4d9a-b347-3e102dff49e8.png">

Luckily these options default off but downstream projects don't need to inherit these to build and use SFML. This PR makes it such that these developer-only options are hidden to those consuming SFML via `add_subdirectory`.

Note how we've already been using this pattern with the `format` target. It's perfectly valid for a downstream project to want to make their own target called `format` so the fact that we hide this target from them helps ensure we're not squatting on target names.

A few reasons why we benefit from doing this:
1. Less clutter in users' CMakeCache.txt files so users can more easily see the options they're most likely to change like disabling certain modules or enabling frameworks.
1. It lets us change the default values of options without worrying about users suddenly building more things by default. If we want to build tests by default for example, all `add_subdirectory` users would now be building the SFML unit tests and would then have to explicitly opt out of that to avoid doing that unnecessary work in their projects.
1. It's very useful to make the `add_subdirectory` interface match the find_package interface. [Recent `FetchContent` features](https://cmake.org/cmake/help/latest/module/FetchContent.html#integrating-with-find-package) added in CMake 3.24 mean it's only getting more common that users swap between find_package and add_subdirectory. Ensuring both have the most similar interfaces possible mean users never have issues when switching from one to the other.
1. We let ourselves use simpler option names. This is useful for the `SFML_BUILD_TEST_SUITE` option which is better replaced by the canonical [`BUILD_TESTING`](https://cmake.org/cmake/help/latest/module/CTest.html) option provided by the CTest module. If we hide tests from downstream users, we can safely use this preexisting option to enable or disable testing and maintain one less project-specific abstraction that all new contributors must learn about. We can't do that now because users with `BUILD_TESTING=ON` in their own projects would end up also enabling SFML's unit tests so we're forced to use a unique, nonstandard name.
