### PR TITLE
Ensure diagnostic pop occur before end of header guard

### DIFF
--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -92,8 +92,8 @@ ALenum alGetLastErrorImpl();
 } // namespace sf
 
 
-#endif // SFML_ALCHECK_HPP
-
 #if defined(__APPLE__)
 #pragma GCC diagnostic pop
 #endif
+
+#endif // SFML_ALCHECK_HPP


### PR DESCRIPTION
## Description

This was breaking unity builds in a separate project. See how the `#pragma` appeared after the end of the header guard.

Maybe we just switch to `#pragma once`...
