### PR TITLE
Add more clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,18 +1,20 @@
 Checks: >
   -*,
   clang-analyzer-*,
+  misc-*,
   modernize-*,
   portability-*,
   readability-*,
-  -clang-analyzer-core.NonNullParamChecker,
-  -clang-analyzer-core.NullDereference,
   -clang-analyzer-nullability.NullablePassedToNonnull,
   -clang-analyzer-optin.cplusplus.VirtualCall,
   -clang-analyzer-optin.osx.*,
-  -clang-analyzer-optin.portability.UnixAPI,
   -clang-analyzer-osx.*,
   -clang-analyzer-security.insecureAPI.rand,
   -clang-analyzer-unix.Malloc,
+  -misc-const-correctness,
+  -misc-misplaced-const,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,
   -modernize-macro-to-enum,
   -modernize-pass-by-value,
@@ -31,7 +33,6 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-uppercase-literal-suffix,
-
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase,           value: CamelCase }
   - { key: readability-identifier-naming.FunctionCase,        value: camelBack }


### PR DESCRIPTION
## Description

The follow clang-tidy checks will be added:

```
clang-analyzer-core.NonNullParamChecker
clang-analyzer-core.NullDereference
clang-analyzer-optin.portability.UnixAPI
misc-confusable-identifiers
misc-definitions-in-headers
misc-misleading-bidirectional
misc-misleading-identifier
misc-new-delete-overloads
misc-non-copyable-objects
misc-redundant-expression
misc-static-assert
misc-throw-by-value-catch-by-reference
misc-unconventional-assign-operator
misc-uniqueptr-reset-release
misc-unused-alias-decls
misc-unused-parameters
misc-unused-using-decls
```

None of these require making any fixes.