### PR TITLE
Remove default `sf::Sprite` constructor

### DIFF
--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -37,7 +37,7 @@
 // Our PIMPL
 struct SFMLmainWindow
 {
-    SFMLmainWindow(sf::WindowHandle win) : renderWindow(win), text(font), background(sf::Color::Blue)
+    SFMLmainWindow(sf::WindowHandle win) : renderWindow(win), text(font), sprite(logo), background(sf::Color::Blue)
     {
         std::string resPath = [[[NSBundle mainBundle] resourcePath] tostdstring];
         if (!logo.loadFromFile(resPath + "/logo.png"))
@@ -45,7 +45,6 @@ struct SFMLmainWindow
 
         logo.setSmooth(true);
 
-        sprite.setTexture(logo, true);
         sf::FloatRect rect = sprite.getLocalBounds();
         sf::Vector2f  size(rect.width, rect.height);
         sprite.setOrigin(size / 2.f);

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -31,7 +31,7 @@ public:
         // Load the texture and initialize the sprite
         if (!m_texture.loadFromFile("resources/background.jpg"))
             return false;
-        m_sprite.setTexture(m_texture);
+        m_sprite.emplace(m_texture);
 
         // Load the shader
         if (!m_shader.loadFromFile("resources/pixelate.frag", sf::Shader::Fragment))
@@ -50,13 +50,13 @@ public:
     {
         sf::RenderStates statesCopy(states);
         statesCopy.shader = &m_shader;
-        target.draw(m_sprite, statesCopy);
+        target.draw(*m_sprite, statesCopy);
     }
 
 private:
-    sf::Texture m_texture;
-    sf::Sprite  m_sprite;
-    sf::Shader  m_shader;
+    sf::Texture               m_texture;
+    std::optional<sf::Sprite> m_sprite;
+    sf::Shader                m_shader;
 };
 
 
@@ -199,8 +199,8 @@ public:
         m_entityTexture.setSmooth(true);
 
         // Initialize the background sprite
-        m_backgroundSprite.setTexture(m_backgroundTexture);
-        m_backgroundSprite.setPosition({135.f, 100.f});
+        m_backgroundSprite.emplace(m_backgroundTexture);
+        m_backgroundSprite->setPosition({135.f, 100.f});
 
         // Load the moving entities
         for (int i = 0; i < 6; ++i)
@@ -234,7 +234,7 @@ public:
 
         // Render the updated scene to the off-screen surface
         m_surface.clear(sf::Color::White);
-        m_surface.draw(m_backgroundSprite);
+        m_surface.draw(*m_backgroundSprite);
         for (const sf::Sprite& entity : m_entities)
             m_surface.draw(entity);
         m_surface.display();
@@ -248,12 +248,12 @@ public:
     }
 
 private:
-    sf::RenderTexture       m_surface;
-    sf::Texture             m_backgroundTexture;
-    sf::Texture             m_entityTexture;
-    sf::Sprite              m_backgroundSprite;
-    std::vector<sf::Sprite> m_entities;
-    sf::Shader              m_shader;
+    sf::RenderTexture         m_surface;
+    sf::Texture               m_backgroundTexture;
+    sf::Texture               m_entityTexture;
+    std::optional<sf::Sprite> m_backgroundSprite;
+    std::vector<sf::Sprite>   m_entities;
+    sf::Shader                m_shader;
 };
 
 

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -54,8 +54,7 @@ int main()
     sf::Texture sfmlLogoTexture;
     if (!sfmlLogoTexture.loadFromFile(resourcesDir() / "sfml_logo.png"))
         return EXIT_FAILURE;
-    sf::Sprite sfmlLogo;
-    sfmlLogo.setTexture(sfmlLogoTexture);
+    sf::Sprite sfmlLogo(sfmlLogoTexture);
     sfmlLogo.setPosition({170.f, 50.f});
 
     // Create the left paddle

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -244,7 +244,12 @@ private:
 /// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML OpenGL");
 ///
 /// // Create a sprite and a text to display
-/// sf::Sprite sprite;
+/// sf::Texture texture;
+/// if (!texture.loadFromFile("circle.png"))
+/// {
+///     // error...
+/// }
+/// sf::Sprite sprite(texture);
 /// sf::Font font;
 /// if (!font.loadFromFile("arial.ttf"))
 /// {

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -48,14 +48,6 @@ class SFML_GRAPHICS_API Sprite : public Drawable, public Transformable
 {
 public:
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// Creates an empty sprite with no source texture.
-    ///
-    ////////////////////////////////////////////////////////////
-    Sprite();
-
-    ////////////////////////////////////////////////////////////
     /// \brief Construct the sprite from a source texture
     ///
     /// \param texture Source texture
@@ -277,8 +269,7 @@ private:
 /// texture.loadFromFile("texture.png");
 ///
 /// // Create a sprite
-/// sf::Sprite sprite;
-/// sprite.setTexture(texture);
+/// sf::Sprite sprite(texture);
 /// sprite.setTextureRect(sf::IntRect({10, 10}, {50, 30}));
 /// sprite.setColor(sf::Color(255, 255, 255, 200));
 /// sprite.setPosition(100, 25);

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -693,8 +693,7 @@ void swap(Texture& left, Texture& right) noexcept;
 ///     return -1;
 ///
 /// // Assign it to a sprite
-/// sf::Sprite sprite;
-/// sprite.setTexture(texture);
+/// sf::Sprite sprite(texture);
 ///
 /// // Draw the textured sprite
 /// window.draw(sprite);

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -29,15 +29,12 @@
 #include <SFML/Graphics/Sprite.hpp>
 #include <SFML/Graphics/Texture.hpp>
 
+#include <cassert>
 #include <cstdlib>
 
 
 namespace sf
 {
-////////////////////////////////////////////////////////////
-Sprite::Sprite() = default;
-
-
 ////////////////////////////////////////////////////////////
 Sprite::Sprite(const Texture& texture)
 {
@@ -133,14 +130,13 @@ FloatRect Sprite::getGlobalBounds() const
 ////////////////////////////////////////////////////////////
 void Sprite::draw(RenderTarget& target, const RenderStates& states) const
 {
-    if (m_texture)
-    {
-        RenderStates statesCopy(states);
+    assert(m_texture);
 
-        statesCopy.transform *= getTransform();
-        statesCopy.texture = m_texture;
-        target.draw(m_vertices, 4, PrimitiveType::TriangleStrip, statesCopy);
-    }
+    RenderStates statesCopy(states);
+
+    statesCopy.transform *= getTransform();
+    statesCopy.texture = m_texture;
+    target.draw(m_vertices, 4, PrimitiveType::TriangleStrip, statesCopy);
 }
 
 

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -14,11 +14,11 @@ int main()
     [[maybe_unused]] sf::Sound               sound;
 
     // Graphics
-    [[maybe_unused]] sf::Color        color;
-    [[maybe_unused]] sf::Font         font;
-    [[maybe_unused]] sf::RenderWindow renderWindow;
-    [[maybe_unused]] sf::Sprite       sprite;
-    [[maybe_unused]] sf::Vertex       vertex;
+    [[maybe_unused]] sf::Color          color;
+    [[maybe_unused]] sf::Font           font;
+    [[maybe_unused]] sf::RenderWindow   renderWindow;
+    [[maybe_unused]] sf::RectangleShape rectangleShape;
+    [[maybe_unused]] sf::Vertex         vertex;
 
     // Network
     [[maybe_unused]] sf::Ftp       ftp;


### PR DESCRIPTION
## Description

Continuation of the new precedent established in #2486.
