### PR TITLE
Enforce parameter case

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,5 +14,6 @@ Checks: >
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase,           value: CamelCase }
   - { key: readability-identifier-naming.FunctionCase,        value: camelBack }
+  - { key: readability-identifier-naming.ParameterCase,       value: camelBack }
 HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'

--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -102,15 +102,18 @@ struct Vector4
     ////////////////////////////////////////////////////////////
     /// \brief Construct from 4 vector components
     ///
-    /// \param X Component of the 4D vector
-    /// \param Y Component of the 4D vector
-    /// \param Z Component of the 4D vector
-    /// \param W Component of the 4D vector
+    /// \param x Component of the 4D vector
+    /// \param y Component of the 4D vector
+    /// \param z Component of the 4D vector
+    /// \param w Component of the 4D vector
     ///
     ////////////////////////////////////////////////////////////
-    Vector4(T X, T Y, T Z, T W) : x(X), y(Y), z(Z), w(W)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+    Vector4(T x, T y, T z, T w) : x(x), y(y), z(z), w(w)
     {
     }
+#pragma GCC diagnostic pop
 
     ////////////////////////////////////////////////////////////
     /// \brief Conversion constructor

--- a/include/SFML/System/Utf.hpp
+++ b/include/SFML/System/Utf.hpp
@@ -41,7 +41,7 @@ namespace sf
 namespace priv
 {
 template <class InputIt, class OutputIt>
-OutputIt copy(InputIt first, InputIt last, OutputIt d_first);
+OutputIt copy(InputIt first, InputIt last, OutputIt dFirst);
 }
 
 template <unsigned int N>

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -36,12 +36,12 @@
 
 ////////////////////////////////////////////////////////////
 template <typename InputIt, typename OutputIt>
-OutputIt priv::copy(InputIt first, InputIt last, OutputIt d_first)
+OutputIt priv::copy(InputIt first, InputIt last, OutputIt dFirst)
 {
     while (first != last)
-        *d_first++ = static_cast<typename OutputIt::container_type::value_type>(*first++);
+        *dFirst++ = static_cast<typename OutputIt::container_type::value_type>(*first++);
 
-    return d_first;
+    return dFirst;
 }
 
 template <typename In>

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -54,11 +54,11 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from cartesian coordinates
     ///
-    /// \param X X coordinate
-    /// \param Y Y coordinate
+    /// \param x X coordinate
+    /// \param y Y coordinate
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2(T X, T Y);
+    constexpr Vector2(T x, T y);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -31,10 +31,13 @@ constexpr Vector2<T>::Vector2() : x(0), y(0)
 
 
 ////////////////////////////////////////////////////////////
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 template <typename T>
-constexpr Vector2<T>::Vector2(T X, T Y) : x(X), y(Y)
+constexpr Vector2<T>::Vector2(T x, T y) : x(x), y(y)
 {
 }
+#pragma GCC diagnostic pop
 
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -51,12 +51,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from its coordinates
     ///
-    /// \param X X coordinate
-    /// \param Y Y coordinate
-    /// \param Z Z coordinate
+    /// \param x X coordinate
+    /// \param y Y coordinate
+    /// \param z Z coordinate
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3(T X, T Y, T Z);
+    constexpr Vector3(T x, T y, T z);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector

--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -31,10 +31,13 @@ constexpr Vector3<T>::Vector3() : x(0), y(0), z(0)
 
 
 ////////////////////////////////////////////////////////////
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 template <typename T>
-constexpr Vector3<T>::Vector3(T X, T Y, T Z) : x(X), y(Y), z(Z)
+constexpr Vector3<T>::Vector3(T x, T y, T z) : x(x), y(y), z(z)
 {
 }
+#pragma GCC diagnostic pop
 
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

The clang-tidy PRs keep coming. This time I added a check for the style of parameters. The style in a few places were wrong. One fix was straightforward but the changes to the vector types were a bit more complicated.

Identifiers like `X` and `Y` don't adhere to our `camelBack` style. I explored a few options. First I tried using a leading underscore but that didn't match the `camelBack` style. Trailing underscores didn't fit it either. I briefly considered using a `the` prefix like in [`sf::Vertex::Vertex`](https://github.com/SFML/SFML/blob/master/include/SFML/Graphics/Vertex.hpp#L58) but that just looked bad. Next I tried adding `NOLINT(readability-identifier-naming)` comments on the offending code but that also felt wrong. I didn't like how I had to add this comment in Vector2.hpp _and_ Vector2.inl. Plus that fix is overkill. That would disable all identifier naming checks for that line, not just those about the parameter names.

I eventually settled on using `x` and `y` style identifiers. I liked how this looked the best and didn't require adding extra comments to all the headers. I only had to temporarily disable `-Wshadow` in the .inl files. Curiously Clang didn't emit `-Wshadow` warnings. It was only GCC which took issue.
