### PR TITLE
Replaced xvfb-run with manually starting Xvfb and running fluxbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         - { name: Windows VS2022 x64,     os: windows-2022, flags: -A x64 }
         - { name: Windows VS2022 ClangCL, os: windows-2022, flags: -T ClangCL }
         - { name: Windows VS2022 Clang,   os: windows-2022, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
-        - { name: Linux GCC,            os: ubuntu-latest, prefix: xvfb-run -a, flags: -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
-        - { name: Linux Clang,          os: ubuntu-latest, prefix: xvfb-run -a, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
+        - { name: Linux GCC,            os: ubuntu-latest, flags: -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
+        - { name: Linux Clang,          os: ubuntu-latest, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: MacOS,                os: macos-11, flags: -GNinja }
         - { name: MacOS Xcode,          os: macos-11, flags: -GXcode }
         config:
@@ -57,7 +57,7 @@ jobs:
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install ninja-build xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev
+      run: sudo apt-get update && sudo apt-get install ninja-build xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev xvfb fluxbox
 
     - name: Install Android Components
       if: matrix.platform.name == 'Android'
@@ -95,18 +95,34 @@ jobs:
       run: cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
 
     - name: Test
-      if: runner.os == 'Windows'
-      shell: bash
-      run: cmake --build $GITHUB_WORKSPACE/build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
-
-    - name: Test
-      if: runner.os != 'Windows'
-      shell: bash
-      run: ${{matrix.platform.prefix}} ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
-
-    - name: Generate Coverage Report
-      if: matrix.type.name == 'Debug' && runner.os != 'Windows' # Coverage is already generated on Windows when running tests.
-      run: gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE
+      uses: nick-fields/retry@v2
+      with:
+        max_attempts: 10
+        timeout_minutes: 3
+        retry_wait_seconds: 5
+        warning_on_retry: false
+        shell: bash
+        command: |
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            # Run the tests
+            cmake --build $GITHUB_WORKSPACE/build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+            # Coverage is already generated on Windows when running tests.
+          else
+            # Start up Xvfb and fluxbox to host display tests on DISPLAY :99
+            if [ "${{ runner.os }}" == "Linux" ]; then
+              export DISPLAY=":99"
+              Xvfb $DISPLAY -screen 0 1920x1080x24 &
+              sleep 5
+              fluxbox > /dev/null 2>&1 &
+              sleep 5
+            fi
+            # Run the tests
+            ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+            # Run gcovr to extract coverage information from the test run
+            if [ "${{ matrix.type.name }}" == "Debug" ]; then
+              gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE
+            fi
+          fi
 
     - name: Download Codecov Uploader
       if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' # Disable upload in forks

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,13 +49,7 @@ target_compile_definitions(test-sfml-system PRIVATE
     EXPECTED_SFML_VERSION_IS_RELEASE=$<IF:$<BOOL:${VERSION_IS_RELEASE}>,true,false>
 )
 
-# FIXME Remove this once the Buildbot supports handling display tests on Linux platforms
-if(SFML_OS_WINDOWS OR SFML_OS_MACOSX)
-    set(SFML_RUN_DISPLAY_TESTS_DEFAULT ON)
-else()
-    set(SFML_RUN_DISPLAY_TESTS_DEFAULT OFF)
-endif()
-sfml_set_option(SFML_RUN_DISPLAY_TESTS ${SFML_RUN_DISPLAY_TESTS_DEFAULT} BOOL "TRUE to run tests that require a display, FALSE to ignore it")
+sfml_set_option(SFML_RUN_DISPLAY_TESTS ON BOOL "TRUE to run tests that require a display, FALSE to ignore it")
 
 set(WINDOW_SRC
     Window/Context.test.cpp


### PR DESCRIPTION
Tests were failing sporadically due to the fact that the Xvfb server that is started by xvfb-run did not have enough time to start up before the tests were run.

This change replaces xvfb-run with manually starting Xvfb and running fluxbox to emulate a window manager. Many aspects of SFML deal with window manager interaction and thus having one to talk to will make the environment in which we test more realistic. Between Xvfb start, fluxbox start and test start we add delays of 5 seconds which should be enough to avoid races.

Since tests might still fail for various other unforeseen reasons, both test steps and coverage step are combined into a single script invocation that can be passed to the retry action.