### PR TITLE
Remove redundant 'reset' calls in 'TransientContext` destructor

### DIFF
--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -221,9 +221,6 @@ struct TransientContext
     {
         if (useSharedContext)
             sharedContext->setActive(false);
-
-        sharedContextLock.reset();
-        context.reset();
     }
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
This should be a simplification & tiny optimization without any visible change in behavior.