### PR TITLE
Use doctest-provided `main` implementation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,6 @@ include(doctest)
 add_subdirectory(install)
 
 add_library(sfml-test-main STATIC
-    DoctestMain.cpp
     TestUtilities/SystemUtil.hpp
     TestUtilities/SystemUtil.cpp
     TestUtilities/WindowUtil.hpp
@@ -22,7 +21,7 @@ add_library(sfml-test-main STATIC
 )
 target_include_directories(sfml-test-main PUBLIC TestUtilities)
 target_compile_definitions(sfml-test-main PUBLIC DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES)
-target_link_libraries(sfml-test-main PUBLIC SFML::System doctest::doctest)
+target_link_libraries(sfml-test-main PUBLIC SFML::System doctest::doctest_with_main)
 set_target_warnings(sfml-test-main)
 
 set(SYSTEM_SRC

--- a/test/DoctestMain.cpp
+++ b/test/DoctestMain.cpp
@@ -1,2 +1,0 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>


### PR DESCRIPTION
## Description

We must have overlooked this `doctest::doctest_with_main` target when replacing the vendored doctest header with the current FetchContent scheme. I'm happy to use this rather than maintain our own equivalent.