### PR TITLE
Added readability-redundant-*, readability-simplify-* checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,8 @@ Checks: >
   readability-isolate-declaration,
   readability-qualified-auto,
   readability-redundant-access-specifiers,
+  readability-redundant-*,
+  readability-simplify-*,
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-core.NullDereference,
   -clang-analyzer-nullability.NullablePassedToNonnull,

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -97,10 +97,7 @@ public:
         m_text.setPosition({30.f, 20.f});
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/wave.vert", "resources/blur.frag"))
-            return false;
-
-        return true;
+        return m_shader.loadFromFile("resources/wave.vert", "resources/blur.frag");
     }
 
     void onUpdate(float time, float x, float y) override
@@ -152,10 +149,7 @@ public:
         }
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/storm.vert", "resources/blink.frag"))
-            return false;
-
-        return true;
+        return m_shader.loadFromFile("resources/storm.vert", "resources/blink.frag");
     }
 
     void onUpdate(float time, float x, float y) override

--- a/examples/sound_capture/SoundCapture.cpp
+++ b/examples/sound_capture/SoundCapture.cpp
@@ -17,7 +17,7 @@
 int main()
 {
     // Check that the device can capture audio
-    if (sf::SoundRecorder::isAvailable() == false)
+    if (!sf::SoundRecorder::isAvailable())
     {
         std::cout << "Sorry, audio capture is not supported by your system" << std::endl;
         return EXIT_SUCCESS;

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -195,7 +195,7 @@ bool Music::onGetData(SoundStream::Chunk& data)
 
     // Check if we have stopped obtaining samples or reached either the EOF or the loop end point
     return (data.sampleCount != 0) && (currentOffset < m_file.getSampleCount()) &&
-           !(currentOffset == loopEnd && m_loopSpan.length != 0);
+           (currentOffset != loopEnd || m_loopSpan.length == 0);
 }
 
 

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -52,10 +52,8 @@ SoundBuffer::SoundBuffer()
 
 
 ////////////////////////////////////////////////////////////
-SoundBuffer::SoundBuffer(const SoundBuffer& copy) :
-m_samples(copy.m_samples),
-m_duration(copy.m_duration),
-m_sounds() // don't copy the attached sounds
+SoundBuffer::SoundBuffer(const SoundBuffer& copy) : m_samples(copy.m_samples), m_duration(copy.m_duration)
+// don't copy the attached sounds
 {
     // Create the buffer
     alCheck(alGenBuffers(1, &m_buffer));

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -72,10 +72,7 @@ bool isActive(std::uint64_t id)
 {
     auto it = contextRenderTargetMap.find(sf::Context::getActiveContextId());
 
-    if ((it == contextRenderTargetMap.end()) || (it->second != id))
-        return false;
-
-    return true;
+    return (it != contextRenderTargetMap.end()) && (it->second == id);
 }
 
 // Convert an sf::BlendMode::Factor constant to the corresponding OpenGL constant.

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -256,10 +256,7 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, 0));
 
-    if ((sourceResult == GL_FALSE) || (destinationResult == GL_FALSE))
-        return false;
-
-    return true;
+    return (sourceResult == GL_TRUE) && (destinationResult == GL_TRUE);
 
 #endif // SFML_OPENGL_ES
 }


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Added `readability-redundant-*` and `readability-simplify-*` checks to `clang-tidy`:

- readability-redundant-preprocessor   
- readability-redundant-smartptr-get
- readability-redundant-string-cstr
- readability-redundant-string-init
- readability-simplify-boolean-expr
- readability-simplify-subscript-expr

This PR is related to the issue #

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

Enabled SFML test suite.