### PR TITLE
Update x11 sf::Cursor::Hand to be consistent across OS's

### DIFF
--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -172,7 +172,7 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
         case Cursor::Arrow:           shape = XC_arrow;               break;
         case Cursor::Wait:            shape = XC_watch;               break;
         case Cursor::Text:            shape = XC_xterm;               break;
-        case Cursor::Hand:            shape = XC_hand1;               break;
+        case Cursor::Hand:            shape = XC_hand2;               break;
         case Cursor::SizeHorizontal:  shape = XC_sb_h_double_arrow;   break;
         case Cursor::SizeVertical:    shape = XC_sb_v_double_arrow;   break;
         case Cursor::SizeLeft:        shape = XC_left_side;           break;


### PR DESCRIPTION
## Description

It's my understanding that sf::Cursor::Hand is intended to be the mouse cursor indicating a clickable item. I am not able to test what it looks like on macOS, but on Windows sf::Cursor::Hand is indeed the clickable hand icon. On x11, however, there are two hand icons -- xc_hand1, and xc_hand2. 

SFML is currently using xc_hand1, which is an open hand that is usually used in the context of dragging windows. This pr changes sf::Cursor::Hand to use xc_hand2 as that's the clickable indicator. 

Please see the image below

![hand](https://user-images.githubusercontent.com/5576311/209585629-d44c055b-e275-463a-84e1-4dd01e993a6f.png)

It's possible that there are some themes out there which use xc_hand1 as the clickable indicator, but the default themes for every major distro I looked at (adwaita, ubuntu, fedora, breeze kde, linux mint, xubuntu) all use hand1(open hand) hand2(clickable). 

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{

    sf::RenderWindow window(sf::VideoMode({600, 800}, 32), "Cursor Test");
    window.setFramerateLimit(144);

    sf::Cursor cursor;
    if (cursor.loadFromSystem(sf::Cursor::Hand))
        window.setMouseCursor(cursor);

    while (window.isOpen())
    {
        for (auto event = sf::Event{}; window.pollEvent(event);)
        {
            if (event.type == sf::Event::Closed)
            {
                window.close();
            }
        }

        window.clear();
        window.display();
    }
}
```
