### PR TITLE
Remove code coverage from build scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         - { name: Windows VS2022 ClangCL, os: windows-2022, flags: -T ClangCL }
         - { name: Windows VS2022 Clang,   os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
         - { name: Linux GCC,            os: ubuntu-latest, prefix: xvfb-run -a, flags: -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
-        - { name: Linux Clang,          os: ubuntu-latest, prefix: xvfb-run -a, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
+        - { name: Linux Clang,          os: ubuntu-latest, prefix: xvfb-run -a, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
         - { name: MacOS,                os: macos-11, flags: -GNinja }
         - { name: MacOS Xcode,          os: macos-11, flags: -GXcode }
         config:
@@ -26,7 +26,7 @@ jobs:
         - { name: Static, flags: -DBUILD_SHARED_LIBS=FALSE }
         type:
         - { name: Release }
-        - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
+        - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
 
         include:
         - platform: { name: Windows VS2022, os: windows-2022 }
@@ -34,7 +34,7 @@ jobs:
           type: { name: Release }
         - platform: { name: Windows VS2022, os: windows-2022 }
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
-          type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
+          type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
         - platform: { name: MacOS, os: macos-11 }
           config: { name: Frameworks, flags: -GNinja -DSFML_BUILD_FRAMEWORKS=TRUE -DBUILD_SHARED_LIBS=TRUE }
         - platform: { name: MacOS, os: macos-11 }
@@ -65,26 +65,9 @@ jobs:
         wget -nv https://dl.google.com/android/repository/android-ndk-r23b-linux.zip -P $GITHUB_WORKSPACE
         unzip -qq -d $GITHUB_WORKSPACE android-ndk-r23b-linux.zip
 
-    - name: Install Linux Tools
-      if: matrix.type.name == 'Debug' && runner.os == 'Linux'
-      run: |
-        CLANG_VERSION=$(clang++ --version | sed -n 's/.*version \([0-9]\+\)\..*/\1/p')
-        echo "CLANG_VERSION=$CLANG_VERSION" >> $GITHUB_ENV
-        sudo apt-get install gcovr ${{ matrix.platform.name == 'Linux Clang' && 'llvm-$CLANG_VERSION' || '' }}
-
     - name: Install macOS Tools
       if: runner.os == 'macOS'
-      run: brew install gcovr ninja
-
-    - name: Install OpenCppCoverage and add to PATH
-      uses: nick-fields/retry@v2
-      if: matrix.type.name == 'Debug' && runner.os == 'Windows'
-      with:
-        max_attempts: 10
-        timeout_minutes: 3
-        command: |
-          choco install OpenCppCoverage -y
-          echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+      run: brew install ninja
 
     - name: Configure CMake
       shell: bash
@@ -92,20 +75,11 @@ jobs:
 
     - name: Build
       shell: bash
-      run: ${{matrix.platform.prefix}} cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
+      run: cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
 
-    - name: Generate Coverage Report
-      if: matrix.type.name == 'Debug' && runner.os != 'Windows' # Coverage is already generated on Windows when running tests.
-      run: gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE
-
-    - name: Upload Coverage Report to Codecov
-      if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' # Disable upload in forks
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        directory: ./build
-        files: ./build/coverage.out
-        fail_ci_if_error: true
+    - name: Test
+      shell: bash
+      run: ${{matrix.platform.prefix}} ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
     - name: Test Install Interface
       if: matrix.platform.name != 'Android' && matrix.config.name != 'iOS'
@@ -174,3 +148,65 @@ jobs:
     - name: Analyze Code
       shell: bash
       run: cmake --build $GITHUB_WORKSPACE/build --target tidy
+
+  coverage:
+    name: Coverage on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { name: Windows,   os: windows-2022, prefix: 'OpenCppCoverage.exe --export_type cobertura:$GITHUB_WORKSPACE/build/coverage.out --cover_children --sources $GITHUB_WORKSPACE\\src --sources $GITHUB_WORKSPACE\\include --' }
+        - { name: Linux,     os: ubuntu-22.04, flags: -DCMAKE_CXX_FLAGS=--coverage -DSFML_RUN_DISPLAY_TESTS=ON, prefix: xvfb-run -a }
+        - { name: Linux DRM, os: ubuntu-22.04, flags: -DCMAKE_CXX_FLAGS=--coverage -DSFML_USE_DRM=TRUE }
+        - { name: macOS,     os: macos-12,     flags: -DCMAKE_CXX_FLAGS=--coverage}
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev gcovr
+
+    - name: Install macOS Tools
+      if: runner.os == 'macOS'
+      run: brew install gcovr
+
+    - name: Install OpenCppCoverage
+      uses: nick-fields/retry@v2
+      if: runner.os == 'Windows'
+      with:
+        max_attempts: 10
+        timeout_minutes: 3
+        command: |
+          choco install OpenCppCoverage -y
+          echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+
+    - name: Configure CMake
+      shell: bash
+      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=Debug -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_ENABLE_COVERAGE=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}}
+
+    - name: Build
+      shell: bash
+      run: cmake --build $GITHUB_WORKSPACE/build --config Debug
+
+    - name: Test
+      shell: bash
+      run: ${{matrix.platform.prefix}} ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config Debug
+
+    - name: Generate Coverage Report
+      if: runner.os != 'Windows' # Coverage is already generated on Windows when running tests.
+      run: gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' $GITHUB_WORKSPACE
+
+    - name: Upload Coverage Report to Codecov
+      if: github.repository == 'SFML/SFML' # Disable upload in forks
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./build
+        files: ./build/coverage.out
+        fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
 
     - name: Configure CMake
       shell: bash
-      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=Debug -DSFML_BUILD_TEST_SUITE=TRUE -DSFML_ENABLE_COVERAGE=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}}
+      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=TRUE -DSFML_BUILD_TEST_SUITE=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}}
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,10 +157,14 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows,   os: windows-2022, prefix: 'OpenCppCoverage.exe --export_type cobertura:$GITHUB_WORKSPACE/build/coverage.out --cover_children --sources $GITHUB_WORKSPACE\\src --sources $GITHUB_WORKSPACE\\include --' }
-        - { name: Linux,     os: ubuntu-22.04, flags: -DCMAKE_CXX_FLAGS=--coverage -DSFML_RUN_DISPLAY_TESTS=ON, prefix: xvfb-run -a }
-        - { name: Linux DRM, os: ubuntu-22.04, flags: -DCMAKE_CXX_FLAGS=--coverage -DSFML_USE_DRM=TRUE }
-        - { name: macOS,     os: macos-12,     flags: -DCMAKE_CXX_FLAGS=--coverage}
+        - { name: Windows VS2019 x86,     os: windows-2019, flags: -A Win32 }
+        - { name: Windows VS2019 x64,     os: windows-2019, flags: -A x64 }
+        - { name: Windows VS2022 x86,     os: windows-2022, flags: -A Win32 }
+        - { name: Windows VS2022 x64,     os: windows-2022, flags: -A x64 }
+        - { name: Windows VS2022 ClangCL, os: windows-2022, flags: -T ClangCL }
+        - { name: Linux GCC,            os: ubuntu-22.04, prefix: xvfb-run -a, flags: -DCMAKE_CXX_FLAGS=--coverage -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
+        - { name: Linux Clang,          os: ubuntu-22.04, prefix: xvfb-run -a, flags: -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
+        - { name: MacOS,                os: macos-12, flags: -DCMAKE_CXX_FLAGS=--coverage -GNinja }
 
     steps:
     - name: Checkout Code
@@ -170,11 +174,11 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev gcovr
+        sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev gcovr ninja-build
 
     - name: Install macOS Tools
       if: runner.os == 'macOS'
-      run: brew install gcovr
+      run: brew install gcovr ninja
 
     - name: Install OpenCppCoverage
       uses: nick-fields/retry@v2
@@ -195,6 +199,12 @@ jobs:
       run: cmake --build $GITHUB_WORKSPACE/build --config Debug
 
     - name: Test
+      if: runner.os == 'Windows'
+      shell: bash
+      run: OpenCppCoverage.exe --export_type cobertura:$GITHUB_WORKSPACE/build/coverage.out --cover_children --sources $GITHUB_WORKSPACE\\src --sources $GITHUB_WORKSPACE\\include -- ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config Debug
+
+    - name: Test
+      if: runner.os != 'Windows'
       shell: bash
       run: ${{matrix.platform.prefix}} ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config Debug
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,9 +528,6 @@ endif()
 # add an option for building the test suite
 sfml_set_option(SFML_BUILD_TEST_SUITE FALSE BOOL "TRUE to build the SFML test suite, FALSE to ignore it")
 
-# add an option for enabling coverage reporting
-sfml_set_option(SFML_ENABLE_COVERAGE FALSE BOOL "TRUE to enable coverage reporting, FALSE to ignore it")
-
 if(SFML_BUILD_TEST_SUITE)
     if(SFML_OS_IOS)
         message(WARNING "Unit testing not supported on iOS")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -78,12 +78,6 @@ macro(sfml_add_library module)
     # enable C++17 support
     target_compile_features(${target} PUBLIC cxx_std_17)
 
-    # Add required flags for GCC if coverage reporting is enabled
-    if(SFML_ENABLE_COVERAGE AND (SFML_COMPILER_GCC OR SFML_COMPILER_CLANG))
-        target_compile_options(${target} PUBLIC $<$<CONFIG:DEBUG>:-O0> $<$<CONFIG:DEBUG>:-g> $<$<CONFIG:DEBUG>:-fprofile-arcs> $<$<CONFIG:DEBUG>:-ftest-coverage>)
-        target_link_options(${target} PUBLIC $<$<CONFIG:DEBUG>:--coverage>)
-    endif()
-
     set_target_warnings(${target})
     set_public_symbols_hidden(${target})
 
@@ -359,14 +353,6 @@ function(sfml_add_test target SOURCES DEPENDS)
 
     set_target_warnings(${target})
     set_public_symbols_hidden(${target})
-
-    # If coverage is enabled for MSVC and we are linking statically, use /WHOLEARCHIVE
-    # to make sure the linker doesn't discard unused code sections before coverage can be measured
-    if(SFML_ENABLE_COVERAGE AND SFML_COMPILER_MSVC AND NOT BUILD_SHARED_LIBS)
-        foreach(DEPENDENCY ${DEPENDS})
-            target_link_options(${target} PRIVATE $<$<CONFIG:DEBUG>:/WHOLEARCHIVE:$<TARGET_LINKER_FILE:${DEPENDENCY}>>)
-        endforeach()
-    endif()
 
     # Add the test
     doctest_discover_tests(${target})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,43 +138,6 @@ if(SFML_OS_WINDOWS AND NOT SFML_USE_SYSTEM_DEPS)
         VERBATIM)
 endif()
 
-# Automatically run the tests at the end of the build
-add_custom_target(runtests ALL
-                  DEPENDS test-sfml-system test-sfml-window test-sfml-graphics test-sfml-network test-sfml-audio
-)
-
-if(SFML_ENABLE_COVERAGE AND SFML_OS_WINDOWS)
-    # Try to find and use OpenCppCoverage for coverage reporting when building with MSVC
-    find_program(OpenCppCoverage_BINARY "OpenCppCoverage.exe")
-
-    if(OpenCppCoverage_BINARY)
-        execute_process(COMMAND "${OpenCppCoverage_BINARY}" --help ERROR_VARIABLE OpenCppCoverage_HELP_OUTPUT OUTPUT_QUIET)
-
-        if(OpenCppCoverage_HELP_OUTPUT MATCHES "OpenCppCoverage Version: ([.0-9]+)")
-            set(OpenCppCoverage_VERSION "${CMAKE_MATCH_1}")
-        endif()
-    endif()
-
-    include(FindPackageHandleStandardArgs)
-
-    find_package_handle_standard_args(OpenCppCoverage
-        REQUIRED_VARS OpenCppCoverage_BINARY
-        VERSION_VAR OpenCppCoverage_VERSION
-    )
-endif()
-
-if(SFML_ENABLE_COVERAGE AND OpenCppCoverage_FOUND)
-    # Use OpenCppCoverage
-    message(STATUS "Using OpenCppCoverage to generate coverage report")
-
-    string(REPLACE "/" "\\" COVERAGE_EXCLUDE "${CMAKE_CTEST_COMMAND}")
-    string(REPLACE "/" "\\" COVERAGE_SRC "${PROJECT_SOURCE_DIR}/src")
-    string(REPLACE "/" "\\" COVERAGE_INCLUDE "${PROJECT_SOURCE_DIR}/include")
-
-    set(COVERAGE_PREFIX ${OpenCppCoverage_BINARY} ARGS --quiet --export_type cobertura:${PROJECT_BINARY_DIR}/coverage.out --cover_children --excluded_modules "${COVERAGE_EXCLUDE}" --sources "${COVERAGE_SRC}" --sources "${COVERAGE_INCLUDE}" --)
-endif()
-
-add_custom_command(TARGET runtests
-                   COMMENT "Run tests"
-                   POST_BUILD COMMAND ${COVERAGE_PREFIX} ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>
-                   VERBATIM)
+# Convenience for building and running tests
+add_custom_target(runtests DEPENDS test-sfml-system test-sfml-window test-sfml-graphics test-sfml-network test-sfml-audio)
+add_custom_command(TARGET runtests POST_BUILD COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG> VERBATIM)


### PR DESCRIPTION
## Description

Closes #2429 

The first commit is the part that closes #2429. The second commit removes the `SFML_ENABLE_COVERAGE` option entirely because after the first commit, there was little remaining need to keep that option. Coverage can be enabled from outside of the build so there's no particular reason that needs to have its own designated option in the build. It's not as if any developers are routinely checking coverage statistics locally so no convenience is being lost.