### PR TITLE
Added modernize-use-nullptr check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@ Checks: >
   -*,
   clang-analyzer-*,
   modernize-concat-nested-namespaces,
+  modernize-use-nullptr,
   readability-identifier-naming,
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-core.NullDereference,

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -209,36 +209,36 @@ public:
     maxFramesInFlight(2),
     currentFrame(0),
     swapchainOutOfDate(false),
-    instance(0),
-    debugReportCallback(0),
-    surface(0),
-    gpu(0),
+    instance(),
+    debugReportCallback(),
+    surface(),
+    gpu(),
     queueFamilyIndex(-1),
-    device(0),
-    queue(0),
+    device(),
+    queue(),
     swapchainFormat(),
     swapchainExtent(),
-    swapchain(0),
+    swapchain(),
     depthFormat(VK_FORMAT_UNDEFINED),
-    depthImage(0),
-    depthImageMemory(0),
-    depthImageView(0),
-    vertexShaderModule(0),
-    fragmentShaderModule(0),
-    descriptorSetLayout(0),
-    pipelineLayout(0),
-    renderPass(0),
-    graphicsPipeline(0),
-    commandPool(0),
-    vertexBuffer(0),
-    vertexBufferMemory(0),
-    indexBuffer(0),
-    indexBufferMemory(0),
-    textureImage(0),
-    textureImageMemory(0),
-    textureImageView(0),
-    textureSampler(0),
-    descriptorPool(0)
+    depthImage(),
+    depthImageMemory(),
+    depthImageView(),
+    vertexShaderModule(),
+    fragmentShaderModule(),
+    descriptorSetLayout(),
+    pipelineLayout(),
+    renderPass(),
+    graphicsPipeline(),
+    commandPool(),
+    vertexBuffer(),
+    vertexBufferMemory(),
+    indexBuffer(),
+    indexBufferMemory(),
+    textureImage(),
+    textureImageMemory(),
+    textureImageView(),
+    textureSampler(),
+    descriptorPool()
     {
         // Vulkan setup procedure
         if (vulkanAvailable)
@@ -316,70 +316,70 @@ public:
 
         // Vulkan teardown procedure
         for (VkFence fence : fences)
-            vkDestroyFence(device, fence, 0);
+            vkDestroyFence(device, fence, nullptr);
 
         for (VkSemaphore renderFinishedSemaphore : renderFinishedSemaphores)
-            vkDestroySemaphore(device, renderFinishedSemaphore, 0);
+            vkDestroySemaphore(device, renderFinishedSemaphore, nullptr);
 
         for (VkSemaphore imageAvailableSemaphore : imageAvailableSemaphores)
-            vkDestroySemaphore(device, imageAvailableSemaphore, 0);
+            vkDestroySemaphore(device, imageAvailableSemaphore, nullptr);
 
         if (descriptorPool)
-            vkDestroyDescriptorPool(device, descriptorPool, 0);
+            vkDestroyDescriptorPool(device, descriptorPool, nullptr);
 
         for (VkDeviceMemory i : uniformBuffersMemory)
-            vkFreeMemory(device, i, 0);
+            vkFreeMemory(device, i, nullptr);
 
         for (VkBuffer uniformBuffer : uniformBuffers)
-            vkDestroyBuffer(device, uniformBuffer, 0);
+            vkDestroyBuffer(device, uniformBuffer, nullptr);
 
         if (textureSampler)
-            vkDestroySampler(device, textureSampler, 0);
+            vkDestroySampler(device, textureSampler, nullptr);
 
         if (textureImageView)
-            vkDestroyImageView(device, textureImageView, 0);
+            vkDestroyImageView(device, textureImageView, nullptr);
 
         if (textureImageMemory)
-            vkFreeMemory(device, textureImageMemory, 0);
+            vkFreeMemory(device, textureImageMemory, nullptr);
 
         if (textureImage)
-            vkDestroyImage(device, textureImage, 0);
+            vkDestroyImage(device, textureImage, nullptr);
 
         if (indexBufferMemory)
-            vkFreeMemory(device, indexBufferMemory, 0);
+            vkFreeMemory(device, indexBufferMemory, nullptr);
 
         if (indexBuffer)
-            vkDestroyBuffer(device, indexBuffer, 0);
+            vkDestroyBuffer(device, indexBuffer, nullptr);
 
         if (vertexBufferMemory)
-            vkFreeMemory(device, vertexBufferMemory, 0);
+            vkFreeMemory(device, vertexBufferMemory, nullptr);
 
         if (vertexBuffer)
-            vkDestroyBuffer(device, vertexBuffer, 0);
+            vkDestroyBuffer(device, vertexBuffer, nullptr);
 
         if (commandPool)
-            vkDestroyCommandPool(device, commandPool, 0);
+            vkDestroyCommandPool(device, commandPool, nullptr);
 
         if (descriptorSetLayout)
-            vkDestroyDescriptorSetLayout(device, descriptorSetLayout, 0);
+            vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
 
         if (fragmentShaderModule)
-            vkDestroyShaderModule(device, fragmentShaderModule, 0);
+            vkDestroyShaderModule(device, fragmentShaderModule, nullptr);
 
         if (vertexShaderModule)
-            vkDestroyShaderModule(device, vertexShaderModule, 0);
+            vkDestroyShaderModule(device, vertexShaderModule, nullptr);
 
         if (device)
-            vkDestroyDevice(device, 0);
+            vkDestroyDevice(device, nullptr);
 
         if (surface)
-            vkDestroySurfaceKHR(instance, surface, 0);
+            vkDestroySurfaceKHR(instance, surface, nullptr);
 
         if (debugReportCallback)
-            vkDestroyDebugReportCallbackEXT(instance, debugReportCallback, 0);
+            vkDestroyDebugReportCallbackEXT(instance, debugReportCallback, nullptr);
 
         if (instance)
-            vkDestroyInstance(instance, 0);
+            vkDestroyInstance(instance, nullptr);
     }
 
     // Cleanup swapchain
@@ -395,35 +395,35 @@ public:
         commandBuffers.clear();
 
         for (VkFramebuffer swapchainFramebuffer : swapchainFramebuffers)
-            vkDestroyFramebuffer(device, swapchainFramebuffer, 0);
+            vkDestroyFramebuffer(device, swapchainFramebuffer, nullptr);
 
         swapchainFramebuffers.clear();
 
         if (graphicsPipeline)
-            vkDestroyPipeline(device, graphicsPipeline, 0);
+            vkDestroyPipeline(device, graphicsPipeline, nullptr);
 
         if (renderPass)
-            vkDestroyRenderPass(device, renderPass, 0);
+            vkDestroyRenderPass(device, renderPass, nullptr);
 
         if (pipelineLayout)
-            vkDestroyPipelineLayout(device, pipelineLayout, 0);
+            vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
 
         if (depthImageView)
-            vkDestroyImageView(device, depthImageView, 0);
+            vkDestroyImageView(device, depthImageView, nullptr);
 
         if (depthImageMemory)
-            vkFreeMemory(device, depthImageMemory, 0);
+            vkFreeMemory(device, depthImageMemory, nullptr);
 
         if (depthImage)
-            vkDestroyImage(device, depthImage, 0);
+            vkDestroyImage(device, depthImage, nullptr);
 
         for (VkImageView swapchainImageView : swapchainImageViews)
-            vkDestroyImageView(device, swapchainImageView, 0);
+            vkDestroyImageView(device, swapchainImageView, nullptr);
 
         swapchainImageViews.clear();
 
         if (swapchain)
-            vkDestroySwapchainKHR(device, swapchain, 0);
+            vkDestroySwapchainKHR(device, swapchain, nullptr);
     }
 
     // Cleanup and recreate swapchain
@@ -462,7 +462,7 @@ public:
     void setupInstance()
     {
         // Load bootstrap entry points
-        gladLoadVulkan(0, getVulkanFunction);
+        gladLoadVulkan({}, getVulkanFunction);
 
         if (!vkCreateInstance)
         {
@@ -475,7 +475,7 @@ public:
 
         std::vector<VkLayerProperties> layers;
 
-        if (vkEnumerateInstanceLayerProperties(&objectCount, 0) != VK_SUCCESS)
+        if (vkEnumerateInstanceLayerProperties(&objectCount, nullptr) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -537,7 +537,7 @@ public:
         instanceCreateInfo.ppEnabledExtensionNames = requiredExtentions.data();
 
         // Try to create a Vulkan instance with debug report enabled
-        VkResult result = vkCreateInstance(&instanceCreateInfo, 0, &instance);
+        VkResult result = vkCreateInstance(&instanceCreateInfo, nullptr, &instance);
 
         // If an extension is missing, try disabling debug report
         if (result == VK_ERROR_EXTENSION_NOT_PRESENT)
@@ -547,7 +547,7 @@ public:
             instanceCreateInfo.enabledExtensionCount   = static_cast<std::uint32_t>(requiredExtentions.size());
             instanceCreateInfo.ppEnabledExtensionNames = requiredExtentions.data();
 
-            result = vkCreateInstance(&instanceCreateInfo, 0, &instance);
+            result = vkCreateInstance(&instanceCreateInfo, nullptr, &instance);
         }
 
         // If instance creation still fails, give up
@@ -558,7 +558,7 @@ public:
         }
 
         // Load instance entry points
-        gladLoadVulkan(0, getVulkanFunction);
+        gladLoadVulkan({}, getVulkanFunction);
     }
 
     // Setup our debug callback function to be called by Vulkan
@@ -576,7 +576,8 @@ public:
         debugReportCallbackCreateInfo.pfnCallback = debugCallback;
 
         // Create the debug callback
-        if (vkCreateDebugReportCallbackEXT(instance, &debugReportCallbackCreateInfo, 0, &debugReportCallback) != VK_SUCCESS)
+        if (vkCreateDebugReportCallbackEXT(instance, &debugReportCallbackCreateInfo, nullptr, &debugReportCallback) !=
+            VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -605,7 +606,7 @@ public:
 
         std::vector<VkPhysicalDevice> devices;
 
-        if (vkEnumeratePhysicalDevices(instance, &objectCount, 0) != VK_SUCCESS)
+        if (vkEnumeratePhysicalDevices(instance, &objectCount, nullptr) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -627,7 +628,7 @@ public:
 
             std::vector<VkExtensionProperties> extensions;
 
-            if (vkEnumerateDeviceExtensionProperties(dev, 0, &objectCount, 0) != VK_SUCCESS)
+            if (vkEnumerateDeviceExtensionProperties(dev, nullptr, &objectCount, nullptr) != VK_SUCCESS)
             {
                 vulkanAvailable = false;
                 return;
@@ -635,7 +636,7 @@ public:
 
             extensions.resize(objectCount);
 
-            if (vkEnumerateDeviceExtensionProperties(dev, 0, &objectCount, extensions.data()) != VK_SUCCESS)
+            if (vkEnumerateDeviceExtensionProperties(dev, nullptr, &objectCount, extensions.data()) != VK_SUCCESS)
             {
                 vulkanAvailable = false;
                 return;
@@ -718,7 +719,7 @@ public:
 
         std::vector<VkQueueFamilyProperties> queueFamilyProperties;
 
-        vkGetPhysicalDeviceQueueFamilyProperties(gpu, &objectCount, 0);
+        vkGetPhysicalDeviceQueueFamilyProperties(gpu, &objectCount, nullptr);
 
         queueFamilyProperties.resize(objectCount);
 
@@ -767,7 +768,7 @@ public:
         deviceCreateInfo.pEnabledFeatures        = &physicalDeviceFeatures;
 
         // Create our logical device
-        if (vkCreateDevice(gpu, &deviceCreateInfo, 0, &device) != VK_SUCCESS)
+        if (vkCreateDevice(gpu, &deviceCreateInfo, nullptr, &device) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -785,7 +786,7 @@ public:
 
         std::vector<VkSurfaceFormatKHR> surfaceFormats;
 
-        if (vkGetPhysicalDeviceSurfaceFormatsKHR(gpu, surface, &objectCount, 0) != VK_SUCCESS)
+        if (vkGetPhysicalDeviceSurfaceFormatsKHR(gpu, surface, &objectCount, nullptr) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -830,7 +831,7 @@ public:
         // Select a swapchain present mode
         std::vector<VkPresentModeKHR> presentModes;
 
-        if (vkGetPhysicalDeviceSurfacePresentModesKHR(gpu, surface, &objectCount, 0) != VK_SUCCESS)
+        if (vkGetPhysicalDeviceSurfacePresentModesKHR(gpu, surface, &objectCount, nullptr) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -891,7 +892,7 @@ public:
         swapchainCreateInfo.oldSwapchain             = VK_NULL_HANDLE;
 
         // Create the swapchain
-        if (vkCreateSwapchainKHR(device, &swapchainCreateInfo, 0, &swapchain) != VK_SUCCESS)
+        if (vkCreateSwapchainKHR(device, &swapchainCreateInfo, nullptr, &swapchain) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -904,7 +905,7 @@ public:
         // Retrieve swapchain images
         std::uint32_t objectCount = 0;
 
-        if (vkGetSwapchainImagesKHR(device, swapchain, &objectCount, 0) != VK_SUCCESS)
+        if (vkGetSwapchainImagesKHR(device, swapchain, &objectCount, nullptr) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -938,7 +939,7 @@ public:
         {
             imageViewCreateInfo.image = swapchainImages[i];
 
-            if (vkCreateImageView(device, &imageViewCreateInfo, 0, &swapchainImageViews[i]) != VK_SUCCESS)
+            if (vkCreateImageView(device, &imageViewCreateInfo, nullptr, &swapchainImageViews[i]) != VK_SUCCESS)
             {
                 vulkanAvailable = false;
                 return;
@@ -973,7 +974,7 @@ public:
             shaderModuleCreateInfo.codeSize = buffer.size() * sizeof(std::uint32_t);
             shaderModuleCreateInfo.pCode    = buffer.data();
 
-            if (vkCreateShaderModule(device, &shaderModuleCreateInfo, 0, &vertexShaderModule) != VK_SUCCESS)
+            if (vkCreateShaderModule(device, &shaderModuleCreateInfo, nullptr, &vertexShaderModule) != VK_SUCCESS)
             {
                 vulkanAvailable = false;
                 return;
@@ -1001,7 +1002,7 @@ public:
             shaderModuleCreateInfo.codeSize = buffer.size() * sizeof(std::uint32_t);
             shaderModuleCreateInfo.pCode    = buffer.data();
 
-            if (vkCreateShaderModule(device, &shaderModuleCreateInfo, 0, &fragmentShaderModule) != VK_SUCCESS)
+            if (vkCreateShaderModule(device, &shaderModuleCreateInfo, nullptr, &fragmentShaderModule) != VK_SUCCESS)
             {
                 vulkanAvailable = false;
                 return;
@@ -1082,7 +1083,7 @@ public:
         renderPassCreateInfo.pDependencies          = &subpassDependency;
 
         // Create the renderpass
-        if (vkCreateRenderPass(device, &renderPassCreateInfo, 0, &renderPass) != VK_SUCCESS)
+        if (vkCreateRenderPass(device, &renderPassCreateInfo, nullptr, &renderPass) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -1114,7 +1115,7 @@ public:
         descriptorSetLayoutCreateInfo.pBindings    = descriptorSetLayoutBindings;
 
         // Create descriptor set layout
-        if (vkCreateDescriptorSetLayout(device, &descriptorSetLayoutCreateInfo, 0, &descriptorSetLayout) != VK_SUCCESS)
+        if (vkCreateDescriptorSetLayout(device, &descriptorSetLayoutCreateInfo, nullptr, &descriptorSetLayout) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -1130,7 +1131,7 @@ public:
         pipelineLayoutCreateInfo.pSetLayouts                = &descriptorSetLayout;
 
         // Create pipeline layout
-        if (vkCreatePipelineLayout(device, &pipelineLayoutCreateInfo, 0, &pipelineLayout) != VK_SUCCESS)
+        if (vkCreatePipelineLayout(device, &pipelineLayoutCreateInfo, nullptr, &pipelineLayout) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -1265,7 +1266,7 @@ public:
         graphicsPipelineCreateInfo.subpass                      = 0;
 
         // Create our graphics pipeline
-        if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &graphicsPipelineCreateInfo, 0, &graphicsPipeline) !=
+        if (vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &graphicsPipelineCreateInfo, nullptr, &graphicsPipeline) !=
             VK_SUCCESS)
         {
             vulkanAvailable = false;
@@ -1294,7 +1295,7 @@ public:
             framebufferCreateInfo.pAttachments = attachments;
 
             // Create the framebuffer
-            if (vkCreateFramebuffer(device, &framebufferCreateInfo, 0, &swapchainFramebuffers[i]) != VK_SUCCESS)
+            if (vkCreateFramebuffer(device, &framebufferCreateInfo, nullptr, &swapchainFramebuffers[i]) != VK_SUCCESS)
             {
                 vulkanAvailable = false;
                 return;
@@ -1312,7 +1313,7 @@ public:
         commandPoolCreateInfo.flags                   = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
 
         // Create our command pool
-        if (vkCreateCommandPool(device, &commandPoolCreateInfo, 0, &commandPool) != VK_SUCCESS)
+        if (vkCreateCommandPool(device, &commandPoolCreateInfo, nullptr, &commandPool) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -1334,7 +1335,7 @@ public:
         bufferCreateInfo.sharingMode        = VK_SHARING_MODE_EXCLUSIVE;
 
         // Create the buffer, this does not allocate any memory for it yet
-        if (vkCreateBuffer(device, &bufferCreateInfo, 0, &buffer) != VK_SUCCESS)
+        if (vkCreateBuffer(device, &bufferCreateInfo, nullptr, &buffer) != VK_SUCCESS)
             return false;
 
         // Check what kind of memory we need to request from the GPU
@@ -1363,7 +1364,7 @@ public:
         memoryAllocateInfo.memoryTypeIndex      = memoryType;
 
         // Allocate the memory out of the GPU pool for the required memory type
-        if (vkAllocateMemory(device, &memoryAllocateInfo, 0, &memory) != VK_SUCCESS)
+        if (vkAllocateMemory(device, &memoryAllocateInfo, nullptr, &memory) != VK_SUCCESS)
             return false;
 
         // Bind the allocated memory to our buffer object
@@ -1476,8 +1477,8 @@ public:
         // clang-format on
 
         // Create a staging buffer that is writable by the CPU
-        VkBuffer       stagingBuffer       = 0;
-        VkDeviceMemory stagingBufferMemory = 0;
+        VkBuffer       stagingBuffer       = {};
+        VkDeviceMemory stagingBufferMemory = {};
 
         if (!createBuffer(sizeof(vertexData),
                           VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
@@ -1494,8 +1495,8 @@ public:
         // Map the buffer into our address space
         if (vkMapMemory(device, stagingBufferMemory, 0, sizeof(vertexData), 0, &ptr) != VK_SUCCESS)
         {
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1514,8 +1515,8 @@ public:
                           vertexBuffer,
                           vertexBufferMemory))
         {
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1525,8 +1526,8 @@ public:
         vulkanAvailable = copyBuffer(vertexBuffer, stagingBuffer, sizeof(vertexData));
 
         // Free the staging buffer and its memory
-        vkFreeMemory(device, stagingBufferMemory, 0);
-        vkDestroyBuffer(device, stagingBuffer, 0);
+        vkFreeMemory(device, stagingBufferMemory, nullptr);
+        vkDestroyBuffer(device, stagingBuffer, nullptr);
     }
 
     // Create our index buffer and upload its data
@@ -1555,8 +1556,8 @@ public:
         // clang-format on
 
         // Create a staging buffer that is writable by the CPU
-        VkBuffer       stagingBuffer       = 0;
-        VkDeviceMemory stagingBufferMemory = 0;
+        VkBuffer       stagingBuffer       = {};
+        VkDeviceMemory stagingBufferMemory = {};
 
         if (!createBuffer(sizeof(indexData),
                           VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
@@ -1573,8 +1574,8 @@ public:
         // Map the buffer into our address space
         if (vkMapMemory(device, stagingBufferMemory, 0, sizeof(indexData), 0, &ptr) != VK_SUCCESS)
         {
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1593,8 +1594,8 @@ public:
                           indexBuffer,
                           indexBufferMemory))
         {
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1604,8 +1605,8 @@ public:
         vulkanAvailable = copyBuffer(indexBuffer, stagingBuffer, sizeof(indexData));
 
         // Free the staging buffer and its memory
-        vkFreeMemory(device, stagingBufferMemory, 0);
-        vkDestroyBuffer(device, stagingBuffer, 0);
+        vkFreeMemory(device, stagingBufferMemory, nullptr);
+        vkDestroyBuffer(device, stagingBuffer, nullptr);
     }
 
     // Create our uniform buffer but don't upload any data yet
@@ -1614,8 +1615,8 @@ public:
         // Create a uniform buffer for every frame that might be in flight to prevent clobbering
         for (std::size_t i = 0; i < swapchainImages.size(); ++i)
         {
-            uniformBuffers.push_back(0);
-            uniformBuffersMemory.push_back(0);
+            uniformBuffers.push_back({});
+            uniformBuffersMemory.push_back({});
 
             // The uniform buffer will be host visible and coherent since we use it for streaming data every frame
             if (!createBuffer(sizeof(Matrix) * 3,
@@ -1657,7 +1658,7 @@ public:
         imageCreateInfo.sharingMode       = VK_SHARING_MODE_EXCLUSIVE;
 
         // Create the image, this does not allocate any memory for it yet
-        if (vkCreateImage(device, &imageCreateInfo, 0, &image) != VK_SUCCESS)
+        if (vkCreateImage(device, &imageCreateInfo, nullptr, &image) != VK_SUCCESS)
             return false;
 
         // Check what kind of memory we need to request from the GPU
@@ -1686,7 +1687,7 @@ public:
         memoryAllocateInfo.memoryTypeIndex      = memoryType;
 
         // Allocate the memory out of the GPU pool for the required memory type
-        if (vkAllocateMemory(device, &memoryAllocateInfo, 0, &imageMemory) != VK_SUCCESS)
+        if (vkAllocateMemory(device, &memoryAllocateInfo, nullptr, &imageMemory) != VK_SUCCESS)
             return false;
 
         // Bind the allocated memory to our image object
@@ -1768,9 +1769,9 @@ public:
                              VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
                              0,
                              0,
+                             nullptr,
                              0,
-                             0,
-                             0,
+                             nullptr,
                              1,
                              &barrier);
 
@@ -1821,7 +1822,7 @@ public:
         imageViewCreateInfo.subresourceRange.layerCount     = 1;
 
         // Create the depth image view
-        if (vkCreateImageView(device, &imageViewCreateInfo, 0, &depthImageView) != VK_SUCCESS)
+        if (vkCreateImageView(device, &imageViewCreateInfo, nullptr, &depthImageView) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -1843,8 +1844,8 @@ public:
         // Create a staging buffer to transfer the data with
         VkDeviceSize imageSize = imageData.getSize().x * imageData.getSize().y * 4;
 
-        VkBuffer       stagingBuffer;
-        VkDeviceMemory stagingBufferMemory;
+        VkBuffer       stagingBuffer       = {};
+        VkDeviceMemory stagingBufferMemory = {};
         createBuffer(imageSize,
                      VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
@@ -1856,8 +1857,8 @@ public:
         // Map the buffer into our address space
         if (vkMapMemory(device, stagingBufferMemory, 0, imageSize, 0, &ptr) != VK_SUCCESS)
         {
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1879,8 +1880,8 @@ public:
                          textureImage,
                          textureImageMemory))
         {
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1897,8 +1898,8 @@ public:
 
         if (vkAllocateCommandBuffers(device, &commandBufferAllocateInfo, &commandBuffer) != VK_SUCCESS)
         {
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1918,8 +1919,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1941,14 +1942,23 @@ public:
         barrier.srcAccessMask                   = 0;
         barrier.dstAccessMask                   = VK_ACCESS_TRANSFER_WRITE_BIT;
 
-        vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, 0, 0, 0, 1, &barrier);
+        vkCmdPipelineBarrier(commandBuffer,
+                             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             0,
+                             0,
+                             nullptr,
+                             0,
+                             nullptr,
+                             1,
+                             &barrier);
 
         if (vkEndCommandBuffer(commandBuffer) != VK_SUCCESS)
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1958,8 +1968,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1970,8 +1980,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -1982,8 +1992,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2012,8 +2022,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2023,8 +2033,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2035,8 +2045,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2047,8 +2057,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2065,9 +2075,9 @@ public:
                              VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                              0,
                              0,
+                             nullptr,
                              0,
-                             0,
-                             0,
+                             nullptr,
                              1,
                              &barrier);
 
@@ -2076,8 +2086,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2087,8 +2097,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2099,8 +2109,8 @@ public:
         {
             vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-            vkFreeMemory(device, stagingBufferMemory, 0);
-            vkDestroyBuffer(device, stagingBuffer, 0);
+            vkFreeMemory(device, stagingBufferMemory, nullptr);
+            vkDestroyBuffer(device, stagingBuffer, nullptr);
 
             vulkanAvailable = false;
             return;
@@ -2109,8 +2119,8 @@ public:
         // Free the command buffer
         vkFreeCommandBuffers(device, commandPool, 1, &commandBuffer);
 
-        vkFreeMemory(device, stagingBufferMemory, 0);
-        vkDestroyBuffer(device, stagingBuffer, 0);
+        vkFreeMemory(device, stagingBufferMemory, nullptr);
+        vkDestroyBuffer(device, stagingBuffer, nullptr);
     }
 
     // Create an image view for our texture
@@ -2128,7 +2138,7 @@ public:
         imageViewCreateInfo.subresourceRange.layerCount     = 1;
 
         // Create our texture image view
-        if (vkCreateImageView(device, &imageViewCreateInfo, 0, &textureImageView) != VK_SUCCESS)
+        if (vkCreateImageView(device, &imageViewCreateInfo, nullptr, &textureImageView) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -2158,7 +2168,7 @@ public:
         samplerCreateInfo.maxLod                  = 0.0f;
 
         // Create our sampler
-        if (vkCreateSampler(device, &samplerCreateInfo, 0, &textureSampler) != VK_SUCCESS)
+        if (vkCreateSampler(device, &samplerCreateInfo, nullptr, &textureSampler) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -2186,7 +2196,7 @@ public:
         descriptorPoolCreateInfo.maxSets                    = static_cast<std::uint32_t>(swapchainImages.size());
 
         // Create the descriptor pool
-        if (vkCreateDescriptorPool(device, &descriptorPoolCreateInfo, 0, &descriptorPool) != VK_SUCCESS)
+        if (vkCreateDescriptorPool(device, &descriptorPoolCreateInfo, nullptr, &descriptorPool) != VK_SUCCESS)
         {
             vulkanAvailable = false;
             return;
@@ -2251,7 +2261,7 @@ public:
             writeDescriptorSets[1].pImageInfo      = &descriptorImageInfo;
 
             // Update the desciptor set
-            vkUpdateDescriptorSets(device, 2, writeDescriptorSets, 0, 0);
+            vkUpdateDescriptorSets(device, 2, writeDescriptorSets, 0, nullptr);
         }
     }
 
@@ -2343,7 +2353,7 @@ public:
                                     1,
                                     &descriptorSets[i],
                                     0,
-                                    0);
+                                    nullptr);
 
             // Draw our primitives
             vkCmdDrawIndexed(commandBuffers[i], 36, 1, 0, 0, 0);
@@ -2369,9 +2379,9 @@ public:
         // Create a semaphore to track when an swapchain image is available for each frame in flight
         for (std::size_t i = 0; i < maxFramesInFlight; ++i)
         {
-            imageAvailableSemaphores.push_back(0);
+            imageAvailableSemaphores.push_back({});
 
-            if (vkCreateSemaphore(device, &semaphoreCreateInfo, 0, &imageAvailableSemaphores[i]) != VK_SUCCESS)
+            if (vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &imageAvailableSemaphores[i]) != VK_SUCCESS)
             {
                 imageAvailableSemaphores.pop_back();
                 vulkanAvailable = false;
@@ -2382,9 +2392,9 @@ public:
         // Create a semaphore to track when rendering is complete for each frame in flight
         for (std::size_t i = 0; i < maxFramesInFlight; ++i)
         {
-            renderFinishedSemaphores.push_back(0);
+            renderFinishedSemaphores.push_back({});
 
-            if (vkCreateSemaphore(device, &semaphoreCreateInfo, 0, &renderFinishedSemaphores[i]) != VK_SUCCESS)
+            if (vkCreateSemaphore(device, &semaphoreCreateInfo, nullptr, &renderFinishedSemaphores[i]) != VK_SUCCESS)
             {
                 renderFinishedSemaphores.pop_back();
                 vulkanAvailable = false;
@@ -2404,9 +2414,9 @@ public:
         // Create a fence to track when queue submission is complete for each frame in flight
         for (std::size_t i = 0; i < maxFramesInFlight; ++i)
         {
-            fences.push_back(0);
+            fences.push_back({});
 
-            if (vkCreateFence(device, &fenceCreateInfo, 0, &fences[i]) != VK_SUCCESS)
+            if (vkCreateFence(device, &fenceCreateInfo, nullptr, &fences[i]) != VK_SUCCESS)
             {
                 fences.pop_back();
                 vulkanAvailable = false;

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -737,7 +737,7 @@ void Shader::bind(const Shader* shader)
     else
     {
         // Bind no shader
-        glCheck(GLEXT_glUseProgramObject(0));
+        glCheck(GLEXT_glUseProgramObject({}));
     }
 }
 

--- a/src/SFML/Window/OSX/HIDInputManager.mm
+++ b/src/SFML/Window/OSX/HIDInputManager.mm
@@ -98,7 +98,7 @@ HIDInputManager::HIDInputManager()
     TISInputSourceRef tis = TISCopyCurrentKeyboardLayoutInputSource();
     m_layoutData          = static_cast<CFDataRef>(TISGetInputSourceProperty(tis, kTISPropertyUnicodeKeyLayoutData));
 
-    if (m_layoutData == 0)
+    if (m_layoutData == nil)
     {
         sf::err() << "Cannot get the keyboard layout" << std::endl;
         freeUp();
@@ -303,16 +303,16 @@ void HIDInputManager::freeUp()
 {
     m_isValid = false;
 
-    if (m_layoutData != 0)
+    if (m_layoutData != nil)
         CFRelease(m_layoutData);
 
-    m_layoutData = 0;
+    m_layoutData = nil;
 
     // Do not release m_layout! It is owned by m_layoutData.
-    if (m_manager != 0)
+    if (m_manager != nil)
         CFRelease(m_manager);
 
-    m_manager = 0;
+    m_manager = nil;
 
     for (unsigned int i = 0; i < Keyboard::KeyCount; ++i)
     {
@@ -333,7 +333,7 @@ CFSetRef HIDInputManager::copyDevices(UInt32 page, UInt32 usage)
     IOHIDManagerSetDeviceMatching(m_manager, mask);
 
     CFRelease(mask);
-    mask = 0;
+    mask = nil;
 
     CFSetRef devices = IOHIDManagerCopyDevices(m_manager);
     if (devices == nullptr)
@@ -360,7 +360,7 @@ bool HIDInputManager::isPressed(IOHIDElements& elements)
 
     for (auto it = elements.begin(); it != elements.end(); /* noop */)
     {
-        IOHIDValueRef value = 0;
+        IOHIDValueRef value = nil;
 
         IOHIDDeviceRef device = IOHIDElementGetDevice(*it);
         IOHIDDeviceGetValue(device, *it, &value);

--- a/src/SFML/Window/OSX/HIDJoystickManager.cpp
+++ b/src/SFML/Window/OSX/HIDJoystickManager.cpp
@@ -101,8 +101,8 @@ HIDJoystickManager::~HIDJoystickManager()
 {
     IOHIDManagerUnscheduleFromRunLoop(m_manager, CFRunLoopGetCurrent(), runLoopMode);
 
-    IOHIDManagerRegisterDeviceMatchingCallback(m_manager, nullptr, 0);
-    IOHIDManagerRegisterDeviceRemovalCallback(m_manager, nullptr, 0);
+    IOHIDManagerRegisterDeviceMatchingCallback(m_manager, nullptr, nullptr);
+    IOHIDManagerRegisterDeviceRemovalCallback(m_manager, nullptr, nullptr);
 
     IOHIDManagerClose(m_manager, kIOHIDOptionsTypeNone);
 }

--- a/src/SFML/Window/OSX/InputImpl.mm
+++ b/src/SFML/Window/OSX/InputImpl.mm
@@ -109,7 +109,7 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const WindowBase& window)
     }
     else
     {
-        if (nsHandle != 0)
+        if (nsHandle != nil)
             sf::err() << "The system handle is neither a <NSWindow*> nor <NSView*>"
                       << "object. This shouldn't happen." << std::endl;
         // Else: this probably means the SFML window was previously closed.

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -202,15 +202,15 @@ bool JoystickImpl::open(unsigned int index)
     CFSetGetValues(devices, devicesArray.data());
 
     // Get the desired joystick.
-    IOHIDDeviceRef self = 0;
-    for (CFIndex i(0); self == 0 && i < joysticksCount; ++i)
+    IOHIDDeviceRef self = nil;
+    for (CFIndex i(0); self == nil && i < joysticksCount; ++i)
     {
         IOHIDDeviceRef d = static_cast<IOHIDDeviceRef>(const_cast<void*>(devicesArray[static_cast<std::size_t>(i)]));
         if (deviceLoc == HIDInputManager::getLocationID(d))
             self = d;
     }
 
-    if (self == 0)
+    if (self == nil)
     {
         CFRelease(devices);
         return false;
@@ -440,7 +440,7 @@ JoystickState JoystickImpl::update()
     unsigned int i = 0;
     for (auto it = m_buttons.begin(); it != m_buttons.end(); ++it, ++i)
     {
-        IOHIDValueRef value = 0;
+        IOHIDValueRef value = nil;
         IOHIDDeviceGetValue(IOHIDElementGetDevice(*it), *it, &value);
 
         // Check for plug out.
@@ -456,7 +456,7 @@ JoystickState JoystickImpl::update()
     // Update axes' state
     for (const auto& [axis, iohidElementRef] : m_axis)
     {
-        IOHIDValueRef value = 0;
+        IOHIDValueRef value = nil;
         IOHIDDeviceGetValue(IOHIDElementGetDevice(iohidElementRef), iohidElementRef, &value);
 
         // Check for plug out.
@@ -493,7 +493,7 @@ JoystickState JoystickImpl::update()
     //
     if (m_hat != nullptr)
     {
-        IOHIDValueRef value = 0;
+        IOHIDValueRef value = nil;
         IOHIDDeviceGetValue(IOHIDElementGetDevice(m_hat), m_hat, &value);
 
         // Check for plug out.

--- a/src/SFML/Window/OSX/NSImage+raw.mm
+++ b/src/SFML/Window/OSX/NSImage+raw.mm
@@ -34,7 +34,7 @@
 {
     // Create an empty image representation.
     NSBitmapImageRep* bitmap = [[NSBitmapImageRep alloc]
-        initWithBitmapDataPlanes:0 // if 0: only allocate memory
+        initWithBitmapDataPlanes:nil // if nil: only allocate memory
                       pixelsWide:(static_cast<NSInteger>(size.width))pixelsHigh
                                 :(static_cast<NSInteger>(size.height))bitsPerSample:8 // The number of bits used to specify
                  // one pixel in a single component of the data.

--- a/src/SFML/Window/OSX/SFContext.mm
+++ b/src/SFML/Window/OSX/SFContext.mm
@@ -113,7 +113,7 @@ GlFunctionPointer SFContext::getFunction(const char* name)
     if (!image)
         image = dlopen("/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL", RTLD_LAZY);
 
-    return (image ? reinterpret_cast<GlFunctionPointer>(reinterpret_cast<intptr_t>(dlsym(image, name))) : 0);
+    return (image ? reinterpret_cast<GlFunctionPointer>(reinterpret_cast<intptr_t>(dlsym(image, name))) : nil);
 }
 
 

--- a/src/SFML/Window/OSX/SFOpenGLView+keyboard.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView+keyboard.mm
@@ -78,7 +78,7 @@
     // Transmit to non-SFML responder
     [[self nextResponder] keyDown:theEvent];
 
-    if (m_requester == 0)
+    if (m_requester == nil)
         return;
 
     // Handle key down event
@@ -153,7 +153,7 @@
     // Transmit to non-SFML responder
     [[self nextResponder] keyUp:theEvent];
 
-    if (m_requester == 0)
+    if (m_requester == nil)
         return;
 
     sf::Event::KeyEvent key = [SFOpenGLView convertNSKeyEventToSFMLEvent:theEvent];
@@ -169,7 +169,7 @@
     // Transmit to non-SFML responder
     [[self nextResponder] flagsChanged:theEvent];
 
-    if (m_requester == 0)
+    if (m_requester == nil)
         return;
 
     NSUInteger modifiers = [theEvent modifierFlags];

--- a/src/SFML/Window/OSX/SFOpenGLView+mouse.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView+mouse.mm
@@ -79,7 +79,7 @@
     m_mouseIsIn     = [self isMouseInside];
 
     // Send event if needed.
-    if (m_requester != 0)
+    if (m_requester != nil)
     {
         if (mouseWasIn && !m_mouseIsIn)
             m_requester->mouseMovedOut();
@@ -133,7 +133,7 @@
 {
     sf::Mouse::Button button = [SFOpenGLView mouseButtonFromEvent:theEvent];
 
-    if (m_requester != 0)
+    if (m_requester != nil)
     {
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
 
@@ -178,7 +178,7 @@
 {
     sf::Mouse::Button button = [SFOpenGLView mouseButtonFromEvent:theEvent];
 
-    if (m_requester != 0)
+    if (m_requester != nil)
     {
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
 
@@ -243,7 +243,7 @@
     // (mouseEntered: and mouseExited: are not immediately called
     //  when the mouse is dragged. That would be too easy!)
     [self updateMouseState];
-    if ((m_requester != 0) && m_mouseIsIn)
+    if ((m_requester != nil) && m_mouseIsIn)
         m_requester->mouseMovedAt(static_cast<int>(loc.x), static_cast<int>(loc.y));
 }
 
@@ -299,7 +299,7 @@
 ////////////////////////////////////////////////////////
 - (void)scrollWheel:(NSEvent*)theEvent
 {
-    if (m_requester != 0)
+    if (m_requester != nil)
     {
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
         m_requester->mouseWheelScrolledAt(static_cast<float>([theEvent deltaX]),

--- a/src/SFML/Window/OSX/SFOpenGLView.mm
+++ b/src/SFML/Window/OSX/SFOpenGLView.mm
@@ -101,7 +101,7 @@
 {
     if ((self = [super initWithFrame:frameRect]))
     {
-        [self setRequesterTo:0];
+        [self setRequesterTo:nullptr];
         [self enableKeyRepeat];
 
         // Register for mouse move event
@@ -242,7 +242,7 @@
     m_scaleFactor            = m_highDpi ? [screen backingScaleFactor] : 1.0;
 
     // Send a resize event if the scaling factor changed
-    if ((m_scaleFactor != oldScaleFactor) && (m_requester != 0))
+    if ((m_scaleFactor != oldScaleFactor) && (m_requester != nullptr))
     {
         NSSize newSize = [self frame].size;
         m_requester->windowResized({static_cast<unsigned int>(newSize.width), static_cast<unsigned int>(newSize.height)});
@@ -272,7 +272,7 @@
     [self update];
 
     // Send an event
-    if (m_requester == 0)
+    if (m_requester == nullptr)
         return;
 
     // The new size
@@ -319,7 +319,7 @@
     [self addTrackingArea:m_trackingArea];
 
     // Fire an mouse entered event if needed
-    if (!m_mouseIsIn && (m_requester != 0))
+    if (!m_mouseIsIn && (m_requester != nullptr))
         m_requester->mouseMovedIn();
 
     // Update status
@@ -333,7 +333,7 @@
     [self removeTrackingArea:m_trackingArea];
 
     // Fire an mouse left event if needed
-    if (m_mouseIsIn && (m_requester != 0))
+    if (m_mouseIsIn && (m_requester != nullptr))
         m_requester->mouseMovedOut();
 
     // Update status
@@ -359,7 +359,7 @@
     [m_silentResponder release];
     [m_trackingArea release];
 
-    [self setRequesterTo:0];
+    [self setRequesterTo:nullptr];
 
     [super dealloc];
 }

--- a/src/SFML/Window/OSX/SFViewController.mm
+++ b/src/SFML/Window/OSX/SFViewController.mm
@@ -44,7 +44,7 @@
 {
     if ((self = [super init]))
     {
-        m_requester = 0;
+        m_requester = nullptr;
 
         // Retain the view for our own use.
         m_view = [view retain];
@@ -261,7 +261,7 @@
     }
 
     // If we don't have a requester we don't fetch event.
-    if (m_requester != 0)
+    if (m_requester != nullptr)
         [SFApplication processEvent];
 }
 

--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -99,7 +99,7 @@
     {
         m_window        = nil;
         m_oglView       = nil;
-        m_requester     = 0;
+        m_requester     = nil;
         m_fullscreen    = NO; // assuming this is the case... too hard to handle anyway.
         m_restoreResize = NO;
         m_highDpi       = NO;
@@ -152,7 +152,7 @@
     {
         m_window        = nil;
         m_oglView       = nil;
-        m_requester     = 0;
+        m_requester     = nil;
         m_fullscreen    = ((style & sf::Style::Fullscreen) != 0) ? YES : NO;
         m_restoreResize = NO;
         m_highDpi       = NO;
@@ -465,7 +465,7 @@
             height = static_cast<unsigned int>(maxVisibleHeight);
 
             // The size is not the requested one, we fire an event
-            if (m_requester != 0)
+            if (m_requester != nil)
                 m_requester->windowResized({width, height - static_cast<unsigned int>([self titlebarHeight])});
         }
 
@@ -506,7 +506,7 @@
     [self applyContext:nil];
     [m_window close];
     [m_window setDelegate:nil];
-    [self setRequesterTo:0];
+    [self setRequesterTo:nil];
     [SFApplication processEvent];
 }
 
@@ -570,7 +570,7 @@
     }
 
     // If we don't have a requester we don't fetch event.
-    if (m_requester != 0)
+    if (m_requester != nil)
         [SFApplication processEvent];
 }
 
@@ -592,7 +592,7 @@
 {
     (void)sender;
 
-    if (m_requester == 0)
+    if (m_requester == nil)
         return YES;
 
     m_requester->windowClosed();

--- a/src/SFML/Window/OSX/WindowImplCocoa.mm
+++ b/src/SFML/Window/OSX/WindowImplCocoa.mm
@@ -139,7 +139,7 @@ WindowImplCocoa::~WindowImplCocoa()
     // Tell the window/view controller (and the OpenGL view) that the delegate
     // (this object) no longer exists to prevent events being sent to the window
     // after it has been deleted.
-    [m_delegate setRequesterTo:0];
+    [m_delegate setRequesterTo:nil];
     [m_delegate release];
 
     // Put the next window in front, if any.

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -216,7 +216,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
             int            format;
             unsigned long  items;
             unsigned long  remainingBytes;
-            unsigned char* data = 0;
+            unsigned char* data = nullptr;
 
             // The selection owner should have wrote the selection
             // data to the specified window property

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -41,8 +41,8 @@
 
 namespace
 {
-udev*         udevContext = 0;
-udev_monitor* udevMonitor = 0;
+udev*         udevContext = nullptr;
+udev_monitor* udevMonitor = nullptr;
 
 struct JoystickRecord
 {
@@ -459,7 +459,7 @@ void JoystickImpl::initialize()
                   << error << std::endl;
 
             udev_monitor_unref(udevMonitor);
-            udevMonitor = 0;
+            udevMonitor = nullptr;
         }
         else
         {
@@ -471,7 +471,7 @@ void JoystickImpl::initialize()
                       << error << std::endl;
 
                 udev_monitor_unref(udevMonitor);
-                udevMonitor = 0;
+                udevMonitor = nullptr;
             }
         }
     }
@@ -488,14 +488,14 @@ void JoystickImpl::cleanup()
     if (udevMonitor)
     {
         udev_monitor_unref(udevMonitor);
-        udevMonitor = 0;
+        udevMonitor = nullptr;
     }
 
     // Unreference the udev context to destroy it
     if (udevContext)
     {
         udev_unref(udevContext);
-        udevContext = 0;
+        udevContext = nullptr;
     }
 }
 

--- a/src/SFML/Window/Unix/VulkanImplX11.cpp
+++ b/src/SFML/Window/Unix/VulkanImplX11.cpp
@@ -127,11 +127,11 @@ bool VulkanImplX11::isAvailable(bool requireGraphics)
 
             std::uint32_t extensionCount = 0;
 
-            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, nullptr);
+            wrapper.vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
 
             extensionProperties.resize(extensionCount);
 
-            wrapper.vkEnumerateInstanceExtensionProperties(0, &extensionCount, extensionProperties.data());
+            wrapper.vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, extensionProperties.data());
 
             // Check if the necessary extensions are available
             bool hasVkKhrSurface         = false;
@@ -165,7 +165,7 @@ bool VulkanImplX11::isAvailable(bool requireGraphics)
 VulkanFunctionPointer VulkanImplX11::getFunction(const char* name)
 {
     if (!isAvailable(false))
-        return 0;
+        return nullptr;
 
     return reinterpret_cast<VulkanFunctionPointer>(dlsym(wrapper.library, name));
 }


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Adds `modernize-use-nullptr` clang-tidy check.

This PR is related to the issue #

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::Vector2u modeSize{200, 200};
    sf::RenderWindow window(sf::VideoMode(modeSize), "SFML works!");
    sf::CircleShape shape(100.f);
    shape.setFillColor(sf::Color::Green);

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }

        window.clear();
        window.draw(shape);
        window.display();
    }

    return 0;
}

g++ main.cpp -o sfml-app -I ./include/ -L./build/lib -lsfml-audio -lsfml-graphics -lsfml-system -lsfml-window

./sfml-app
```
