### PR TITLE
Make use of CODECOV_TOKEN in ci.yml in order to work around Github Actions API errors that occur

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
       if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' # Disable upload in forks
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./build
         files: ./build/coverage.out
         fail_ci_if_error: true


### PR DESCRIPTION
Title.

It seems like the failures have been getting pretty bad lately. If we provide CODECOV_TOKEN ourselves then codecov can skip the Github Actions API query that fails and we should see much less failures.