### PR TITLE
Use Per Monitor Aware instead of System Aware for DPI scaling on Windows

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -92,8 +92,12 @@ namespace
             {
                 // We only check for E_INVALIDARG because we would get
                 // E_ACCESSDENIED if the DPI was already set previously
-                // and S_OK means the call was successful
-                if (SetProcessDpiAwarenessFunc(ProcessSystemDpiAware) == E_INVALIDARG)
+                // and S_OK means the call was successful.
+                // We intentionally don't use Per Monitor V2 which can be
+                // enabled with SetProcessDpiAwarenessContext, because that
+                // would scale the title bar and thus change window size
+                // by default when moving the window between monitors.
+                if (SetProcessDpiAwarenessFunc(ProcessPerMonitorDpiAware) == E_INVALIDARG)
                 {
                     sf::err() << "Failed to set process DPI awareness" << std::endl;
                 }


### PR DESCRIPTION
## Description

As mentioned in my recent [forum post](https://en.sfml-dev.org/forums/index.php?topic=28770.0), I believe SFML should enable Per Monitor Aware instead of System Aware DPI scaling on Windows.

I know that SFML 2.6 doesn't support high-DPI scaling yet nor has proper support for multiple monitors, but by calling `SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE)` before creating the window it has been forcing a non-optimal behavior which can easily be improved.

### Old behavior

When an 800x600 window is requested, SFML creates an 800x600 window irrelevant of the DPI scaling of the monitor.

When changing the DPI of the monitor while the application is running, or when moving the window to a monitor with a different scale factor, Windows stretches the window however. The example code will keep printing "800x600" in the command line, but the real window size will be different. Everything still worked, but all rendering is being stretched by Windows.

### New behavior

Nothing changes on window creation, you still get an 800x600 window irrelevant of the DPI scaling of the monitor.

When changing the DPI of the monitor while the application is running, or when moving the window to a monitor with a different scale factor, the window now keeps it 800x600 size with a 1:1 mapping between window coordinates and pixels.

Per Monitor awareness was added with Windows 8.1, which is the same version where SetProcessDpiAwareness was introduced (which was already used to set DPI awareness), so this change keeps all Windows versions supported. I thus see no downsides to this new behavior.

## How to test this PR?

The following code will create a window and print "800x600" in the command line the whole time.
You can change the scaling factor in Windows in the Display settings to something other than "100%" to see the behavior described above. What is printed in the command line never changes, but without the change from this PR, the window size would visually change.

```cpp
#include <SFML/Graphics.hpp>
#include <iostream>

int main()
{
    sf::RenderWindow window{{800, 600}, "SFML"};
    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }

        std::cerr << window.getSize().x << "x" << window.getSize().y << "\n";

        window.clear();
        window.display();
    }
}
```
