### PR TITLE
Manually upload coverage report instead of using codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     name: ${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}
     runs-on: ${{ matrix.platform.os }}
+    env:
+      HAVE_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
 
     strategy:
       fail-fast: false
@@ -108,14 +110,32 @@ jobs:
       if: matrix.type.name == 'Debug' && runner.os != 'Windows' # Coverage is already generated on Windows when running tests.
       run: gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE
 
+    - name: Download Codecov Uploader
+      if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' && env.HAVE_CODECOV_TOKEN == 'true' # Disable upload in forks and when Codecov token isn't available
+      shell: bash
+      run: |
+        platform=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+        if [ "$platform" == "windows" ]; then CODECOV_BINARY="codecov.exe"; else CODECOV_BINARY="codecov"; fi
+        curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+        curl -s --remote-name-all "https://uploader.codecov.io/latest/$platform/{$CODECOV_BINARY,$CODECOV_BINARY.SHA256SUM,$CODECOV_BINARY.SHA256SUM.sig}"
+        gpgv "$CODECOV_BINARY.SHA256SUM.sig" "$CODECOV_BINARY.SHA256SUM"
+        if [ "$platform" == "windows" ]; then powershell 'If ($(Compare-Object -ReferenceObject $(($(certUtil -hashfile codecov.exe SHA256)[1], "codecov.exe") -join "  ") -DifferenceObject $(Get-Content codecov.exe.SHA256SUM)).length -eq 0) {echo "codecov: OK"} Else {exit 1}';
+        else shasum -a 256 -c codecov.SHA256SUM; fi
+        chmod +x "$CODECOV_BINARY"
+        echo "CODECOV_BINARY=$CODECOV_BINARY" >> $GITHUB_ENV
+
     - name: Upload Coverage Report to Codecov
-      if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' # Disable upload in forks
-      uses: codecov/codecov-action@v3
+      if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' && env.HAVE_CODECOV_TOKEN == 'true' # Disable upload in forks and when Codecov token isn't available
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      uses: nick-fields/retry@v2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        directory: ./build
-        files: ./build/coverage.out
-        fail_ci_if_error: true
+        timeout_seconds: 30
+        max_attempts: 10
+        retry_wait_seconds: 60
+        warning_on_retry: false
+        shell: bash
+        command: ./${{ env.CODECOV_BINARY }} -n "${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}" -Z -f ./build/coverage.out -C ${{ github.sha }} -s ./build -e CODECOV_TOKEN,GITHUB_ACTION,GITHUB_RUN_ID,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_SHA,GITHUB_HEAD_REF
 
     - name: Test Install Interface
       if: matrix.platform.name != 'Android' && matrix.config.name != 'iOS'


### PR DESCRIPTION
Title.

According to Codecov maintainers, the reason why uploading sporadically fails is because they try to query _some_ data from the GitHub API and that can fail if they manage to hit their rate limit, e.g. if by coincidence many projects simultaneously try to upload coverage data at the same time. This seems to be independent of whether we provide the `CODECOV_TOKEN` ourselves or not. Obviously the most elegant solution would be for their backend to handle the limit and just retry a few seconds/minutes later but it seems like they are taking the route of trying to convince GitHub to make a rate limit exception for them.

Whatever they end up doing, because I don't like holding my breath over such things, this change adds the ability to keep on trying ~till we run out of cake~ until the upload finally succeeds. To be able to do this, we have to roll our own implementation of what the codecov-action would have did itself and call the binary using the retry action.