### PR TITLE
Replace `std::rand` with `<random>`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ Checks: >
   -clang-analyzer-optin.cplusplus.VirtualCall,
   -clang-analyzer-optin.osx.*,
   -clang-analyzer-osx.*,
-  -clang-analyzer-security.insecureAPI.rand,
   -clang-analyzer-unix.Malloc,
   -misc-const-correctness,
   -misc-misplaced-const,

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -279,8 +279,9 @@ public:
         {
             // Spread the coordinates from -480 to +480
             // So they'll always fill the viewport at 800x600
-            m_pointCloud[i].position.x = static_cast<float>(rand() % 960) - 480.f;
-            m_pointCloud[i].position.y = static_cast<float>(rand() % 960) - 480.f;
+            std::uniform_real_distribution<float> positionDistribution(-480, 480);
+            m_pointCloud[i].position.x = positionDistribution(rng);
+            m_pointCloud[i].position.y = positionDistribution(rng);
         }
 
         // Load the texture

--- a/src/SFML/Audio/SoundFileWriterOgg.cpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.cpp
@@ -32,8 +32,8 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
-#include <cstdlib>
 #include <ostream>
+#include <random>
 
 
 namespace sf::priv
@@ -63,7 +63,8 @@ bool SoundFileWriterOgg::open(const std::filesystem::path& filename, unsigned in
     m_channelCount = channelCount;
 
     // Initialize the ogg/vorbis stream
-    ogg_stream_init(&m_ogg, std::rand());
+    static std::mt19937 rng(std::random_device{}());
+    ogg_stream_init(&m_ogg, std::uniform_int_distribution(0, std::numeric_limits<int>::max())(rng));
     vorbis_info_init(&m_vorbis);
 
     // Setup the encoder: VBR, automatic bitrate management


### PR DESCRIPTION
## Description

https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER&id=SFML_SFML&open=AYaqzWMqgNPC4qRKFLQx

Addresses some static analysis warnings about our use of `std::rand`.
