### PR TITLE
[2124] FIX Window.setSize() while resizing not working

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -882,7 +882,6 @@ void WindowImplX11::setSize(const Vector2u& size)
         (loopStartTimer.getElapsedTime() < sf::milliseconds(50))) {
         processEvents();
         XResizeWindow(m_display, m_window, size.x, size.y);
-        sf::sleep(sf::milliseconds(2));
     }
     XFlush(m_display);
 }

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -889,7 +889,11 @@ void WindowImplX11::setSize(const Vector2u& size)
         XSync(m_display, False);
         sf::sleep(sf::milliseconds(10));
     }
+    // Flush all of the queued resizes to prevent the window from spazzing.
     XSync(m_display, True);
+    // Do one last resize to ensure the correct resize is queued
+    // This just makes our setSize a bit less lossy than SDL
+    XResizeWindow(m_display, m_window, size.x, size.y);
     XFlush(m_display);
 }
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -873,18 +873,23 @@ void WindowImplX11::setSize(const Vector2u& size)
         XFree(sizeHints);
     }
 
-    // Sometimes, Xorg doesn't want to let the XResizeWindow function call to work.
-    // Looping is an attempt to convice Xorg to allow this resize to occur.
-    // If xorg doesn't allow this resize after 100 milliseconds, or another resize occurs, quit trying.
     Vector2u original_size = getSize();
+    XSync(m_display, False);
+    XResizeWindow(m_display, m_window, size.x, size.y);
+
+    // Sometimes, Xorg doesn't want to let the XResizeWindow function call to
+    // work. Looping is an attempt to convice Xorg to allow this resize to
+    // occur. If xorg doesn't allow this resize after 100 milliseconds, or
+    // another resize occurs, quit trying.
     sf::Clock cancellationTimer;
     while((getSize() != size) &&
         getSize() == original_size &&
         (cancellationTimer.getElapsedTime() < sf::milliseconds(100))) 
     {
-        XResizeWindow(m_display, m_window, size.x, size.y);
+        XSync(m_display, False);
         sf::sleep(sf::milliseconds(10));
     }
+    XSync(m_display, True);
     XFlush(m_display);
 }
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -873,7 +873,7 @@ void WindowImplX11::setSize(const Vector2u& size)
         XFree(sizeHints);
     }
 
-    Vector2u original_size = getSize();
+    Vector2u originalSize = getSize();
     XSync(m_display, False);
     XResizeWindow(m_display, m_window, size.x, size.y);
 
@@ -883,7 +883,7 @@ void WindowImplX11::setSize(const Vector2u& size)
     // another resize occurs, quit trying.
     sf::Clock cancellationTimer;
     while((getSize() != size) &&
-        getSize() == original_size &&
+        getSize() == originalSize &&
         (cancellationTimer.getElapsedTime() < sf::milliseconds(100))) 
     {
         XSync(m_display, False);

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -880,6 +880,7 @@ void WindowImplX11::setSize(const Vector2u& size)
         (cancellationTimer.getElapsedTime() < sf::milliseconds(100))) 
     {
         XResizeWindow(m_display, m_window, size.x, size.y);
+        sf::sleep(sf::milliseconds(10));
     }
     XFlush(m_display);
 }

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -873,6 +873,9 @@ void WindowImplX11::setSize(const Vector2u& size)
         XFree(sizeHints);
     }
 
+    // Sometimes, Xorg doesn't want to let the XResizeWindow function call to work.
+    // Looping is an attempt to convice Xorg to allow this resize to occur.
+    // If xorg doesn't allow this resize after 100 milliseconds, or another resize occurs, quit trying.
     Vector2u original_size = getSize();
     sf::Clock cancellationTimer;
     while((getSize() != size) &&

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -387,7 +387,6 @@ m_hiddenCursor   (0),
 m_lastCursor     (None),
 m_keyRepeat      (true),
 m_previousSize   (-1, -1),
-m_resizeOccuredDuringSetSize(false),
 m_useSizeHints   (false),
 m_fullscreen     (false),
 m_cursorGrabbed  (false),
@@ -439,7 +438,6 @@ m_hiddenCursor   (0),
 m_lastCursor     (None),
 m_keyRepeat      (true),
 m_previousSize   (-1, -1),
-m_resizeOccuredDuringSetSize(false),
 m_useSizeHints   (false),
 m_fullscreen     ((style & Style::Fullscreen) != 0),
 m_cursorGrabbed  (m_fullscreen),
@@ -875,12 +873,12 @@ void WindowImplX11::setSize(const Vector2u& size)
         XFree(sizeHints);
     }
 
-    m_resizeOccuredDuringSetSize = false;
-    sf::Clock loopStartTimer;
+    Vector2u original_size = getSize();
+    sf::Clock cancellationTimer;
     while((getSize() != size) &&
-        !m_resizeOccuredDuringSetSize &&
-        (loopStartTimer.getElapsedTime() < sf::milliseconds(50))) {
-        processEvents();
+        getSize() == original_size &&
+        (cancellationTimer.getElapsedTime() < sf::milliseconds(100))) 
+    {
         XResizeWindow(m_display, m_window, size.x, size.y);
     }
     XFlush(m_display);
@@ -1746,8 +1744,6 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
 
                 m_previousSize.x = windowEvent.xconfigure.width;
                 m_previousSize.y = windowEvent.xconfigure.height;
-
-                m_resizeOccuredDuringSetSize = true;
             }
             break;
         }

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -300,26 +300,25 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    ::Window   m_window;                      ///< X identifier defining our window
-    ::Display* m_display;                     ///< Pointer to the display
-    int        m_screen;                      ///< Screen identifier
-    XIM        m_inputMethod;                 ///< Input method linked to the X display
-    XIC        m_inputContext;                ///< Input context used to get unicode input in our window
-    bool       m_isExternal;                  ///< Tell whether the window has been created externally or by SFML
-    RRMode     m_oldVideoMode;                ///< Video mode in use before we switch to fullscreen
-    RRCrtc     m_oldRRCrtc;                   ///< RRCrtc in use before we switch to fullscreen
-    ::Cursor   m_hiddenCursor;                ///< As X11 doesn't provide cursor hiding, we must create a transparent one
-    ::Cursor   m_lastCursor;                  ///< Last cursor used -- this data is not owned by the window and is required to be always valid
-    bool       m_keyRepeat;                   ///< Is the KeyRepeat feature enabled?
-    Vector2i   m_previousSize;                ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
-    bool       m_resizeOccuredDuringSetSize;  ///< if resize occurs during setSize, setSize knows to stop looping XResizeWindow
-    bool       m_useSizeHints;                ///< Is the size of the window fixed with size hints?
-    bool       m_fullscreen;                  ///< Is the window in fullscreen?
-    bool       m_cursorGrabbed;               ///< Is the mouse cursor trapped?
-    bool       m_windowMapped;                ///< Has the window been mapped by the window manager?
-    Pixmap     m_iconPixmap;                  ///< The current icon pixmap if in use
-    Pixmap     m_iconMaskPixmap;              ///< The current icon mask pixmap if in use
-    ::Time     m_lastInputTime;               ///< Last time we received user input
+    ::Window   m_window;         ///< X identifier defining our window
+    ::Display* m_display;        ///< Pointer to the display
+    int        m_screen;         ///< Screen identifier
+    XIM        m_inputMethod;    ///< Input method linked to the X display
+    XIC        m_inputContext;   ///< Input context used to get unicode input in our window
+    bool       m_isExternal;     ///< Tell whether the window has been created externally or by SFML
+    RRMode     m_oldVideoMode;   ///< Video mode in use before we switch to fullscreen
+    RRCrtc     m_oldRRCrtc;      ///< RRCrtc in use before we switch to fullscreen
+    ::Cursor   m_hiddenCursor;   ///< As X11 doesn't provide cursor hiding, we must create a transparent one
+    ::Cursor   m_lastCursor;     ///< Last cursor used -- this data is not owned by the window and is required to be always valid
+    bool       m_keyRepeat;      ///< Is the KeyRepeat feature enabled?
+    Vector2i   m_previousSize;   ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
+    bool       m_useSizeHints;   ///< Is the size of the window fixed with size hints?
+    bool       m_fullscreen;     ///< Is the window in fullscreen?
+    bool       m_cursorGrabbed;  ///< Is the mouse cursor trapped?
+    bool       m_windowMapped;   ///< Has the window been mapped by the window manager?
+    Pixmap     m_iconPixmap;     ///< The current icon pixmap if in use
+    Pixmap     m_iconMaskPixmap; ///< The current icon mask pixmap if in use
+    ::Time     m_lastInputTime;  ///< Last time we received user input
 };
 
 } // namespace priv

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -300,25 +300,26 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    ::Window   m_window;         ///< X identifier defining our window
-    ::Display* m_display;        ///< Pointer to the display
-    int        m_screen;         ///< Screen identifier
-    XIM        m_inputMethod;    ///< Input method linked to the X display
-    XIC        m_inputContext;   ///< Input context used to get unicode input in our window
-    bool       m_isExternal;     ///< Tell whether the window has been created externally or by SFML
-    RRMode     m_oldVideoMode;   ///< Video mode in use before we switch to fullscreen
-    RRCrtc     m_oldRRCrtc;      ///< RRCrtc in use before we switch to fullscreen
-    ::Cursor   m_hiddenCursor;   ///< As X11 doesn't provide cursor hiding, we must create a transparent one
-    ::Cursor   m_lastCursor;     ///< Last cursor used -- this data is not owned by the window and is required to be always valid
-    bool       m_keyRepeat;      ///< Is the KeyRepeat feature enabled?
-    Vector2i   m_previousSize;   ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
-    bool       m_useSizeHints;   ///< Is the size of the window fixed with size hints?
-    bool       m_fullscreen;     ///< Is the window in fullscreen?
-    bool       m_cursorGrabbed;  ///< Is the mouse cursor trapped?
-    bool       m_windowMapped;   ///< Has the window been mapped by the window manager?
-    Pixmap     m_iconPixmap;     ///< The current icon pixmap if in use
-    Pixmap     m_iconMaskPixmap; ///< The current icon mask pixmap if in use
-    ::Time     m_lastInputTime;  ///< Last time we received user input
+    ::Window   m_window;                      ///< X identifier defining our window
+    ::Display* m_display;                     ///< Pointer to the display
+    int        m_screen;                      ///< Screen identifier
+    XIM        m_inputMethod;                 ///< Input method linked to the X display
+    XIC        m_inputContext;                ///< Input context used to get unicode input in our window
+    bool       m_isExternal;                  ///< Tell whether the window has been created externally or by SFML
+    RRMode     m_oldVideoMode;                ///< Video mode in use before we switch to fullscreen
+    RRCrtc     m_oldRRCrtc;                   ///< RRCrtc in use before we switch to fullscreen
+    ::Cursor   m_hiddenCursor;                ///< As X11 doesn't provide cursor hiding, we must create a transparent one
+    ::Cursor   m_lastCursor;                  ///< Last cursor used -- this data is not owned by the window and is required to be always valid
+    bool       m_keyRepeat;                   ///< Is the KeyRepeat feature enabled?
+    Vector2i   m_previousSize;                ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
+    bool       m_resizeOccuredDuringSetSize;  ///< if resize occurs during setSize, setSize knows to stop looping XResizeWindow
+    bool       m_useSizeHints;                ///< Is the size of the window fixed with size hints?
+    bool       m_fullscreen;                  ///< Is the window in fullscreen?
+    bool       m_cursorGrabbed;               ///< Is the mouse cursor trapped?
+    bool       m_windowMapped;                ///< Has the window been mapped by the window manager?
+    Pixmap     m_iconPixmap;                  ///< The current icon pixmap if in use
+    Pixmap     m_iconMaskPixmap;              ///< The current icon mask pixmap if in use
+    ::Time     m_lastInputTime;               ///< Last time we received user input
 };
 
 } // namespace priv


### PR DESCRIPTION
I deleted my repository causing
https://github.com/SFML/SFML/pull/2316 to disappear. This is a new PR to resolve that.

## Description

This fix forces XResizeWindow to occur after the user is done resizing the window. If you use the test code I have provided, you will see that setSize is called after a resize event is done. Before this commit, setSize would run XResizeWindow, but since the user's mouse was still holding onto the window, the window would resize to whatever size the user's mouse is at. With my fix, XResizeWindow is GUARENTEED to occur once the user is done dragging the window.

Here is a video demonstrating my fix working: https://youtu.be/mLMVFbeuRIs

This PR is related to the issue #2124 

## Tasks

X11 LINUX ISSUE ONLY
* [x] Tested on Linux

## How to test this PR?

After you install SFML, go ahead and compile, link, and run the code below. You will see that the resize event is seemingly not called.

Install my fix, compile, link, and run the code below. You will see the resize event being called and resizing the window if you drag and drop the window quickly enough.

```cpp
#include <SFML/Graphics.hpp>
#include <SFML/Window.hpp>
#include <SFML/System.hpp>

int main() {
    sf::RenderWindow window(sf::VideoMode(200, 200), "SFML works!");

    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
            if (event.type == sf::Event::Resized) {
                const sf::Vector2u window_size(event.size.width, event.size.height);

                if (window_size.x < 200) {
                    window.setSize(sf::Vector2u(200, window_size.y));
                }
                if (window_size.y < 200) {
                    window.setSize(sf::Vector2u(window_size.x, 200));
                }
            }
        }

        window.clear();
        window.display();
    }

    return 0;
}
```

## SDL2 comparison:

SDL2 does the same thing. They loop X calls for the window set size function. https://github.com/libsdl-org/SDL/blob/main/src/video/x11/SDL_x11window.c

Scroll down to X11_SetWindowSize and at the end of the function you will see them looping X calls.

The end result is similar to what I am doing. You will notice that if you drag and drop an sdl window quickly enough, a forced resize can occur after a resize event has been called.

This is the min reproducible with sdl:
```c++
// SDL2 Hello, World!
// This should display a white screen for 2 seconds
// compile with: clang++ main.cpp -o hello_sdl2 -lSDL2
// run with: ./hello_sdl2
#include <SDL2/SDL.h>
#include <stdio.h>

#define SCREEN_WIDTH 640
#define SCREEN_HEIGHT 480

int main(int argc, char* args[]) {
    SDL_Window* window = NULL;
    SDL_Surface* screenSurface = NULL;
    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
        fprintf(stderr, "could not initialize sdl2: %s\n", SDL_GetError());
        return 1;
    }
    window = SDL_CreateWindow(
            "hello_sdl2",
            SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
            SCREEN_WIDTH, SCREEN_HEIGHT,
            SDL_WINDOW_RESIZABLE
            );
    if (window == NULL) {
        fprintf(stderr, "could not create window: %s\n", SDL_GetError());
        return 1;
    }
    bool game_is_still_running = true;
    while (game_is_still_running) {
        SDL_Event event;
        while (SDL_PollEvent(&event)) {  // poll until all events are handled!
                                         // decide what to do with this event.
            switch (event.type) {
                case SDL_QUIT:
                    game_is_still_running = false;
                    break;
                case SDL_WINDOWEVENT: 
                    switch (event.window.event) {
                        case SDL_WINDOWEVENT_RESIZED:
                            {
                                const int new_w = event.window.data1, new_h = event.window.data2;
                                if (new_w < 200) {
                                    SDL_SetWindowSize(window, 200, new_h);
                                }
                                if (new_h < 200) {
                                    SDL_SetWindowSize(window, new_w, 200);
                                }
                                break;
                            }
                        default:
                            break;
                    }
                    break;
                default:
                    break;
            }
        }

        // update game state, draw the current frame
        screenSurface = SDL_GetWindowSurface(window);
        SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0xFF, 0xFF, 0xFF));
        SDL_UpdateWindowSurface(window);
    }
    SDL_DestroyWindow(window);
    SDL_Quit();
    return 0;
}
```



## ADDITIONAL NOTES:
I made a slight change from the original pull request. I added a 2-millisecond sleep during my X calls. That way my loop isn't slamming X calls. 

Edit:
I noticed the window felt funny to use with the sleep. Decided to get rid of that.