### PR TITLE
Disable stringop-overflow warning when including minimp3 since it produces false positives.

### DIFF
--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -34,12 +34,17 @@
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4242 4244 4267 4456 4706)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
 
 #include <minimp3_ex.h>
 
 #ifdef _MSC_VER
 #pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
 #endif
 
 #undef NOMINMAX


### PR DESCRIPTION
When building with 32-bit GCC 12.2.0 with -O3 the stringop-overflow warning produces false positives when including minimp3.

https://gcc.godbolt.org/z/aq7zf1z1q

CI currently fails to because of this, see [here](https://ci.sfml-dev.org/#/builders/42/builds/3/steps/13/logs/stdio).

This change disables stringop-overflow when including minimp3.

Until this change is merged, no other PRs will pass checks since MinGW 12.2.0 is a requirement now.