### PR TITLE
Don't remove format target unnecessarily

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,13 +528,12 @@ set(CPACK_NSIS_INSTALLER_MUI_ICON_CODE "!define MUI_WELCOMEFINISHPAGE_BITMAP \\\
 
 include(CPack)
 
-if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    return()
+sfml_set_option(SFML_FORMAT TRUE BOOL "Set to enable SFML's format target")
+if(SFML_FORMAT)
+    sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires minimum version 12")
+    add_custom_target(format
+        COMMAND ${CMAKE_COMMAND} "-DCLANG_FORMAT_EXECUTABLE=${CLANG_FORMAT_EXECUTABLE}" -P ./cmake/Format.cmake
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}" VERBATIM)
+
+    add_custom_target(tidy COMMAND run-clang-tidy -p ${PROJECT_BINARY_DIR} VERBATIM)
 endif()
-
-sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires minimum version 12")
-add_custom_target(format
-    COMMAND ${CMAKE_COMMAND} "-DCLANG_FORMAT_EXECUTABLE=${CLANG_FORMAT_EXECUTABLE}" -P ./cmake/Format.cmake
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}" VERBATIM)
-
-add_custom_target(tidy COMMAND run-clang-tidy -p ${PROJECT_BINARY_DIR} VERBATIM)


### PR DESCRIPTION
Noticed we're removing the format target, I think the intention is to prevent it being available when added as a subdirectory.

I don't see any advantage to doing this - Whether I've got SFML as a subdirectory or not doesn't really have any bearing on whether I want to format it, and if we're encouraging contributors to use it then it should be available at all times