### PR TITLE
Allow setting window icon with `sf::Image`

### DIFF
--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -35,6 +35,8 @@
 
 namespace sf
 {
+class Image;
+
 ////////////////////////////////////////////////////////////
 /// \brief Window that can serve as a target for 2D drawing
 ///
@@ -112,6 +114,18 @@ public:
     ////////////////////////////////////////////////////////////
     Vector2u getSize() const override;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the window's icon
+    ///
+    /// The OS default icon is used by default.
+    ///
+    /// \param icon Image to use as the icon. The image is copied,
+    ///             so you need not keep the source alive after
+    ///             calling this function.
+    ///
+    ////////////////////////////////////////////////////////////
+    void setIcon(const Image& icon);
+    using Window::setIcon;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell if the window will use sRGB encoding when drawing on it

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/GLCheck.hpp>
+#include <SFML/Graphics/Image.hpp>
 #include <SFML/Graphics/RenderTextureImplFBO.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Graphics/Texture.hpp>
@@ -62,6 +63,13 @@ RenderWindow::~RenderWindow() = default;
 Vector2u RenderWindow::getSize() const
 {
     return Window::getSize();
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderWindow::setIcon(const Image& icon)
+{
+    setIcon(icon.getSize(), icon.getPixelsPtr());
 }
 
 


### PR DESCRIPTION
## Description

Currently, setting window icon is only allowed using a size & pixel pointer.

This overload wraps that, allowing users to set the window icon using an `sf::Image` directly.
`sf::Image` has the same 32bit RGBA pixel format as required by `setIcon`.
This is only implemented for `sf::RenderWindow`, as `sf::Image` is part of the graphics module.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android