### PR TITLE
Fix typo in error message

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -2212,7 +2212,7 @@ Vector2i WindowImplX11::getPrimaryMonitorPosition()
     XRRScreenResources* res = XRRGetScreenResources(m_display, rootWindow);
     if (!res)
     {
-        err() << "Failed to get the current screen resources for.primary monitor position" << std::endl;
+        err() << "Failed to get the current screen resources for primary monitor position" << std::endl;
         return monitorPosition;
     }
 
@@ -2233,7 +2233,7 @@ Vector2i WindowImplX11::getPrimaryMonitorPosition()
         if (outputInfo)
             XRRFreeOutputInfo(outputInfo);
 
-        err() << "Failed to get output info for.primary monitor position" << std::endl;
+        err() << "Failed to get output info for primary monitor position" << std::endl;
         return monitorPosition;
     }
 
@@ -2243,7 +2243,7 @@ Vector2i WindowImplX11::getPrimaryMonitorPosition()
     {
         XRRFreeScreenResources(res);
         XRRFreeOutputInfo(outputInfo);
-        err() << "Failed to get crtc info for.primary monitor position" << std::endl;
+        err() << "Failed to get crtc info for primary monitor position" << std::endl;
         return monitorPosition;
     }
 


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [x] If you have additional steps which need to be performed list them as tasks!

----

## Description

Changes:
 - `Failed to get output info for.primary monitor position` -> `Failed to get output info for primary monitor position`
 - `Failed to get crtc info for.primary monitor position` -> `Failed to get crtc info for primary monitor position`
 - `Failed to get the current screen resources for.primary monitor position` -> `Failed to get the current screen resources for primary monitor position`
 
I got one of those error messages and I think the dot isn't supposed to be there.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Test if compiling works.
