### PR TITLE
Fix bug where clang-tidy CI job always passes

### DIFF
--- a/cmake/Tidy.cmake
+++ b/cmake/Tidy.cmake
@@ -20,4 +20,7 @@ else()
 endif()
 
 # Run
-execute_process(COMMAND run-clang-tidy -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -p ${PROJECT_BINARY_DIR})
+execute_process(COMMAND run-clang-tidy -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
+if(NOT EXIT_CODE STREQUAL 0)
+    message(FATAL_ERROR "Analysis failed")
+endif()


### PR DESCRIPTION
## Description

The CMake script itself isn't returning non-zero when run-clang-tidy fails meaning clang-tidy errors are going undetected in CI.