### PR TITLE
Update checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: Upload Coverage Report to Codecov
       if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' # Disable upload in forks
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         directory: ./build
         files: ./build/coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           config: { name: Shared DRM, flags: -DBUILD_SHARED_LIBS=TRUE -DSFML_USE_DRM=TRUE }
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
@@ -122,7 +122,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'


### PR DESCRIPTION
## Description

CI recently started throwing all these warnings about our checkout action being deprecated soon.

<img width="1416" alt="Screen Shot 2022-10-16 at 2 58 26 PM" src="https://user-images.githubusercontent.com/39244355/196058018-f5c1102a-c060-4f52-8d32-425ceeb6a88c.png">
<img width="678" alt="Screen Shot 2022-10-16 at 2 59 32 PM" src="https://user-images.githubusercontent.com/39244355/196058032-f8d2f8dd-0050-4c46-8362-5f18cd69f05a.png">

The fix is as easy as just updating the latest major release.