### PR TITLE
Reimplementing `Rect` in terms of position and size

### DIFF
--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -46,9 +46,7 @@ struct SFMLmainWindow
         logo.setSmooth(true);
 
         sprite.setTexture(logo, true);
-        sf::FloatRect rect = sprite.getLocalBounds();
-        sf::Vector2f  size(rect.width, rect.height);
-        sprite.setOrigin(size / 2.f);
+        sprite.setOrigin(sprite.getLocalBounds().getCenter());
         sprite.scale({0.3f, 0.3f});
 
         unsigned int ww = renderWindow.getSize().x;

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -157,8 +157,8 @@ int main()
     }
 
     // Center the status text
-    statusText.setPosition({(windowWidth - statusText.getLocalBounds().width) / 2.f,
-                            (windowHeight - statusText.getLocalBounds().height) / 2.f});
+    sf::Vector2f windowSize(windowWidth, windowHeight);
+    statusText.setPosition((windowSize - statusText.getLocalBounds().size) / 2.f);
 
     // Set up an array of pointers to our settings for arrow navigation
     constexpr std::array<Setting, 9> settings = {

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -46,8 +46,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
-    /// Creates an empty rectangle (it is equivalent to calling
-    /// Rect(0, 0, 0, 0)).
+    /// Creates an empty rectangle.
     ///
     ////////////////////////////////////////////////////////////
     constexpr Rect();
@@ -55,10 +54,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from position and size
     ///
-    /// Be careful, the last parameter is the size,
-    /// not the bottom-right corner!
-    ///
-    /// \param position Position of the top-left corner of the rectangle
+    /// \param position Position of the rectangle
     /// \param size     Size of the rectangle
     ///
     ////////////////////////////////////////////////////////////
@@ -67,10 +63,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from another type of rectangle
     ///
-    /// This constructor doesn't replace the copy constructor,
-    /// it's called only when U != T.
-    /// A call to this constructor will fail to compile if U
-    /// is not convertible to T.
+    /// This constructor does not replace the copy constructor.
     ///
     /// \param rectangle Rectangle to convert
     ///
@@ -79,14 +72,86 @@ public:
     constexpr explicit Rect(const Rect<U>& rectangle);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Check if a point is inside the rectangle's area
+    /// \brief Get the left edge of the rectangle
     ///
-    /// This check is non-inclusive. If the point lies on the
-    /// edge of the rectangle, this function will return false.
+    /// \return Coordinate of the left edge of the rectangle
     ///
-    /// \param point Point to test
+    ////////////////////////////////////////////////////////////
+    constexpr T getLeft() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the top edge of the rectangle
     ///
-    /// \return True if the point is inside, false otherwise
+    /// \return Coordinate of the top edge of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr T getTop() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the right edge of the rectangle
+    ///
+    /// \return Coordinate of the right edge of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr T getRight() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the bottom edge of the rectangle
+    ///
+    /// \return Coordinate of the bottom edge of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr T getBottom() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the top-left point of the rectangle
+    ///
+    /// \return Top-left point of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2<T> getStart() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the bottom-right point of the rectangle
+    ///
+    /// \return Bottom-right point of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2<T> getEnd() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the center point of the rectangle
+    ///
+    /// \return Center point of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2<T> getCenter() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the absolute size of the rectangle
+    ///
+    /// \return Absolute size of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2<T> getAbsoluteSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get positive sized representaion of the rectangle
+    ///
+    /// \return Same rectangle, represented with positive size
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Rect<T> getAbsoluteRect() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if the rectangle contains a given point
+    ///
+    /// This check assumes that a rectangle contains it's own left and
+    /// top edges, but does not contain it's right and bottom edges.
+    ///
+    /// \param point Point to check
+    ///
+    /// \return True if the rectangle contains the point, false otherwise
     ///
     /// \see findIntersection
     ///
@@ -94,44 +159,22 @@ public:
     constexpr bool contains(const Vector2<T>& point) const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Check the intersection between two rectangles
+    /// \brief Find intersection between two rectangles
     ///
-    /// \param rectangle Rectangle to test
+    /// \param rectangle Rectangle to find intersection with
     ///
-    /// \return Intersection rectangle if intersecting, std::nullopt otherwise
+    /// \return Intersection rectangle if intersects, std::nullopt otherwise
     ///
     /// \see contains
     ///
     ////////////////////////////////////////////////////////////
-    constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the position of the rectangle's top-left corner
-    ///
-    /// \return Position of rectangle
-    ///
-    /// \see getSize
-    ///
-    ////////////////////////////////////////////////////////////
-    constexpr Vector2<T> getPosition() const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the size of the rectangle
-    ///
-    /// \return Size of rectangle
-    ///
-    /// \see getPosition
-    ///
-    ////////////////////////////////////////////////////////////
-    constexpr Vector2<T> getSize() const;
+    [[nodiscard]] constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    T left;   //!< Left coordinate of the rectangle
-    T top;    //!< Top coordinate of the rectangle
-    T width;  //!< Width of the rectangle
-    T height; //!< Height of the rectangle
+    Vector2<T> position; //!< Position of the rectangle
+    Vector2<T> size;     //!< Size of the rectangle
 };
 
 ////////////////////////////////////////////////////////////
@@ -180,49 +223,32 @@ using FloatRect = Rect<float>;
 /// \class sf::Rect
 /// \ingroup graphics
 ///
-/// A rectangle is defined by its top-left corner and its size.
-/// It is a very simple class defined for convenience, so
-/// its member variables (left, top, width and height) are public
-/// and can be accessed directly, just like the vector classes
-/// (Vector2 and Vector3).
+/// A rectangle is defined by its sf::Vector2 position and size.
 ///
-/// To keep things simple, sf::Rect doesn't define
-/// functions to emulate the properties that are not directly
-/// members (such as right, bottom, center, etc.), it rather
-/// only provides intersection functions.
+/// sf::Rect is a template and may be used with any numeric type,
+/// but for simplicity the following type aliases are given:
+/// \li sf::IntRect = sf::Rect<int>
+/// \li sf::FloatRect = sf::Rect<float>
 ///
-/// sf::Rect uses the usual rules for its boundaries:
-/// \li The left and top edges are included in the rectangle's area
-/// \li The right (left + width) and bottom (top + height) edges are excluded from the rectangle's area
-///
-/// This means that sf::IntRect(0, 0, 1, 1) and sf::IntRect(1, 1, 1, 1)
-/// don't intersect.
-///
-/// sf::Rect is a template and may be used with any numeric type, but
-/// for simplicity type aliases for the instantiations used by SFML are given:
-/// \li sf::Rect<int> is sf::IntRect
-/// \li sf::Rect<float> is sf::FloatRect
-///
-/// So that you don't have to care about the template syntax.
+/// The methods of sf::Rect assume that a rectangle contains it's own
+/// left and top edges, but does not contain it's right and bottom edges.
 ///
 /// Usage example:
 /// \code
-/// // Define a rectangle, located at (0, 0) with a size of 20x5
-/// sf::IntRect r1(0, 0, 20, 5);
+/// // Define a rectangle located at {0, 0} with a size of {10, 10}
+/// sf::IntRect rect1({0, 0}, {10, 10});
 ///
-/// // Define another rectangle, located at (4, 2) with a size of 18x10
-/// sf::Vector2i position(4, 2);
-/// sf::Vector2i size(18, 10);
-/// sf::IntRect r2(position, size);
+/// // Be careful, negative size is allowed!
+/// sf::IntRect rect2({5, 5}, {-10, -10});
 ///
-/// // Test intersections with the point (3, 1)
-/// bool b1 = r1.contains(3, 1); // true
-/// bool b2 = r2.contains(3, 1); // false
+/// // Test intersection with a point
+/// bool test1 = rect1.contains({9, 9}); // true
+/// bool test2 = rect1.contains({10, 10}); // false
 ///
-/// // Test the intersection between r1 and r2
-/// std::optional<sf::IntRect> result = r1.findIntersection(r2);
+/// // Test intersection with another rectangle
+/// std::optional<sf::IntRect> result = rect1.findIntersection(rect2);
 /// // result.has_value() == true
-/// // result.value() == (4, 2, 16, 3)
+/// // result.value() == sf::IntRect({0, 0}, {5, 5})
 /// \endcode
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -102,10 +102,10 @@ constexpr Vector2f Transform::transformPoint(const Vector2f& point) const
 constexpr FloatRect Transform::transformRect(const FloatRect& rectangle) const
 {
     // Transform the 4 corners of the rectangle
-    const Vector2f points[] = {transformPoint({rectangle.left, rectangle.top}),
-                               transformPoint({rectangle.left, rectangle.top + rectangle.height}),
-                               transformPoint({rectangle.left + rectangle.width, rectangle.top}),
-                               transformPoint({rectangle.left + rectangle.width, rectangle.top + rectangle.height})};
+    const Vector2f points[] = {transformPoint(rectangle.position),
+                               transformPoint({rectangle.position.x, rectangle.position.y + rectangle.size.y}),
+                               transformPoint({rectangle.position.x + rectangle.size.x, rectangle.position.y}),
+                               transformPoint(rectangle.position + rectangle.size)};
 
     // Compute the bounding rectangle of the transformed points
     float left   = points[0].x;

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -636,6 +636,7 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
         // Leave a small padding around characters, so that filtering doesn't
         // pollute them with pixels from neighbors
         const unsigned int padding = 2;
+        const Vector2i     paddingVec(Vector2u(padding, padding));
 
         width += 2 * padding;
         height += 2 * padding;
@@ -648,16 +649,12 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
 
         // Make sure the texture data is positioned in the center
         // of the allocated texture rectangle
-        glyph.textureRect.left += static_cast<int>(padding);
-        glyph.textureRect.top += static_cast<int>(padding);
-        glyph.textureRect.width -= static_cast<int>(2 * padding);
-        glyph.textureRect.height -= static_cast<int>(2 * padding);
+        glyph.textureRect.position += paddingVec;
+        glyph.textureRect.size -= paddingVec * 2;
 
         // Compute the glyph's bounding box
-        glyph.bounds.left   = static_cast<float>(bitmapGlyph->left);
-        glyph.bounds.top    = static_cast<float>(-bitmapGlyph->top);
-        glyph.bounds.width  = static_cast<float>(bitmap.width);
-        glyph.bounds.height = static_cast<float>(bitmap.rows);
+        glyph.bounds.position = Vector2f(Vector2i(bitmapGlyph->left, -bitmapGlyph->top));
+        glyph.bounds.size     = Vector2f(static_cast<float>(bitmap.width), static_cast<float>(bitmap.rows));
 
         // Resize the pixel buffer to the new size and fill it with transparent white pixels
         m_pixelBuffer.resize(static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4);
@@ -705,11 +702,9 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
         }
 
         // Write the pixels to the texture
-        unsigned int x = static_cast<unsigned int>(glyph.textureRect.left) - padding;
-        unsigned int y = static_cast<unsigned int>(glyph.textureRect.top) - padding;
-        unsigned int w = static_cast<unsigned int>(glyph.textureRect.width) + 2 * padding;
-        unsigned int h = static_cast<unsigned int>(glyph.textureRect.height) + 2 * padding;
-        page.texture.update(m_pixelBuffer.data(), {w, h}, {x, y});
+        page.texture.update(m_pixelBuffer.data(),
+                            Vector2u(glyph.textureRect.size + paddingVec * 2),
+                            Vector2u(glyph.textureRect.position - paddingVec));
     }
 
     // Delete the FT glyph

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -187,8 +187,7 @@ void Shape::update()
     m_insideBounds = m_vertices.getBounds();
 
     // Compute the center and make it the first vertex
-    m_vertices[0].position.x = m_insideBounds.left + m_insideBounds.width / 2;
-    m_vertices[0].position.y = m_insideBounds.top + m_insideBounds.height / 2;
+    m_vertices[0].position = m_insideBounds.getCenter();
 
     // Color
     updateFillColors();
@@ -232,15 +231,21 @@ void Shape::updateFillColors()
 ////////////////////////////////////////////////////////////
 void Shape::updateTexCoords()
 {
-    FloatRect convertedTextureRect(m_textureRect);
+    FloatRect textureRect(m_textureRect);
 
     for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
     {
-        float xratio = m_insideBounds.width > 0 ? (m_vertices[i].position.x - m_insideBounds.left) / m_insideBounds.width : 0;
-        float yratio = m_insideBounds.height > 0 ? (m_vertices[i].position.y - m_insideBounds.top) / m_insideBounds.height
-                                                 : 0;
-        m_vertices[i].texCoords.x = convertedTextureRect.left + convertedTextureRect.width * xratio;
-        m_vertices[i].texCoords.y = convertedTextureRect.top + convertedTextureRect.height * yratio;
+        float xratio = 0.f;
+        float yratio = 0.f;
+
+        if (m_insideBounds.size.x > 0.f)
+            xratio = (m_vertices[i].position.x - m_insideBounds.position.x) / m_insideBounds.size.x;
+
+        if (m_insideBounds.size.y > 0.f)
+            yratio = (m_vertices[i].position.y - m_insideBounds.position.y) / m_insideBounds.size.y;
+
+        m_vertices[i].texCoords.x = textureRect.position.x + textureRect.size.x * xratio;
+        m_vertices[i].texCoords.y = textureRect.position.y + textureRect.size.y * yratio;
     }
 }
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -118,10 +118,7 @@ const Color& Sprite::getColor() const
 ////////////////////////////////////////////////////////////
 FloatRect Sprite::getLocalBounds() const
 {
-    auto width  = static_cast<float>(std::abs(m_textureRect.width));
-    auto height = static_cast<float>(std::abs(m_textureRect.height));
-
-    return FloatRect({0.f, 0.f}, {width, height});
+    return FloatRect({0, 0}, Vector2f(m_textureRect.getAbsoluteSize()));
 }
 
 
@@ -149,29 +146,24 @@ void Sprite::draw(RenderTarget& target, const RenderStates& states) const
 ////////////////////////////////////////////////////////////
 void Sprite::updatePositions()
 {
-    FloatRect bounds = getLocalBounds();
+    Vector2f size(m_textureRect.getAbsoluteSize());
 
-    m_vertices[0].position = Vector2f(0, 0);
-    m_vertices[1].position = Vector2f(0, bounds.height);
-    m_vertices[2].position = Vector2f(bounds.width, 0);
-    m_vertices[3].position = Vector2f(bounds.width, bounds.height);
+    m_vertices[0].position = Vector2f();
+    m_vertices[1].position = Vector2f(0, size.y);
+    m_vertices[2].position = Vector2f(size.x, 0);
+    m_vertices[3].position = size;
 }
 
 
 ////////////////////////////////////////////////////////////
 void Sprite::updateTexCoords()
 {
-    FloatRect convertedTextureRect(m_textureRect);
+    FloatRect textureRect(m_textureRect);
 
-    float left   = convertedTextureRect.left;
-    float right  = left + convertedTextureRect.width;
-    float top    = convertedTextureRect.top;
-    float bottom = top + convertedTextureRect.height;
-
-    m_vertices[0].texCoords = Vector2f(left, top);
-    m_vertices[1].texCoords = Vector2f(left, bottom);
-    m_vertices[2].texCoords = Vector2f(right, top);
-    m_vertices[3].texCoords = Vector2f(right, bottom);
+    m_vertices[0].texCoords = textureRect.position;
+    m_vertices[1].texCoords = Vector2f(textureRect.position.x, textureRect.position.y + textureRect.size.y);
+    m_vertices[2].texCoords = Vector2f(textureRect.position.x + textureRect.size.x, textureRect.position.y);
+    m_vertices[3].texCoords = textureRect.position + textureRect.size;
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -108,10 +108,8 @@ void View::setViewport(const FloatRect& viewport)
 ////////////////////////////////////////////////////////////
 void View::reset(const FloatRect& rectangle)
 {
-    m_center.x = rectangle.left + rectangle.width / 2.f;
-    m_center.y = rectangle.top + rectangle.height / 2.f;
-    m_size.x   = rectangle.width;
-    m_size.y   = rectangle.height;
+    m_center   = rectangle.getCenter();
+    m_size     = rectangle.size;
     m_rotation = Angle::Zero;
 
     m_transformUpdated    = false;

--- a/test/Graphics/Shape.cpp
+++ b/test/Graphics/Shape.cpp
@@ -101,9 +101,7 @@ TEST_CASE("[Graphics] sf::Shape")
         triangleShape.move({1, 1});
         triangleShape.rotate(sf::degrees(90));
         CHECK(triangleShape.getLocalBounds() == sf::FloatRect({0, 0}, {2, 3}));
-        CHECK(triangleShape.getGlobalBounds().left == Approx(-2.f));
-        CHECK(triangleShape.getGlobalBounds().top == Approx(1.f));
-        CHECK(triangleShape.getGlobalBounds().width == Approx(3.f));
-        CHECK(triangleShape.getGlobalBounds().height == Approx(2.f));
+        CHECK(triangleShape.getGlobalBounds().position == Approx(sf::Vector2f(-2, 1)));
+        CHECK(triangleShape.getGlobalBounds().size == Approx(sf::Vector2f(3, 2)));
     }
 }

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -27,7 +27,7 @@ std::ostream& operator<<(std::ostream& os, const Rect<T>& rect)
 {
     const auto flags = os.flags();
     os << std::fixed << std::setprecision(std::numeric_limits<T>::max_digits10);
-    os << "(left=" << rect.left << ", top=" << rect.top << ", width=" << rect.width << ", height=" << rect.height << ")";
+    os << "(position=" << rect.position << ", size=" << rect.size << ")";
     os.flags(flags);
     return os;
 }


### PR DESCRIPTION
## Description

Class `sf::Rect` is a simple and straightforward construct, widely used in SFML library. However, it lacks many basic features and doesn't follow object oriented intuition, as well as standards established in, for example, PR #2055. This PR improves the `Rect` class by indroducing the following changes:

* A `Rect` is now defined in terms of it's `Vector2` `position` and `size`, rather than `left`, `top`, `width` and `height`.
* The class now has 4 methods for acquiring it's edges: `getLeft()`, `getTop()`, `getRight()` and `getBottom()`.
* The class now has 3 methods for acquiring it's measurements: `getStart()`, `getEnd()` and `getCenter()`.
* The class now has `getAbsoluteSize()` method.
* The class now has `getAbsoluteRect()` method, which returns the same bounding rectangle, but described with it's actual starting position and positive size.
* All mentioned methods are designed to handle rectangles with negative size.
* The implementation of old methods (`contains` and `findIntersection`) as well as methods in other classes, which are dependent on the `Rect` class, have been refactored using the new functionality.

## Tasks

* [x] Tested on Windows (first-hand)
* [x] Tested on Linux, macOS, iOS and Android (CI)

## How to test this PR?

```cpp
#include <iostream>
#include <SFML/Graphics/Rect.hpp>

// This is basically a unit test. Every line should say "1"

int main()
{
  // Positive size
  {
    const sf::IntRect rectangle({0, 0}, {10, 10});
    
    std::cout << rectangle.getLeft() == 0 << "\n";
    std::cout << rectangle.getTop() == 0 << "\n";
    std::cout << rectangle.getRight() == 10 << "\n";
    std::cout << rectangle.getBottom() == 10 << "\n";
    
    std::cout << rectangle.getStart() == sf::Vector2i(0, 0) << "\n";
    std::cout << rectangle.getEnd() == sf::Vector2i(10, 10) << "\n";
    std::cout << rectangle.getCenter() == sf::Vector2i(5, 5) << "\n";
    
    std::cout << rectangle.getAbsoluteSize() == sf::Vector2i(10, 10) << "\n";
    std::cout << rectangle.getAbsoluteRect() == rectangle << "\n";
    
    std::cout << rectangle.contains({0, 0}) << "\n";
    std::cout << !rectangle.contains({10, 10}) << "\n";
    
    std::cout << rectangle.findIntersection(sf::IntRect({5, 5}, {10, 10})) == sf::IntRect({5, 5}, {5, 5}) << "\n";
    std::cout << !rectangle.findIntersection(sf::IntRect({10, 10}, {10, 10})) << "\n";
  }
  
  // Negative size
  {
    const sf::IntRect rectangle({0, 0}, {-10, -10});
    
    std::cout << rectangle.getLeft() == -10 << "\n";
    std::cout << rectangle.getTop() == -10 << "\n";
    std::cout << rectangle.getRight() == 0 << "\n";
    std::cout << rectangle.getBottom() == 0 << "\n";
    
    std::cout << rectangle.getStart() == sf::Vector2i(-10, -10) << "\n";
    std::cout << rectangle.getEnd() == sf::Vector2i(0, 0) << "\n";
    std::cout << rectangle.getCenter() == sf::Vector2i(-5, -5) << "\n";
    
    std::cout << rectangle.getAbsoluteSize() == sf::Vector2i(10, 10) << "\n";
    std::cout << rectangle.getAbsoluteRect() == sf::IntRect({-10, -10}, {10, 10})<< "\n";
    
    std::cout << rectangle.contains({-10, -10}) << "\n";
    std::cout << !rectangle.contains({0, 0}) << "\n";
    
    std::cout << rectangle.findIntersection(sf::IntRect({-5, -5}, {10, 10})) == sf::IntRect({-5, -5}, {5, 5}) << "\n";
    std::cout << !rectangle.findIntersection(sf::IntRect({0, 0}, {10, 10})) << "\n";
  }
  
  return 0;
}
```

## P. S.

I've had to reopen this PR because I've ruined the original one. Sorry for the inconvenience.