### PR TITLE
Fix condition for trailing bytes count in UTF-8 decoder.

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -69,7 +69,7 @@ In Utf<8>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replace
 
     // decode the character
     int trailingBytes = trailing[static_cast<std::uint8_t>(*begin)];
-    if (begin + trailingBytes < end)
+    if (trailingBytes < std::distance(begin, end))
     {
         output = 0;
 

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -230,18 +230,30 @@ TEST_CASE("[System] sf::String")
 
     SUBCASE("fromUtf8()")
     {
-        constexpr std::array<std::uint8_t, 4> characters{'w', 'x', 'y', 'z'};
-        const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
-        CHECK(std::string(string) == "wxyz"s);
-        CHECK(std::wstring(string) == L"wxyz"s);
-        CHECK(string.toAnsiString() == "wxyz"s);
-        CHECK(string.toWideString() == L"wxyz"s);
-        CHECK(string.toUtf8() == std::basic_string<std::uint8_t>{'w', 'x', 'y', 'z'});
-        CHECK(string.toUtf16() == u"wxyz"s);
-        CHECK(string.toUtf32() == U"wxyz"s);
-        CHECK(string.getSize() == 4);
-        CHECK(!string.isEmpty());
-        CHECK(string.getData() != nullptr);
+        SUBCASE("Nominal")
+        {
+            constexpr std::array<std::uint8_t, 4> characters{'w', 'x', 'y', 'z'};
+            const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
+            CHECK(std::string(string) == "wxyz"s);
+            CHECK(std::wstring(string) == L"wxyz"s);
+            CHECK(string.toAnsiString() == "wxyz"s);
+            CHECK(string.toWideString() == L"wxyz"s);
+            CHECK(string.toUtf8() == std::basic_string<std::uint8_t>{'w', 'x', 'y', 'z'});
+            CHECK(string.toUtf16() == u"wxyz"s);
+            CHECK(string.toUtf32() == U"wxyz"s);
+            CHECK(string.getSize() == 4);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
+        }
+
+        SUBCASE("Insufficient input")
+        {
+            constexpr std::array<std::uint8_t, 1> characters{251};
+            const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
+            constexpr char32_t                    defaultReplacementCharacter = 0;
+            CHECK(string.getSize() == 1);
+            CHECK(string[0] == defaultReplacementCharacter);
+        }
     }
 
     SUBCASE("fromUtf16()")


### PR DESCRIPTION
This PR fixes bug reported here: https://github.com/SFML/SFML/issues/2113

Originally, the `if` condition in question would be incorrect (and triggered an assertion in Visual Studio) when there are less bytes in the input range than inferred from the last decoded byte.
Using std::distance lets me safely calculate the remaining bytes available in the input sequence and then the result can be compared to the required number of trailing bytes.

To reproduce the bug:

```cpp
#include <SFML/System.hpp>
int main()
{
    std::string s(1, (char)251);
    sf::String::fromUtf8(s.begin(), s.end());
}
```
