### PR TITLE
Enable testing types which require the presence of a display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
         - platform: { name: Android, os: ubuntu-latest  }
           config: { name: x86_64, flags: -DCMAKE_ANDROID_ARCH_ABI=x86_64 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-ndk-r23b/build/cmake/android.toolchain.cmake -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r23b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 -DANDROID_PLATFORM=26 }
         - platform: { name: Linux GCC, os: ubuntu-latest  }
-          config: { name: Static DRM, flags: -DBUILD_SHARED_LIBS=FALSE -DSFML_USE_DRM=TRUE }
+          config: { name: Static DRM, flags: -DBUILD_SHARED_LIBS=FALSE -DSFML_USE_DRM=TRUE -DSFML_RUN_DISPLAY_TESTS=FALSE }
         - platform: { name: Linux GCC, os: ubuntu-latest  }
-          config: { name: Shared DRM, flags: -DBUILD_SHARED_LIBS=TRUE -DSFML_USE_DRM=TRUE }
+          config: { name: Shared DRM, flags: -DBUILD_SHARED_LIBS=TRUE -DSFML_USE_DRM=TRUE -DSFML_RUN_DISPLAY_TESTS=FALSE }
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         - { name: Windows VS2022 x64,     os: windows-2022, flags: -A x64 }
         - { name: Windows VS2022 ClangCL, os: windows-2022, flags: -T ClangCL }
         - { name: Windows VS2022 Clang,   os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
-        - { name: Linux GCC,            os: ubuntu-latest }
-        - { name: Linux Clang,          os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++, gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
+        - { name: Linux GCC,            os: ubuntu-latest, prefix: xvfb-run -a }
+        - { name: Linux Clang,          os: ubuntu-latest, prefix: xvfb-run -a, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++, gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: MacOS,                os: macos-11 }
         - { name: MacOS Xcode,          os: macos-11, flags: -GXcode }
         config:
@@ -57,7 +57,7 @@ jobs:
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev
+      run: sudo apt-get update && sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev
 
     - name: Install Android Components
       if: matrix.platform.name == 'Android'
@@ -94,7 +94,7 @@ jobs:
 
     - name: Build
       shell: bash
-      run: cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
+      run: ${{matrix.platform.prefix}} cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
 
     - name: Generate Coverage Report
       if: matrix.type.name == 'Debug' && runner.os != 'Windows' # Coverage is already generated on Windows when running tests.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -157,14 +157,10 @@ if(SFML_ENABLE_COVERAGE AND OpenCppCoverage_FOUND)
     string(REPLACE "/" "\\" COVERAGE_SRC "${PROJECT_SOURCE_DIR}/src")
     string(REPLACE "/" "\\" COVERAGE_INCLUDE "${PROJECT_SOURCE_DIR}/include")
 
-    add_custom_command(TARGET runtests
-                       COMMENT "Run tests"
-                       POST_BUILD COMMAND "${OpenCppCoverage_BINARY}" ARGS --quiet --export_type cobertura:${PROJECT_BINARY_DIR}/coverage.out --cover_children --excluded_modules "${COVERAGE_EXCLUDE}" --sources "${COVERAGE_SRC}" --sources "${COVERAGE_INCLUDE}" -- "${CMAKE_CTEST_COMMAND}" --output-on-failure -C $<CONFIG>
-                       VERBATIM)
-else()
-    # Run tests without a coverage runner
-    add_custom_command(TARGET runtests
-                       COMMENT "Run tests"
-                       POST_BUILD COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure -C $<CONFIG>
-                       VERBATIM)
+    set(COVERAGE_PREFIX ${OpenCppCoverage_BINARY} ARGS --quiet --export_type cobertura:${PROJECT_BINARY_DIR}/coverage.out --cover_children --excluded_modules "${COVERAGE_EXCLUDE}" --sources "${COVERAGE_SRC}" --sources "${COVERAGE_INCLUDE}" --)
 endif()
+
+add_custom_command(TARGET runtests
+                   COMMENT "Run tests"
+                   POST_BUILD COMMAND ${COVERAGE_PREFIX} ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>
+                   VERBATIM)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,14 @@ target_compile_definitions(test-sfml-system PRIVATE
     EXPECTED_SFML_VERSION_IS_RELEASE=$<IF:$<BOOL:${VERSION_IS_RELEASE}>,true,false>
 )
 
+# FIXME Remove this once the Buildbot supports handling display tests on Linux platforms
+if(SFML_OS_WINDOWS OR SFML_OS_MACOSX)
+    set(SFML_RUN_DISPLAY_TESTS_DEFAULT ON)
+else()
+    set(SFML_RUN_DISPLAY_TESTS_DEFAULT OFF)
+endif()
+sfml_set_option(SFML_RUN_DISPLAY_TESTS ${SFML_RUN_DISPLAY_TESTS_DEFAULT} BOOL "TRUE to run tests that require a display, FALSE to ignore it")
+
 set(WINDOW_SRC
     Window/Context.test.cpp
     Window/ContextSettings.test.cpp
@@ -88,6 +96,9 @@ set(GRAPHICS_SRC
     Graphics/View.test.cpp
 )
 sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" SFML::Graphics)
+if(SFML_RUN_DISPLAY_TESTS)
+    target_compile_definitions(test-sfml-graphics PRIVATE SFML_RUN_DISPLAY_TESTS)
+endif()
 
 set(NETWORK_SRC
     Network/Ftp.test.cpp

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -12,7 +12,7 @@ static_assert(!std::is_nothrow_move_constructible_v<sf::Texture>);
 static_assert(std::is_move_assignable_v<sf::Texture>);
 static_assert(!std::is_nothrow_move_assignable_v<sf::Texture>);
 
-TEST_CASE("[Graphics] sf::Texture")
+TEST_CASE("[Graphics] sf::Texture" * doctest::skip(skipDisplayTests))
 {
     SUBCASE("Construction")
     {

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -1,5 +1,8 @@
 #include <SFML/Graphics/Texture.hpp>
 
+#include <doctest/doctest.h>
+
+#include <GraphicsUtil.hpp>
 #include <type_traits>
 
 static_assert(std::is_copy_constructible_v<sf::Texture>);
@@ -8,3 +11,16 @@ static_assert(std::is_move_constructible_v<sf::Texture>);
 static_assert(!std::is_nothrow_move_constructible_v<sf::Texture>);
 static_assert(std::is_move_assignable_v<sf::Texture>);
 static_assert(!std::is_nothrow_move_assignable_v<sf::Texture>);
+
+TEST_CASE("[Graphics] sf::Texture")
+{
+    SUBCASE("Construction")
+    {
+        sf::Texture texture;
+        CHECK(texture.getSize() == sf::Vector2u());
+        CHECK(!texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() == 0);
+    }
+}

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -11,6 +11,12 @@
 #include <iomanip>
 #include <limits>
 
+#ifdef SFML_RUN_DISPLAY_TESTS
+static constexpr bool skipDisplayTests = false;
+#else
+static constexpr bool skipDisplayTests = true;
+#endif
+
 namespace sf
 {
 struct BlendMode;


### PR DESCRIPTION
## Description

Certain SFML types like `sf::Texture` require a display to be present to even construct an instance. This means we cannot write unit tests for them on headless machines as it the case with the Linux CI runners. This PR uses `xvfb-run` to run a dummy X11 server that lets us construct such types and run the code in CI.

Note that we don't yet have a solution for the DRM CI jobs so I'm disabling tests on those builds. This solution is not ideal but it is pragmatic. It's hard to imagine tests failing on those jobs but not elsewhere so I think it's a reasonable tradeoff to make to let us increase the Graphics module code coverage significantly.

I went ahead and added some basic `sf::Texture` tests to prove that this works. Basically all Graphics module types without runtime tests are candidates for unit testing now!