### PR TITLE
Add clang-tidy portability checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >
   modernize-use-equals-default,
   modernize-use-equals-delete,  
   modernize-use-nullptr,
+  portability-*,
   readability-container-size-empty,
   readability-identifier-naming,
   readability-isolate-declaration,


### PR DESCRIPTION
## Description

No fixes required 🙂

There are only 3 portability checks. Read about there here: https://clang.llvm.org/extra/clang-tidy/checks/list.html