### PR TITLE
Adding support for std::string_view to sf::String

### DIFF
--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -33,6 +33,7 @@
 
 #include <locale>
 #include <string>
+#include <string_view>
 
 
 namespace sf
@@ -117,6 +118,7 @@ public:
     /// \param locale     Locale to use for conversion
     ///
     ////////////////////////////////////////////////////////////
+    String(std::string_view ansiString, const std::locale& locale = std::locale());
     String(const std::string& ansiString, const std::locale& locale = std::locale());
 
     ////////////////////////////////////////////////////////////
@@ -133,6 +135,7 @@ public:
     /// \param wideString Wide string to convert
     ///
     ////////////////////////////////////////////////////////////
+    String(std::wstring_view wideString);
     String(const std::wstring& wideString);
 
     ////////////////////////////////////////////////////////////
@@ -149,6 +152,7 @@ public:
     /// \param utf32String UTF-32 string to assign
     ///
     ////////////////////////////////////////////////////////////
+    String(std::basic_string_view<std::uint32_t> utf32String);
     String(const std::basic_string<std::uint32_t>& utf32String);
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -75,12 +75,18 @@ String::String(const char* ansiString, const std::locale& locale)
 
 
 ////////////////////////////////////////////////////////////
-String::String(const std::string& ansiString, const std::locale& locale)
+String::String(std::string_view ansiString, const std::locale& locale)
 {
     m_string.reserve(ansiString.length() + 1);
     Utf32::fromAnsi(ansiString.begin(), ansiString.end(), std::back_inserter(m_string), locale);
 }
 
+
+////////////////////////////////////////////////////////////
+String::String(const std::string& ansiString, const std::locale& locale) :
+    String(std::string_view(ansiString), locale)
+{
+}
 
 ////////////////////////////////////////////////////////////
 String::String(const wchar_t* wideString)
@@ -98,10 +104,17 @@ String::String(const wchar_t* wideString)
 
 
 ////////////////////////////////////////////////////////////
-String::String(const std::wstring& wideString)
+String::String(std::wstring_view wideString)
 {
     m_string.reserve(wideString.length() + 1);
     Utf32::fromWide(wideString.begin(), wideString.end(), std::back_inserter(m_string));
+}
+
+
+////////////////////////////////////////////////////////////
+String::String(const std::wstring& wideString) :
+    String(std::wstring_view(wideString))
+{
 }
 
 
@@ -114,10 +127,16 @@ String::String(const std::uint32_t* utf32String)
 
 
 ////////////////////////////////////////////////////////////
-String::String(const std::basic_string<std::uint32_t>& utf32String) : m_string(utf32String)
+String::String(std::basic_string_view<std::uint32_t> utf32String) : m_string(utf32String)
 {
 }
 
+
+////////////////////////////////////////////////////////////
+String::String(const std::basic_string<std::uint32_t>& utf32String) :
+    String(std::basic_string_view<std::uint32_t>(utf32String))
+{
+}
 
 ////////////////////////////////////////////////////////////
 String::String(const String& copy) = default;


### PR DESCRIPTION
## Description

This is a modification to sf::String to add support for conversion from std::string_view and related derivations of std::basic_string_view, similar to the existing conversions within sf::String.

This PR is related to the issue #2445

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

This is the test program I used, although a better one is probably appropriate. (I've never worked with uint32_t characters, so I wouldn't know where to begin with that.)

```cpp
#include <SFML/Main.hpp>
#include <SFML/Graphics.hpp>
#include <SFML/Window.hpp>

#include <string_view>

int main() {
  sf::RenderWindow window(sf::VideoMode(sf::Vector2u(800, 600)), "SFML Testbed");
  window.setFramerateLimit(60);

  sf::Font font;
  bool derp = font.loadFromFile("c:/Windows/Fonts/arial.ttf");
  
  const char data[] = "derpdurr";
  const wchar_t wdata[] = L"herpboing";

  std::string str(data + 4, 4);
  std::string_view sv(data, 4);
  std::wstring wstr(wdata, 4);
  std::wstring_view wsv(wdata + 4);

  std::vector<sf::Text> texts;
  texts.emplace_back(wstr, font);
  texts.back().setPosition(sf::Vector2f(10, 0));
  texts.emplace_back(sv, font);
  texts.back().setPosition(sf::Vector2f(10, 40));
  texts.emplace_back(str, font);
  texts.back().setPosition(sf::Vector2f(10, 80));
  texts.emplace_back(wsv, font);
  texts.back().setPosition(sf::Vector2f(10, 120));
  
  for(bool run = true; run;) {
    window.clear();
    for(auto& text : texts) {
      window.draw(text);
    }
    window.display();

    sf::Event event;
    while(window.pollEvent(event)) {
      if(event.type == sf::Event::Closed) {
        run = false; break;
      }
    }
  }
}
```
