### PR TITLE
Disable certain GCC pragmas when using other compilers

### DIFF
--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -108,12 +108,16 @@ struct Vector4
     /// \param w Component of the 4D vector
     ///
     ////////////////////////////////////////////////////////////
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
+#endif
     Vector4(T x, T y, T z, T w) : x(x), y(y), z(z), w(w)
     {
     }
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 
     ////////////////////////////////////////////////////////////
     /// \brief Conversion constructor

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -31,13 +31,17 @@ constexpr Vector2<T>::Vector2() : x(0), y(0)
 
 
 ////////////////////////////////////////////////////////////
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
+#endif
 template <typename T>
 constexpr Vector2<T>::Vector2(T x, T y) : x(x), y(y)
 {
 }
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -31,13 +31,17 @@ constexpr Vector3<T>::Vector3() : x(0), y(0), z(0)
 
 
 ////////////////////////////////////////////////////////////
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
+#endif
 template <typename T>
 constexpr Vector3<T>::Vector3(T x, T y, T z) : x(x), y(y), z(z)
 {
 }
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Fixes MSVC warning C4068 in public headers while keeping that warning disabled for uses of GCC pragmas in SFML source files. Closes #2266.

I'd like reenable the C4068 warning so that we can systematically catch these issues going forward but the issue is that there are tons of GCC pragmas in TcpSocket.cpp and it would be pretty ugly to disable them all. For now I'm making the smallest change possible to fix the immediate issue.