### PR TITLE
Use `std::string_view` for parameter type

### DIFF
--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -48,7 +48,7 @@ thread_local ALenum lastError(AL_NO_ERROR);
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-void alCheckError(const std::filesystem::path& file, unsigned int line, const char* expression)
+void alCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression)
 {
     // Get the last error
     ALenum errorCode = alGetError();

--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -30,6 +30,7 @@
 #include <SFML/Config.hpp>
 
 #include <filesystem>
+#include <string_view>
 
 #if defined(__APPLE__)
 #pragma GCC diagnostic push
@@ -73,7 +74,7 @@ namespace sf::priv
 /// \param expression The evaluated expression as a string
 ///
 ////////////////////////////////////////////////////////////
-void alCheckError(const std::filesystem::path& file, unsigned int line, const char* expression);
+void alCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression);
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -35,7 +35,7 @@
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-void glCheckError(const std::filesystem::path& file, unsigned int line, const char* expression)
+void glCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression)
 {
     // Get the last error
     GLenum errorCode = glGetError();

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -32,6 +32,7 @@
 #include <SFML/Graphics/GLExtensions.hpp>
 
 #include <filesystem>
+#include <string_view>
 
 
 namespace sf::priv
@@ -65,6 +66,6 @@ namespace sf::priv
 /// \param expression The evaluated expression as a string
 ///
 ////////////////////////////////////////////////////////////
-void glCheckError(const std::filesystem::path& file, unsigned int line, const char* expression);
+void glCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression);
 
 } // namespace sf::priv

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -38,7 +38,7 @@
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-void eglCheckError(const std::filesystem::path& file, unsigned int line, const char* expression)
+void eglCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression)
 {
     // Obtain information about the success or failure of the most recent EGL
     // function called in the current thread

--- a/src/SFML/Window/EGLCheck.hpp
+++ b/src/SFML/Window/EGLCheck.hpp
@@ -30,6 +30,7 @@
 #include <SFML/Config.hpp>
 
 #include <filesystem>
+#include <string_view>
 
 
 namespace sf::priv
@@ -63,6 +64,6 @@ namespace sf::priv
 /// \param expression The evaluated expression as a string
 ///
 ////////////////////////////////////////////////////////////
-void eglCheckError(const std::filesystem::path& file, unsigned int line, const char* expression);
+void eglCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression);
 
 } // namespace sf::priv


### PR DESCRIPTION
## Description

We can use a slightly more expressive type for this internal interface. I'm trying to find more places where we can replace `const char*` with more expressive and safer types.