### PR TITLE
Backport macOS + Clang compiler error fix

### DIFF
--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -630,8 +630,7 @@
     NSDictionary* deviceDescription = [[m_window screen] deviceDescription];
     NSNumber* screenNumber = [deviceDescription valueForKey:@"NSScreenNumber"];
     CGDirectDisplayID screenID = static_cast<CGDirectDisplayID>([screenNumber intValue]);
-    CGFloat height = CGDisplayPixelsHigh(screenID);
-    return static_cast<float>(height);
+    return static_cast<float>(CGDisplayPixelsHigh(screenID));
 }
 
 


### PR DESCRIPTION
## Description

This back ports https://github.com/SFML/SFML/commit/79250d958403b16e475d92139ecd90192e538af2 / #2040 into 2.x. A user in the SFML Discord reported running into this issue trying to build the SFML CMake template with Clang (not AppleClang) so it seems to be a warning that Clang applies by default but because we don't test with non-Apple Clang on macOS our CI pipeline didn't catch it.
