### PR TITLE
Mark move operators as noexcept

### DIFF
--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -83,13 +83,13 @@ public:
     /// \brief Move constructor
     ///
     ////////////////////////////////////////////////////////////
-    FileInputStream(FileInputStream&&);
+    FileInputStream(FileInputStream&&) noexcept;
 
     ////////////////////////////////////////////////////////////
     /// \brief Move assignment
     ///
     ////////////////////////////////////////////////////////////
-    FileInputStream& operator=(FileInputStream&&);
+    FileInputStream& operator=(FileInputStream&&) noexcept;
 
     ////////////////////////////////////////////////////////////
     /// \brief Open the stream from a file path

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -52,11 +52,11 @@ FileInputStream::~FileInputStream() = default;
 
 
 ////////////////////////////////////////////////////////////
-FileInputStream::FileInputStream(FileInputStream&&) = default;
+FileInputStream::FileInputStream(FileInputStream&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
-FileInputStream& FileInputStream::operator=(FileInputStream&&) = default;
+FileInputStream& FileInputStream::operator=(FileInputStream&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -6,7 +6,13 @@
 #include <fstream>
 #include <sstream>
 #include <string_view>
+#include <type_traits>
 #include <utility>
+
+static_assert(!std::is_copy_constructible_v<sf::FileInputStream>);
+static_assert(!std::is_copy_assignable_v<sf::FileInputStream>);
+static_assert(std::is_nothrow_move_constructible_v<sf::FileInputStream>);
+static_assert(std::is_nothrow_move_assignable_v<sf::FileInputStream>);
 
 static std::string getTemporaryFilePath()
 {


### PR DESCRIPTION
## Description

I forgot to add static_assert type trait tests for `sf::FileInputStream` so it's lack of `noexcept` slipped through the cracks.
