### PR TITLE
Improve test utility header compilation speed

### DIFF
--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -4,6 +4,7 @@
 
 #include <GraphicsUtil.hpp>
 #include <array>
+#include <cassert>
 #include <iomanip>
 #include <sstream>
 #include <type_traits>

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -1,8 +1,10 @@
 #include <SFML/Graphics/BlendMode.hpp>
 #include <SFML/Graphics/Color.hpp>
+#include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/Transform.hpp>
 
 #include <GraphicsUtil.hpp>
+#include <SystemUtil.hpp>
 #include <ostream>
 
 namespace sf
@@ -28,6 +30,19 @@ std::ostream& operator<<(std::ostream& os, const Transform& transform)
     os << matrix[3] << ", " << matrix[7] << ", " << matrix[15];
     return os;
 }
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const Rect<T>& rect)
+{
+    const auto flags = os.flags();
+    setStreamPrecision(os, std::numeric_limits<T>::max_digits10);
+    os << "(left=" << rect.left << ", top=" << rect.top << ", width=" << rect.width << ", height=" << rect.height << ")";
+    os.flags(flags);
+    return os;
+}
+
+template std::ostream& operator<<(std::ostream&, const Rect<int>&);
+template std::ostream& operator<<(std::ostream&, const Rect<float>&);
 } // namespace sf
 
 bool operator==(const sf::Transform& lhs, const Approx<sf::Transform>& rhs)
@@ -41,4 +56,10 @@ bool operator==(const sf::Transform& lhs, const Approx<sf::Transform>& rhs)
            lhs.getMatrix()[3] == Approx(rhs.value.getMatrix()[3]) &&
            lhs.getMatrix()[7] == Approx(rhs.value.getMatrix()[7]) &&
            lhs.getMatrix()[15] == Approx(rhs.value.getMatrix()[15]);
+}
+
+template <>
+std::ostream& operator<<(std::ostream& os, const Approx<sf::Transform>& approx)
+{
+    return os << approx.value;
 }

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -5,10 +5,8 @@
 
 #pragma once
 
-#include <SFML/Graphics/Rect.hpp>
-
 #include <WindowUtil.hpp>
-#include <iomanip>
+#include <iosfwd>
 #include <limits>
 
 namespace sf
@@ -17,19 +15,15 @@ struct BlendMode;
 class Color;
 class Transform;
 
+template <typename>
+class Rect;
+
 std::ostream& operator<<(std::ostream& os, const BlendMode& blendMode);
 std::ostream& operator<<(std::ostream& os, const Color& color);
 std::ostream& operator<<(std::ostream& os, const Transform& transform);
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const Rect<T>& rect)
-{
-    const auto flags = os.flags();
-    os << std::fixed << std::setprecision(std::numeric_limits<T>::max_digits10);
-    os << "(left=" << rect.left << ", top=" << rect.top << ", width=" << rect.width << ", height=" << rect.height << ")";
-    os.flags(flags);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const Rect<T>& rect);
 } // namespace sf
 
 bool operator==(const sf::Transform& lhs, const Approx<sf::Transform>& rhs);

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -1,16 +1,25 @@
 #include <SFML/System/Angle.hpp>
 #include <SFML/System/String.hpp>
 #include <SFML/System/Time.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/System/Vector3.hpp>
 
 #include <doctest/doctest.h>
 
 #include <SystemUtil.hpp>
+#include <iomanip>
+#include <limits>
 
 namespace sf
 {
+void setStreamPrecision(std::ostream& os, int maxDigits10)
+{
+    os << std::fixed << std::setprecision(maxDigits10);
+}
+
 std::ostream& operator<<(std::ostream& os, const Angle& angle)
 {
-    os << std::fixed << std::setprecision(std::numeric_limits<float>::max_digits10);
+    setStreamPrecision(os, std::numeric_limits<float>::max_digits10);
     return os << angle.asDegrees() << " deg";
 }
 
@@ -23,6 +32,28 @@ std::ostream& operator<<(std::ostream& os, Time time)
 {
     return os << time.asMicroseconds() << "us";
 }
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const Vector2<T>& vector)
+{
+    setStreamPrecision(os, std::numeric_limits<T>::max_digits10);
+    return os << "(" << vector.x << ", " << vector.y << ")";
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector)
+{
+    setStreamPrecision(os, std::numeric_limits<T>::max_digits10);
+    return os << "(" << vector.x << ", " << vector.y << ", " << vector.z << ")";
+}
+
+template std::ostream& operator<<(std::ostream&, const Vector2<int>&);
+template std::ostream& operator<<(std::ostream&, const Vector2<unsigned int>&);
+template std::ostream& operator<<(std::ostream&, const Vector2<float>&);
+
+template std::ostream& operator<<(std::ostream&, const Vector3<int>&);
+template std::ostream& operator<<(std::ostream&, const Vector3<unsigned int>&);
+template std::ostream& operator<<(std::ostream&, const Vector3<float>&);
 } // namespace sf
 
 bool operator==(const float& lhs, const Approx<float>& rhs)
@@ -44,3 +75,15 @@ bool operator==(const sf::Angle& lhs, const Approx<sf::Angle>& rhs)
 {
     return lhs.asDegrees() == Approx(rhs.value.asDegrees());
 }
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const Approx<T>& approx)
+{
+    return os << approx.value;
+}
+
+template std::ostream& operator<<(std::ostream&, const Approx<int>&);
+template std::ostream& operator<<(std::ostream&, const Approx<float>&);
+template std::ostream& operator<<(std::ostream&, const Approx<sf::Vector2<float>>&);
+template std::ostream& operator<<(std::ostream&, const Approx<sf::Vector3<float>>&);
+template std::ostream& operator<<(std::ostream&, const Approx<sf::Angle>&);

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -5,12 +5,7 @@
 
 #pragma once
 
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
-
-#include <iomanip>
-#include <limits>
-#include <ostream>
+#include <iosfwd>
 
 // String conversions for doctest framework
 namespace sf
@@ -19,22 +14,23 @@ class Angle;
 class String;
 class Time;
 
+template <typename>
+class Vector2;
+
+template <typename>
+class Vector3;
+
+void setStreamPrecision(std::ostream& os, int maxDigits10);
+
 std::ostream& operator<<(std::ostream& os, const Angle& angle);
 std::ostream& operator<<(std::ostream& os, const String& string);
 std::ostream& operator<<(std::ostream& os, Time time);
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const Vector2<T>& vector)
-{
-    os << std::fixed << std::setprecision(std::numeric_limits<T>::max_digits10);
-    return os << "(" << vector.x << ", " << vector.y << ")";
-}
+std::ostream& operator<<(std::ostream& os, const Vector2<T>& vector);
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector)
-{
-    return os << "(" << vector.x << ", " << vector.y << ", " << vector.z << ")";
-}
+std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector);
 } // namespace sf
 
 ////////////////////////////////////////////////////////////
@@ -48,16 +44,14 @@ struct Approx
     explicit Approx(const T& t) : value(t)
     {
     }
+
     const T& value;
 };
 
 bool operator==(const float& lhs, const Approx<float>& rhs);
-bool operator==(const sf::Vector2f& lhs, const Approx<sf::Vector2f>& rhs);
-bool operator==(const sf::Vector3f& lhs, const Approx<sf::Vector3f>& rhs);
+bool operator==(const sf::Vector2<float>& lhs, const Approx<sf::Vector2<float>>& rhs);
+bool operator==(const sf::Vector3<float>& lhs, const Approx<sf::Vector3<float>>& rhs);
 bool operator==(const sf::Angle& lhs, const Approx<sf::Angle>& rhs);
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const Approx<T>& approx)
-{
-    return os << approx.value;
-}
+std::ostream& operator<<(std::ostream& os, const Approx<T>& approx);


### PR DESCRIPTION
This PR reduces physical dependencies between headers for test utilities, resulting in 1-2s average compilation speedup on my machine.