### PR TITLE
Rename `Key::Tilde` to `Key::Grave`

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -108,7 +108,7 @@ public:
         Apostrophe,   //!< The ' key
         Slash,        //!< The / key
         Backslash,    //!< The \ key
-        Tilde,        //!< The ~ key
+        Grave,        //!< The ` key
         Equal,        //!< The = key
         Hyphen,       //!< The - key (hyphen)
         Space,        //!< The Space key
@@ -160,6 +160,7 @@ public:
 
         // Deprecated values:
 
+        Tilde     = Grave,     //!< \deprecated Use Grave instead
         Dash      = Hyphen,    //!< \deprecated Use Hyphen instead
         BackSpace = Backspace, //!< \deprecated Use Backspace instead
         BackSlash = Backslash, //!< \deprecated Use Backslash instead

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -633,7 +633,7 @@ Keyboard::Key WindowImplAndroid::androidKeyToSF(int32_t key)
         case AKEYCODE_ENTER:              return Keyboard::Enter;
         case AKEYCODE_DEL:                return Keyboard::Backspace;
         case AKEYCODE_FORWARD_DEL:        return Keyboard::Delete;
-        case AKEYCODE_GRAVE:              return Keyboard::Tilde;
+        case AKEYCODE_GRAVE:              return Keyboard::Grave;
         case AKEYCODE_MINUS:              return Keyboard::Subtract;
         case AKEYCODE_EQUALS:             return Keyboard::Equal;
         case AKEYCODE_LEFT_BRACKET:       return Keyboard::LBracket;

--- a/src/SFML/Window/DRM/InputImplUDev.cpp
+++ b/src/SFML/Window/DRM/InputImplUDev.cpp
@@ -218,7 +218,7 @@ namespace
             case KEY_L:             return sf::Keyboard::L;
             case KEY_SEMICOLON:     return sf::Keyboard::Semicolon;
             case KEY_APOSTROPHE:    return sf::Keyboard::Quote;
-            case KEY_GRAVE:         return sf::Keyboard::Tilde;
+            case KEY_GRAVE:         return sf::Keyboard::Grave;
             case KEY_LEFTSHIFT:     return sf::Keyboard::LShift;
             case KEY_BACKSLASH:     return sf::Keyboard::Backslash;
             case KEY_Z:             return sf::Keyboard::Z;

--- a/src/SFML/Window/OSX/HIDInputManager.mm
+++ b/src/SFML/Window/OSX/HIDInputManager.mm
@@ -182,7 +182,7 @@ Keyboard::Key HIDInputManager::localizedKey(UniChar ch)
         case 0x27: return Keyboard::Apostrophe;
         case 0x2f: return Keyboard::Slash;
         case 0x5c: return Keyboard::Backslash;
-        case 0x7e: return Keyboard::Tilde;
+        case 0x60: return Keyboard::Grave;
         case 0x3d: return Keyboard::Equal;
         case 0x2d: return Keyboard::Hyphen;
         case 0x20: return Keyboard::Space;
@@ -310,7 +310,7 @@ UniChar HIDInputManager::toUnicode(Keyboard::Key key)
         case Keyboard::Apostrophe: return 0x27;
         case Keyboard::Slash:      return 0x2f;
         case Keyboard::Backslash:  return 0x5c;
-        case Keyboard::Tilde:      return 0x7e;
+        case Keyboard::Grave:      return 0x60;
         case Keyboard::Equal:      return 0x3d;
         case Keyboard::Hyphen:     return 0x2d;
         case Keyboard::Space:      return 0x20;

--- a/src/SFML/Window/OSX/HIDInputManager.mm
+++ b/src/SFML/Window/OSX/HIDInputManager.mm
@@ -866,7 +866,7 @@ void HIDInputManager::buildMappings()
             // Use current layout for translation
             OSStatus error = UCKeyTranslate(
                 layout, virtualCode, kUCKeyActionDown, modifiers, LMGetKbdType(),
-                kUCKeyTranslateNoDeadKeysBit, &deadKeyState, MAX_LENGTH, &length, string
+                kUCKeyTranslateNoDeadKeysMask, &deadKeyState, MAX_LENGTH, &length, string
             );
 
             if (error != noErr)

--- a/src/SFML/Window/Unix/KeySymToKeyMapping.cpp
+++ b/src/SFML/Window/Unix/KeySymToKeyMapping.cpp
@@ -59,7 +59,7 @@ Keyboard::Key keySymToKey(KeySym symbol)
         case XK_period:       return Keyboard::Period;
         case XK_apostrophe:   return Keyboard::Quote;
         case XK_backslash:    return Keyboard::BackSlash;
-        case XK_grave:        return Keyboard::Tilde;
+        case XK_grave:        return Keyboard::Grave;
         case XK_space:        return Keyboard::Space;
         case XK_Return:       return Keyboard::Return;
         case XK_KP_Enter:     return Keyboard::Return;
@@ -172,7 +172,7 @@ KeySym keyToKeySym(Keyboard::Key key)
         case Keyboard::Period:     return XK_period;
         case Keyboard::Quote:      return XK_apostrophe;
         case Keyboard::BackSlash:  return XK_backslash;
-        case Keyboard::Tilde:      return XK_grave;
+        case Keyboard::Grave:      return XK_grave;
         case Keyboard::Space:      return XK_space;
         case Keyboard::Return:     return XK_Return;
         case Keyboard::BackSpace:  return XK_BackSpace;

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -106,7 +106,7 @@ Keyboard::Key virtualKeyToSfKey(UINT virtualKey)
         case VK_OEM_7:      key = Keyboard::Apostrophe; break;
         case VK_OEM_2:      key = Keyboard::Slash;      break;
         case VK_OEM_5:      key = Keyboard::Backslash;  break;
-        case VK_OEM_3:      key = Keyboard::Tilde;      break;
+        case VK_OEM_3:      key = Keyboard::Grave;      break;
         case VK_OEM_PLUS:   key = Keyboard::Equal;      break;
         case VK_OEM_MINUS:  key = Keyboard::Hyphen;     break;
         case VK_SPACE:      key = Keyboard::Space;      break;
@@ -218,7 +218,7 @@ int sfKeyToVirtualKey(Keyboard::Key key)
         case Keyboard::Apostrophe: virtualKey = VK_OEM_7;      break;
         case Keyboard::Slash:      virtualKey = VK_OEM_2;      break;
         case Keyboard::Backslash:  virtualKey = VK_OEM_5;      break;
-        case Keyboard::Tilde:      virtualKey = VK_OEM_3;      break;
+        case Keyboard::Grave:      virtualKey = VK_OEM_3;      break;
         case Keyboard::Equal:      virtualKey = VK_OEM_PLUS;   break;
         case Keyboard::Hyphen:     virtualKey = VK_OEM_MINUS;  break;
         case Keyboard::Space:      virtualKey = VK_SPACE;      break;

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -1169,7 +1169,7 @@ Keyboard::Key WindowImplWin32::virtualKeyCodeToSF(WPARAM key, LPARAM flags)
         case VK_OEM_PERIOD: return Keyboard::Period;
         case VK_OEM_7:      return Keyboard::Apostrophe;
         case VK_OEM_5:      return Keyboard::Backslash;
-        case VK_OEM_3:      return Keyboard::Tilde;
+        case VK_OEM_3:      return Keyboard::Grave;
         case VK_ESCAPE:     return Keyboard::Escape;
         case VK_SPACE:      return Keyboard::Space;
         case VK_RETURN:     return Keyboard::Enter;


### PR DESCRIPTION
## Description

`sf::Keyboard::Key::Tilde` is actually used to represent a key which writes <code>\`</code>, and not `~`, so it makes sense not to name it `Key::Tilde`.
I suggest `Key::Grave` instead, which is consistent with the naming used for scancode `Scan::Grave`.

This PR is related to #1235.

## Tasks

* [x] Tested on Linux (X11)
* [x] Tested on Windows
* [x] Tested on macOS

~~I can test this patch on other platforms later.~~ Done.

## How to test this PR?

Running [SFML-Input](https://github.com/eXpl0it3r/SFML-Input) and pressing the key above tab or a key that writes <code>\`</code> depending on keyboard layout, checking that it shows consistent feedback.

The behavior looks strange on windows when not using US layout, but that is already the case before this patch.