### PR TITLE
Lock 2.6.x branch to macOS 11 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         - { name: Windows VS2022 Clang, os: windows-2022, flags: -T ClangCL }
         - { name: Linux GCC,      os: ubuntu-latest  }
         - { name: Linux Clang,    os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
-        - { name: MacOS XCode,    os: macos-latest   }
+        - { name: MacOS XCode,    os: macos-11   }
         config:
         - { name: Shared,       flags: -DBUILD_SHARED_LIBS=TRUE }
         - { name: Static,       flags: -DBUILD_SHARED_LIBS=FALSE }
@@ -24,9 +24,9 @@ jobs:
         include:
         - platform: { name: Windows VS2022, os: windows-2022 }
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
-        - platform: { name: MacOS XCode, os: macos-latest }
+        - platform: { name: MacOS XCode, os: macos-11 }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }
-        - platform: { name: MacOS XCode, os: macos-latest }
+        - platform: { name: MacOS XCode, os: macos-11 }
           config: { name: iOS, flags: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/cmake/toolchains/iOS.toolchain.cmake -DIOS_PLATFORM=SIMULATOR }
         - platform: { name: Android, os: ubuntu-latest }
           config: { name: x86, flags: -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }


### PR DESCRIPTION
## Description

The macos-latest image recently upgraded to macOS 12. This includes the iOS 16 SDK which deprecates some features which we're using. The short term fix is to just keep using macOS 11 for 2.6.x.
