### PR TITLE
Apply warnings to install interface test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ get_target_property(DOCTEST_INCLUDE_DIRS doctest INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(doctest SYSTEM INTERFACE ${DOCTEST_INCLUDE_DIRS})
 
 add_subdirectory(install)
+set_target_warnings(test-sfml-install)
 
 add_library(sfml-test-main STATIC
     TestUtilities/SystemUtil.hpp

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -6,32 +6,32 @@
 int main()
 {
     // Audio
-    sf::InputSoundFile input_sound_file;
-    sf::Listener       listener;
-    sf::Music          music;
-    sf::Sound          sound;
+    [[maybe_unused]] sf::InputSoundFile inputSoundFile;
+    [[maybe_unused]] sf::Listener       listener;
+    [[maybe_unused]] sf::Music          music;
+    [[maybe_unused]] sf::Sound          sound;
 
     // Graphics
-    sf::Color        color;
-    sf::Font         font;
-    sf::RenderWindow render_window;
-    sf::Sprite       sprite;
-    sf::Vertex       vertex;
+    [[maybe_unused]] sf::Color        color;
+    [[maybe_unused]] sf::Font         font;
+    [[maybe_unused]] sf::RenderWindow renderWindow;
+    [[maybe_unused]] sf::Sprite       sprite;
+    [[maybe_unused]] sf::Vertex       vertex;
 
     // Network
-    sf::Ftp       ftp;
-    sf::Http      http;
-    sf::Packet    packet;
-    sf::UdpSocket udp_socket;
+    [[maybe_unused]] sf::Ftp       ftp;
+    [[maybe_unused]] sf::Http      http;
+    [[maybe_unused]] sf::Packet    packet;
+    [[maybe_unused]] sf::UdpSocket udpSocket;
 
     // System
-    sf::Angle           angle;
-    sf::FileInputStream file_input_stream;
-    sf::String          string;
-    sf::Time            time;
+    [[maybe_unused]] sf::Angle           angle;
+    [[maybe_unused]] sf::FileInputStream fileInputStream;
+    [[maybe_unused]] sf::String          string;
+    [[maybe_unused]] sf::Time            time;
 
     // Window
-    sf::Context   context;
-    sf::VideoMode video_mode;
-    sf::Window    window;
+    [[maybe_unused]] sf::Context   context;
+    [[maybe_unused]] sf::VideoMode videoMode;
+    [[maybe_unused]] sf::Window    window;
 }


### PR DESCRIPTION
## Description

I overlooked that I wasn't applying warnings to test-sfml-install. This was leading to an issue where the additional pragmas introduced in #2258 were causing warnings to be emitted in the Windows build. I want to disable these pragmas for Windows builds since they're public headers and may annoy users but for now let's stop these warnings from appearing in developer builds.

I marked everything as unused to tell the compiler that this is nonsense code. While I was at it I fixed the style of the variables. 