### PR TITLE
Don't automatically run tests after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,17 @@ jobs:
 
     - name: Build
       shell: bash
-      run: ${{matrix.platform.prefix}} cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
+      run: cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
+
+    - name: Test
+      if: runner.os == 'Windows'
+      shell: bash
+      run: cmake --build $GITHUB_WORKSPACE/build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+
+    - name: Test
+      if: runner.os != 'Windows'
+      shell: bash
+      run: ${{matrix.platform.prefix}} ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
     - name: Generate Coverage Report
       if: matrix.type.name == 'Debug' && runner.os != 'Windows' # Coverage is already generated on Windows when running tests.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,11 +138,6 @@ if(SFML_OS_WINDOWS AND NOT SFML_USE_SYSTEM_DEPS)
         VERBATIM)
 endif()
 
-# Automatically run the tests at the end of the build
-add_custom_target(runtests ALL
-                  DEPENDS test-sfml-system test-sfml-window test-sfml-graphics test-sfml-network test-sfml-audio
-)
-
 if(SFML_ENABLE_COVERAGE AND SFML_OS_WINDOWS)
     # Try to find and use OpenCppCoverage for coverage reporting when building with MSVC
     find_program(OpenCppCoverage_BINARY "OpenCppCoverage.exe")
@@ -174,6 +169,8 @@ if(SFML_ENABLE_COVERAGE AND OpenCppCoverage_FOUND)
     set(COVERAGE_PREFIX ${OpenCppCoverage_BINARY} ARGS --quiet --export_type cobertura:${PROJECT_BINARY_DIR}/coverage.out --cover_children --excluded_modules "${COVERAGE_EXCLUDE}" --sources "${COVERAGE_SRC}" --sources "${COVERAGE_INCLUDE}" --)
 endif()
 
+# Convenience for building and running tests in a single command
+add_custom_target(runtests DEPENDS test-sfml-system test-sfml-window test-sfml-graphics test-sfml-network test-sfml-audio)
 add_custom_command(TARGET runtests
                    COMMENT "Run tests"
                    POST_BUILD COMMAND ${COVERAGE_PREFIX} ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>


### PR DESCRIPTION
## Description

Closes #2429
Supersedes #2430 

Removing `ALL` from the `runtests` target means it's no longer automatically built as part of a default build. This means the tests no longer get run after every build. Keeping this target around also means we're not forced to refactor all the code coverage so that can stay in place. I still hope to eventually remove code coverage from the build scripts and to eventually swap it all out with a uniform LLVM-based solution that works on all platforms but that was never my goal so it can wait.

See the extended commit message for there are two "Test" CI jobs. TL;DR It's because of OpenCppCoverage.
