### PR TITLE
Disable unreliable tests

### DIFF
--- a/test/Graphics/VertexBuffer.test.cpp
+++ b/test/Graphics/VertexBuffer.test.cpp
@@ -16,7 +16,8 @@ static_assert(!std::is_nothrow_move_constructible_v<sf::VertexBuffer>);
 static_assert(std::is_move_assignable_v<sf::VertexBuffer>);
 static_assert(!std::is_nothrow_move_assignable_v<sf::VertexBuffer>);
 
-TEST_CASE("[Graphics] sf::VertexBuffer" * doctest::skip(skipDisplayTests))
+// Skip these tests because they produce flakey failures in CI when using xvfb-run
+TEST_CASE("[Graphics] sf::VertexBuffer" * doctest::skip(true))
 {
     // Skip tests if vertex buffers aren't available
     if (!sf::VertexBuffer::isAvailable())

--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -11,7 +11,8 @@ static_assert(!std::is_copy_assignable_v<sf::Cursor>);
 static_assert(!std::is_nothrow_move_constructible_v<sf::Cursor>);
 static_assert(!std::is_nothrow_move_assignable_v<sf::Cursor>);
 
-TEST_CASE("[Window] sf::Cursor" * doctest::skip(skipDisplayTests))
+// Skip these tests because they fail when using DRM which hasn't implemented sf::Cursor
+TEST_CASE("[Window] sf::Cursor" * doctest::skip(true))
 {
     SUBCASE("Construction")
     {


### PR DESCRIPTION
## Description

The `sf::Cursor` tests fail with the DRM backend which means keeping these would mess with any DRM users trying to develop the library. The `sf::VertexBuffer` tests fail on Linux about 10% of the time which is enough for at least one to fail every CI run which means it almost never passes on the first pass.

This commit is basically a soft revert of those two tests. However It's still worth keeping the code around even if we never run these tests.
