### PR TITLE
Changed sf::String::InvalidPos from 'inline const' to constexpr

### DIFF
--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -58,7 +58,7 @@ public:
     ////////////////////////////////////////////////////////////
     // NOLINTBEGIN(readability-identifier-naming)
     /// Represents an invalid position in the string
-    static inline const std::size_t InvalidPos{std::basic_string<std::uint32_t>::npos};
+    static constexpr std::size_t InvalidPos{std::basic_string<std::uint32_t>::npos};
     // NOLINTEND(readability-identifier-naming)
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

While looking through all of the header files for an unrelated issue I noticed this and wanted to update it for both modernization reasons as well as clarity. (It's a very trivial change)

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [x] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

```cpp
#include <SFML/System.hpp>
#include <iostream>
int main() try
{
    sf::String str{};
    if(str.find("empty") == sf::String::InvalidPos) throw std::runtime_error("this should not throw");
    return 0;
    
}
catch(std::runtime_error const & e){
   std::cerr << e.what();
}
```
