### PR TITLE
[2124] fix. Window.setSize() while resizing causes extraneous behavior

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -300,25 +300,26 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    ::Window   m_window;         ///< X identifier defining our window
-    ::Display* m_display;        ///< Pointer to the display
-    int        m_screen;         ///< Screen identifier
-    XIM        m_inputMethod;    ///< Input method linked to the X display
-    XIC        m_inputContext;   ///< Input context used to get unicode input in our window
-    bool       m_isExternal;     ///< Tell whether the window has been created externally or by SFML
-    RRMode     m_oldVideoMode;   ///< Video mode in use before we switch to fullscreen
-    RRCrtc     m_oldRRCrtc;      ///< RRCrtc in use before we switch to fullscreen
-    ::Cursor   m_hiddenCursor;   ///< As X11 doesn't provide cursor hiding, we must create a transparent one
-    ::Cursor   m_lastCursor;     ///< Last cursor used -- this data is not owned by the window and is required to be always valid
-    bool       m_keyRepeat;      ///< Is the KeyRepeat feature enabled?
-    Vector2i   m_previousSize;   ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
-    bool       m_useSizeHints;   ///< Is the size of the window fixed with size hints?
-    bool       m_fullscreen;     ///< Is the window in fullscreen?
-    bool       m_cursorGrabbed;  ///< Is the mouse cursor trapped?
-    bool       m_windowMapped;   ///< Has the window been mapped by the window manager?
-    Pixmap     m_iconPixmap;     ///< The current icon pixmap if in use
-    Pixmap     m_iconMaskPixmap; ///< The current icon mask pixmap if in use
-    ::Time     m_lastInputTime;  ///< Last time we received user input
+    ::Window   m_window;                      ///< X identifier defining our window
+    ::Display* m_display;                     ///< Pointer to the display
+    int        m_screen;                      ///< Screen identifier
+    XIM        m_inputMethod;                 ///< Input method linked to the X display
+    XIC        m_inputContext;                ///< Input context used to get unicode input in our window
+    bool       m_isExternal;                  ///< Tell whether the window has been created externally or by SFML
+    RRMode     m_oldVideoMode;                ///< Video mode in use before we switch to fullscreen
+    RRCrtc     m_oldRRCrtc;                   ///< RRCrtc in use before we switch to fullscreen
+    ::Cursor   m_hiddenCursor;                ///< As X11 doesn't provide cursor hiding, we must create a transparent one
+    ::Cursor   m_lastCursor;                  ///< Last cursor used -- this data is not owned by the window and is required to be always valid
+    bool       m_keyRepeat;                   ///< Is the KeyRepeat feature enabled?
+    Vector2i   m_previousSize;                ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
+    bool       m_resizeOccuredDuringSetSize;  ///< if resize occurs during setSize, setSize knows to stop looping XResizeWindow
+    bool       m_useSizeHints;                ///< Is the size of the window fixed with size hints?
+    bool       m_fullscreen;                  ///< Is the window in fullscreen?
+    bool       m_cursorGrabbed;               ///< Is the mouse cursor trapped?
+    bool       m_windowMapped;                ///< Has the window been mapped by the window manager?
+    Pixmap     m_iconPixmap;                  ///< The current icon pixmap if in use
+    Pixmap     m_iconMaskPixmap;              ///< The current icon mask pixmap if in use
+    ::Time     m_lastInputTime;               ///< Last time we received user input
 };
 
 } // namespace priv


### PR DESCRIPTION
## Description

This fix forces XResizeWindow to occur after the user is done resizing the window. If you use the test code I have provided, you will see that setSize is called after a resize event is done. Before this commit, setSize would run XResizeWindow, but since the user's mouse was still holding onto the window, the window would resize to whatever size the user's mouse is at. With my fix, XResizeWindow is GUARENTEED to occur once the user is done dragging the window.  

Here is a video demonstrating my fix working: https://youtu.be/mLMVFbeuRIs 

This PR is related to the issue #2124 

## Tasks

X11 LINUX ISSUE ONLY
* [ Works] Tested on Linux
----------INVALID TESTS----------
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

After you install SFML, go ahead and compile, link, and run the code below. You will see that the resize event is seemingly not called.

Install my fix, compile, link, and run the code below. You will see the resize event being called and resizing the window.

```cpp
#include <SFML/Graphics.hpp>
#include <SFML/Window.hpp>
#include <SFML/System.hpp>

int main() {
    sf::RenderWindow window(sf::VideoMode(200, 200), "SFML works!");

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
            if (event.type == sf::Event::Resized) {
                const sf::Vector2u window_size(event.size.width, event.size.height);

                if (window_size.x < 200) {
                    window.setSize(sf::Vector2u(200, window_size.y));
                }
                if (window_size.y < 200) {
                    window.setSize(sf::Vector2u(window_size.x, 200));
                }
            }
        }

        window.clear();
        window.display();
    }

    return 0;
}

```
