### PR TITLE
Start enforcing naming style

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: >
   -*,
   clang-analyzer-*,
+  readability-identifier-naming,
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-core.NullDereference,
   -clang-analyzer-nullability.NullablePassedToNonnull,
@@ -10,5 +11,8 @@ Checks: >
   -clang-analyzer-osx.*,
   -clang-analyzer-security.insecureAPI.rand,
   -clang-analyzer-unix.Malloc,
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,           value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase,        value: camelBack }
 HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -37,7 +37,7 @@
 
 namespace
 {
-bool JoystickButtonSortPredicate(IOHIDElementRef b1, IOHIDElementRef b2)
+bool joystickButtonSortPredicate(IOHIDElementRef b1, IOHIDElementRef b2)
 {
     return IOHIDElementGetUsage(b1) < IOHIDElementGetUsage(b2);
 }
@@ -322,7 +322,7 @@ bool JoystickImpl::open(unsigned int index)
 
     // Ensure that the buttons will be indexed in the same order as their
     // HID Usage (assigned by manufacturer and/or a driver).
-    std::sort(m_buttons.begin(), m_buttons.end(), JoystickButtonSortPredicate);
+    std::sort(m_buttons.begin(), m_buttons.end(), joystickButtonSortPredicate);
 
     // Retain all these objects for personal use
     for (IOHIDElementRef iohidElementRef : m_buttons)

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -77,7 +77,7 @@ void ClipboardImpl::processEvents()
 ClipboardImpl::ClipboardImpl() : m_window(0), m_requestResponded(false)
 {
     // Open a connection with the X server
-    m_display = OpenDisplay();
+    m_display = openDisplay();
 
     // Get the atoms we need to make use of the clipboard
     m_clipboard      = getAtom("CLIPBOARD", false);
@@ -105,7 +105,7 @@ ClipboardImpl::~ClipboardImpl()
     }
 
     // Close the connection with the X server
-    CloseDisplay(m_display);
+    closeDisplay(m_display);
 }
 
 

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -42,7 +42,7 @@ namespace priv
 {
 
 ////////////////////////////////////////////////////////////
-CursorImpl::CursorImpl() : m_display(OpenDisplay()), m_cursor(None)
+CursorImpl::CursorImpl() : m_display(openDisplay()), m_cursor(None)
 {
     // That's it.
 }
@@ -53,7 +53,7 @@ CursorImpl::~CursorImpl()
 {
     release();
 
-    CloseDisplay(m_display);
+    closeDisplay(m_display);
 }
 
 

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -55,7 +55,7 @@ namespace sf
 namespace priv
 {
 ////////////////////////////////////////////////////////////
-Display* OpenDisplay()
+Display* openDisplay()
 {
     std::scoped_lock lock(mutex);
 
@@ -78,7 +78,7 @@ Display* OpenDisplay()
 
 
 ////////////////////////////////////////////////////////////
-void CloseDisplay(Display* display)
+void closeDisplay(Display* display)
 {
     std::scoped_lock lock(mutex);
 
@@ -90,7 +90,7 @@ void CloseDisplay(Display* display)
 }
 
 ////////////////////////////////////////////////////////////
-XIM OpenXIM()
+XIM openXim()
 {
     std::scoped_lock lock(mutex);
 
@@ -128,7 +128,7 @@ XIM OpenXIM()
 }
 
 ////////////////////////////////////////////////////////////
-void CloseXIM(XIM xim)
+void closeXim(XIM xim)
 {
     std::scoped_lock lock(mutex);
 
@@ -146,11 +146,11 @@ Atom getAtom(const std::string& name, bool onlyIfExists)
     if (auto it = atoms.find(name); it != atoms.end())
         return it->second;
 
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
 
     Atom atom = XInternAtom(display, name.c_str(), onlyIfExists ? True : False);
 
-    CloseDisplay(display);
+    closeDisplay(display);
 
     atoms[name] = atom;
 

--- a/src/SFML/Window/Unix/Display.hpp
+++ b/src/SFML/Window/Unix/Display.hpp
@@ -43,12 +43,12 @@ namespace priv
 /// \brief Get the shared Display
 ///
 /// This function increments the reference count of the display,
-/// it must be matched with a call to CloseDisplay.
+/// it must be matched with a call to closeDisplay.
 ///
 /// \return Pointer to the shared display
 ///
 ////////////////////////////////////////////////////////////
-Display* OpenDisplay();
+Display* openDisplay();
 
 ////////////////////////////////////////////////////////////
 /// \brief Release a reference to the shared display
@@ -56,7 +56,7 @@ Display* OpenDisplay();
 /// \param display Display to release
 ///
 ////////////////////////////////////////////////////////////
-void CloseDisplay(Display* display);
+void closeDisplay(Display* display);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the shared XIM context for the Display
@@ -69,7 +69,7 @@ void CloseDisplay(Display* display);
 /// \return XIM handle (a pointer) of the context
 ///
 ////////////////////////////////////////////////////////////
-XIM OpenXIM();
+XIM openXim();
 
 ////////////////////////////////////////////////////////////
 /// \brief Release a reference to the shared XIM context
@@ -77,7 +77,7 @@ XIM OpenXIM();
 /// \param xim XIM context to release
 ///
 ////////////////////////////////////////////////////////////
-void CloseXIM(XIM xim);
+void closeXim(XIM xim);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the atom with the specified name

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -71,7 +71,7 @@ void ensureExtensionsInit(::Display* display, int screen)
 }
 
 
-int HandleXError(::Display*, XErrorEvent*)
+int handleXError(::Display*, XErrorEvent*)
 {
     glxErrorOccurred = true;
     return 0;
@@ -84,7 +84,7 @@ public:
     GlxErrorHandler(::Display* display) : m_lock(glxErrorMutex), m_display(display)
     {
         glxErrorOccurred  = false;
-        m_previousHandler = XSetErrorHandler(HandleXError);
+        m_previousHandler = XSetErrorHandler(handleXError);
     }
 
     ~GlxErrorHandler()
@@ -117,7 +117,7 @@ m_ownsWindow(false)
     m_settings = ContextSettings();
 
     // Open the connection with the X server
-    m_display = OpenDisplay();
+    m_display = openDisplay();
 
     // Make sure that extensions are initialized
     ensureExtensionsInit(m_display, DefaultScreen(m_display));
@@ -142,7 +142,7 @@ m_ownsWindow(false)
     m_settings = settings;
 
     // Open the connection with the X server
-    m_display = OpenDisplay();
+    m_display = openDisplay();
 
     // Make sure that extensions are initialized
     ensureExtensionsInit(m_display, DefaultScreen(m_display));
@@ -167,7 +167,7 @@ m_ownsWindow(false)
     m_settings = settings;
 
     // Open the connection with the X server
-    m_display = OpenDisplay();
+    m_display = openDisplay();
 
     // Make sure that extensions are initialized
     ensureExtensionsInit(m_display, DefaultScreen(m_display));
@@ -216,7 +216,7 @@ GlxContext::~GlxContext()
     }
 
     // Close the connection with the X server
-    CloseDisplay(m_display);
+    closeDisplay(m_display);
 }
 
 

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -157,7 +157,7 @@ bool InputImpl::isKeyPressed(Keyboard::Key key)
         return false;
 
     // Open a connection with the X server
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
 
     // Convert to keycode
     KeyCode keycode = XKeysymToKeycode(display, keysym);
@@ -168,7 +168,7 @@ bool InputImpl::isKeyPressed(Keyboard::Key key)
         XQueryKeymap(display, keys);
 
         // Close the connection with the X server
-        CloseDisplay(display);
+        closeDisplay(display);
 
         // Check our keycode
         return (keys[keycode / 8] & (1 << (keycode % 8))) != 0;
@@ -176,7 +176,7 @@ bool InputImpl::isKeyPressed(Keyboard::Key key)
     else
     {
         // Close the connection with the X server
-        CloseDisplay(display);
+        closeDisplay(display);
 
         return false;
     }
@@ -194,7 +194,7 @@ void InputImpl::setVirtualKeyboardVisible(bool /*visible*/)
 bool InputImpl::isMouseButtonPressed(Mouse::Button button)
 {
     // Open a connection with the X server
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
 
     // we don't care about these but they are required
     ::Window root, child;
@@ -205,7 +205,7 @@ bool InputImpl::isMouseButtonPressed(Mouse::Button button)
     XQueryPointer(display, DefaultRootWindow(display), &root, &child, &gx, &gy, &wx, &wy, &buttons);
 
     // Close the connection with the X server
-    CloseDisplay(display);
+    closeDisplay(display);
 
     // clang-format off
     switch (button)
@@ -227,7 +227,7 @@ bool InputImpl::isMouseButtonPressed(Mouse::Button button)
 Vector2i InputImpl::getMousePosition()
 {
     // Open a connection with the X server
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
 
     // we don't care about these but they are required
     ::Window     root, child;
@@ -239,7 +239,7 @@ Vector2i InputImpl::getMousePosition()
     XQueryPointer(display, DefaultRootWindow(display), &root, &child, &gx, &gy, &x, &y, &buttons);
 
     // Close the connection with the X server
-    CloseDisplay(display);
+    closeDisplay(display);
 
     return Vector2i(gx, gy);
 }
@@ -252,7 +252,7 @@ Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
     if (handle)
     {
         // Open a connection with the X server
-        Display* display = OpenDisplay();
+        Display* display = openDisplay();
 
         // we don't care about these but they are required
         ::Window     root, child;
@@ -264,7 +264,7 @@ Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
         XQueryPointer(display, handle, &root, &child, &gx, &gy, &x, &y, &buttons);
 
         // Close the connection with the X server
-        CloseDisplay(display);
+        closeDisplay(display);
 
         return Vector2i(x, y);
     }
@@ -279,13 +279,13 @@ Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
 void InputImpl::setMousePosition(const Vector2i& position)
 {
     // Open a connection with the X server
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
 
     XWarpPointer(display, None, DefaultRootWindow(display), 0, 0, 0, 0, position.x, position.y);
     XFlush(display);
 
     // Close the connection with the X server
-    CloseDisplay(display);
+    closeDisplay(display);
 }
 
 
@@ -293,7 +293,7 @@ void InputImpl::setMousePosition(const Vector2i& position)
 void InputImpl::setMousePosition(const Vector2i& position, const WindowBase& relativeTo)
 {
     // Open a connection with the X server
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
 
     WindowHandle handle = relativeTo.getSystemHandle();
     if (handle)
@@ -303,7 +303,7 @@ void InputImpl::setMousePosition(const Vector2i& position, const WindowBase& rel
     }
 
     // Close the connection with the X server
-    CloseDisplay(display);
+    closeDisplay(display);
 }
 
 

--- a/src/SFML/Window/Unix/VideoModeImpl.cpp
+++ b/src/SFML/Window/Unix/VideoModeImpl.cpp
@@ -46,7 +46,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     std::vector<VideoMode> modes;
 
     // Open a connection with the X server
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
     if (display)
     {
         // Retrieve the default screen number
@@ -114,7 +114,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
         }
 
         // Close the connection with the X server
-        CloseDisplay(display);
+        closeDisplay(display);
     }
     else
     {
@@ -132,7 +132,7 @@ VideoMode VideoModeImpl::getDesktopMode()
     VideoMode desktopMode;
 
     // Open a connection with the X server
-    Display* display = OpenDisplay();
+    Display* display = openDisplay();
     if (display)
     {
         // Retrieve the default screen number
@@ -183,7 +183,7 @@ VideoMode VideoModeImpl::getDesktopMode()
         }
 
         // Close the connection with the X server
-        CloseDisplay(display);
+        closeDisplay(display);
     }
     else
     {

--- a/src/SFML/Window/Unix/VulkanImplX11.cpp
+++ b/src/SFML/Window/Unix/VulkanImplX11.cpp
@@ -211,12 +211,12 @@ bool VulkanImplX11::createVulkanSurface(const VkInstance&            instance,
     // to the X display will stay open even after we open and close it here
     VkXlibSurfaceCreateInfoKHR surfaceCreateInfo = VkXlibSurfaceCreateInfoKHR();
     surfaceCreateInfo.sType                      = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
-    surfaceCreateInfo.dpy                        = OpenDisplay();
+    surfaceCreateInfo.dpy                        = openDisplay();
     surfaceCreateInfo.window                     = windowHandle;
 
     bool result = (vkCreateXlibSurfaceKHR(instance, &surfaceCreateInfo, allocator, &surface) == VK_SUCCESS);
 
-    CloseDisplay(surfaceCreateInfo.dpy);
+    closeDisplay(surfaceCreateInfo.dpy);
 
     return result;
 }

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -165,7 +165,7 @@ bool ewmhSupported()
     if (!netSupportingWmCheck || !netSupported)
         return false;
 
-    ::Display* display = sf::priv::OpenDisplay();
+    ::Display* display = sf::priv::openDisplay();
 
     Atom           actualType;
     int            actualFormat;
@@ -191,7 +191,7 @@ bool ewmhSupported()
         if (result == Success)
             XFree(data);
 
-        sf::priv::CloseDisplay(display);
+        sf::priv::closeDisplay(display);
         return false;
     }
 
@@ -204,7 +204,7 @@ bool ewmhSupported()
 
     if (!rootWindow)
     {
-        sf::priv::CloseDisplay(display);
+        sf::priv::closeDisplay(display);
         return false;
     }
 
@@ -226,7 +226,7 @@ bool ewmhSupported()
         if (result == Success)
             XFree(data);
 
-        sf::priv::CloseDisplay(display);
+        sf::priv::closeDisplay(display);
         return false;
     }
 
@@ -239,14 +239,14 @@ bool ewmhSupported()
 
     if (!childWindow)
     {
-        sf::priv::CloseDisplay(display);
+        sf::priv::closeDisplay(display);
         return false;
     }
 
     // Conforming window managers should return the same window for both queries
     if (rootWindow != childWindow)
     {
-        sf::priv::CloseDisplay(display);
+        sf::priv::closeDisplay(display);
         return false;
     }
 
@@ -258,7 +258,7 @@ bool ewmhSupported()
 
     if (!netWmName)
     {
-        sf::priv::CloseDisplay(display);
+        sf::priv::closeDisplay(display);
         return true;
     }
 
@@ -293,7 +293,7 @@ bool ewmhSupported()
     if (result == Success)
         XFree(data);
 
-    sf::priv::CloseDisplay(display);
+    sf::priv::closeDisplay(display);
 
     return true;
 }
@@ -516,7 +516,7 @@ m_lastInputTime(0)
     using namespace WindowsImplX11Impl;
 
     // Open a connection with the X server
-    m_display = OpenDisplay();
+    m_display = openDisplay();
 
     // Make sure to check for EWMH support before we do anything
     ewmhSupported();
@@ -567,7 +567,7 @@ m_lastInputTime(0)
     using namespace WindowsImplX11Impl;
 
     // Open a connection with the X server
-    m_display = OpenDisplay();
+    m_display = openDisplay();
 
     // Make sure to check for EWMH support before we do anything
     ewmhSupported();
@@ -804,10 +804,10 @@ WindowImplX11::~WindowImplX11()
 
     // Close the input method
     if (m_inputMethod)
-        CloseXIM(m_inputMethod);
+        closeXim(m_inputMethod);
 
     // Close the connection with the X server
-    CloseDisplay(m_display);
+    closeDisplay(m_display);
 
     // Remove this window from the global list of windows (required for focus request)
     std::scoped_lock lock(allWindowsMutex);
@@ -1616,7 +1616,7 @@ void WindowImplX11::initialize()
     using namespace WindowsImplX11Impl;
 
     // Create the input context
-    m_inputMethod = OpenXIM();
+    m_inputMethod = openXim();
 
     if (m_inputMethod)
     {


### PR DESCRIPTION
## Description

Now let's actually use clang-tidy to make improvements! This one was pretty easy since all classes already adhered to the correct style and only a few functions needed to be fixed.
