### PR TITLE
Test install interface with frameworks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
           type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
         - platform: { name: MacOS, os: macos-11 }
-          config: { name: Frameworks, flags: -GNinja -DSFML_BUILD_FRAMEWORKS=TRUE }
+          config: { name: Frameworks, flags: -GNinja -DSFML_BUILD_FRAMEWORKS=TRUE -DBUILD_SHARED_LIBS=TRUE }
         - platform: { name: MacOS, os: macos-11 }
           config: { name: iOS, flags: -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/cmake/toolchains/iOS.toolchain.cmake -DIOS_PLATFORM=SIMULATOR }
         - platform: { name: Android, os: ubuntu-latest }
@@ -107,7 +107,7 @@ jobs:
         fail_ci_if_error: true
 
     - name: Test Install Interface
-      if: matrix.platform.name != 'Android' && matrix.config.name != 'Frameworks' && matrix.config.name != 'iOS'
+      if: matrix.platform.name != 'Android' && matrix.config.name != 'iOS'
       shell: bash
       run: |
         cmake -S $GITHUB_WORKSPACE/test/install -B $GITHUB_WORKSPACE/test/install/build -DSFML_ROOT=$GITHUB_WORKSPACE/install -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}


### PR DESCRIPTION
## Description

Fixes another bit of tech debt added in #2206. Because SFML defaults to shared libs but the install test uses CMake's default of static libs, it was trying to find the static build of the frameworks which doesn't exist causing it to fail. When writing #2206 I was too lazy to fix this so I just disabled the install tests when using frameworks.
