### PR TITLE
Turn off Codecov annotations

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -37,4 +37,4 @@ comment:
   require_base: no
 
 github_checks:
-  annotations: true
+  annotations: false


### PR DESCRIPTION
## Description

Those annotations create enormous clutter in diff views on GitHub, making PR reviews complicated. Since we are currently not headed toward 100% coverage, they provide little benefit.

Codecov stats aggregation still runs, this is specifically about the inline dialogs.

![grafik](https://user-images.githubusercontent.com/708488/197736582-bc4acc77-7f53-431e-9f95-b2ee7d9e0c3b.png)


See also: https://github.com/codecov/codecov-action/issues/135

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

To truly test this, we might need to have some actual code changes 🤔

Since this changes only the config, we can't see the effect inside this PR.