### PR TITLE
Rearanged members of Transformable for a smaller object size

### DIFF
--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -235,8 +235,8 @@ private:
     Angle             m_rotation;                   //!< Orientation of the object
     Vector2f          m_scale;                      //!< Scale of the object
     mutable Transform m_transform;                  //!< Combined transformation of the object
-    mutable bool      m_transformNeedUpdate;        //!< Does the transform need to be recomputed?
     mutable Transform m_inverseTransform;           //!< Combined transformation of the object
+    mutable bool      m_transformNeedUpdate;        //!< Does the transform need to be recomputed?
     mutable bool      m_inverseTransformNeedUpdate; //!< Does the transform need to be recomputed?
 };
 


### PR DESCRIPTION
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?

----

## Description

The order of fields on `sf::Transformable` requires an additional byte in memory layout compared to grouping the two bools together.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

This mock example can be tested in Compiler Explorer:
https://godbolt.org/z/bfn844PPb

```cpp
namespace sf{

template<typename T>
class Vector2
{
    T x;
    T y;
};

typedef Vector2<float> Vector2f;

class Transform
{
    float m_matrix[16];
};

class TransformableOld
{
    Vector2f          m_origin;                     //!< Origin of translation/rotation/scaling of the object
    Vector2f          m_position;                   //!< Position of the object in the 2D world
    float             m_rotation;                   //!< Orientation of the object, in degrees
    Vector2f          m_scale;                      //!< Scale of the object
    mutable Transform m_transform;                  //!< Combined transformation of the object
    mutable bool      m_inverseTransformNeedUpdate; //!< Does the transform need to be recomputed?
    mutable Transform m_inverseTransform;           //!< Combined transformation of the object
    mutable bool      m_transformNeedUpdate;        //!< Does the transform need to be recomputed?
};

class TransformableNew
{
    Vector2f          m_origin;                     //!< Origin of translation/rotation/scaling of the object
    Vector2f          m_position;                   //!< Position of the object in the 2D world
    float             m_rotation;                   //!< Orientation of the object, in degrees
    Vector2f          m_scale;                      //!< Scale of the object
    mutable Transform m_transform;                  //!< Combined transformation of the object
    mutable Transform m_inverseTransform;           //!< Combined transformation of the object
    mutable bool      m_transformNeedUpdate;        //!< Does the transform need to be recomputed?
    mutable bool      m_inverseTransformNeedUpdate; //!< Does the transform need to be recomputed?
};

static_assert(sizeof(TransformableNew) < sizeof(TransformableOld), "size of original Transformable is smaller!");
}
```
