### PR TITLE
Fixed Codecov uploader being run with the wrong SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,9 @@ jobs:
         retry_wait_seconds: 60
         warning_on_retry: false
         shell: bash
-        command: ./${{ env.CODECOV_BINARY }} -n "${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}" -Z -f ./build/coverage.out -C ${{ github.sha }} -s ./build -e CODECOV_TOKEN,GITHUB_ACTION,GITHUB_RUN_ID,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_SHA,GITHUB_HEAD_REF
+        command: |
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "pull_request_target" ]]; then COMMIT_OVERRIDE="-C ${{ github.event.pull_request.head.sha }}"; fi
+          ./${{ env.CODECOV_BINARY }} -n "${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}" -Z -f ./build/coverage.out $COMMIT_OVERRIDE -s ./build -e CODECOV_TOKEN,GITHUB_ACTION,GITHUB_RUN_ID,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_SHA,GITHUB_HEAD_REF
 
     - name: Test Install Interface
       if: matrix.platform.name != 'Android' && matrix.config.name != 'iOS'


### PR DESCRIPTION
When GitHub actions are run for a pull request, the checkout provided to the jobs for the pull request workflow isn't the HEAD commit of the PR (the latest commit the user pushed). Instead it is a hypothetical merge commit that GitHub automatically creates by merging the HEAD commit of the pull request onto the base branch that the pull request targets. This is also the case if a repository only uses rebase merging like we do.

The HEAD of this PR is: e4b6c1428258822fceb3f884e0972534e8622b91
The merge commit of this PR is:  b71abafdd1e31f07493425dc5af39b6aef02409b

When the Codecov uploader is run, we have to provide it the commit SHA of the HEAD and not of the merge commit if it is run in a pull request context. If we don't, the comment that Codecov adds to the pull request will complain about the head differing from the pull request most recent head as can be seen [here](https://github.com/SFML/SFML/pull/2455#issuecomment-1472722074). This can also affect other metrics that Codecov computes based on HEAD and the base commit.

This change sets the commit provided to the uploader (via `-C`) to that of the HEAD commit when a job is run in a pull request context. This should be equivalent to what the codecov-action does as well. See [here](https://github.com/codecov/codecov-action/blob/9b87723d6ac0be351efc7242ba5ec28fa641c77c/src/buildExec.ts#L136).