### PR TITLE
Fix unreachable code warning when using OpenGLES

### DIFF
--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -262,6 +262,8 @@ bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, 
                                                     GLEXT_GL_DEPTH24_STENCIL8,
                                                     static_cast<GLsizei>(size.x),
                                                     static_cast<GLsizei>(size.y)));
+                
+                m_stencil = true;
 
 #else
 
@@ -271,7 +273,7 @@ bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, 
 
 #endif // SFML_OPENGL_ES
 
-                m_stencil = true;
+
             }
             else if (settings.depthBits)
             {
@@ -354,6 +356,8 @@ bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, 
                                                                static_cast<GLsizei>(size.x),
                                                                static_cast<GLsizei>(size.y)));
             }
+            
+            m_multisample = true;
 
 #else
 
@@ -362,7 +366,7 @@ bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, 
 
 #endif // SFML_OPENGL_ES
 
-            m_multisample = true;
+
         }
     }
 


### PR DESCRIPTION
## Description

Specifically, when using OpenGLES there is a warning for unreachable code.

![image](https://user-images.githubusercontent.com/54750550/228054066-4e56a919-cd3e-484d-b9da-ffb0c6025b19.png)

![image](https://user-images.githubusercontent.com/54750550/228054091-be99bc12-feea-4b8e-a6d9-7cc4731a7ae8.png)
