### PR TITLE
Add `sf::UniqueResource` to simplify the implementation of move semantics

### DIFF
--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -671,7 +671,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    UniqueResource<unsigned int, ShaderProgramDeleter> m_shaderProgram{{}}; //!< OpenGL identifier for the program
+    UniqueResource<unsigned int, ShaderProgramDeleter> m_shaderProgram; //!< OpenGL identifier for the program
     int          m_currentTexture{-1}; //!< Location of the current texture in the shader
     TextureTable m_textures;           //!< Texture variables in the shader, mapped to their location
     UniformTable m_uniforms;           //!< Parameters location cache

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -33,6 +33,7 @@
 
 #include <SFML/Window/GlResource.hpp>
 
+#include <SFML/System/UniqueResource.hpp>
 #include <SFML/System/Vector2.hpp>
 #include <SFML/System/Vector3.hpp>
 
@@ -85,45 +86,6 @@ public:
     ////////////////////////////////////////////////////////////
     // NOLINTNEXTLINE(readability-identifier-naming)
     static CurrentTextureType CurrentTexture;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// This constructor creates an invalid shader.
-    ///
-    ////////////////////////////////////////////////////////////
-    Shader();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Destructor
-    ///
-    ////////////////////////////////////////////////////////////
-    ~Shader();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Deleted copy constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    Shader(const Shader&) = delete;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Deleted copy assignment
-    ///
-    ////////////////////////////////////////////////////////////
-    Shader& operator=(const Shader&) = delete;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Move constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    Shader(Shader&& source) noexcept;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Move assignment
-    ///
-    ////////////////////////////////////////////////////////////
-    Shader& operator=(Shader&& right) noexcept;
-
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry or fragment shader from a file
@@ -701,11 +663,15 @@ private:
     ////////////////////////////////////////////////////////////
     using TextureTable = std::unordered_map<int, const Texture*>;
     using UniformTable = std::unordered_map<std::string, int>;
+    struct SFML_GRAPHICS_API ShaderProgramDeleter
+    {
+        void operator()(unsigned int shaderProgram) const;
+    };
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int m_shaderProgram{};    //!< OpenGL identifier for the program
+    UniqueResource<unsigned int, ShaderProgramDeleter> m_shaderProgram{{}}; //!< OpenGL identifier for the program
     int          m_currentTexture{-1}; //!< Location of the current texture in the shader
     TextureTable m_textures;           //!< Texture variables in the shader, mapped to their location
     UniformTable m_uniforms;           //!< Parameters location cache

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -33,6 +33,8 @@
 
 #include <SFML/Window/GlResource.hpp>
 
+#include <SFML/System/UniqueResource.hpp>
+
 #include <filesystem>
 
 
@@ -69,12 +71,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     Texture();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Destructor
-    ///
-    ////////////////////////////////////////////////////////////
-    ~Texture();
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
@@ -616,18 +612,26 @@ private:
     void invalidateMipmap();
 
     ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    struct SFML_GRAPHICS_API TextureDeleter
+    {
+        void operator()(unsigned int texture) const;
+    };
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Vector2u      m_size;            //!< Public texture size
-    Vector2u      m_actualSize;      //!< Actual texture size (can be greater than public size because of padding)
-    unsigned int  m_texture{};       //!< Internal texture identifier
-    bool          m_isSmooth{};      //!< Status of the smooth filter
-    bool          m_sRgb{};          //!< Should the texture source be converted from sRGB?
-    bool          m_isRepeated{};    //!< Is the texture in repeat mode?
-    mutable bool  m_pixelsFlipped{}; //!< To work around the inconsistency in Y orientation
-    bool          m_fboAttachment{}; //!< Is this texture owned by a framebuffer object?
-    bool          m_hasMipmap{};     //!< Has the mipmap been generated?
-    std::uint64_t m_cacheId;         //!< Unique number that identifies the texture to the render target's cache
+    Vector2u m_size;       //!< Public texture size
+    Vector2u m_actualSize; //!< Actual texture size (can be greater than public size because of padding)
+    UniqueResource<unsigned int, TextureDeleter> m_texture{{}};  //!< Internal texture identifier
+    bool                                         m_isSmooth{};   //!< Status of the smooth filter
+    bool                                         m_sRgb{};       //!< Should the texture source be converted from sRGB?
+    bool                                         m_isRepeated{}; //!< Is the texture in repeat mode?
+    mutable bool  m_pixelsFlipped{};                             //!< To work around the inconsistency in Y orientation
+    bool          m_fboAttachment{};                             //!< Is this texture owned by a framebuffer object?
+    bool          m_hasMipmap{};                                 //!< Has the mipmap been generated?
+    std::uint64_t m_cacheId; //!< Unique number that identifies the texture to the render target's cache
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -624,7 +624,7 @@ private:
     ////////////////////////////////////////////////////////////
     Vector2u m_size;       //!< Public texture size
     Vector2u m_actualSize; //!< Actual texture size (can be greater than public size because of padding)
-    UniqueResource<unsigned int, TextureDeleter> m_texture{{}};  //!< Internal texture identifier
+    UniqueResource<unsigned int, TextureDeleter> m_texture;      //!< Internal texture identifier
     bool                                         m_isSmooth{};   //!< Status of the smooth filter
     bool                                         m_sRgb{};       //!< Should the texture source be converted from sRGB?
     bool                                         m_isRepeated{}; //!< Is the texture in repeat mode?

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -34,6 +34,8 @@
 
 #include <SFML/Window/GlResource.hpp>
 
+#include <SFML/System/UniqueResource.hpp>
+
 #include <cstddef>
 
 
@@ -113,12 +115,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     VertexBuffer(const VertexBuffer& copy);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Destructor
-    ///
-    ////////////////////////////////////////////////////////////
-    ~VertexBuffer() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the vertex buffer
@@ -331,12 +327,20 @@ private:
     void draw(RenderTarget& target, const RenderStates& states) const override;
 
     ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    struct SFML_GRAPHICS_API BufferDeleter
+    {
+        void operator()(unsigned int buffer) const;
+    };
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int  m_buffer{};                             //!< Internal buffer identifier
-    std::size_t   m_size{};                               //!< Size in Vertices of the currently allocated buffer
-    PrimitiveType m_primitiveType{PrimitiveType::Points}; //!< Type of primitives to draw
-    Usage         m_usage{Stream};                        //!< How this vertex buffer is to be used
+    UniqueResource<unsigned int, BufferDeleter> m_buffer{{}}; //!< Internal buffer identifier
+    std::size_t                                 m_size{};     //!< Size in Vertices of the currently allocated buffer
+    PrimitiveType                               m_primitiveType{PrimitiveType::Points}; //!< Type of primitives to draw
+    Usage                                       m_usage{Stream}; //!< How this vertex buffer is to be used
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -337,8 +337,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    UniqueResource<unsigned int, BufferDeleter> m_buffer{{}}; //!< Internal buffer identifier
-    std::size_t                                 m_size{};     //!< Size in Vertices of the currently allocated buffer
+    UniqueResource<unsigned int, BufferDeleter> m_buffer; //!< Internal buffer identifier
+    std::size_t                                 m_size{}; //!< Size in Vertices of the currently allocated buffer
     PrimitiveType                               m_primitiveType{PrimitiveType::Points}; //!< Type of primitives to draw
     Usage                                       m_usage{Stream}; //!< How this vertex buffer is to be used
 };

--- a/include/SFML/System/UniqueResource.hpp
+++ b/include/SFML/System/UniqueResource.hpp
@@ -27,17 +27,14 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <optional>
 #include <type_traits>
 #include <utility>
-
-#include <cassert>
 
 
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-/// \brief Class template for storing non-copyable resource handles
+/// \brief Class template for storing noncopyable resource handles
 ///
 ////////////////////////////////////////////////////////////
 template <typename Handle, typename Deleter>
@@ -51,18 +48,12 @@ class UniqueResource
 
 public:
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    UniqueResource();
-
-    ////////////////////////////////////////////////////////////
     /// \brief Construct from handle
     ///
-    /// \param handle Handle to the resource to store
+    /// \param handle Handle to the resource
     ///
     ////////////////////////////////////////////////////////////
-    UniqueResource(Handle handle);
+    explicit UniqueResource(Handle handle = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Delete the resource
@@ -101,17 +92,10 @@ public:
     void release();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Dispose of the resource by calling the deleter
+    /// \brief Delete the resource and assign new handle
     ///
     ////////////////////////////////////////////////////////////
-    void reset();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Dispose of the resource by calling the deleter
-    /// then assign to the resource
-    ///
-    ////////////////////////////////////////////////////////////
-    void reset(Handle handle);
+    void reset(Handle handle = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Access the underlying handle
@@ -119,9 +103,17 @@ public:
     ////////////////////////////////////////////////////////////
     [[nodiscard]] Handle get() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Determine if resource has non-null handle
+    ///
+    /// \return True if handle is non-null
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] operator bool() const;
+
 private:
-    std::optional<Handle> m_handle;    //!< Handle to the managed resource
-    Deleter               m_deleter{}; //!< Functor to clean up resource
+    Handle  m_handle{};  //!< Handle to the managed resource
+    Deleter m_deleter{}; //!< Functor to clean up resource
 };
 
 #include <SFML/System/UniqueResource.inl>
@@ -136,6 +128,13 @@ private:
 /// This class provides a wrapper around a handle to a resource
 /// with a custom deleter that cleans up that resource at the
 /// end of its lifetime.
+///
+/// Like std::unique_ptr, sf::UniqueResource uses the default
+/// constructed state of the handle to represent the "null" state
+/// of the resource. Default construction of a unique resource
+/// or moving out of a unique resource entails the handle being
+/// reset to its default constructed state which typically means
+/// a value of 0.
 ///
 /// Usage example:
 /// \code

--- a/include/SFML/System/UniqueResource.hpp
+++ b/include/SFML/System/UniqueResource.hpp
@@ -1,0 +1,161 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include <cassert>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Class template for storing non-copyable resource handles
+///
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+class UniqueResource
+{
+    static_assert(!std::is_pointer_v<Handle>, "Handle cannot be a pointer");
+    static_assert(!std::is_const_v<Handle>, "Handle cannot be const");
+    static_assert(std::is_trivially_constructible_v<Handle>, "Handle must be trivially constructible");
+    static_assert(std::is_trivially_destructible_v<Handle>, "Handle must be trivially destructible");
+    static_assert(std::is_invocable_v<Deleter, Handle>, "Deleter must define operator()(Handle)");
+
+public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    UniqueResource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from handle
+    ///
+    /// \param handle Handle to the resource to store
+    ///
+    ////////////////////////////////////////////////////////////
+    UniqueResource(Handle handle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Delete the resource
+    ///
+    ////////////////////////////////////////////////////////////
+    ~UniqueResource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Deleted copy constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    UniqueResource(const UniqueResource&) = delete;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Deleted copy assignment
+    ///
+    ////////////////////////////////////////////////////////////
+    UniqueResource& operator=(const UniqueResource&) = delete;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    UniqueResource(UniqueResource&& other) noexcept;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move assignment
+    ///
+    ////////////////////////////////////////////////////////////
+    UniqueResource& operator=(UniqueResource&& other) noexcept;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Release ownership of the managed resource
+    ///
+    ////////////////////////////////////////////////////////////
+    void release();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Dispose of the resource by calling the deleter
+    ///
+    ////////////////////////////////////////////////////////////
+    void reset();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Dispose of the resource by calling the deleter
+    /// then assign to the resource
+    ///
+    ////////////////////////////////////////////////////////////
+    void reset(Handle handle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Access the underlying handle
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] Handle get() const;
+
+private:
+    std::optional<Handle> m_handle;    //!< Handle to the managed resource
+    Deleter               m_deleter{}; //!< Functor to clean up resource
+};
+
+#include <SFML/System/UniqueResource.inl>
+
+} // namespace sf
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::UniqueResource
+/// \ingroup system
+///
+/// This class provides a wrapper around a handle to a resource
+/// with a custom deleter that cleans up that resource at the
+/// end of its lifetime.
+///
+/// Usage example:
+/// \code
+/// struct Deleter
+/// {
+///     void operator()(int) const
+///     {
+///         std::cout << "Cleanup\n";
+///     }
+/// };
+///
+/// sf::UniqueResource<int, Deleter> uniqueResource(42);
+/// useResource(uniqueResource.get());
+/// ...
+/// // When destructing, prints "Cleanup"
+/// \endcode
+///
+/// This type is not copyeable but is moveable. If you move
+/// from this type, the deleter will not be called on the
+/// moved-from instance. This ensures that the resource it
+/// owns will never be deleted twice.
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/System/UniqueResource.inl
+++ b/include/SFML/System/UniqueResource.inl
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+UniqueResource<Handle, Deleter>::UniqueResource() = default;
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+UniqueResource<Handle, Deleter>::UniqueResource(Handle handle) : m_handle(handle)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+UniqueResource<Handle, Deleter>::~UniqueResource()
+{
+    reset();
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+UniqueResource<Handle, Deleter>::UniqueResource(UniqueResource&& other) noexcept :
+m_handle(std::exchange(other.m_handle, {})),
+m_deleter(std::exchange(other.m_deleter, {}))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+UniqueResource<Handle, Deleter>& UniqueResource<Handle, Deleter>::operator=(UniqueResource&& other) noexcept
+{
+    if (this != &other)
+    {
+        reset();
+        m_handle  = std::exchange(other.m_handle, {});
+        m_deleter = std::exchange(other.m_deleter, {});
+    }
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+void UniqueResource<Handle, Deleter>::release()
+{
+    m_handle.reset();
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+void UniqueResource<Handle, Deleter>::reset()
+{
+    if (m_handle.has_value())
+        m_deleter(*m_handle);
+    m_handle.reset();
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+void UniqueResource<Handle, Deleter>::reset(Handle handle)
+{
+    reset();
+    m_handle = handle;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+Handle UniqueResource<Handle, Deleter>::get() const
+{
+    assert(m_handle);
+    return *m_handle;
+}

--- a/include/SFML/System/UniqueResource.inl
+++ b/include/SFML/System/UniqueResource.inl
@@ -25,11 +25,6 @@
 
 ////////////////////////////////////////////////////////////
 template <typename Handle, typename Deleter>
-UniqueResource<Handle, Deleter>::UniqueResource() = default;
-
-
-////////////////////////////////////////////////////////////
-template <typename Handle, typename Deleter>
 UniqueResource<Handle, Deleter>::UniqueResource(Handle handle) : m_handle(handle)
 {
 }
@@ -70,17 +65,7 @@ UniqueResource<Handle, Deleter>& UniqueResource<Handle, Deleter>::operator=(Uniq
 template <typename Handle, typename Deleter>
 void UniqueResource<Handle, Deleter>::release()
 {
-    m_handle.reset();
-}
-
-
-////////////////////////////////////////////////////////////
-template <typename Handle, typename Deleter>
-void UniqueResource<Handle, Deleter>::reset()
-{
-    if (m_handle.has_value())
-        m_deleter(*m_handle);
-    m_handle.reset();
+    m_handle = {};
 }
 
 
@@ -88,7 +73,8 @@ void UniqueResource<Handle, Deleter>::reset()
 template <typename Handle, typename Deleter>
 void UniqueResource<Handle, Deleter>::reset(Handle handle)
 {
-    reset();
+    if (m_handle)
+        m_deleter(m_handle);
     m_handle = handle;
 }
 
@@ -97,6 +83,13 @@ void UniqueResource<Handle, Deleter>::reset(Handle handle)
 template <typename Handle, typename Deleter>
 Handle UniqueResource<Handle, Deleter>::get() const
 {
-    assert(m_handle);
-    return *m_handle;
+    return m_handle;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Handle, typename Deleter>
+UniqueResource<Handle, Deleter>::operator bool() const
+{
+    return m_handle;
 }

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -77,7 +77,7 @@ bool RenderTexture::create(const Vector2u& size, const ContextSettings& settings
     }
 
     // Initialize the render texture
-    if (!m_impl->create(size, m_texture.m_texture, settings))
+    if (!m_impl->create(size, m_texture.m_texture.get(), settings))
         return false;
 
     // We can now initialize the render target part
@@ -153,7 +153,7 @@ void RenderTexture::display()
     // Update the target texture
     if (m_impl && (priv::RenderTextureImplFBO::isAvailable() || setActive(true)))
     {
-        m_impl->updateTexture(m_texture.m_texture);
+        m_impl->updateTexture(m_texture.m_texture.get());
         m_texture.m_pixelsFlipped = true;
         m_texture.invalidateMipmap();
     }

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -233,11 +233,9 @@ struct Shader::UniformBinder
 ////////////////////////////////////////////////////////////
 void Shader::ShaderProgramDeleter::operator()(unsigned int shaderProgram) const
 {
-    const TransientContextLock lock;
-
     // Destroy effect program
-    if (shaderProgram)
-        glCheck(GLEXT_glDeleteObject(castToGlHandle(shaderProgram)));
+    const TransientContextLock lock;
+    glCheck(GLEXT_glDeleteObject(castToGlHandle(shaderProgram)));
 }
 
 
@@ -548,7 +546,7 @@ void Shader::setUniform(const std::string& name, const Glsl::Mat4& matrix)
 ////////////////////////////////////////////////////////////
 void Shader::setUniform(const std::string& name, const Texture& texture)
 {
-    if (m_shaderProgram.get())
+    if (m_shaderProgram)
     {
         const TransientContextLock lock;
 
@@ -583,7 +581,7 @@ void Shader::setUniform(const std::string& name, const Texture& texture)
 ////////////////////////////////////////////////////////////
 void Shader::setUniform(const std::string& name, CurrentTextureType)
 {
-    if (m_shaderProgram.get())
+    if (m_shaderProgram)
     {
         const TransientContextLock lock;
 
@@ -685,7 +683,7 @@ void Shader::bind(const Shader* shader)
         return;
     }
 
-    if (shader && shader->m_shaderProgram.get())
+    if (shader && shader->m_shaderProgram)
     {
         // Enable the program
         glCheck(GLEXT_glUseProgramObject(castToGlHandle(shader->m_shaderProgram.get())));

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -77,7 +77,7 @@ m_sRgb(copy.m_sRgb),
 m_isRepeated(copy.m_isRepeated),
 m_cacheId(TextureImpl::getUniqueId())
 {
-    if (copy.m_texture.get())
+    if (copy.m_texture)
     {
         if (create(copy.getSize()))
         {
@@ -143,7 +143,7 @@ bool Texture::create(const Vector2u& size)
     m_fboAttachment = false;
 
     // Create the OpenGL texture if it doesn't exist yet
-    if (!m_texture.get())
+    if (!m_texture)
     {
         GLuint texture;
         glCheck(glGenTextures(1, &texture));
@@ -324,7 +324,7 @@ Vector2u Texture::getSize() const
 Image Texture::copyToImage() const
 {
     // Easy case: empty texture
-    if (!m_texture.get())
+    if (!m_texture)
         return Image();
 
     const TransientContextLock lock;
@@ -417,7 +417,7 @@ void Texture::update(const std::uint8_t* pixels, const Vector2u& size, const Vec
     assert(dest.x + size.x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + size.y <= m_size.y && "Destination y coordinate is outside of texture");
 
-    if (pixels && m_texture.get())
+    if (pixels && m_texture)
     {
         const TransientContextLock lock;
 
@@ -461,7 +461,7 @@ void Texture::update(const Texture& texture, const Vector2u& dest)
     assert(dest.x + texture.m_size.x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + texture.m_size.y <= m_size.y && "Destination y coordinate is outside of texture");
 
-    if (!m_texture.get() || !texture.m_texture.get())
+    if (!m_texture || !texture.m_texture)
         return;
 
 #ifndef SFML_OPENGL_ES
@@ -594,7 +594,7 @@ void Texture::update(const Window& window, const Vector2u& dest)
     assert(dest.x + window.getSize().x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + window.getSize().y <= m_size.y && "Destination y coordinate is outside of texture");
 
-    if (m_texture.get() && window.setActive(true))
+    if (m_texture && window.setActive(true))
     {
         const TransientContextLock lock;
 
@@ -630,7 +630,7 @@ void Texture::setSmooth(bool smooth)
     {
         m_isSmooth = smooth;
 
-        if (m_texture.get())
+        if (m_texture)
         {
             const TransientContextLock lock;
 
@@ -683,7 +683,7 @@ void Texture::setRepeated(bool repeated)
     {
         m_isRepeated = repeated;
 
-        if (m_texture.get())
+        if (m_texture)
         {
             const TransientContextLock lock;
 
@@ -730,7 +730,7 @@ bool Texture::isRepeated() const
 ////////////////////////////////////////////////////////////
 bool Texture::generateMipmap()
 {
-    if (!m_texture.get())
+    if (!m_texture)
         return false;
 
     const TransientContextLock lock;
@@ -779,7 +779,7 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
 {
     const TransientContextLock lock;
 
-    if (texture && texture->m_texture.get())
+    if (texture && texture->m_texture)
     {
         // Bind the texture
         glCheck(glBindTexture(GL_TEXTURE_2D, texture->m_texture.get()));
@@ -902,11 +902,8 @@ unsigned int Texture::getValidSize(unsigned int size)
 void Texture::TextureDeleter::operator()(unsigned int texture) const
 {
     // Destroy the OpenGL texture
-    if (texture)
-    {
-        const TransientContextLock lock;
-        glCheck(glDeleteTextures(1, &texture));
-    }
+    const TransientContextLock lock;
+    glCheck(glDeleteTextures(1, &texture));
 }
 
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -77,7 +77,7 @@ m_sRgb(copy.m_sRgb),
 m_isRepeated(copy.m_isRepeated),
 m_cacheId(TextureImpl::getUniqueId())
 {
-    if (copy.m_texture)
+    if (copy.m_texture.get())
     {
         if (create(copy.getSize()))
         {
@@ -92,60 +92,20 @@ m_cacheId(TextureImpl::getUniqueId())
 
 
 ////////////////////////////////////////////////////////////
-Texture::~Texture()
+Texture& Texture::operator=(const Texture& right)
 {
-    // Destroy the OpenGL texture
-    if (m_texture)
-    {
-        const TransientContextLock lock;
-
-        const GLuint texture = m_texture;
-        glCheck(glDeleteTextures(1, &texture));
-    }
-}
-
-////////////////////////////////////////////////////////////
-Texture::Texture(Texture&& right) noexcept :
-m_size(std::exchange(right.m_size, {})),
-m_actualSize(std::exchange(right.m_actualSize, {})),
-m_texture(std::exchange(right.m_texture, 0)),
-m_isSmooth(std::exchange(right.m_isSmooth, false)),
-m_sRgb(std::exchange(right.m_sRgb, false)),
-m_isRepeated(std::exchange(right.m_isRepeated, false)),
-m_fboAttachment(std::exchange(right.m_fboAttachment, false)),
-m_cacheId(std::exchange(right.m_cacheId, 0))
-{
-}
-
-////////////////////////////////////////////////////////////
-Texture& Texture::operator=(Texture&& right) noexcept
-{
-    // Catch self-moving.
-    if (&right == this)
-    {
-        return *this;
-    }
-
-    // Destroy the OpenGL texture
-    if (m_texture)
-    {
-        const TransientContextLock lock;
-
-        const GLuint texture = m_texture;
-        glCheck(glDeleteTextures(1, &texture));
-    }
-
-    // Move old to new.
-    m_size          = std::exchange(right.m_size, {});
-    m_actualSize    = std::exchange(right.m_actualSize, {});
-    m_texture       = std::exchange(right.m_texture, 0);
-    m_isSmooth      = std::exchange(right.m_isSmooth, false);
-    m_sRgb          = std::exchange(right.m_sRgb, false);
-    m_isRepeated    = std::exchange(right.m_isRepeated, false);
-    m_fboAttachment = std::exchange(right.m_fboAttachment, false);
-    m_cacheId       = std::exchange(right.m_cacheId, 0);
+    Texture temp(right);
+    swap(temp);
     return *this;
 }
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(Texture&&) noexcept = default;
+
+
+////////////////////////////////////////////////////////////
+Texture& Texture::operator=(Texture&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
@@ -183,11 +143,11 @@ bool Texture::create(const Vector2u& size)
     m_fboAttachment = false;
 
     // Create the OpenGL texture if it doesn't exist yet
-    if (!m_texture)
+    if (!m_texture.get())
     {
         GLuint texture;
         glCheck(glGenTextures(1, &texture));
-        m_texture = texture;
+        m_texture.reset(texture);
     }
 
     // Make sure that the current texture binding will be preserved
@@ -232,7 +192,7 @@ bool Texture::create(const Vector2u& size)
     }
 
     // Initialize the texture
-    glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+    glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
     glCheck(glTexImage2D(GL_TEXTURE_2D,
                          0,
                          (m_sRgb ? GLEXT_GL_SRGB8_ALPHA8 : GL_RGBA),
@@ -329,7 +289,7 @@ bool Texture::loadFromImage(const Image& image, const IntRect& area)
 
             // Copy the pixels to the texture, row by row
             const std::uint8_t* pixels = image.getPixelsPtr() + 4 * (rectangle.left + (width * rectangle.top));
-            glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+            glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
             for (int i = 0; i < rectangle.height; ++i)
             {
                 glCheck(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, i, rectangle.width, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
@@ -364,7 +324,7 @@ Vector2u Texture::getSize() const
 Image Texture::copyToImage() const
 {
     // Easy case: empty texture
-    if (!m_texture)
+    if (!m_texture.get())
         return Image();
 
     const TransientContextLock lock;
@@ -387,7 +347,8 @@ Image Texture::copyToImage() const
         glCheck(glGetIntegerv(GLEXT_GL_FRAMEBUFFER_BINDING, &previousFrameBuffer));
 
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, frameBuffer));
-        glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0));
+        glCheck(
+            GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture.get(), 0));
         glCheck(glReadPixels(0, 0, m_size.x, m_size.y, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data()));
         glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
 
@@ -399,7 +360,7 @@ Image Texture::copyToImage() const
     if ((m_size == m_actualSize) && !m_pixelsFlipped)
     {
         // Texture is not padded nor flipped, we can use a direct copy
-        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
         glCheck(glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data()));
     }
     else
@@ -408,7 +369,7 @@ Image Texture::copyToImage() const
 
         // All the pixels will first be copied to a temporary array
         std::vector<std::uint8_t> allPixels(m_actualSize.x * m_actualSize.y * 4);
-        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
         glCheck(glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, allPixels.data()));
 
         // Then we copy the useful pixels from the temporary array to the final one
@@ -456,7 +417,7 @@ void Texture::update(const std::uint8_t* pixels, const Vector2u& size, const Vec
     assert(dest.x + size.x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + size.y <= m_size.y && "Destination y coordinate is outside of texture");
 
-    if (pixels && m_texture)
+    if (pixels && m_texture.get())
     {
         const TransientContextLock lock;
 
@@ -464,7 +425,7 @@ void Texture::update(const std::uint8_t* pixels, const Vector2u& size, const Vec
         const priv::TextureSaver save;
 
         // Copy pixels from the given array to the texture
-        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
         glCheck(glTexSubImage2D(GL_TEXTURE_2D,
                                 0,
                                 static_cast<GLint>(dest.x),
@@ -500,7 +461,7 @@ void Texture::update(const Texture& texture, const Vector2u& dest)
     assert(dest.x + texture.m_size.x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + texture.m_size.y <= m_size.y && "Destination y coordinate is outside of texture");
 
-    if (!m_texture || !texture.m_texture)
+    if (!m_texture.get() || !texture.m_texture.get())
         return;
 
 #ifndef SFML_OPENGL_ES
@@ -540,13 +501,13 @@ void Texture::update(const Texture& texture, const Vector2u& dest)
         glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_READ_FRAMEBUFFER,
                                              GLEXT_GL_COLOR_ATTACHMENT0,
                                              GL_TEXTURE_2D,
-                                             texture.m_texture,
+                                             texture.m_texture.get(),
                                              0));
 
         // Link the destination texture to the destination frame buffer
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, destFrameBuffer));
         glCheck(
-            GLEXT_glFramebufferTexture2D(GLEXT_GL_DRAW_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0));
+            GLEXT_glFramebufferTexture2D(GLEXT_GL_DRAW_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture.get(), 0));
 
         // A final check, just to be sure...
         GLenum sourceStatus;
@@ -586,7 +547,7 @@ void Texture::update(const Texture& texture, const Vector2u& dest)
         const priv::TextureSaver save;
 
         // Set the parameters of this texture
-        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
         glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
         m_hasMipmap     = false;
         m_pixelsFlipped = false;
@@ -633,7 +594,7 @@ void Texture::update(const Window& window, const Vector2u& dest)
     assert(dest.x + window.getSize().x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + window.getSize().y <= m_size.y && "Destination y coordinate is outside of texture");
 
-    if (m_texture && window.setActive(true))
+    if (m_texture.get() && window.setActive(true))
     {
         const TransientContextLock lock;
 
@@ -641,7 +602,7 @@ void Texture::update(const Window& window, const Vector2u& dest)
         const priv::TextureSaver save;
 
         // Copy pixels from the back-buffer to the texture
-        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+        glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
         glCheck(glCopyTexSubImage2D(GL_TEXTURE_2D,
                                     0,
                                     static_cast<GLint>(dest.x),
@@ -669,14 +630,14 @@ void Texture::setSmooth(bool smooth)
     {
         m_isSmooth = smooth;
 
-        if (m_texture)
+        if (m_texture.get())
         {
             const TransientContextLock lock;
 
             // Make sure that the current texture binding will be preserved
             const priv::TextureSaver save;
 
-            glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+            glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
             glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
 
             if (m_hasMipmap)
@@ -722,7 +683,7 @@ void Texture::setRepeated(bool repeated)
     {
         m_isRepeated = repeated;
 
-        if (m_texture)
+        if (m_texture.get())
         {
             const TransientContextLock lock;
 
@@ -745,7 +706,7 @@ void Texture::setRepeated(bool repeated)
                 }
             }
 
-            glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+            glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
             glCheck(
                 glTexParameteri(GL_TEXTURE_2D,
                                 GL_TEXTURE_WRAP_S,
@@ -769,7 +730,7 @@ bool Texture::isRepeated() const
 ////////////////////////////////////////////////////////////
 bool Texture::generateMipmap()
 {
-    if (!m_texture)
+    if (!m_texture.get())
         return false;
 
     const TransientContextLock lock;
@@ -783,7 +744,7 @@ bool Texture::generateMipmap()
     // Make sure that the current texture binding will be preserved
     const priv::TextureSaver save;
 
-    glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+    glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
     glCheck(GLEXT_glGenerateMipmap(GL_TEXTURE_2D));
     glCheck(glTexParameteri(GL_TEXTURE_2D,
                             GL_TEXTURE_MIN_FILTER,
@@ -806,7 +767,7 @@ void Texture::invalidateMipmap()
     // Make sure that the current texture binding will be preserved
     const priv::TextureSaver save;
 
-    glCheck(glBindTexture(GL_TEXTURE_2D, m_texture));
+    glCheck(glBindTexture(GL_TEXTURE_2D, m_texture.get()));
     glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_isSmooth ? GL_LINEAR : GL_NEAREST));
 
     m_hasMipmap = false;
@@ -818,10 +779,10 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
 {
     const TransientContextLock lock;
 
-    if (texture && texture->m_texture)
+    if (texture && texture->m_texture.get())
     {
         // Bind the texture
-        glCheck(glBindTexture(GL_TEXTURE_2D, texture->m_texture));
+        glCheck(glBindTexture(GL_TEXTURE_2D, texture->m_texture.get()));
 
         // Check if we need to define a special texture matrix
         if ((coordinateType == Pixels) || texture->m_pixelsFlipped)
@@ -893,17 +854,6 @@ unsigned int Texture::getMaximumSize()
 
 
 ////////////////////////////////////////////////////////////
-Texture& Texture::operator=(const Texture& right)
-{
-    Texture temp(right);
-
-    swap(temp);
-
-    return *this;
-}
-
-
-////////////////////////////////////////////////////////////
 void Texture::swap(Texture& right) noexcept
 {
     std::swap(m_size, right.m_size);
@@ -924,7 +874,7 @@ void Texture::swap(Texture& right) noexcept
 ////////////////////////////////////////////////////////////
 unsigned int Texture::getNativeHandle() const
 {
-    return m_texture;
+    return m_texture.get();
 }
 
 
@@ -944,6 +894,18 @@ unsigned int Texture::getValidSize(unsigned int size)
             powerOfTwo *= 2;
 
         return powerOfTwo;
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void Texture::TextureDeleter::operator()(unsigned int texture) const
+{
+    // Destroy the OpenGL texture
+    if (texture)
+    {
+        const TransientContextLock lock;
+        glCheck(glDeleteTextures(1, &texture));
     }
 }
 

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -89,7 +89,7 @@ GlResource(copy),
 m_primitiveType(copy.m_primitiveType),
 m_usage(copy.m_usage)
 {
-    if (copy.m_buffer.get() && copy.m_size)
+    if (copy.m_buffer && copy.m_size)
     {
         if (!create(copy.m_size))
         {
@@ -111,14 +111,14 @@ bool VertexBuffer::create(std::size_t vertexCount)
 
     const TransientContextLock contextLock;
 
-    if (!m_buffer.get())
+    if (!m_buffer)
     {
         auto buffer = m_buffer.get();
         glCheck(GLEXT_glGenBuffers(1, &buffer));
         m_buffer.reset(buffer);
     }
 
-    if (!m_buffer.get())
+    if (!m_buffer)
     {
         err() << "Could not create vertex buffer, generation failed" << std::endl;
         return false;
@@ -155,7 +155,7 @@ bool VertexBuffer::update(const Vertex* vertices)
 bool VertexBuffer::update(const Vertex* vertices, std::size_t vertexCount, unsigned int offset)
 {
     // Sanity checks
-    if (!m_buffer.get())
+    if (!m_buffer)
         return false;
 
     if (!vertices)
@@ -199,7 +199,7 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
 
 #else
 
-    if (!m_buffer.get() || !vertexBuffer.m_buffer.get())
+    if (!m_buffer || !vertexBuffer.m_buffer)
         return false;
 
     const TransientContextLock contextLock;
@@ -344,7 +344,7 @@ bool VertexBuffer::isAvailable()
 ////////////////////////////////////////////////////////////
 void VertexBuffer::draw(RenderTarget& target, const RenderStates& states) const
 {
-    if (m_buffer.get() && m_size)
+    if (m_buffer && m_size)
         target.draw(*this, 0, m_size, states);
 }
 
@@ -359,11 +359,8 @@ void swap(VertexBuffer& left, VertexBuffer& right) noexcept
 ////////////////////////////////////////////////////////////
 void VertexBuffer::BufferDeleter::operator()(unsigned int buffer) const
 {
-    if (buffer)
-    {
-        const TransientContextLock contextLock;
-        glCheck(GLEXT_glDeleteBuffers(1, &buffer));
-    }
+    const TransientContextLock contextLock;
+    glCheck(GLEXT_glDeleteBuffers(1, &buffer));
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -89,7 +89,7 @@ GlResource(copy),
 m_primitiveType(copy.m_primitiveType),
 m_usage(copy.m_usage)
 {
-    if (copy.m_buffer && copy.m_size)
+    if (copy.m_buffer.get() && copy.m_size)
     {
         if (!create(copy.m_size))
         {
@@ -104,18 +104,6 @@ m_usage(copy.m_usage)
 
 
 ////////////////////////////////////////////////////////////
-VertexBuffer::~VertexBuffer()
-{
-    if (m_buffer)
-    {
-        const TransientContextLock contextLock;
-
-        glCheck(GLEXT_glDeleteBuffers(1, &m_buffer));
-    }
-}
-
-
-////////////////////////////////////////////////////////////
 bool VertexBuffer::create(std::size_t vertexCount)
 {
     if (!isAvailable())
@@ -123,16 +111,20 @@ bool VertexBuffer::create(std::size_t vertexCount)
 
     const TransientContextLock contextLock;
 
-    if (!m_buffer)
-        glCheck(GLEXT_glGenBuffers(1, &m_buffer));
+    if (!m_buffer.get())
+    {
+        auto buffer = m_buffer.get();
+        glCheck(GLEXT_glGenBuffers(1, &buffer));
+        m_buffer.reset(buffer);
+    }
 
-    if (!m_buffer)
+    if (!m_buffer.get())
     {
         err() << "Could not create vertex buffer, generation failed" << std::endl;
         return false;
     }
 
-    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
+    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer.get()));
     glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER,
                                static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexCount),
                                nullptr,
@@ -163,7 +155,7 @@ bool VertexBuffer::update(const Vertex* vertices)
 bool VertexBuffer::update(const Vertex* vertices, std::size_t vertexCount, unsigned int offset)
 {
     // Sanity checks
-    if (!m_buffer)
+    if (!m_buffer.get())
         return false;
 
     if (!vertices)
@@ -174,7 +166,7 @@ bool VertexBuffer::update(const Vertex* vertices, std::size_t vertexCount, unsig
 
     const TransientContextLock contextLock;
 
-    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
+    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer.get()));
 
     // Check if we need to resize or orphan the buffer
     if (vertexCount >= m_size)
@@ -207,7 +199,7 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
 
 #else
 
-    if (!m_buffer || !vertexBuffer.m_buffer)
+    if (!m_buffer.get() || !vertexBuffer.m_buffer.get())
         return false;
 
     const TransientContextLock contextLock;
@@ -217,8 +209,8 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
 
     if (GLEXT_copy_buffer)
     {
-        glCheck(GLEXT_glBindBuffer(GLEXT_GL_COPY_READ_BUFFER, vertexBuffer.m_buffer));
-        glCheck(GLEXT_glBindBuffer(GLEXT_GL_COPY_WRITE_BUFFER, m_buffer));
+        glCheck(GLEXT_glBindBuffer(GLEXT_GL_COPY_READ_BUFFER, vertexBuffer.m_buffer.get()));
+        glCheck(GLEXT_glBindBuffer(GLEXT_GL_COPY_WRITE_BUFFER, m_buffer.get()));
 
         glCheck(GLEXT_glCopyBufferSubData(GLEXT_GL_COPY_READ_BUFFER,
                                           GLEXT_GL_COPY_WRITE_BUFFER,
@@ -232,7 +224,7 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
         return true;
     }
 
-    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
+    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer.get()));
     glCheck(GLEXT_glBufferData(GLEXT_GL_ARRAY_BUFFER,
                                static_cast<GLsizeiptrARB>(sizeof(Vertex) * vertexBuffer.m_size),
                                nullptr,
@@ -241,7 +233,7 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
     void* destination = nullptr;
     glCheck(destination = GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_WRITE_ONLY));
 
-    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, vertexBuffer.m_buffer));
+    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, vertexBuffer.m_buffer.get()));
 
     void* source = nullptr;
     glCheck(source = GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_READ_ONLY));
@@ -251,7 +243,7 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
     GLboolean sourceResult = GL_FALSE;
     glCheck(sourceResult = GLEXT_glUnmapBuffer(GLEXT_GL_ARRAY_BUFFER));
 
-    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
+    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer.get()));
 
     GLboolean destinationResult = GL_FALSE;
     glCheck(destinationResult = GLEXT_glUnmapBuffer(GLEXT_GL_ARRAY_BUFFER));
@@ -288,7 +280,7 @@ void VertexBuffer::swap(VertexBuffer& right) noexcept
 ////////////////////////////////////////////////////////////
 unsigned int VertexBuffer::getNativeHandle() const
 {
-    return m_buffer;
+    return m_buffer.get();
 }
 
 
@@ -300,7 +292,7 @@ void VertexBuffer::bind(const VertexBuffer* vertexBuffer)
 
     const TransientContextLock lock;
 
-    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, vertexBuffer ? vertexBuffer->m_buffer : 0));
+    glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, vertexBuffer ? vertexBuffer->m_buffer.get() : 0));
 }
 
 
@@ -352,7 +344,7 @@ bool VertexBuffer::isAvailable()
 ////////////////////////////////////////////////////////////
 void VertexBuffer::draw(RenderTarget& target, const RenderStates& states) const
 {
-    if (m_buffer && m_size)
+    if (m_buffer.get() && m_size)
         target.draw(*this, 0, m_size, states);
 }
 
@@ -361,6 +353,17 @@ void VertexBuffer::draw(RenderTarget& target, const RenderStates& states) const
 void swap(VertexBuffer& left, VertexBuffer& right) noexcept
 {
     left.swap(right);
+}
+
+
+////////////////////////////////////////////////////////////
+void VertexBuffer::BufferDeleter::operator()(unsigned int buffer) const
+{
+    if (buffer)
+    {
+        const TransientContextLock contextLock;
+        glCheck(GLEXT_glDeleteBuffers(1, &buffer));
+    }
 }
 
 } // namespace sf

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -20,6 +20,8 @@ set(SRC
     ${INCROOT}/String.inl
     ${INCROOT}/Time.hpp
     ${INCROOT}/Time.inl
+    ${INCROOT}/UniqueResource.hpp
+    ${INCROOT}/UniqueResource.inl
     ${INCROOT}/Utf.hpp
     ${INCROOT}/Utf.inl
     ${SRCROOT}/Utils.hpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SYSTEM_SRC
     System/Sleep.test.cpp
     System/String.test.cpp
     System/Time.test.cpp
+    System/UniqueResource.test.cpp
     System/Vector2.test.cpp
     System/Vector3.test.cpp
 )

--- a/test/Graphics/Shader.test.cpp
+++ b/test/Graphics/Shader.test.cpp
@@ -159,8 +159,8 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
     {
         STATIC_CHECK(!std::is_copy_constructible_v<sf::Shader>);
         STATIC_CHECK(!std::is_copy_assignable_v<sf::Shader>);
-        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Shader>);
-        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Shader>);
+        STATIC_CHECK(std::is_move_constructible_v<sf::Shader>);
+        STATIC_CHECK(std::is_move_assignable_v<sf::Shader>);
     }
 
     SECTION("Construction")

--- a/test/System/UniqueResource.test.cpp
+++ b/test/System/UniqueResource.test.cpp
@@ -1,0 +1,111 @@
+#include <SFML/System/UniqueResource.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <SystemUtil.hpp>
+#include <type_traits>
+
+namespace
+{
+struct Deleter
+{
+    static inline std::size_t count{0};
+
+    void operator()(int)
+    {
+        ++count;
+    }
+};
+} // namespace
+
+TEST_CASE("[System] sf::UniqueResource")
+{
+    SECTION("Type traits")
+    {
+        STATIC_CHECK(!std::is_copy_constructible_v<sf::UniqueResource<int, Deleter>>);
+        STATIC_CHECK(!std::is_copy_assignable_v<sf::UniqueResource<int, Deleter>>);
+        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::UniqueResource<int, Deleter>>);
+        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::UniqueResource<int, Deleter>>);
+    }
+
+    SECTION("Construction")
+    {
+        SECTION("Default constructor")
+        {
+            const auto deleteCount = Deleter::count;
+            {
+                const sf::UniqueResource<int, Deleter> uniqueResource;
+            }
+            CHECK(Deleter::count == deleteCount);
+        }
+
+        SECTION("Handle constructor")
+        {
+            const auto deleteCount = Deleter::count;
+            {
+                const sf::UniqueResource<int, Deleter> uniqueResource(42);
+                CHECK(uniqueResource.get() == 42);
+            }
+            CHECK(Deleter::count == deleteCount + 1);
+        }
+    }
+
+    SECTION("Move semantics")
+    {
+        SECTION("Construction")
+        {
+            const auto deleteCount = Deleter::count;
+            {
+                sf::UniqueResource<int, Deleter>       movedUniqueResource(42);
+                const sf::UniqueResource<int, Deleter> uniqueResource(std::move(movedUniqueResource));
+                CHECK(Deleter::count == deleteCount);
+            }
+            CHECK(Deleter::count == deleteCount + 1);
+        }
+
+        SECTION("Assignment")
+        {
+            const auto deleteCount = Deleter::count;
+            {
+                sf::UniqueResource<int, Deleter> movedUniqueResource(42);
+                sf::UniqueResource<int, Deleter> uniqueResource;
+                uniqueResource = std::move(movedUniqueResource);
+                CHECK(Deleter::count == deleteCount);
+            }
+            CHECK(Deleter::count == deleteCount + 1);
+        }
+    }
+
+    SECTION("release()")
+    {
+        const auto deleteCount = Deleter::count;
+        {
+            sf::UniqueResource<int, Deleter> uniqueResource(42);
+            uniqueResource.release();
+            CHECK(Deleter::count == deleteCount);
+        }
+        CHECK(Deleter::count == deleteCount);
+    }
+
+    SECTION("reset()")
+    {
+        const auto deleteCount = Deleter::count;
+        {
+            sf::UniqueResource<int, Deleter> uniqueResource(42);
+            uniqueResource.reset();
+            CHECK(Deleter::count == deleteCount + 1);
+        }
+        CHECK(Deleter::count == deleteCount + 1);
+    }
+
+    SECTION("reset(T)")
+    {
+        const auto deleteCount = Deleter::count;
+        {
+            sf::UniqueResource<int, Deleter> uniqueResource(42);
+            uniqueResource.reset(123);
+            CHECK(Deleter::count == deleteCount + 1);
+        }
+        CHECK(Deleter::count == deleteCount + 2);
+    }
+}


### PR DESCRIPTION
## Description

`sf::UniqueResource` is a class template that owns a handle to a resource in such a way that you can safely move that handle while ensuring that you never free a given resource more than once. Inspired by [`std::experimental::unique_resource`](https://en.cppreference.com/w/cpp/experimental/unique_resource).

This has potential to be used in a number of place. Whether this is worth merging largely hinges on whether it can be used in 3 or more places.

Places to consider using `sf::UniqueResource`:
* `sf::Texture` (Won't let us remove custom copy operations but move operations are simplified)
* `sf::Shader`
* `sf::VertexBuffer`
* `sf::SoundBuffer` (Doesn't let us entirely remove destructor)
* `sf::AudioDevice` (Doesn't let us entirely remove destructor)
* `sf::SoundSource` (This potentially breaks the assumption that `0`-value handles represent a "null" state but maybe I'm misunderstanding OpenAL)
* `XFreePixmap` and other X11 resource cleanup functions (This is possible but painfully verbose for little gain other than purity and satisfaction)
* ~~`sf::priv::WindowImplWin32`~~ (`std::unique_ptr` is better fit for `m_icon` since it's a pointer type and the other members need destruction logic too complicated to capture in a single deleter function)
* ~~`sf::Font::FontHandles`~~ (`std::unique_ptr` is a better fit since these are pointer types but that's also not possible because other Freetype APIs need to take the address of the underlying pointer which is not possible)