### PR TITLE
Simplify options for extra targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       run: sudo apt-get install clang-format-${{ matrix.version }}
 
     - name: Format Code
-      run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-${{ matrix.version }} -P $GITHUB_WORKSPACE/cmake/Format.cmake
+      run: cmake -DSFML_FORMAT=ON -DCLANG_FORMAT_EXECUTABLE=clang-format-${{ matrix.version }} -P $GITHUB_WORKSPACE/cmake/Format.cmake
 
     - name: Check Formatting
       run: git diff --exit-code
@@ -170,7 +170,7 @@ jobs:
 
     - name: Configure
       shell: bash
-      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DSFML_BUILD_EXAMPLES=TRUE -DSFML_BUILD_TEST_SUITE=TRUE ${{matrix.platform.flags}}
+      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DSFML_TIDY=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DSFML_BUILD_EXAMPLES=TRUE -DSFML_BUILD_TEST_SUITE=TRUE ${{matrix.platform.flags}}
 
     - name: Analyze Code
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,19 +500,6 @@ string(REGEX REPLACE "/" "\\\\\\\\" NSIS_IMAGE_PATH ${NSIS_IMAGE_PATH})
 set(CPACK_NSIS_INSTALLER_MUI_ICON_CODE "!define MUI_WELCOMEFINISHPAGE_BITMAP \\\"${NSIS_IMAGE_PATH}sidebar.bmp\\\"\n!define MUI_HEADERIMAGE_BITMAP \\\"${NSIS_IMAGE_PATH}header.bmp\\\"\n!define MUI_ICON \\\"${NSIS_IMAGE_PATH}sfml.ico\\\"")
 
 include(CPack)
-
-# configure extras by default when building SFML directly, otherwise hide them
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    set(SFML_CONFIGURE_EXTRAS_DEFAULT TRUE)
-else()
-    set(SFML_CONFIGURE_EXTRAS_DEFAULT FALSE)
-endif()
-sfml_set_option(SFML_CONFIGURE_EXTRAS ${SFML_CONFIGURE_EXTRAS_DEFAULT} BOOL "TRUE to configure extras, FALSE to ignore them")
-
-if(NOT SFML_CONFIGURE_EXTRAS)
-    return()
-endif()
-
 # add an option for building the API documentation
 sfml_set_option(SFML_BUILD_DOC FALSE BOOL "TRUE to generate the API documentation, FALSE to ignore it")
 if(SFML_BUILD_DOC)
@@ -542,12 +529,18 @@ if(SFML_BUILD_TEST_SUITE)
     endif()
 endif()
 
-sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires version 12, 13, or 14")
-add_custom_target(format
-    COMMAND ${CMAKE_COMMAND} -DCLANG_FORMAT_EXECUTABLE=${CLANG_FORMAT_EXECUTABLE} -P ./cmake/Format.cmake
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)
+sfml_set_option(SFML_FORMAT FALSE BOOL "TRUE to include the SFML format target, FALSE otherwise")
+if (SFML_FORMAT)
+    sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires version 12, 13, or 14")
+    add_custom_target(format
+        COMMAND ${CMAKE_COMMAND} -DCLANG_FORMAT_EXECUTABLE=${CLANG_FORMAT_EXECUTABLE} -P ./cmake/Format.cmake
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)
+endif()
 
-sfml_set_option(CLANG_TIDY_EXECUTABLE clang-tidy STRING "Override clang-tidy executable, requires minimum version 14")
-add_custom_target(tidy
-    COMMAND ${CMAKE_COMMAND} -DCLANG_TIDY_EXECUTABLE=${CLANG_TIDY_EXECUTABLE} -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} -P ./cmake/Tidy.cmake
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)
+sfml_set_option(SFML_TIDY FALSE BOOL "TRUE to include the SFML tidy target, FALSE otherwise")
+if (SFML_TIDY)
+    sfml_set_option(CLANG_TIDY_EXECUTABLE clang-tidy STRING "Override clang-tidy executable, requires minimum version 14")
+    add_custom_target(tidy
+        COMMAND ${CMAKE_COMMAND} -DCLANG_TIDY_EXECUTABLE=${CLANG_TIDY_EXECUTABLE} -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} -P ./cmake/Tidy.cmake
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)
+endif()


### PR DESCRIPTION
Currently the options for enabling/disabling our extra cmake targets are inconsistent, have unnecessary dependencies between each other and don't give users full control over which targets they can use.

This PR:
- Makes each target only relate to one configuration option, so is simpler
- Gives the user full control over which targets they include in the SFML project
- Makes the tidy/format options false by default to be consistent with the other extra targets (so also avoids a logic branch in our cmake script)
- Means less maintenance/support overall