### PR TITLE
Only run formatting job on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,28 +115,19 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
   format:
-    name: Formatting on ${{ matrix.platform.name }}
-    runs-on: ${{ matrix.platform.os }}
+    name: Formatting
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix:
-        platform:
-        - { name: Windows, os: windows-2022,  executable: clang-format }
-        - { name: Linux,   os: ubuntu-latest, executable: clang-format-12 }
-        - { name: macOS,   os: macos-12,      executable: clang-format }
 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
 
-    - name: Install macOS Dependencies
-      if: runner.os == 'macOS'
-      run: brew install clang-format
-
     - name: Format Code
       shell: bash
-      run: cmake -DCLANG_FORMAT_EXECUTABLE=${{ matrix.platform.executable }} -P $GITHUB_WORKSPACE/cmake/Format.cmake
+      run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-12 -P $GITHUB_WORKSPACE/cmake/Format.cmake
 
     - name: Check Formatting
       run: git diff --exit-code


### PR DESCRIPTION
It's currently failing on mac as brew has updated to clang-format 15 which has different rules.

Formatting shouldn't be platform specific anyway, so we really only need to run it on one platform, and linux is fixed on version 12

May also want to consider adding a max version to the check in Format.cmake too, as it seems >=15 won't work