### PR TITLE
Remove the use of `std::memset`

### DIFF
--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -97,10 +97,8 @@ bool SoundFileReaderMp3::check(InputStream& stream)
 
 
 ////////////////////////////////////////////////////////////
-SoundFileReaderMp3::SoundFileReaderMp3() : m_numSamples(0), m_position(0)
+SoundFileReaderMp3::SoundFileReaderMp3() : m_io(), m_decoder(), m_numSamples(0), m_position(0)
 {
-    std::memset(&m_io, 0, sizeof(m_io));
-    std::memset(&m_decoder, 0, sizeof(m_decoder));
     m_io.read = readCallback;
     m_io.seek = seekCallback;
 }

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -293,8 +293,7 @@ bool Font::loadFromStream(InputStream& stream)
     }
 
     // Prepare a wrapper for our stream, that we'll pass to FreeType callbacks
-    fontHandles->streamRec = std::make_unique<FT_StreamRec>();
-    std::memset(fontHandles->streamRec.get(), 0, sizeof(*fontHandles->streamRec));
+    fontHandles->streamRec                     = std::make_unique<FT_StreamRec>();
     fontHandles->streamRec->base               = nullptr;
     fontHandles->streamRec->size               = static_cast<unsigned long>(stream.getSize());
     fontHandles->streamRec->pos                = 0;

--- a/src/SFML/Network/Unix/SocketImpl.cpp
+++ b/src/SFML/Network/Unix/SocketImpl.cpp
@@ -41,8 +41,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 sockaddr_in SocketImpl::createAddress(std::uint32_t address, unsigned short port)
 {
-    sockaddr_in addr;
-    std::memset(&addr, 0, sizeof(addr));
+    auto addr            = sockaddr_in();
     addr.sin_addr.s_addr = htonl(address);
     addr.sin_family      = AF_INET;
     addr.sin_port        = htons(port);

--- a/src/SFML/Network/Win32/SocketImpl.cpp
+++ b/src/SFML/Network/Win32/SocketImpl.cpp
@@ -37,8 +37,7 @@ namespace priv
 ////////////////////////////////////////////////////////////
 sockaddr_in SocketImpl::createAddress(std::uint32_t address, unsigned short port)
 {
-    sockaddr_in addr;
-    std::memset(&addr, 0, sizeof(addr));
+    auto addr            = sockaddr_in();
     addr.sin_addr.s_addr = htonl(address);
     addr.sin_family      = AF_INET;
     addr.sin_port        = htons(port);

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -119,8 +119,8 @@ void cleanup()
     drmNode.fd   = -1;
     drmNode.mode = 0;
 
-    std::memset(&pollFD, 0, sizeof(pollfd));
-    std::memset(&drmEventCtx, 0, sizeof(drmEventContext));
+    pollFD      = {};
+    drmEventCtx = {};
 
     waitingForFlip = 0;
 

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -398,8 +398,7 @@ std::string getJoystickName(unsigned int index)
     if (fd >= 0)
     {
         // Get the name
-        char name[128];
-        std::memset(name, 0, sizeof(name));
+        char name[128] = {};
 
         int result = ioctl(fd, JSIOCGNAME(sizeof(name)), name);
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -662,8 +662,7 @@ m_lastInputTime(0)
                 unsigned long state;
             };
 
-            WMHints hints;
-            std::memset(&hints, 0, sizeof(hints));
+            auto hints        = WMHints();
             hints.flags       = MWM_HINTS_FUNCTIONS | MWM_HINTS_DECORATIONS;
             hints.decorations = 0;
             hints.functions   = 0;
@@ -1324,9 +1323,7 @@ void WindowImplX11::grabFocus()
 
     if (netActiveWindow)
     {
-        XEvent event;
-        std::memset(&event, 0, sizeof(event));
-
+        auto event                 = XEvent();
         event.type                 = ClientMessage;
         event.xclient.window       = m_window;
         event.xclient.format       = 32;
@@ -1550,9 +1547,7 @@ void WindowImplX11::switchToFullscreen()
             return;
         }
 
-        XEvent event;
-        std::memset(&event, 0, sizeof(event));
-
+        auto event                 = XEvent();
         event.type                 = ClientMessage;
         event.xclient.window       = m_window;
         event.xclient.format       = 32;

--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -58,9 +58,7 @@ bool CursorImpl::loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vecto
     release();
 
     // Create the bitmap that will hold our color data
-    BITMAPV5HEADER bitmapHeader;
-    std::memset(&bitmapHeader, 0, sizeof(BITMAPV5HEADER));
-
+    auto bitmapHeader           = BITMAPV5HEADER();
     bitmapHeader.bV5Size        = sizeof(BITMAPV5HEADER);
     bitmapHeader.bV5Width       = static_cast<LONG>(size.x);
     bitmapHeader.bV5Height      = -static_cast<LONG>(size.y); // Negative indicates origin is in upper-left corner
@@ -108,9 +106,7 @@ bool CursorImpl::loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vecto
     }
 
     // Create the structure that describes our cursor
-    ICONINFO cursorInfo;
-    std::memset(&cursorInfo, 0, sizeof(ICONINFO));
-
+    auto cursorInfo     = ICONINFO();
     cursorInfo.fIcon    = FALSE; // This is a cursor and not an icon
     cursorInfo.xHotspot = hotspot.x;
     cursorInfo.yHotspot = hotspot.y;

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -545,7 +545,7 @@ bool JoystickImpl::openDInput(unsigned int index)
     for (int& button : m_buttons)
         button = -1;
 
-    std::memset(&m_deviceCaps, 0, sizeof(DIDEVCAPS));
+    m_deviceCaps        = {};
     m_deviceCaps.dwSize = sizeof(DIDEVCAPS);
     m_state             = JoystickState();
     m_buffered          = false;
@@ -566,8 +566,7 @@ bool JoystickImpl::openDInput(unsigned int index)
             }
 
             // Get vendor and product id of the device
-            DIPROPDWORD property;
-            std::memset(&property, 0, sizeof(property));
+            auto property              = DIPROPDWORD();
             property.diph.dwSize       = sizeof(property);
             property.diph.dwHeaderSize = sizeof(property.diph);
             property.diph.dwHow        = DIPH_DEVICE;
@@ -596,8 +595,7 @@ bool JoystickImpl::openDInput(unsigned int index)
             }
 
             // Get friendly product name of the device
-            DIPROPSTRING stringProperty;
-            std::memset(&stringProperty, 0, sizeof(stringProperty));
+            auto stringProperty              = DIPROPSTRING();
             stringProperty.diph.dwSize       = sizeof(stringProperty);
             stringProperty.diph.dwHeaderSize = sizeof(stringProperty.diph);
             stringProperty.diph.dwHow        = DIPH_DEVICE;
@@ -740,7 +738,7 @@ bool JoystickImpl::openDInput(unsigned int index)
             {
                 if (axis != -1)
                 {
-                    std::memset(&property, 0, sizeof(property));
+                    property                   = {};
                     property.diph.dwSize       = sizeof(property);
                     property.diph.dwHeaderSize = sizeof(property.diph);
                     property.diph.dwHow        = DIPH_DEVICE;
@@ -763,7 +761,7 @@ bool JoystickImpl::openDInput(unsigned int index)
                     if (property.dwData == DIPROPAXISMODE_ABS)
                         break;
 
-                    std::memset(&property, 0, sizeof(property));
+                    property                   = {};
                     property.diph.dwSize       = sizeof(property);
                     property.diph.dwHeaderSize = sizeof(property.diph);
                     property.diph.dwHow        = DIPH_DEVICE;
@@ -772,7 +770,7 @@ bool JoystickImpl::openDInput(unsigned int index)
                     m_device->SetProperty(DIPROP_AXISMODE, &property.diph);
 
                     // Check if the axis mode has been set to absolute
-                    std::memset(&property, 0, sizeof(property));
+                    property                   = {};
                     property.diph.dwSize       = sizeof(property);
                     property.diph.dwHeaderSize = sizeof(property.diph);
                     property.diph.dwHow        = DIPH_DEVICE;
@@ -816,7 +814,7 @@ bool JoystickImpl::openDInput(unsigned int index)
             }
 
             // Try to enable buffering by setting the buffer size
-            std::memset(&property, 0, sizeof(property));
+            property                   = {};
             property.diph.dwSize       = sizeof(property);
             property.diph.dwHeaderSize = sizeof(property.diph);
             property.diph.dwHow        = DIPH_DEVICE;
@@ -1129,9 +1127,7 @@ BOOL CALLBACK JoystickImpl::deviceObjectEnumerationCallback(const DIDEVICEOBJECT
             return DIENUM_CONTINUE;
 
         // Set the axis' value range to that of a signed short: [-32768, 32767]
-        DIPROPRANGE propertyRange;
-
-        std::memset(&propertyRange, 0, sizeof(propertyRange));
+        auto propertyRange              = DIPROPRANGE();
         propertyRange.diph.dwSize       = sizeof(propertyRange);
         propertyRange.diph.dwHeaderSize = sizeof(propertyRange.diph);
         propertyRange.diph.dwObj        = deviceObjectInstance->dwType;


### PR DESCRIPTION
## Description

`std::memset` was being used to zero-initialize some C structs so I replaced that with their modern C++ equivalent. In some cases, no extra initialization code was required since functions like `make_unique` already ensure the members get initialized.

https://en.cppreference.com/w/cpp/language/zero_initialization