### PR TITLE
Improve PCH by adding more commonly used headers

### DIFF
--- a/src/SFML/PCH.hpp
+++ b/src/SFML/PCH.hpp
@@ -32,9 +32,10 @@
 
 #ifdef SFML_SYSTEM_WINDOWS
 
-#define UNICODE  1
-#define _UNICODE 1
 #include <SFML/System/Win32/WindowsHeader.hpp>
+
+#include <dinput.h>
+#include <mmsystem.h>
 
 #endif // SFML_SYSTEM_WINDOWS
 
@@ -48,11 +49,14 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
+#include <locale>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <unordered_map>

--- a/src/SFML/System/Win32/WindowsHeader.hpp
+++ b/src/SFML/System/Win32/WindowsHeader.hpp
@@ -44,4 +44,12 @@
 #define WINVER 0x0501
 #endif
 
+#ifndef UNICODE
+#define UNICODE 1
+#endif
+
+#ifndef _UNICODE
+#define _UNICODE 1
+#endif
+
 #include <windows.h>

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -85,9 +85,6 @@ if(SFML_OS_WINDOWS)
         )
     endif()
     source_group("windows" FILES ${PLATFORM_SRC})
-
-    # make sure that we use the Unicode version of the Win API functions
-    add_definitions(-DUNICODE -D_UNICODE)
 elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
     if(SFML_USE_DRM)
         add_definitions(-DSFML_USE_DRM)


### PR DESCRIPTION
Adding these headers results in a full-rebuild speedup of 150-250ms on my machine.