### PR TITLE
Add clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,14 @@
+Checks: >
+  -*,
+  clang-analyzer-*,
+  -clang-analyzer-core.NonNullParamChecker,
+  -clang-analyzer-core.NullDereference,
+  -clang-analyzer-nullability.NullablePassedToNonnull,
+  -clang-analyzer-optin.cplusplus.VirtualCall,
+  -clang-analyzer-optin.osx.*,
+  -clang-analyzer-optin.portability.UnixAPI,
+  -clang-analyzer-osx.*,
+  -clang-analyzer-security.insecureAPI.rand,
+  -clang-analyzer-unix.Malloc,
+HeaderFilterRegex: '.*'
+WarningsAsErrors: '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,34 @@ jobs:
 
     - name: Check Formatting
       run: git diff --exit-code
+
+  tidy:
+    name: Analyzing on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { name: Linux, os: ubuntu-latest }
+        - { name: macOS, os: macos-12 }
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev
+
+    - name: Install macOS Dependencies
+      if: runner.os == 'macOS'
+      run: |
+        brew install llvm
+        echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
+
+    - name: Configure
+      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DSFML_BUILD_EXAMPLES=TRUE -DSFML_BUILD_TEST_SUITE=TRUE
+
+    - name: Analyze Code
+      run: cmake --build $GITHUB_WORKSPACE/build --target tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,3 +536,5 @@ sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-form
 add_custom_target(format
     COMMAND ${CMAKE_COMMAND} "-DCLANG_FORMAT_EXECUTABLE=${CLANG_FORMAT_EXECUTABLE}" -P ./cmake/Format.cmake
     WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}" VERBATIM)
+
+add_custom_target(tidy COMMAND run-clang-tidy -p ${PROJECT_BINARY_DIR} VERBATIM)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,12 +2,16 @@ include(FetchContent)
 
 set(DOCTEST_NO_INSTALL ON)
 FetchContent_Declare(doctest
-    GIT_REPOSITORY "https://github.com/doctest/doctest.git"
+    GIT_REPOSITORY https://github.com/doctest/doctest.git
     GIT_TAG v2.4.9
 )
 FetchContent_MakeAvailable(doctest)
-list(APPEND CMAKE_MODULE_PATH ${doctest_SOURCE_DIR}/scripts/cmake)
-include(doctest)
+include(${doctest_SOURCE_DIR}/scripts/cmake/doctest.cmake)
+
+# Ensure that doctest sources and headers are not analyzed by any tools
+set_target_properties(doctest_with_main PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
+get_target_property(DOCTEST_INCLUDE_DIRS doctest INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(doctest SYSTEM INTERFACE ${DOCTEST_INCLUDE_DIRS})
 
 add_subdirectory(install)
 


### PR DESCRIPTION
## Description

With most of the easy unit testing out of the way, this is the next step in SFML's journey towards better software engineering practices. For the uninitiated, read about clang-tidy [here](https://clang.llvm.org/extra/clang-tidy/).

This PR does 2 things, 1 in each commit.

1. The first commit prepares the way for clang-tidy by ensuring that Doctest's source files do not appear in the compile commands database and that it's public headers are correctly listed as `SYSTEM` headers. I'm merely mimicking how Doctest would appear if we consumed it via `find_package`.
1. The second commit adds a new custom target named `tidy` which invokes [`run-clang-tidy`](https://github.com/llvm-mirror/clang-tools-extra/blob/master/clang-tidy/tool/run-clang-tidy.py), a Python script from the LLVM project which automatically runs clang-tidy in parallel across all source files in the compile commands database. This behavior is critical because different configurations (often split on OS boundaries) compile different source files. If you try to analyze an X11 source file on macOS, you won't get meaningful results since clang-tidy won't know what settings are required to build such a file. Vice versa when trying to analyze a Objective-C++ in Ubuntu.

I chose to only run clang-tidy twice since I have no reason to believe that testing it with debug/release/shared/static will ever yield different result. Given that choice, it made the most sense to make separate jobs for running it, mimicking the pattern already established for building the `format` target.

You may notice that I actually fixed no clang-tidy findings in that PR and that's intentional. I chose to ignore all the warnings that were cropping up so that this PR could focus on only the infrastructure to run clang-tidy. It will require its own separate discussion to address the things clang-tidy is actually finding. There are many `clang-analyze-*` checks to enable and many more families of checks I want to start enabling.

I do specifically want to mention the [`readability-identifier-naming`](https://releases.llvm.org/11.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-identifier-naming.html) which can let us enforce things like UpperCase class names and lowerCamelCase variable and function names. These are probably the checks I'm most eager to enable.

_"But what about Windows?"_ One of the requirements to using clang-tidy is having a compile commands database. This is a file you may have seen in your build directory called compile_commands.json. CMake will generate it (when using Makefiles or Ninja) with the `-DCMAKE_EXPORT_COMPILE_COMMANDS` variable. Unfortunately MS Build will not generate such a file for us so I'm not aware of any way to run clang-tidy on the Windows-only source files.