### PR TITLE
Fixed GlContext not being activated if it shares the same address as a previously destroyed GlContext.

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -346,3 +346,14 @@ elseif(SFML_OS_IOS)
 elseif(SFML_OS_ANDROID)
     target_link_libraries(sfml-window PRIVATE android)
 endif()
+
+# on some platforms (e.g. Raspberry Pi 3 armhf), GCC requires linking libatomic to use <atomic> features
+# that aren't supported by native CPU instructions (64-bit atomic operations on 32-bit architecture)
+if(SFML_COMPILER_GCC)
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("#include <atomic>
+        int main(){std::atomic_ullong x(1); return x.fetch_add(1);}" ATOMIC_TEST)
+    if(NOT ATOMIC_TEST)
+        target_link_libraries(sfml-window PRIVATE atomic)
+    endif()
+endif()


### PR DESCRIPTION
Depending on how merciful the memory allocator is, by chance we might end up creating a `sf::Context` (directly or indirectly through another object) that lives at the same memory address as a previously destroyed `sf::Context`. Because the check for whether a context is active or not is performed based on its address, this can mean a new context is not activated if it has the same address as an older one.

This change performs the comparison based on a unique ID and makes sure to reset the current context ID when it is destroyed if necessary. Even if a newer context is created at the same address, it should get a higher ID than the previous one and force the code to activate it if it wasn't already active.

Because this behaviour is highly dependent on the memory allocator, you might need a bit of luck to trigger it. The best chance of seeing it is by running the following code for a while in a 32-bit build.
```cpp
#include <SFML/Window/Context.hpp>

int main()
{
    while (true)
        sf::Context context;
}
```
It will eventually crash or trigger an assert somewhere.
