### PR TITLE
Fix clang-tidy-16 errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
 
     - name: Install macOS Tools
       if: runner.os == 'macOS'
-      run: brew install gcovr ninja
+      run: |
+        brew update
+        brew install gcovr ninja
 
     - name: Install OpenCppCoverage and add to PATH
       uses: nick-fields/retry@v2
@@ -192,6 +194,7 @@ jobs:
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
+        brew update
         brew install llvm
         echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
 

--- a/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
+++ b/src/SFML/Window/OSX/SFKeyboardModifiersHelper.mm
@@ -70,9 +70,12 @@ struct ModifiersState
 // Global Variables
 ////////////////////////////////////////////////////////////
 
+namespace
+{
 /// Share 'modifiers' state with all windows to correctly fire pressed/released events
-static ModifiersState state;
-static BOOL           isStateInitialized = NO;
+ModifiersState state;
+BOOL           isStateInitialized = NO;
+}
 
 
 ////////////////////////////////////////////////////////////

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -14,7 +14,9 @@ static_assert(!std::is_copy_assignable_v<sf::FileInputStream>);
 static_assert(std::is_nothrow_move_constructible_v<sf::FileInputStream>);
 static_assert(std::is_nothrow_move_assignable_v<sf::FileInputStream>);
 
-static std::string getTemporaryFilePath()
+namespace
+{
+std::string getTemporaryFilePath()
 {
     static int counter = 0;
 
@@ -63,6 +65,7 @@ public:
         return m_path;
     }
 };
+} // namespace
 
 TEST_CASE("[System] sf::FileInputStream")
 {


### PR DESCRIPTION
## Description

clang-tidy-16 adds a new [`misc-use-anonymous-namespace`](https://clang.llvm.org/extra/clang-tidy/checks/misc/use-anonymous-namespace.html) check. We already prefer anonymous namespaces over using `static` so this check is a great addition.

LLVM was released last week and has just now landed in Homebrew so we should expect this error to start appearing in CI soon. I ran clang-tidy-16 locally to go ahead and catch all the new checks that we're violating. 
