### PR TITLE
Fix two issues present in Debian patches

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -45,7 +45,7 @@ configure_file(${DOXYGEN_INPUT_DIR}/doc/header.html.in ${DOXYGEN_OUTPUT_DIR}/hea
 configure_file(${DOXYGEN_INPUT_DIR}/doc/doxygen.css ${DOXYGEN_OUTPUT_DIR}/html/doxygen.css COPYONLY)
 
 # target setup
-add_custom_target(doc ALL
+add_custom_target(doc
                   COMMAND ${CMAKE_COMMAND} -E echo_append "Building API Documentation..."
                   COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIGURED_INPUT}
                   COMMAND ${CMAKE_COMMAND} -E echo "Done."

--- a/doc/header.html.in
+++ b/doc/header.html.in
@@ -4,7 +4,6 @@
         <title>SFML - Simple and Fast Multimedia Library</title>
         <meta http-equiv="Content-Type" content="text/html;"/>
         <meta charset="utf-8"/>
-        <!--<link rel='stylesheet' type='text/css' href="https://fonts.googleapis.com/css?family=Ubuntu:400,700,400italic"/>-->
         <link rel="stylesheet" type="text/css" href="doxygen.css" title="default" media="screen,print" />
         <script type="text/javascript" src="jquery.js"></script>
         <script type="text/javascript" src="dynsections.js"></script>


### PR DESCRIPTION
## Description

Fixes https://salsa.debian.org/games-team/libsfml/-/blob/master/debian/patches/01_remove-googleapi-css.patch and https://salsa.debian.org/games-team/libsfml/-/blob/master/debian/patches/02_build-doc-once.patch.

The first one about removing a comment is mostly a curtesy to the Debian folks but we don't like commented code either so it makes sense.

The second one about the `doc` target is something I agree with. I never build the docs because I have to modify a cache variable then deal with the massive console output that Doxygen produces every single time I build the library. It's much better if I can leave that option enabled but only build docs on demand. I think it would be even better if we made Doxygen an optional dependency and only configured the docs if Doxygen is found. That way we don't even need the `SFML_BUILD_DOC` option.
