### PR TITLE
Add `modernize-use-auto` clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,7 +19,6 @@ Checks: >
   -modernize-macro-to-enum,
   -modernize-pass-by-value,
   -modernize-return-braced-init-list,
-  -modernize-use-auto,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -readability-braces-around-statements,

--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -56,14 +56,14 @@ namespace
 {
 std::size_t readCallback(void* ptr, std::size_t size, void* data)
 {
-    sf::InputStream* stream = static_cast<sf::InputStream*>(data);
+    auto* stream = static_cast<sf::InputStream*>(data);
     return static_cast<std::size_t>(stream->read(ptr, static_cast<std::int64_t>(size)));
 }
 
 int seekCallback(std::uint64_t offset, void* data)
 {
-    sf::InputStream* stream   = static_cast<sf::InputStream*>(data);
-    std::int64_t     position = stream->seek(static_cast<std::int64_t>(offset));
+    auto*        stream   = static_cast<sf::InputStream*>(data);
+    std::int64_t position = stream->seek(static_cast<std::int64_t>(offset));
     return position < 0 ? -1 : 0;
 }
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -227,7 +227,7 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
                 // Interpolate RGBA components using the alpha values of the destination and source pixels
                 std::uint8_t srcAlpha = src[3];
                 std::uint8_t dstAlpha = dst[3];
-                std::uint8_t outAlpha = static_cast<std::uint8_t>(srcAlpha + dstAlpha - srcAlpha * dstAlpha / 255);
+                auto         outAlpha = static_cast<std::uint8_t>(srcAlpha + dstAlpha - srcAlpha * dstAlpha / 255);
 
                 dst[3] = outAlpha;
 

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -555,8 +555,8 @@ Ftp::Response Ftp::DataChannel::open(Ftp::TransferMode mode)
             }
 
             // Reconstruct connection port and address
-            unsigned short port = static_cast<std::uint16_t>(data[4] * 256 + data[5]);
-            IpAddress      address(data[0], data[1], data[2], data[3]);
+            auto      port = static_cast<std::uint16_t>(data[4] * 256 + data[5]);
+            IpAddress address(data[0], data[1], data[2], data[3]);
 
             // Connect the data channel to the server
             if (m_dataSocket.connect(address, port) == Socket::Status::Done)

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -434,7 +434,7 @@ Packet& Packet::operator<<(std::uint16_t data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator<<(std::int32_t data)
 {
-    std::int32_t toWrite = static_cast<std::int32_t>(htonl(static_cast<std::uint32_t>(data)));
+    auto toWrite = static_cast<std::int32_t>(htonl(static_cast<std::uint32_t>(data)));
     append(&toWrite, sizeof(toWrite));
     return *this;
 }

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -134,8 +134,8 @@ void cleanup()
 
 void drmFbDestroyCallback(gbm_bo* bo, void* data)
 {
-    int    drmFd = gbm_device_get_fd(gbm_bo_get_device(bo));
-    DrmFb* fb    = static_cast<DrmFb*>(data);
+    int   drmFd = gbm_device_get_fd(gbm_bo_get_device(bo));
+    auto* fb    = static_cast<DrmFb*>(data);
 
     if (fb->fbId)
         drmModeRmFB(drmFd, fb->fbId);
@@ -145,8 +145,8 @@ void drmFbDestroyCallback(gbm_bo* bo, void* data)
 
 DrmFb* drmFbGetFromBo(gbm_bo& bo)
 {
-    int    drmFd = gbm_device_get_fd(gbm_bo_get_device(&bo));
-    DrmFb* fb    = static_cast<DrmFb*>(gbm_bo_get_user_data(&bo));
+    int   drmFd = gbm_device_get_fd(gbm_bo_get_device(&bo));
+    auto* fb    = static_cast<DrmFb*>(gbm_bo_get_user_data(&bo));
     if (fb)
         return fb;
 

--- a/src/SFML/Window/OSX/HIDInputManager.mm
+++ b/src/SFML/Window/OSX/HIDInputManager.mm
@@ -58,7 +58,7 @@ long HIDInputManager::getLocationID(IOHIDDeviceRef device)
     if (!typeRef || (CFGetTypeID(typeRef) != CFNumberGetTypeID()))
         return 0;
 
-    CFNumberRef locRef = static_cast<CFNumberRef>(typeRef);
+    const auto* locRef = static_cast<CFNumberRef>(typeRef);
 
     if (!CFNumberGetValue(locRef, kCFNumberLongType, &loc))
         return 0;
@@ -753,7 +753,7 @@ void HIDInputManager::initializeKeyboard()
         return;
     }
 
-    NSSet* keyboards = static_cast<NSSet*>(underlying); // Toll-Free Bridge
+    auto* keyboards = static_cast<NSSet*>(underlying); // Toll-Free Bridge
     for (id keyboard in keyboards)
         loadKeyboard(static_cast<IOHIDDeviceRef>(keyboard));
 
@@ -774,10 +774,10 @@ void HIDInputManager::loadKeyboard(IOHIDDeviceRef keyboard)
         return;
     }
 
-    NSArray* keys = static_cast<NSArray*>(underlying); // Toll-Free Bridge
+    auto* keys = static_cast<NSArray*>(underlying); // Toll-Free Bridge
     for (id key in keys)
     {
-        IOHIDElementRef elem = static_cast<IOHIDElementRef>(key);
+        auto* elem = static_cast<IOHIDElementRef>(key);
         if (IOHIDElementGetUsagePage(elem) == kHIDPage_KeyboardOrKeypad)
             loadKey(elem);
     }
@@ -809,8 +809,8 @@ void HIDInputManager::buildMappings()
         key = Keyboard::Unknown;
 
     // Get the current keyboard layout
-    TISInputSourceRef tis = TISCopyCurrentKeyboardLayoutInputSource();
-    CFDataRef layoutData  = static_cast<CFDataRef>(TISGetInputSourceProperty(tis, kTISPropertyUnicodeKeyLayoutData));
+    TISInputSourceRef tis  = TISCopyCurrentKeyboardLayoutInputSource();
+    const auto* layoutData = static_cast<CFDataRef>(TISGetInputSourceProperty(tis, kTISPropertyUnicodeKeyLayoutData));
 
     if (layoutData == nullptr)
     {
@@ -819,14 +819,14 @@ void HIDInputManager::buildMappings()
         return;
     }
 
-    UCKeyboardLayout* layout = reinterpret_cast<UCKeyboardLayout*>(const_cast<std::uint8_t*>(CFDataGetBytePtr(layoutData)));
+    auto* layout = reinterpret_cast<UCKeyboardLayout*>(const_cast<std::uint8_t*>(CFDataGetBytePtr(layoutData)));
 
     // For each scancode having a IOHIDElement, we translate the corresponding
     // virtual code to a localized Key.
     for (int i = 0; i < static_cast<int>(Keyboard::Scan::ScancodeCount); ++i)
     {
-        Keyboard::Scancode scan        = static_cast<Keyboard::Scancode>(i);
-        std::uint8_t       virtualCode = scanToVirtualCode(scan);
+        auto         scan        = static_cast<Keyboard::Scancode>(i);
+        std::uint8_t virtualCode = scanToVirtualCode(scan);
 
         if (virtualCode == unknownVirtualCode)
             continue;
@@ -912,7 +912,7 @@ void HIDInputManager::keyboardChanged(CFNotificationCenterRef /* center */,
                                       const void* /* object */,
                                       CFDictionaryRef /* userInfo */)
 {
-    HIDInputManager* manager = static_cast<HIDInputManager*>(observer);
+    auto* manager = static_cast<HIDInputManager*>(observer);
     manager->buildMappings();
 }
 

--- a/src/SFML/Window/OSX/HIDJoystickManager.cpp
+++ b/src/SFML/Window/OSX/HIDJoystickManager.cpp
@@ -123,7 +123,7 @@ void HIDJoystickManager::update()
 ////////////////////////////////////////////////////////////
 void HIDJoystickManager::pluggedIn(void* context, IOReturn, void*, IOHIDDeviceRef)
 {
-    HIDJoystickManager* manager = static_cast<HIDJoystickManager*>(context);
+    auto* manager = static_cast<HIDJoystickManager*>(context);
     ++manager->m_joystickCount;
 }
 
@@ -131,7 +131,7 @@ void HIDJoystickManager::pluggedIn(void* context, IOReturn, void*, IOHIDDeviceRe
 ////////////////////////////////////////////////////////////
 void HIDJoystickManager::pluggedOut(void* context, IOReturn, void*, IOHIDDeviceRef)
 {
-    HIDJoystickManager* manager = static_cast<HIDJoystickManager*>(context);
+    auto* manager = static_cast<HIDJoystickManager*>(context);
     --manager->m_joystickCount;
 }
 

--- a/src/SFML/Window/OSX/JoystickImpl.cpp
+++ b/src/SFML/Window/OSX/JoystickImpl.cpp
@@ -58,7 +58,7 @@ std::string getDeviceString(IOHIDDeviceRef ref, CFStringRef prop, unsigned int i
     CFTypeRef typeRef = IOHIDDeviceGetProperty(ref, prop);
     if (typeRef && (CFGetTypeID(typeRef) == CFStringGetTypeID()))
     {
-        CFStringRef str = static_cast<CFStringRef>(typeRef);
+        const auto* str = static_cast<CFStringRef>(typeRef);
         return stringFromCFString(str);
     }
 
@@ -153,8 +153,7 @@ bool JoystickImpl::isConnected(unsigned int index)
 
                     for (CFIndex didx(0); !state && didx < size; ++didx)
                     {
-                        IOHIDDeviceRef d = static_cast<IOHIDDeviceRef>(
-                            const_cast<void*>(array[static_cast<std::size_t>(didx)]));
+                        auto* d = static_cast<IOHIDDeviceRef>(const_cast<void*>(array[static_cast<std::size_t>(didx)]));
                         Location dloc = HIDInputManager::getLocationID(d);
 
                         bool foundJ = false;
@@ -205,7 +204,7 @@ bool JoystickImpl::open(unsigned int index)
     IOHIDDeviceRef self = nil;
     for (CFIndex i(0); self == nil && i < joysticksCount; ++i)
     {
-        IOHIDDeviceRef d = static_cast<IOHIDDeviceRef>(const_cast<void*>(devicesArray[static_cast<std::size_t>(i)]));
+        auto* d = static_cast<IOHIDDeviceRef>(const_cast<void*>(devicesArray[static_cast<std::size_t>(i)]));
         if (deviceLoc == HIDInputManager::getLocationID(d))
             self = d;
     }
@@ -233,7 +232,7 @@ bool JoystickImpl::open(unsigned int index)
     CFIndex elementsCount = CFArrayGetCount(elements);
     for (int i = 0; i < elementsCount; ++i)
     {
-        IOHIDElementRef element = static_cast<IOHIDElementRef>(const_cast<void*>(CFArrayGetValueAtIndex(elements, i)));
+        auto* element = static_cast<IOHIDElementRef>(const_cast<void*>(CFArrayGetValueAtIndex(elements, i)));
         switch (IOHIDElementGetUsagePage(element))
         {
             case kHIDPage_GenericDesktop:
@@ -424,7 +423,7 @@ JoystickState JoystickImpl::update()
     bool found = false;
     for (CFIndex i(0); !found && i < joysticksCount; ++i)
     {
-        IOHIDDeviceRef d = static_cast<IOHIDDeviceRef>(const_cast<void*>(devicesArray[static_cast<std::size_t>(i)]));
+        auto* d = static_cast<IOHIDDeviceRef>(const_cast<void*>(devicesArray[static_cast<std::size_t>(i)]));
         if (selfLoc == HIDInputManager::getLocationID(d))
             found = true;
     }
@@ -475,12 +474,12 @@ JoystickState JoystickImpl::update()
         // This method might not be very accurate (the "0 position" can be
         // slightly shift with some device) but we don't care because most
         // of devices are so sensitive that this is not relevant.
-        double physicalMax   = static_cast<double>(IOHIDElementGetPhysicalMax(iohidElementRef));
-        double physicalMin   = static_cast<double>(IOHIDElementGetPhysicalMin(iohidElementRef));
+        auto   physicalMax   = static_cast<double>(IOHIDElementGetPhysicalMax(iohidElementRef));
+        auto   physicalMin   = static_cast<double>(IOHIDElementGetPhysicalMin(iohidElementRef));
         double scaledMin     = -100;
         double scaledMax     = 100;
         double physicalValue = IOHIDValueGetScaledValue(value, kIOHIDValueScaleTypePhysical);
-        float  scaledValue   = static_cast<float>(
+        auto   scaledValue   = static_cast<float>(
             (((physicalValue - physicalMin) * (scaledMax - scaledMin)) / (physicalMax - physicalMin)) + scaledMin);
         state.axes[axis] = scaledValue;
     }

--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -606,9 +606,9 @@
 ////////////////////////////////////////////////////////
 - (float)screenHeight
 {
-    NSDictionary*     deviceDescription = [[m_window screen] deviceDescription];
-    NSNumber*         screenNumber      = [deviceDescription valueForKey:@"NSScreenNumber"];
-    CGDirectDisplayID screenID          = static_cast<CGDirectDisplayID>([screenNumber intValue]);
+    NSDictionary* deviceDescription = [[m_window screen] deviceDescription];
+    NSNumber*     screenNumber      = [deviceDescription valueForKey:@"NSScreenNumber"];
+    auto          screenID          = static_cast<CGDirectDisplayID>([screenNumber intValue]);
     return static_cast<float>(CGDisplayPixelsHigh(screenID));
 }
 

--- a/src/SFML/Window/OSX/VideoModeImpl.cpp
+++ b/src/SFML/Window/OSX/VideoModeImpl.cpp
@@ -56,7 +56,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     const CFIndex modesCount = CFArrayGetCount(cgmodes);
     for (CFIndex i = 0; i < modesCount; ++i)
     {
-        CGDisplayModeRef cgmode = static_cast<CGDisplayModeRef>(const_cast<void*>(CFArrayGetValueAtIndex(cgmodes, i)));
+        auto* cgmode = static_cast<CGDisplayModeRef>(const_cast<void*>(CFArrayGetValueAtIndex(cgmodes, i)));
 
         VideoMode mode = convertCGModeToSFMode(cgmode);
 

--- a/src/SFML/Window/OSX/cpp_objc_conversion.mm
+++ b/src/SFML/Window/OSX/cpp_objc_conversion.mm
@@ -45,8 +45,8 @@ NSString* stringToNSString(const std::string& string)
 ////////////////////////////////////////////////////////////
 NSString* sfStringToNSString(const sf::String& string)
 {
-    std::uint32_t length = static_cast<std::uint32_t>(string.getSize() * sizeof(std::uint32_t));
-    const void*   data   = reinterpret_cast<const void*>(string.getData());
+    auto        length = static_cast<std::uint32_t>(string.getSize() * sizeof(std::uint32_t));
+    const void* data   = reinterpret_cast<const void*>(string.getData());
 
     NSStringEncoding encoding;
     if (NSHostByteOrder() == NS_LittleEndian)

--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -484,9 +484,8 @@ void ensureMapping()
         std::memcpy(name, descriptor->names->keys[keycode].name, XkbKeyNameLength);
         name[XkbKeyNameLength] = '\0';
 
-        std::unordered_map<std::string, sf::Keyboard::Scancode>::iterator mappedScancode = nameScancodeMap.find(
-            std::string(name));
-        scancode = sf::Keyboard::Scan::Unknown;
+        auto mappedScancode = nameScancodeMap.find(std::string(name));
+        scancode            = sf::Keyboard::Scan::Unknown;
 
         if (mappedScancode != nameScancodeMap.end())
             scancode = mappedScancode->second;

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -543,9 +543,9 @@ void InputImpl::ensureMappings()
     // Phase 2: Translate scancode to virtual code to key names
     for (int i = 0; i < static_cast<int>(Keyboard::Scan::ScancodeCount); ++i)
     {
-        Keyboard::Scancode scan       = static_cast<Keyboard::Scancode>(i);
-        UINT               virtualKey = sfScanToVirtualKey(scan);
-        Keyboard::Key      key        = virtualKeyToSfKey(virtualKey);
+        auto          scan       = static_cast<Keyboard::Scancode>(i);
+        UINT          virtualKey = sfScanToVirtualKey(scan);
+        Keyboard::Key key        = virtualKeyToSfKey(virtualKey);
         if (key != Keyboard::Unknown && m_keyToScancodeMapping[key] == Keyboard::Scan::Unknown)
             m_keyToScancodeMapping[key] = scan;
         m_scancodeToKeyMapping[static_cast<std::size_t>(scan)] = key;

--- a/test/Graphics/Color.test.cpp
+++ b/test/Graphics/Color.test.cpp
@@ -166,7 +166,7 @@ TEST_CASE("[Graphics] sf::Color")
         static_assert(alignof(sf::Color) == 1);
 
         const std::vector<sf::Color> pixels = {{10, 11, 12, 13}, {14, 15, 16, 17}, {18, 19, 20, 21}};
-        const std::uint8_t*          begin  = reinterpret_cast<const std::uint8_t*>(pixels.data());
+        const auto*                  begin  = reinterpret_cast<const std::uint8_t*>(pixels.data());
         CHECK(begin[0] == pixels[0].r);
         CHECK(begin[1] == pixels[0].g);
         CHECK(begin[2] == pixels[0].b);


### PR DESCRIPTION
## Description

All these changes should improve readability by avoiding writing really long type names or avoiding writing the type name twice on the same line.
