### PR TITLE
Build sfml-main with position-independent code

### DIFF
--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -17,6 +17,9 @@ endif()
 sfml_add_library(sfml-main STATIC SOURCES ${SRC})
 
 if(SFML_OS_ANDROID)
+    # ensure that linking into shared libraries doesn't fail
+    set_target_properties(sfml-main PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
     # glad sources
     target_include_directories(sfml-main SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/glad/include")
 endif()


### PR DESCRIPTION
## Description

Closes #2393

This fixes an Android build problem since linking a static library into a shared library is prone to cause issues with that static library not using position independent code but those who use the shared library require position independent code.