### PR TITLE
Remove bugprone `sf::Text` constructor

### DIFF
--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -30,7 +30,7 @@
 ///     sf::Font font;
 ///     if (!font.loadFromFile("arial.ttf"))
 ///         return EXIT_FAILURE;
-///     sf::Text text("Hello SFML", font, 50);
+///     sf::Text text(font, "Hello SFML", 50);
 ///
 ///     // Load a music to play
 ///     sf::Music music;

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
     if (!font.loadFromFile("tuffy.ttf"))
         return EXIT_FAILURE;
 
-    sf::Text text("Tap anywhere to move the logo.", font, 64);
+    sf::Text text(font, "Tap anywhere to move the logo.", 64);
     text.setFillColor(sf::Color::Black);
     text.setPosition({10, 10});
 

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -37,7 +37,7 @@
 // Our PIMPL
 struct SFMLmainWindow
 {
-    SFMLmainWindow(sf::WindowHandle win) : renderWindow(win), background(sf::Color::Blue)
+    SFMLmainWindow(sf::WindowHandle win) : renderWindow(win), text(font), background(sf::Color::Blue)
     {
         std::string resPath = [[[NSBundle mainBundle] resourcePath] tostdstring];
         if (!logo.loadFromFile(resPath + "/logo.png"))
@@ -59,7 +59,6 @@ struct SFMLmainWindow
             NSLog(@"Couldn't load the font");
 
         text.setFillColor(sf::Color::White);
-        text.setFont(font);
     }
 
     sf::RenderWindow renderWindow;

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -95,20 +95,18 @@ int main()
         return EXIT_FAILURE;
 
     // Create all of our graphics resources
-    sf::Text         hudText;
-    sf::Text         statusText;
+    sf::Text         hudText(font);
+    sf::Text         statusText(font);
     sf::Shader       terrainShader;
     sf::RenderStates terrainStates(&terrainShader);
     sf::VertexBuffer terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Static);
 
     // Set up our text drawables
-    statusText.setFont(font);
     statusText.setCharacterSize(28);
     statusText.setFillColor(sf::Color::White);
     statusText.setOutlineColor(sf::Color::Black);
     statusText.setOutlineThickness(2.0f);
 
-    hudText.setFont(font);
     hudText.setCharacterSize(14);
     hudText.setFillColor(sf::Color::White);
     hudText.setOutlineColor(sf::Color::Black);

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -41,8 +41,9 @@ void updateIdentification(unsigned int index)
 {
     sstr.str("");
     sstr << "Joystick " << index << ":";
-    texts.at("ID").label.setString(sstr.str());
-    texts.at("ID").value.setString(sf::Joystick::getIdentification(index).name);
+    auto& [label, value] = texts.at("ID");
+    label.setString(sstr.str());
+    value.setString(sf::Joystick::getIdentification(index).name);
 }
 
 // Update joystick axes
@@ -103,37 +104,40 @@ int main()
     sstr.setf(std::ios::fixed | std::ios::boolalpha);
 
     // Set up our joystick identification sf::Text objects
-    texts.emplace("ID", JoystickObject{{"<Not Connected>", font}, {"", font}});
-    texts.at("ID").label.setPosition({5.f, 5.f});
-    texts.at("ID").value.setPosition({80.f, 5.f});
+    {
+        auto [it, success]   = texts.emplace("ID", JoystickObject{{font, "<Not Connected>"}, {font}});
+        auto& [label, value] = it->second;
+        label.setPosition({5.f, 5.f});
+        value.setPosition({80.f, 5.f});
+    }
 
     // Set up our threshold sf::Text objects
     sstr.str("");
     sstr << threshold << "  (Change with up/down arrow keys)";
-
-    texts.emplace("Threshold", JoystickObject{{"Threshold:", font}, {sstr.str(), font}});
-    texts.at("Threshold").label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
-    texts.at("Threshold").value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
+    {
+        auto [it, success]   = texts.emplace("Threshold", JoystickObject{{font, "Threshold:"}, {font, sstr.str()}});
+        auto& [label, value] = it->second;
+        label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
+        value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
+    }
 
     // Set up our label-value sf::Text objects
     for (unsigned int i = 0; i < sf::Joystick::AxisCount; ++i)
     {
-        auto& object = texts.insert({axislabels[i], {{axislabels[i] + ":", font}, {"N/A", font}}}).first->second;
-
-        object.label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
-        object.value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
+        auto [it, success]   = texts.emplace(axislabels[i], JoystickObject{{font, axislabels[i] + ":"}, {font, "N/A"}});
+        auto& [label, value] = it->second;
+        label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
+        value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
     }
 
     for (unsigned int i = 0; i < sf::Joystick::ButtonCount; ++i)
     {
         sstr.str("");
         sstr << "Button " << i;
-        auto& object = texts.insert({sstr.str(), {{sstr.str() + ":", font}, {"N/A", font}}}).first->second;
-
-        object.label.setPosition(
-            {5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
-        object.value.setPosition(
-            {80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
+        auto [it, success]   = texts.emplace(sstr.str(), JoystickObject{{font, sstr.str() + ":"}, {font, "N/A"}});
+        auto& [label, value] = it->second;
+        label.setPosition({5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
+        value.setPosition({80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
     }
 
     for (auto& [label, joystickObject] : texts)
@@ -176,8 +180,9 @@ int main()
                 for (auto& [label, joystickObject] : texts)
                     joystickObject.value.setString("N/A");
 
-                texts.at("ID").label.setString("<Not Connected>");
-                texts.at("ID").value.setString("");
+                auto& [label, value] = texts.at("ID");
+                label.setString("<Not Connected>");
+                value.setString("");
 
                 sstr.str("");
                 sstr << threshold << "  (Change with up/down arrow keys)";

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -24,16 +24,16 @@ Texts              texts;
 std::ostringstream sstr;
 float              threshold = 0.1f;
 
-// Axes labels in as C strings
-constexpr std::array axislabels = {"X", "Y", "Z", "R", "U", "V", "PovX", "PovY"};
+// Axes labels in as strings
+const std::array<std::string, 8> axislabels = {"X", "Y", "Z", "R", "U", "V", "PovX", "PovY"};
 
 // Helper to set text entries to a specified value
 template <typename T>
-void set(const char* label, const T& value)
+void set(const std::string& label, const T& value)
 {
     sstr.str("");
     sstr << value;
-    texts[label].value.setString(sstr.str());
+    texts.at(label).value.setString(sstr.str());
 }
 
 // Update joystick identification
@@ -41,8 +41,8 @@ void updateIdentification(unsigned int index)
 {
     sstr.str("");
     sstr << "Joystick " << index << ":";
-    texts["ID"].label.setString(sstr.str());
-    texts["ID"].value.setString(sf::Joystick::getIdentification(index).name);
+    texts.at("ID").label.setString(sstr.str());
+    texts.at("ID").value.setString(sf::Joystick::getIdentification(index).name);
 }
 
 // Update joystick axes
@@ -63,7 +63,7 @@ void updateButtons(unsigned int index)
         sstr.str("");
         sstr << "Button " << j;
 
-        set(sstr.str().c_str(), sf::Joystick::isButtonPressed(index, j));
+        set(sstr.str(), sf::Joystick::isButtonPressed(index, j));
     }
 }
 
@@ -103,58 +103,43 @@ int main()
     sstr.setf(std::ios::fixed | std::ios::boolalpha);
 
     // Set up our joystick identification sf::Text objects
-    texts["ID"].label.setPosition({5.f, 5.f});
-    texts["ID"].value.setPosition({80.f, 5.f});
-
-    texts["ID"].label.setString("<Not Connected>");
-    texts["ID"].value.setString("");
+    texts.emplace("ID", JoystickObject{{"<Not Connected>", font}, {"", font}});
+    texts.at("ID").label.setPosition({5.f, 5.f});
+    texts.at("ID").value.setPosition({80.f, 5.f});
 
     // Set up our threshold sf::Text objects
     sstr.str("");
     sstr << threshold << "  (Change with up/down arrow keys)";
 
-    texts["Threshold"].label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
-    texts["Threshold"].value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
-
-    texts["Threshold"].label.setString("Threshold:");
-    texts["Threshold"].value.setString(sstr.str());
+    texts.emplace("Threshold", JoystickObject{{"Threshold:", font}, {sstr.str(), font}});
+    texts.at("Threshold").label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
+    texts.at("Threshold").value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
 
     // Set up our label-value sf::Text objects
     for (unsigned int i = 0; i < sf::Joystick::AxisCount; ++i)
     {
-        JoystickObject& object = texts[axislabels[i]];
+        auto& object = texts.insert({axislabels[i], {{axislabels[i] + ":", font}, {"N/A", font}}}).first->second;
 
         object.label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
-        object.label.setString(std::string(axislabels[i]) + ":");
-
         object.value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
-        object.value.setString("N/A");
     }
 
     for (unsigned int i = 0; i < sf::Joystick::ButtonCount; ++i)
     {
         sstr.str("");
         sstr << "Button " << i;
-        JoystickObject& object = texts[sstr.str()];
+        auto& object = texts.insert({sstr.str(), {{sstr.str() + ":", font}, {"N/A", font}}}).first->second;
 
         object.label.setPosition(
             {5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
-        object.label.setString(sstr.str() + ":");
-
         object.value.setPosition(
             {80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
-        object.value.setString("N/A");
     }
 
     for (auto& [label, joystickObject] : texts)
     {
-        joystickObject.label.setFont(font);
         joystickObject.label.setCharacterSize(14);
-        joystickObject.label.setFillColor(sf::Color::White);
-
-        joystickObject.value.setFont(font);
         joystickObject.value.setCharacterSize(14);
-        joystickObject.value.setFillColor(sf::Color::White);
     }
 
     // Update initially displayed joystick values if a joystick is already connected on startup
@@ -191,13 +176,13 @@ int main()
                 for (auto& [label, joystickObject] : texts)
                     joystickObject.value.setString("N/A");
 
-                texts["ID"].label.setString("<Not Connected>");
-                texts["ID"].value.setString("");
+                texts.at("ID").label.setString("<Not Connected>");
+                texts.at("ID").value.setString("");
 
                 sstr.str("");
                 sstr << threshold << "  (Change with up/down arrow keys)";
 
-                texts["Threshold"].value.setString(sstr.str());
+                texts.at("Threshold").value.setString(sstr.str());
             }
         }
 
@@ -220,7 +205,7 @@ int main()
             sstr.str("");
             sstr << threshold << "  (Change with up/down arrow keys)";
 
-            texts["Threshold"].value.setString(sstr.str());
+            texts.at("Threshold").value.setString(sstr.str());
         }
 
         // Clear the window

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -62,9 +62,9 @@ int main()
         if (!font.loadFromFile(resourcesDir() / "tuffy.ttf"))
             return EXIT_FAILURE;
 
-        sf::Text text("SFML / OpenGL demo", font);
-        sf::Text sRgbInstructions("Press space to toggle sRGB conversion", font);
-        sf::Text mipmapInstructions("Press return to toggle mipmapping", font);
+        sf::Text text(font, "SFML / OpenGL demo");
+        sf::Text sRgbInstructions(font, "Press space to toggle sRGB conversion");
+        sf::Text mipmapInstructions(font, "Press return to toggle mipmapping");
         text.setFillColor(sf::Color(255, 255, 255, 170));
         sRgbInstructions.setFillColor(sf::Color(255, 255, 255, 170));
         mipmapInstructions.setFillColor(sf::Color(255, 255, 255, 170));

--- a/examples/shader/Effect.hpp
+++ b/examples/shader/Effect.hpp
@@ -46,7 +46,7 @@ public:
         }
         else
         {
-            sf::Text error("Shader not\nsupported", getFont());
+            sf::Text error(getFont(), "Shader not\nsupported");
             error.setPosition({320.f, 200.f});
             error.setCharacterSize(36);
             target.draw(error, states);

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -66,7 +66,7 @@ private:
 class WaveBlur : public Effect
 {
 public:
-    WaveBlur() : Effect("Wave + Blur")
+    WaveBlur() : Effect("Wave + Blur"), m_text(getFont())
     {
     }
 
@@ -92,7 +92,6 @@ public:
             "Mauris ultricies dolor sed massa convallis sed aliquet augue fringilla.\n"
             "Duis erat eros, porta in accumsan in, blandit quis sem.\n"
             "In hac habitasse platea dictumst. Etiam fringilla est id odio dapibus sit amet semper dui laoreet.\n");
-        m_text.setFont(getFont());
         m_text.setCharacterSize(22);
         m_text.setPosition({30.f, 20.f});
 
@@ -378,12 +377,12 @@ int main()
     textBackground.setColor(sf::Color(255, 255, 255, 200));
 
     // Create the description text
-    sf::Text description("Current effect: " + effects[current]->getName(), font, 20);
+    sf::Text description(font, "Current effect: " + effects[current]->getName(), 20);
     description.setPosition({10.f, 530.f});
     description.setFillColor(sf::Color(80, 80, 80));
 
     // Create the instructions text
-    sf::Text instructions("Press left and right arrows to change the current shader", font, 20);
+    sf::Text instructions(font, "Press left and right arrows to change the current shader", 20);
     instructions.setPosition({280.f, 555.f});
     instructions.setFillColor(sf::Color(80, 80, 80));
 

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -87,8 +87,7 @@ int main()
         return EXIT_FAILURE;
 
     // Initialize the pause message
-    sf::Text pauseMessage;
-    pauseMessage.setFont(font);
+    sf::Text pauseMessage(font);
     pauseMessage.setCharacterSize(40);
     pauseMessage.setPosition({170.f, 200.f});
     pauseMessage.setFillColor(sf::Color::White);

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -480,14 +480,12 @@ private:
 /// }
 ///
 /// // Create a text which uses our font
-/// sf::Text text1;
-/// text1.setFont(font);
+/// sf::Text text1(font);
 /// text1.setCharacterSize(30);
 /// text1.setStyle(sf::Text::Regular);
 ///
 /// // Create another text using the same font, but with different parameters
-/// sf::Text text2;
-/// text2.setFont(font);
+/// sf::Text text2(font);
 /// text2.setCharacterSize(50);
 /// text2.setStyle(sf::Text::Italic);
 /// \endcode

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -244,7 +244,12 @@ private:
 ///
 /// // Create a sprite and a text to display
 /// sf::Sprite sprite;
-/// sf::Text text;
+/// sf::Font font;
+/// if (!font.loadFromFile("arial.ttf"))
+/// {
+///     // error...
+/// }
+/// sf::Text text(font);
 /// ...
 ///
 /// // Perform OpenGL initializations

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -63,14 +63,6 @@ public:
     };
 
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// Creates an empty text.
-    ///
-    ////////////////////////////////////////////////////////////
-    Text();
-
-    ////////////////////////////////////////////////////////////
     /// \brief Construct the text from a string, font and size
     ///
     /// Note that if the used font is a bitmap font, it is not
@@ -85,13 +77,13 @@ public:
     /// \param characterSize  Base size of characters, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Text(const String& string, const Font& font, unsigned int characterSize = 30);
+    Text(const Font& font, const String& string = "", unsigned int characterSize = 30);
 
     ////////////////////////////////////////////////////////////
     /// \brief Disallow construction from a temporary font
     ///
     ////////////////////////////////////////////////////////////
-    Text(const String& string, Font&& font, unsigned int characterSize = 30) = delete;
+    Text(Font&& font, const String& string = "", unsigned int characterSize = 30) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
@@ -499,7 +491,7 @@ private:
 /// font.loadFromFile("arial.ttf");
 ///
 /// // Create a text
-/// sf::Text text("hello", font);
+/// sf::Text text(font, "hello");
 /// text.setCharacterSize(30);
 /// text.setStyle(sf::Text::Bold);
 /// text.setFillColor(sf::Color::Red);

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -94,11 +94,7 @@ void addGlyphQuad(sf::VertexArray& vertices, sf::Vector2f position, const sf::Co
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Text::Text() = default;
-
-
-////////////////////////////////////////////////////////////
-Text::Text(const String& string, const Font& font, unsigned int characterSize) :
+Text::Text(const Font& font, const String& string, unsigned int characterSize) :
 m_string(string),
 m_font(&font),
 m_characterSize(characterSize)
@@ -301,10 +297,6 @@ float Text::getOutlineThickness() const
 ////////////////////////////////////////////////////////////
 Vector2f Text::findCharacterPos(std::size_t index) const
 {
-    // Make sure that we have a valid font
-    if (!m_font)
-        return Vector2f();
-
     // Adjust the index if it's out of range
     if (index > m_string.getSize())
         index = m_string.getSize();
@@ -372,30 +364,24 @@ FloatRect Text::getGlobalBounds() const
 ////////////////////////////////////////////////////////////
 void Text::draw(RenderTarget& target, const RenderStates& states) const
 {
-    if (m_font)
-    {
-        ensureGeometryUpdate();
+    ensureGeometryUpdate();
 
-        RenderStates statesCopy(states);
+    RenderStates statesCopy(states);
 
-        statesCopy.transform *= getTransform();
-        statesCopy.texture = &m_font->getTexture(m_characterSize);
+    statesCopy.transform *= getTransform();
+    statesCopy.texture = &m_font->getTexture(m_characterSize);
 
-        // Only draw the outline if there is something to draw
-        if (m_outlineThickness != 0)
-            target.draw(m_outlineVertices, statesCopy);
+    // Only draw the outline if there is something to draw
+    if (m_outlineThickness != 0)
+        target.draw(m_outlineVertices, statesCopy);
 
-        target.draw(m_vertices, statesCopy);
-    }
+    target.draw(m_vertices, statesCopy);
 }
 
 
 ////////////////////////////////////////////////////////////
 void Text::ensureGeometryUpdate() const
 {
-    if (!m_font)
-        return;
-
     // Do nothing, if geometry has not changed and the font texture has not changed
     if (!m_geometryNeedUpdate && m_font->getTexture(m_characterSize).m_cacheId == m_fontTextureId)
         return;

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -47,7 +47,7 @@ int main(int, char const**)
     {
         return EXIT_FAILURE;
     }
-    sf::Text text("Hello SFML", font, 50);
+    sf::Text text(font, "Hello SFML", 50);
     text.setFillColor(sf::Color::Black);
 
     // Load a music to play

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char const** argv)
     {
         return EXIT_FAILURE;
     }
-    sf::Text text("Hello SFML", font, 50);
+    sf::Text text(font, "Hello SFML", 50);
     text.setFillColor(sf::Color::Black);
 
     // Load a music to play


### PR DESCRIPTION
## Description

Closes #2194 

The default constructor for `sf::Text` made it possible to accidentally forget to assign a font. Removing that default constructor means users are forced to supply a font making `sf::Text` harder to misuse. While I was at it, I also tweaked the existing constructor to allow users to specify a font without a default string to avoid the needless `""` argument.

This required some changes to the Joystick example which made heavy use of default constructed text objects. The modifications to that example prove that a default constructor is not required to effectively use `sf::Text`.
