### PR TITLE
Fix outdated use of the sf::VideoMode constructor

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,7 +27,7 @@ Tell us how to reproduce this issue. Please provide a [minimal, complete and ver
 
 int main()
 {
-    sf::RenderWindow window(sf::VideoMode(1280, 720), "Minimal, complete and verifiable example");
+    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
     window.setFramerateLimit(60);
 
     while (window.isOpen())

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ Describe how to best test these changes. Please provide a [minimal, complete and
 
 int main()
 {
-    sf::RenderWindow window(sf::VideoMode(1280, 720), "Minimal, complete and verifiable example");
+    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
     window.setFramerateLimit(60);
 
     while (window.isOpen())

--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -18,7 +18,7 @@
 /// int main()
 /// {
 ///     // Create the main window
-///     sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+///     sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 ///     // Load a sprite to display
 ///     sf::Texture texture;

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -258,7 +258,7 @@ private:
 ///
 /// \code
 /// // Create a new render-window
-/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+/// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // Create a new render-texture
 /// sf::RenderTexture texture;

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -195,7 +195,7 @@ private:
 ///
 /// \code
 /// // Declare and create a new render-window
-/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+/// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // Limit the framerate to 60 frames per second (this step is optional)
 /// window.setFramerateLimit(60);
@@ -230,7 +230,7 @@ private:
 ///
 /// \code
 /// // Create the render window
-/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML OpenGL");
+/// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML OpenGL");
 ///
 /// // Create a sprite and a text to display
 /// sf::Sprite sprite;

--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -222,7 +222,7 @@ SFML_WINDOW_API bool operator>=(const VideoMode& left, const VideoMode& right);
 ///
 /// // Create a window with the same pixel depth as the desktop
 /// sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
-/// window.create(sf::VideoMode(1024, 768, desktop.bitsPerPixel), "SFML window");
+/// window.create(sf::VideoMode({1024, 768}, desktop.bitsPerPixel), "SFML window");
 /// \endcode
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -329,7 +329,7 @@ private:
 /// Usage example:
 /// \code
 /// // Declare and create a new window
-/// sf::Window window(sf::VideoMode(800, 600), "SFML window");
+/// sf::Window window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // Limit the framerate to 60 frames per second (this step is optional)
 /// window.setFramerateLimit(60);

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -508,7 +508,7 @@ private:
 /// Usage example:
 /// \code
 /// // Declare and create a new window
-/// sf::WindowBase window(sf::VideoMode(800, 600), "SFML window");
+/// sf::WindowBase window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // The main loop - ends as soon as the window is closed
 /// while (window.isOpen())

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -23,7 +23,7 @@
 int main(int, char const**)
 {
     // Create the main window
-    sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+    sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 
     // Set the Icon
     sf::Image icon;

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -21,7 +21,7 @@
 int main(int argc, char const** argv)
 {
     // Create the main window
-    sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+    sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 
     // Set the Icon
     sf::Image icon;


### PR DESCRIPTION
## Description

Fixes the use of the `sf::VideoMode` constructor in the documentation that no longer accepts separate dimensions and instead requires a vector.

