### PR TITLE
[DRM] Fix forecefully switching to the preferred mode, use the current mode rather

### DIFF
--- a/extlibs/headers/drm/drm-common.c
+++ b/extlibs/headers/drm/drm-common.c
@@ -285,34 +285,6 @@ int init_drm(struct drm *drm, const char *device, const char *mode_str,
 			printf("requested mode not found, using default mode!\n");
 	}
 
-	/* find preferred mode or the highest resolution mode: */
-	if (!drm->mode)
-	{
-		for (i = 0, area = 0; i < connector->count_modes; i++)
-		{
-			drmModeModeInfo *current_mode = &connector->modes[i];
-
-			if (current_mode->type & DRM_MODE_TYPE_PREFERRED)
-			{
-				drm->mode = current_mode;
-				break;
-			}
-
-			int current_area = current_mode->hdisplay * current_mode->vdisplay;
-			if (current_area > area)
-			{
-				drm->mode = current_mode;
-				area = current_area;
-			}
-		}
-	}
-
-	if (!drm->mode)
-	{
-		printf("could not find mode!\n");
-		return -1;
-	}
-
 	/* find encoder: */
 	for (i = 0; i < resources->count_encoders; i++)
 	{
@@ -349,7 +321,17 @@ int init_drm(struct drm *drm, const char *device, const char *mode_str,
     // get original display mode so we can restore display mode after program exits
     drm->original_crtc = drmModeGetCrtc(drm->fd, drm->crtc_id);
 
-	if(getenv("SFML_DRM_DEBUG"))
+	/* Let's use the current mode rather than the preferred one if the user didn't
+	 * specify a mode with env vars
+	 */
+	if (!drm->mode)
+	{
+		if(getenv("SFML_DRM_DEBUG"))
+			printf("DRM using the current mode\n");
+		drm->mode = &(drm->original_crtc->mode);
+	}
+
+	if (getenv("SFML_DRM_DEBUG"))
 	{
 		printf("DRM Mode used: %s@%d\n", drm->mode->name, drm->mode->vrefresh);
 	}

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -94,14 +94,18 @@ namespace
         if (!initialized)
             return;
 
-        drmModeSetCrtc(drmNode.fd,
-                       drmNode.original_crtc->crtc_id,
-                       drmNode.original_crtc->buffer_id,
-                       drmNode.original_crtc->x,
-                       drmNode.original_crtc->y,
-                       &drmNode.connector_id,
-                       1,
-                       &drmNode.original_crtc->mode);
+        /* Avoid a modeswitch if possible */
+        if (drmNode.mode != &drmNode.original_crtc->mode)
+            drmModeSetCrtc(drmNode.fd,
+                           drmNode.original_crtc->crtc_id,
+                           drmNode.original_crtc->buffer_id,
+                           drmNode.original_crtc->x,
+                           drmNode.original_crtc->y,
+                           &drmNode.connector_id,
+                           1,
+                           &drmNode.original_crtc->mode);
+        else if (getenv("SFML_DRM_DEBUG"))
+            printf("DRM keeping the same mode since using the original one\n");
 
         drmModeFreeConnector(drmNode.saved_connector);
         drmModeFreeEncoder(drmNode.saved_encoder);


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

In order to prevent an unnecessary modeswitch and use the current TTY resolution, don't use the preferred mode reported by DRM. This is useful for people who set a custom resolution at boot and are forced into the monitor's preferred resolution when a SFML DRM app starts

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Make sure your TTY is not set at your monitor's preferred resolution and start any app
