### PR TITLE
Document that checking XButton1 and XButton2 state on X11 is not supported

### DIFF
--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -72,6 +72,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check if a mouse button is pressed
     ///
+    /// \warning Checking the state of buttons Mouse::XButton1 and
+    /// Mouse::XButton2 is not supported on Linux with X11.
+    ///
     /// \param button Button to check
     ///
     /// \return True if the button is pressed, false otherwise

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -202,6 +202,9 @@ bool InputImpl::isMouseButtonPressed(Mouse::Button button)
     // Close the connection with the X server
     CloseDisplay(display);
 
+    // Buttons 4 and 5 are the vertical wheel and 6 and 7 the horizontal wheel.
+    // There is no mask for buttons 8 and 9, so checking the state of buttons
+    // Mouse::XButton1 and Mouse::XButton2 is not supported.
     switch (button)
     {
         case Mouse::Left:     return buttons & Button1Mask;

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -2020,8 +2020,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
         // Mouse button pressed
         case ButtonPress:
         {
-            // XXX: Why button 8 and 9?
-            // Because 4 and 5 are the vertical wheel and 6 and 7 are horizontal wheel ;)
+            // Buttons 4 and 5 are the vertical wheel and 6 and 7 the horizontal wheel.
             unsigned int button = windowEvent.xbutton.button;
             if ((button == Button1) ||
                 (button == Button2) ||


### PR DESCRIPTION
Here is a little bit of documentation.
Related to PR #2038, to [this project card](https://github.com/SFML/SFML/projects/4#card-78773315), and [this forum thread](https://en.sfml-dev.org/forums/index.php?topic=28414.msg177452).