### PR TITLE
Assert extension string is not null

### DIFF
--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -276,6 +276,7 @@ void loadExtensions()
     {
         // Try to load the < 3.0 way
         const char* extensionString = reinterpret_cast<const char*>(glGetStringFunc(GL_EXTENSIONS));
+        assert(extensionString);
 
         do
         {


### PR DESCRIPTION
## Description

This PR is related to the issue #2403 

Ideally we'd be able to recover from this error in some way but an assert is a step in the right direction to avoid UB in Debug builds.