### PR TITLE
EGL pixel format selection and OpenGL version parsing fixes

### DIFF
--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -263,15 +263,17 @@ bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, 
                                                     static_cast<GLsizei>(size.x),
                                                     static_cast<GLsizei>(size.y)));
 
+                m_stencil = true;
+
 #else
+
+                m_stencil = false;
 
                 err() << "Impossible to create render texture (failed to create the attached depth/stencil buffer)"
                       << std::endl;
                 return false;
 
 #endif // SFML_OPENGL_ES
-
-                m_stencil = true;
             }
             else if (settings.depthBits)
             {
@@ -355,14 +357,16 @@ bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, 
                                                                static_cast<GLsizei>(size.y)));
             }
 
+            m_multisample = true;
+
 #else
+
+            m_multisample = false;
 
             err() << "Impossible to create render texture (failed to create the multisample render buffers)" << std::endl;
             return false;
 
 #endif // SFML_OPENGL_ES
-
-            m_multisample = true;
         }
     }
 


### PR DESCRIPTION
We've seen that in certain situations e.g. running on certain Android platforms (#2395) or running tests on the GitHub actions VMs, the OpenGL implementation can become pretty broken and start returning values that don't follow the specification. Because failing to parse an OpenGL context version doesn't really hinder us from continuing operation if everything else works, this change just assumes a conservative version and continues instead of causing the application to terminate.

The EGL pixel format selection procedure before this change relied on `eglChooseConfig()`. Using this function to select a pixel format bears the same problems as its `wgl` and `glX` counterparts (which we don't use): The way the SFML API is designed, the user has to resort to guessing a conservative configuration to request or else it will fail and graphics becomes unusable or even causes the application to terminate (see #2395). `eglChooseConfig()` takes a set of attributes that it tries to match exactly to a pixel format available on the system. If an exact match isn't found it will just fail. The other context implementations are a bit more "user friendly" in this respect, if an exact match isn't found they will still return something that is a close enough match and emit a warning to the console if a certain attribute could not be met. This gives the user helpful feedback and allows them to adjust their requested settings based on e.g. tester feedback. This changeset makes EGL pixel format selection follow the same procedure as the other context types.

Fixes #2395
Closes #2422

