### PR TITLE
Fixed Android OpenGL context 0.0 and antialiasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,3 @@ build/
 .cache/
 .vscode/
 .idea/
-/.vs
-/out/install
-/CMakeSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ build/
 .cache/
 .vscode/
 .idea/
+/.vs
+/out/install
+/CMakeSettings.json

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -153,8 +153,22 @@ m_config  (NULL)
     // Get the initialized EGL display
     m_display = EglContextImpl::getInitializedDisplay();
 
+#ifndef SFML_SYSTEM_ANDROID
+
     // Get the best EGL config matching the requested video settings
     m_config = getBestConfig(m_display, bitsPerPixel, settings);
+
+#else
+
+    // On Android, make sure that antialiasing level isn't above 4,
+    // otherwise surface creation will fail
+    ContextSettings Asettings = settings;
+    if (Asettings.antialiasingLevel > 4)
+        Asettings.antialiasingLevel = 4;
+    m_config = getBestConfig(m_display, bitsPerPixel, Asettings);
+
+#endif
+
     updateSettings();
 
     // Create EGL context

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -293,6 +293,8 @@ namespace
             }
         }
 
+#ifndef SFML_SYSTEM_ANDROID
+
         // Helper to parse OpenGL version strings
         bool parseVersionString(const char* version, const char* prefix, unsigned int &major, unsigned int &minor)
         {
@@ -312,6 +314,9 @@ namespace
 
             return false;
         }
+
+#endif
+
     }
 }
 
@@ -756,10 +761,6 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
     // Activate the context
     setActive(true);
 
-    // Retrieve the context version number
-    int majorVersion = 0;
-    int minorVersion = 0;
-
     // Try the new way first
     glGetIntegervFuncType glGetIntegervFunc = reinterpret_cast<glGetIntegervFuncType>(getFunction("glGetIntegerv"));
     glGetErrorFuncType glGetErrorFunc = reinterpret_cast<glGetErrorFuncType>(getFunction("glGetError"));
@@ -772,6 +773,11 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
         err() << "Could not load necessary function to initialize OpenGL context" << std::endl;
         return;
     }
+#ifndef SFML_SYSTEM_ANDROID
+
+    // Retrieve the context version number
+    int majorVersion = 0;
+    int minorVersion = 0;
 
     glGetIntegervFunc(GL_MAJOR_VERSION, &majorVersion);
     glGetIntegervFunc(GL_MINOR_VERSION, &minorVersion);
@@ -812,6 +818,14 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
             err() << "Unable to retrieve OpenGL version string, defaulting to 1.1" << std::endl;
         }
     }
+
+#else
+
+    // Android contexts are always defaulting to 1.1 since SFML is still using GLES 1
+    m_settings.majorVersion = 1;
+    m_settings.minorVersion = 1;
+
+#endif
 
     // 3.0 contexts only deprecate features, but do not remove them yet
     // 3.1 contexts remove features if ARB_compatibility is not present


### PR DESCRIPTION

* [X] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [X] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Fixes the OpenGL context 0.0 bug and fixes the black screen and egl surface crash when antialiasing is > 4.

This PR is related to the issue https://github.com/SFML/SFML/issues/2395

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [X] Tested on Android

## How to test this PR?

Describe how to best test these changes. Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start:

```cpp
#include <SFML/Graphics.hpp>
int main()
{
    sf::RenderWindow window;
    //change antialiasing and major minor version of sf::ContextSettings to test
    window.create(sf::VideoMode::getDesktopMode(), "SFML works!", sf::Style::Fullscreen, sf::ContextSettings(0, 0, 8));
    window.setFramerateLimit(3);
    sf::CircleShape shape(400.f);
    shape.setFillColor(sf::Color::Green);
    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            if (event.type == sf::Event::Closed)
                window.close();
            if (event.type == sf::Event::LostFocus)
                window.setActive(0);
            if (event.type == sf::Event::GainedFocus)
                window.setActive(1);
            if (event.type == sf::Event::KeyReleased)
                if (event.key.code == sf::Keyboard::Escape)
                    window.close();
        }
        if (!window.hasFocus())
            continue;
        window.clear();
        window.draw(shape);
        window.display();

    }
}
```
