### PR TITLE
Export symbol required to use sfml-activity

### DIFF
--- a/src/SFML/Main/SFMLActivity.cpp
+++ b/src/SFML/Main/SFMLActivity.cpp
@@ -132,7 +132,7 @@ void* loadLibrary(const char* libraryName, JNIEnv* lJNIEnv, jobject& ObjectActiv
     return handle;
 }
 
-void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, std::size_t savedStateSize)
+JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedState, std::size_t savedStateSize)
 {
     // Before we can load a library, we need to find out its location. As
     // we're powerless here in C/C++, we need the JNI interface to communicate


### PR DESCRIPTION
## Description

I believe what was going on is that those on Windows building for Android didn't execute this code path meaning the Android shared libraries continued to have all symbols exported by default as is the case with GCC and Clang. https://github.com/SFML/SFML/commit/5fde1ca613b7c308b6155594e5d067b1a02f5179 meant that now even on Android those symbols are hidden which revealed that some symbols in that library aren't getting exported like they need to be.
