### PR TITLE
Add tests for `sf::WindowBase`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         - { name: Windows VS2022 x64,     os: windows-2022, flags: -A x64 }
         - { name: Windows VS2022 ClangCL, os: windows-2022, flags: -T ClangCL }
         - { name: Windows VS2022 Clang,   os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
-        - { name: Linux GCC,            os: ubuntu-latest, prefix: xvfb-run -a, flags: -GNinja }
-        - { name: Linux Clang,          os: ubuntu-latest, prefix: xvfb-run -a, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
+        - { name: Linux GCC,            os: ubuntu-latest, prefix: xvfb-run -a, flags: -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
+        - { name: Linux Clang,          os: ubuntu-latest, prefix: xvfb-run -a, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: MacOS,                os: macos-11, flags: -GNinja }
         - { name: MacOS Xcode,          os: macos-11, flags: -GXcode }
         config:

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -112,7 +112,8 @@ void cleanup()
     drmModeFreeEncoder(drmNode.savedEncoder);
     drmModeFreeCrtc(drmNode.originalCrtc);
 
-    eglTerminate(display);
+    if (display != EGL_NO_DISPLAY)
+        eglTerminate(display);
     display = EGL_NO_DISPLAY;
 
     gbm_device_destroy(gbmDevice);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,9 @@ set(WINDOW_SRC
     Window/WindowBase.test.cpp
 )
 sfml_add_test(test-sfml-window "${WINDOW_SRC}" SFML::Window)
+if(SFML_RUN_DISPLAY_TESTS)
+    target_compile_definitions(test-sfml-window PRIVATE SFML_RUN_DISPLAY_TESTS)
+endif()
 
 set(GRAPHICS_SRC
     Graphics/BlendMode.test.cpp

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -11,12 +11,6 @@
 #include <iomanip>
 #include <limits>
 
-#ifdef SFML_RUN_DISPLAY_TESTS
-static constexpr bool skipDisplayTests = false;
-#else
-static constexpr bool skipDisplayTests = true;
-#endif
-
 namespace sf
 {
 struct BlendMode;

--- a/test/TestUtilities/WindowUtil.hpp
+++ b/test/TestUtilities/WindowUtil.hpp
@@ -7,6 +7,12 @@
 
 #include <SystemUtil.hpp>
 
+#ifdef SFML_RUN_DISPLAY_TESTS
+static constexpr bool skipDisplayTests = false;
+#else
+static constexpr bool skipDisplayTests = true;
+#endif
+
 // String conversions for doctest framework
 namespace sf
 {

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -1,8 +1,114 @@
 #include <SFML/Window/WindowBase.hpp>
 
+// Other 1st party headers
+#include <SFML/System/String.hpp>
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/VideoMode.hpp>
+
+#include <doctest/doctest.h>
+
+#include <WindowUtil.hpp>
 #include <type_traits>
 
 static_assert(!std::is_copy_constructible_v<sf::WindowBase>);
 static_assert(!std::is_copy_assignable_v<sf::WindowBase>);
 static_assert(!std::is_nothrow_move_constructible_v<sf::WindowBase>);
 static_assert(!std::is_nothrow_move_assignable_v<sf::WindowBase>);
+
+TEST_CASE("[Window] sf::WindowBase" * doctest::skip(skipDisplayTests))
+{
+    SUBCASE("Construction")
+    {
+        SUBCASE("Default constructor")
+        {
+            const sf::WindowBase windowBase;
+            CHECK(!windowBase.isOpen());
+            CHECK(windowBase.getPosition() == sf::Vector2i());
+            CHECK(windowBase.getSize() == sf::Vector2u());
+            CHECK(!windowBase.hasFocus());
+            CHECK(windowBase.getSystemHandle() == sf::WindowHandle());
+        }
+
+        SUBCASE("Mode and title constructor")
+        {
+            const sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests");
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(360, 240));
+            CHECK(windowBase.getSystemHandle() != sf::WindowHandle());
+        }
+
+        SUBCASE("Mode, title, and style constructor")
+        {
+            const sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests", sf::Style::Resize);
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(360, 240));
+            CHECK(windowBase.getSystemHandle() != sf::WindowHandle());
+        }
+    }
+
+    SUBCASE("create()")
+    {
+        sf::WindowBase windowBase;
+
+        SUBCASE("Mode and title")
+        {
+            windowBase.create(sf::VideoMode({240, 360}), "WindowBase Tests");
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(240, 360));
+            CHECK(windowBase.getSystemHandle() != sf::WindowHandle());
+        }
+
+        SUBCASE("Mode, title, and style")
+        {
+            windowBase.create(sf::VideoMode({240, 360}), "WindowBase Tests", sf::Style::Resize);
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(240, 360));
+            CHECK(windowBase.getSystemHandle() != sf::WindowHandle());
+        }
+    }
+
+    SUBCASE("close()")
+    {
+        sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests");
+        windowBase.close();
+        CHECK(!windowBase.isOpen());
+    }
+
+    SUBCASE("pollEvent()")
+    {
+        sf::WindowBase windowBase;
+        sf::Event      event;
+        CHECK(!windowBase.pollEvent(event));
+    }
+
+    SUBCASE("waitEvent()")
+    {
+        sf::WindowBase windowBase;
+        sf::Event      event;
+        CHECK(!windowBase.waitEvent(event));
+    }
+
+    SUBCASE("Get/set position")
+    {
+        sf::WindowBase windowBase;
+        windowBase.setPosition({12, 34});
+        CHECK(windowBase.getPosition() == sf::Vector2i());
+    }
+
+    SUBCASE("Set/get size")
+    {
+        SUBCASE("Uninitialized window")
+        {
+            sf::WindowBase windowBase;
+            windowBase.setSize({128, 256});
+            CHECK(windowBase.getSize() == sf::Vector2u());
+        }
+
+        SUBCASE("Initialized window")
+        {
+            sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests");
+            windowBase.setSize({128, 256});
+            CHECK(windowBase.getSize() == sf::Vector2u(128, 256));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Unit tests are back on the menu!

The first commit fixes an oversight from #2302 where I forgot to enable these display tests for the Linux jobs that are already using `xvfb-run`. The second commit fixes a DRM bug where the code will attempt to terminate a null display causing a segfault. I'm not sure why this only appeared in these tests but it did. 

The main commit adds tests for `sf::WindowBase`. Certain APIs had inconsistent behavior across platforms so those tests were omitted. For example, the value of `sf::WindowBase::hasFocus` is not consistent. Other APIs like `sf::WindowBase::setMouseCursor` result in no observable changes we could test for so I didn't add tests for those.

It's important to realize that going forward we'll still need to manually build and run tests with the DRM backend since we can't run these display tests with the DRM backend in CI. 
