### PR TITLE
Fixed OpenGL entry point loading on Windows

### DIFF
--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -945,29 +945,6 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
 void GlContext::checkSettings(const ContextSettings& requestedSettings) const
 {
     // Perform checks to inform the user if they are getting a context they might not have expected
-
-    auto glGetStringFunc = reinterpret_cast<glGetStringFuncType>(getFunction("glGetString"));
-
-    if (!glGetStringFunc)
-    {
-        err() << "Could not load glGetString function" << std::endl;
-
-        return;
-    }
-
-    // Detect any known non-accelerated implementations and warn
-    const char* vendorName   = reinterpret_cast<const char*>(glGetStringFunc(GL_VENDOR));
-    const char* rendererName = reinterpret_cast<const char*>(glGetStringFunc(GL_RENDERER));
-
-    if (vendorName && rendererName)
-    {
-        if (std::string_view(vendorName) == "Microsoft Corporation" && std::string_view(rendererName) == "GDI Generic")
-        {
-            err() << "Warning: Detected \"Microsoft Corporation GDI Generic\" OpenGL implementation" << '\n'
-                  << "The current OpenGL implementation is not hardware-accelerated" << std::endl;
-        }
-    }
-
     int version          = static_cast<int>(m_settings.majorVersion * 10u + m_settings.minorVersion);
     int requestedVersion = static_cast<int>(requestedSettings.majorVersion * 10u + requestedSettings.minorVersion);
 

--- a/src/SFML/Window/Win32/WglContext.hpp
+++ b/src/SFML/Window/Win32/WglContext.hpp
@@ -181,6 +181,7 @@ private:
     HDC         m_deviceContext{}; //!< Device context associated to the context
     HGLRC       m_context{};       //!< OpenGL context
     bool        m_ownsWindow{};    //!< Do we own the target window?
+    bool        m_isGeneric{};     //!< Is this context provided by the generic GDI implementation?
 };
 
 } // namespace sf::priv


### PR DESCRIPTION
The way OpenGL entry points are loaded on Windows is unique compared to other platforms. Whereas on other platforms, the entry points returned by e.g. `glXGetProcAddressARB` can be used independently of the context they were queried in, the entry points returned by `wglGetProcAddress` should only be used in the context they were queried in. This means in theory, any OpenGL function could have multiple different addresses on Windows depending on the context that was active when the query was made.

In practice, we just have to differentiate between 2 cases on Windows, either an ICD (hardware accelerated vendor driver) is available or an ICD is not available. In the former case, `wglGetProcAddress` forwards the query to the ICD providing the context that is currently active and it returns the address of the function from the concrete ICD .dll. In the latter case, when an ICD is not available, Windows provides a generic GDI software rendering implementation. For whatever reason, when the generic implementation is in use, `wglGetProcAddress` cannot be used to query entry points available for the active context, it will always return `NULL`. Instead they have to be loaded from the generic implementation library (OpenGL32.dll) itself using `GetProcAddress`.

So in summary:
- ICD available -> Create ICD context, activate and load using `wglGetProcAddress`
- ICD not available -> Create generic context, activate and load using `GetProcAddress`

The current implementation in SFML isn't 100% correct since it will try to fall back to `GetProcAddress` even when an ICD context is active but `wglGetProcAddress` does not return an address for whatever reason.

This is bad for 2 reasons:
1. We get entry points that are incompatible with the context they are supposed to be used in
2. We get a false impression that something is supported when it really isn't

This change fixes OpenGL entry points being loaded from OpenGL32.dll instead of failing to load if they are not provided by the ICD on Windows.

This is technically still not a 100% correct implementation, since in theory there could be multiple ICDs installed on a given system, each providing their specific entry points. The entry points would have to be stored per context that is created instead of globally for the entire application. Because this scenario occurs so rarely if at all, any OpenGL entry point loader (like glad which SFML uses) assumes the same entry points can be used across any context that is created by the application and thus stores them globally. This is correct on any platform except Windows, but I guess they weren't willing to make an exception just for Windows.

The only way to test this is by running a test application on both a system that has an ICD installed and one that only provides the generic implementation and inspecting where the function pointers originate from. In the former case, they should be addresses in the ICD (e.g. atioglxx.dll for AMD, nvoglv32.dll for Nvidia) and in the latter case they should be addresses inside OpenGL32.dll.