### PR TITLE
Enable warnings-as-errors for clang-cl

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -38,7 +38,6 @@ function(set_target_warnings target)
             /permissive- # standards conformance mode
 
             # Disables, remove when appropriate
-            /wd4996 # disable warnings about deprecated functions
             /wd4068 # disable warnings about unknown pragmas (e.g. #pragma GCC)
             /wd4505 # disable warnings about unused functions that might be platform-specific
             /wd4800 # disable warnings regarding implicit conversions to bool
@@ -84,5 +83,11 @@ function(set_target_warnings target)
         target_compile_options(${target} PRIVATE
             -Wno-unknown-warning-option # do not warn on GCC-specific warning diagnostic pragmas
         )
+    endif()
+
+    # Disable certain deprecation warnings
+    if(SFML_OS_WINDOWS)
+        target_compile_definitions(${target} PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+        target_compile_definitions(${target} PRIVATE -D_WINSOCK_DEPRECATED_NO_WARNINGS)
     endif()
 endfunction()

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -6,12 +6,6 @@
 function(set_target_warnings target)
     option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
 
-    # For now if we're using MSVC-like clang interface on Windows
-    # we'll disable warnings as errors 
-    if(SFML_OS_WINDOWS AND SFML_COMPILER_CLANG_CL)
-        set(WARNINGS_AS_ERRORS FALSE)
-    endif()
-
     if(SFML_COMPILER_MSVC)
         target_compile_options(${target} PRIVATE
             $<$<BOOL:${WARNINGS_AS_ERRORS}>:/WX>
@@ -79,7 +73,7 @@ function(set_target_warnings target)
         )
     endif()
 
-    if(SFML_COMPILER_CLANG)
+    if(SFML_COMPILER_CLANG OR SFML_COMPILER_CLANG_CL)
         target_compile_options(${target} PRIVATE
             -Wno-unknown-warning-option # do not warn on GCC-specific warning diagnostic pragmas
         )


### PR DESCRIPTION
## Description

When #2114 was merged, there were some clang-cl compiler warnings we couldn't entirely make sense of so we disabled warnings as errors for that compiler. This PR fixes those compiler errors.

clang-cl recognizes `/WX /W4` which translate to `-Werror -Wdeprecated-declarations` internally to Clang. Because we use some deprecated APIs in the Windows code, this caused a build break. This isn't a problem on MSVC because we also added `/wd4996` which disables deprecation warnings in the compiler. However, that flag isn't recognized by clang-cl which continues to use `-Werror -Wdeprecated-declarations`.

Luckily there are some preprocessor definitions we can set which disable deprecation warnings in the code so that no matter what compiler we use, we don't get deprecation warnings for those specific APIs.