### PR TITLE
Add 'extern template' to Vector2, Vector3, and Rect

### DIFF
--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -51,7 +51,7 @@ public:
     /// Rect({0, 0}, {0, 0})).
     ///
     ////////////////////////////////////////////////////////////
-    SFML_GRAPHICS_API constexpr Rect();
+    SFML_API_EXPORT constexpr Rect();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from position and size
@@ -63,7 +63,7 @@ public:
     /// \param size     Size of the rectangle
     ///
     ////////////////////////////////////////////////////////////
-    SFML_GRAPHICS_API constexpr Rect(const Vector2<T>& position, const Vector2<T>& size);
+    SFML_API_EXPORT constexpr Rect(const Vector2<T>& position, const Vector2<T>& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from another type of rectangle
@@ -77,7 +77,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    SFML_GRAPHICS_API constexpr explicit Rect(const Rect<U>& rectangle);
+    SFML_API_EXPORT constexpr explicit Rect(const Rect<U>& rectangle);
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if a point is inside the rectangle's area
@@ -92,7 +92,7 @@ public:
     /// \see findIntersection
     ///
     ////////////////////////////////////////////////////////////
-    SFML_GRAPHICS_API constexpr bool contains(const Vector2<T>& point) const;
+    SFML_API_EXPORT constexpr bool contains(const Vector2<T>& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check the intersection between two rectangles
@@ -104,7 +104,7 @@ public:
     /// \see contains
     ///
     ////////////////////////////////////////////////////////////
-    SFML_GRAPHICS_API constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
+    SFML_API_EXPORT constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the rectangle's top-left corner
@@ -114,7 +114,7 @@ public:
     /// \see getSize
     ///
     ////////////////////////////////////////////////////////////
-    SFML_GRAPHICS_API constexpr Vector2<T> getPosition() const;
+    SFML_API_EXPORT constexpr Vector2<T> getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the rectangle
@@ -124,7 +124,7 @@ public:
     /// \see getPosition
     ///
     ////////////////////////////////////////////////////////////
-    SFML_GRAPHICS_API constexpr Vector2<T> getSize() const;
+    SFML_API_EXPORT constexpr Vector2<T> getSize() const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+
 #include <SFML/System/Vector2.hpp>
 
 #include <optional>
@@ -49,7 +51,7 @@ public:
     /// Rect({0, 0}, {0, 0})).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Rect();
+    SFML_GRAPHICS_API constexpr Rect();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from position and size
@@ -61,7 +63,7 @@ public:
     /// \param size     Size of the rectangle
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Rect(const Vector2<T>& position, const Vector2<T>& size);
+    SFML_GRAPHICS_API constexpr Rect(const Vector2<T>& position, const Vector2<T>& size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from another type of rectangle
@@ -75,7 +77,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    constexpr explicit Rect(const Rect<U>& rectangle);
+    SFML_GRAPHICS_API constexpr explicit Rect(const Rect<U>& rectangle);
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if a point is inside the rectangle's area
@@ -90,7 +92,7 @@ public:
     /// \see findIntersection
     ///
     ////////////////////////////////////////////////////////////
-    constexpr bool contains(const Vector2<T>& point) const;
+    SFML_GRAPHICS_API constexpr bool contains(const Vector2<T>& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check the intersection between two rectangles
@@ -102,7 +104,7 @@ public:
     /// \see contains
     ///
     ////////////////////////////////////////////////////////////
-    constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
+    SFML_GRAPHICS_API constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the rectangle's top-left corner
@@ -112,7 +114,7 @@ public:
     /// \see getSize
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2<T> getPosition() const;
+    SFML_GRAPHICS_API constexpr Vector2<T> getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the rectangle
@@ -122,7 +124,7 @@ public:
     /// \see getPosition
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2<T> getSize() const;
+    SFML_GRAPHICS_API constexpr Vector2<T> getSize() const;
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -163,12 +165,27 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr bool operator!=(const Rect<T>& left, const Rect<T>& right);
 
-#include <SFML/Graphics/Rect.inl>
-
 // Create type aliases for the most common types
 using IntRect   = Rect<int>;
 using FloatRect = Rect<float>;
 
+} // namespace sf
+
+
+////////////////////////////////////////////////////////////
+// Explicit instantiation declarations
+////////////////////////////////////////////////////////////
+
+extern template class sf::Rect<float>;
+extern template class sf::Rect<double>;
+extern template class sf::Rect<long double>;
+extern template class sf::Rect<int>;
+extern template class sf::Rect<unsigned int>;
+
+
+namespace sf
+{
+#include <SFML/Graphics/Rect.inl>
 } // namespace sf
 
 

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -48,7 +48,7 @@ public:
     /// Creates a Vector2(0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2();
+    SFML_SYSTEM_API constexpr Vector2();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from cartesian coordinates
@@ -57,7 +57,7 @@ public:
     /// \param y Y coordinate
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2(T x, T y);
+    SFML_SYSTEM_API constexpr Vector2(T x, T y);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector
@@ -71,7 +71,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    constexpr explicit Vector2(const Vector2<U>& vector);
+    SFML_SYSTEM_API constexpr explicit Vector2(const Vector2<U>& vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from polar coordinates <i><b>(floating-point)</b></i>
@@ -103,7 +103,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T lengthSq() const;
+    SFML_SYSTEM_API constexpr T lengthSq() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -165,13 +165,13 @@ public:
     /// this amounts to a clockwise rotation.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2 perpendicular() const;
+    SFML_SYSTEM_API constexpr Vector2 perpendicular() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Dot product of two 2D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T dot(const Vector2& rhs) const;
+    SFML_SYSTEM_API constexpr T dot(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Z component of the cross product of two 2D vectors.
@@ -180,7 +180,7 @@ public:
     /// and returns the result's Z component (X and Y components are always zero).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T cross(const Vector2& rhs) const;
+    SFML_SYSTEM_API constexpr T cross(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise multiplication of \c *this and \c rhs.
@@ -191,7 +191,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2 cwiseMul(const Vector2& rhs) const;
+    SFML_SYSTEM_API constexpr Vector2 cwiseMul(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -203,7 +203,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
+    SFML_SYSTEM_API constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
 
 
     ////////////////////////////////////////////////////////////
@@ -398,8 +398,24 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr bool operator!=(const Vector2<T>& left, const Vector2<T>& right);
 
-#include <SFML/System/Vector2.inl>
+} // namespace sf
 
+
+////////////////////////////////////////////////////////////
+// Explicit instantiation declarations
+////////////////////////////////////////////////////////////
+
+extern template class sf::Vector2<float>;
+extern template class sf::Vector2<double>;
+extern template class sf::Vector2<long double>;
+extern template class sf::Vector2<bool>;
+extern template class sf::Vector2<int>;
+extern template class sf::Vector2<unsigned int>;
+
+
+namespace sf
+{
+#include <SFML/System/Vector2.inl>
 } // namespace sf
 
 

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -237,7 +237,7 @@ using Vector2f = Vector2<float>;
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator-(const Vector2<T>& right);
+[[nodiscard]] SFML_API_EXPORT constexpr Vector2<T> operator-(const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -253,7 +253,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator+=(Vector2<T>& left, const Vector2<T>& right);
+SFML_API_EXPORT constexpr Vector2<T>& operator+=(Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -269,7 +269,7 @@ constexpr Vector2<T>& operator+=(Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator-=(Vector2<T>& left, const Vector2<T>& right);
+SFML_API_EXPORT constexpr Vector2<T>& operator-=(Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -282,7 +282,7 @@ constexpr Vector2<T>& operator-=(Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator+(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] SFML_API_EXPORT constexpr Vector2<T> operator+(const Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -295,7 +295,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator-(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] SFML_API_EXPORT constexpr Vector2<T> operator-(const Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -308,7 +308,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator*(const Vector2<T>& left, T right);
+[[nodiscard]] SFML_API_EXPORT constexpr Vector2<T> operator*(const Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -321,7 +321,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator*(T left, const Vector2<T>& right);
+[[nodiscard]] SFML_API_EXPORT constexpr Vector2<T> operator*(T left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -337,7 +337,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator*=(Vector2<T>& left, T right);
+SFML_API_EXPORT constexpr Vector2<T>& operator*=(Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -350,7 +350,7 @@ constexpr Vector2<T>& operator*=(Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator/(const Vector2<T>& left, T right);
+[[nodiscard]] SFML_API_EXPORT constexpr Vector2<T> operator/(const Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -366,7 +366,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator/=(Vector2<T>& left, T right);
+SFML_API_EXPORT constexpr Vector2<T>& operator/=(Vector2<T>& left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -381,7 +381,7 @@ constexpr Vector2<T>& operator/=(Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr bool operator==(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] SFML_API_EXPORT constexpr bool operator==(const Vector2<T>& left, const Vector2<T>& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -396,7 +396,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr bool operator!=(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] SFML_API_EXPORT constexpr bool operator!=(const Vector2<T>& left, const Vector2<T>& right);
 
 } // namespace sf
 
@@ -411,6 +411,27 @@ extern template class sf::Vector2<long double>;
 extern template class sf::Vector2<bool>;
 extern template class sf::Vector2<int>;
 extern template class sf::Vector2<unsigned int>;
+
+#define SFML_DECLARE_VECTOR2_FUNCTIONS(type)                                                               \
+    extern template sf::Vector2<type>  sf::operator-(const sf::Vector2<type>&);                            \
+    extern template sf::Vector2<type>& sf::operator+=(sf::Vector2<type>&, const sf::Vector2<type>&);       \
+    extern template sf::Vector2<type>& sf::operator-=(sf::Vector2<type>&, const sf::Vector2<type>&);       \
+    extern template sf::Vector2<type>  sf::operator+(const sf::Vector2<type>&, const sf::Vector2<type>&);  \
+    extern template sf::Vector2<type>  sf::operator-(const sf::Vector2<type>&, const sf::Vector2<type>&);  \
+    extern template sf::Vector2<type>  sf::operator*(const sf::Vector2<type>&, type);                      \
+    extern template sf::Vector2<type>  sf::operator*(type, const sf::Vector2<type>&);                      \
+    extern template sf::Vector2<type>& sf::operator*=(sf::Vector2<type>&, type);                           \
+    extern template sf::Vector2<type>  sf::operator/(const sf::Vector2<type>&, type);                      \
+    extern template sf::Vector2<type>& sf::operator/=(sf::Vector2<type>&, type);                           \
+    extern template bool               sf::operator==(const sf::Vector2<type>&, const sf::Vector2<type>&); \
+    extern template bool               sf::operator!=(const sf::Vector2<type>&, const sf::Vector2<type>&);
+
+SFML_DECLARE_VECTOR2_FUNCTIONS(float)
+SFML_DECLARE_VECTOR2_FUNCTIONS(double)
+SFML_DECLARE_VECTOR2_FUNCTIONS(long double)
+SFML_DECLARE_VECTOR2_FUNCTIONS(bool)
+SFML_DECLARE_VECTOR2_FUNCTIONS(int)
+SFML_DECLARE_VECTOR2_FUNCTIONS(unsigned int)
 
 
 namespace sf

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -48,7 +48,7 @@ public:
     /// Creates a Vector2(0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector2();
+    SFML_API_EXPORT constexpr Vector2();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from cartesian coordinates
@@ -57,7 +57,7 @@ public:
     /// \param y Y coordinate
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector2(T x, T y);
+    SFML_API_EXPORT constexpr Vector2(T x, T y);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector
@@ -71,7 +71,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    SFML_SYSTEM_API constexpr explicit Vector2(const Vector2<U>& vector);
+    SFML_API_EXPORT constexpr explicit Vector2(const Vector2<U>& vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from polar coordinates <i><b>(floating-point)</b></i>
@@ -103,7 +103,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr T lengthSq() const;
+    SFML_API_EXPORT constexpr T lengthSq() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -165,13 +165,13 @@ public:
     /// this amounts to a clockwise rotation.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector2 perpendicular() const;
+    SFML_API_EXPORT constexpr Vector2 perpendicular() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Dot product of two 2D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr T dot(const Vector2& rhs) const;
+    SFML_API_EXPORT constexpr T dot(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Z component of the cross product of two 2D vectors.
@@ -180,7 +180,7 @@ public:
     /// and returns the result's Z component (X and Y components are always zero).
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr T cross(const Vector2& rhs) const;
+    SFML_API_EXPORT constexpr T cross(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise multiplication of \c *this and \c rhs.
@@ -191,7 +191,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector2 cwiseMul(const Vector2& rhs) const;
+    SFML_API_EXPORT constexpr Vector2 cwiseMul(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -203,7 +203,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
+    SFML_API_EXPORT constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
 
 
     ////////////////////////////////////////////////////////////
@@ -217,8 +217,8 @@ public:
     // Static member data
     ////////////////////////////////////////////////////////////
     // NOLINTBEGIN(readability-identifier-naming)
-    static const Vector2 UnitX; //!< The X unit vector (1, 0), usually facing right
-    static const Vector2 UnitY; //!< The Y unit vector (0, 1), usually facing down
+    SFML_API_EXPORT static const Vector2 UnitX; //!< The X unit vector (1, 0), usually facing right
+    SFML_API_EXPORT static const Vector2 UnitY; //!< The Y unit vector (0, 1), usually facing down
     // NOLINTEND(readability-identifier-naming)
 };
 

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -45,7 +45,7 @@ public:
     /// Creates a Vector3(0, 0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector3();
+    SFML_API_EXPORT constexpr Vector3();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from its coordinates
@@ -55,7 +55,7 @@ public:
     /// \param z Z coordinate
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector3(T x, T y, T z);
+    SFML_API_EXPORT constexpr Vector3(T x, T y, T z);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector
@@ -69,7 +69,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    SFML_SYSTEM_API constexpr explicit Vector3(const Vector3<U>& vector);
+    SFML_API_EXPORT constexpr explicit Vector3(const Vector3<U>& vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Length of the vector <i><b>(floating-point)</b></i>.
@@ -85,7 +85,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr T lengthSq() const;
+    SFML_API_EXPORT constexpr T lengthSq() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -99,13 +99,13 @@ public:
     /// \brief Dot product of two 3D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr T dot(const Vector3& rhs) const;
+    SFML_API_EXPORT constexpr T dot(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Cross product of two 3D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector3 cross(const Vector3& rhs) const;
+    SFML_API_EXPORT constexpr Vector3 cross(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise multiplication of \c *this and \c rhs.
@@ -116,7 +116,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector3 cwiseMul(const Vector3& rhs) const;
+    SFML_API_EXPORT constexpr Vector3 cwiseMul(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -128,7 +128,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API constexpr Vector3 cwiseDiv(const Vector3& rhs) const;
+    SFML_API_EXPORT constexpr Vector3 cwiseDiv(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -45,7 +45,7 @@ public:
     /// Creates a Vector3(0, 0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3();
+    SFML_SYSTEM_API constexpr Vector3();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from its coordinates
@@ -55,7 +55,7 @@ public:
     /// \param z Z coordinate
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3(T x, T y, T z);
+    SFML_SYSTEM_API constexpr Vector3(T x, T y, T z);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from another type of vector
@@ -69,7 +69,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    constexpr explicit Vector3(const Vector3<U>& vector);
+    SFML_SYSTEM_API constexpr explicit Vector3(const Vector3<U>& vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Length of the vector <i><b>(floating-point)</b></i>.
@@ -85,7 +85,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T lengthSq() const;
+    SFML_SYSTEM_API constexpr T lengthSq() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -99,13 +99,13 @@ public:
     /// \brief Dot product of two 3D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T dot(const Vector3& rhs) const;
+    SFML_SYSTEM_API constexpr T dot(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Cross product of two 3D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3 cross(const Vector3& rhs) const;
+    SFML_SYSTEM_API constexpr Vector3 cross(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise multiplication of \c *this and \c rhs.
@@ -116,7 +116,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3 cwiseMul(const Vector3& rhs) const;
+    SFML_SYSTEM_API constexpr Vector3 cwiseMul(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -128,7 +128,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3 cwiseDiv(const Vector3& rhs) const;
+    SFML_SYSTEM_API constexpr Vector3 cwiseDiv(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -309,12 +309,28 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr bool operator!=(const Vector3<T>& left, const Vector3<T>& right);
 
-#include <SFML/System/Vector3.inl>
-
 // Define the most common types
 using Vector3i = Vector3<int>;
 using Vector3f = Vector3<float>;
 
+} // namespace sf
+
+
+////////////////////////////////////////////////////////////
+// Explicit instantiation declarations
+////////////////////////////////////////////////////////////
+
+extern template class sf::Vector3<float>;
+extern template class sf::Vector3<double>;
+extern template class sf::Vector3<long double>;
+extern template class sf::Vector3<bool>;
+extern template class sf::Vector3<int>;
+extern template class sf::Vector3<unsigned int>;
+
+
+namespace sf
+{
+#include <SFML/System/Vector3.inl>
 } // namespace sf
 
 

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SRC
     ${SRCROOT}/ImageLoader.cpp
     ${SRCROOT}/ImageLoader.hpp
     ${INCROOT}/PrimitiveType.hpp
+    ${SRCROOT}/Rect.cpp
     ${INCROOT}/Rect.hpp
     ${INCROOT}/Rect.inl
     ${SRCROOT}/RenderStates.cpp

--- a/src/SFML/Graphics/Rect.cpp
+++ b/src/SFML/Graphics/Rect.cpp
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#include <SFML/Graphics/Rect.hpp>
+
+
+////////////////////////////////////////////////////////////
+// Explicit instantiation definitions
+////////////////////////////////////////////////////////////
+
+template class sf::Rect<float>;
+template class sf::Rect<double>;
+template class sf::Rect<long double>;
+template class sf::Rect<int>;
+template class sf::Rect<unsigned int>;

--- a/src/SFML/System/Vector2.cpp
+++ b/src/SFML/System/Vector2.cpp
@@ -115,9 +115,30 @@ T Vector2<T>::length() const
 
 
 ////////////////////////////////////////////////////////////
-// Explicit template instantiations
+// Explicit instantiation definitions
 ////////////////////////////////////////////////////////////
 
 template class sf::Vector2<float>;
 template class sf::Vector2<double>;
 template class sf::Vector2<long double>;
+
+#define SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(type)                \
+    template /*                   */ sf::Vector2<type>::Vector2();           \
+    template /*                   */ sf::Vector2<type>::Vector2(type, type); \
+    template const sf::Vector2<type> sf::Vector2<type>::UnitX;               \
+    template const sf::Vector2<type> sf::Vector2<type>::UnitY;
+
+#define SFML_INSTANTIATE_VECTOR2_INTEGRAL_MEMBER_FUNCTIONS(type)                      \
+    template type              sf::Vector2<type>::lengthSq() const;                   \
+    template sf::Vector2<type> sf::Vector2<type>::perpendicular() const;              \
+    template type              sf::Vector2<type>::dot(const Vector2& rhs) const;      \
+    template type              sf::Vector2<type>::cross(const Vector2& rhs) const;    \
+    template sf::Vector2<type> sf::Vector2<type>::cwiseMul(const Vector2& rhs) const; \
+    template sf::Vector2<type> sf::Vector2<type>::cwiseDiv(const Vector2& rhs) const;
+
+SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(bool)
+SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(int)
+SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(unsigned int)
+
+SFML_INSTANTIATE_VECTOR2_INTEGRAL_MEMBER_FUNCTIONS(int)
+SFML_INSTANTIATE_VECTOR2_INTEGRAL_MEMBER_FUNCTIONS(unsigned int)

--- a/src/SFML/System/Vector2.cpp
+++ b/src/SFML/System/Vector2.cpp
@@ -115,12 +115,58 @@ T Vector2<T>::length() const
 
 
 ////////////////////////////////////////////////////////////
-// Explicit instantiation definitions
+// Explicit instantiation definitions -- classes
 ////////////////////////////////////////////////////////////
 
 template class sf::Vector2<float>;
 template class sf::Vector2<double>;
 template class sf::Vector2<long double>;
+
+
+////////////////////////////////////////////////////////////
+// Explicit instantiation definitions -- non-member functions
+////////////////////////////////////////////////////////////
+
+#define SFML_INSTANTIATE_VECTOR2_BASIC_NON_MEMBER_FUNCTIONS(type)                     \
+    template bool sf::operator==(const sf::Vector2<type>&, const sf::Vector2<type>&); \
+    template bool sf::operator!=(const sf::Vector2<type>&, const sf::Vector2<type>&);
+
+#define SFML_INSTANTIATE_VECTOR2_NUMERICAL_NON_MEMBER_FUNCTIONS(type)                              \
+    template sf::Vector2<type>& sf::operator-=(sf::Vector2<type>&, const sf::Vector2<type>&);      \
+    template sf::Vector2<type>  sf::operator-(const sf::Vector2<type>&, const sf::Vector2<type>&); \
+    template sf::Vector2<type>& sf::operator+=(sf::Vector2<type>&, const sf::Vector2<type>&);      \
+    template sf::Vector2<type>  sf::operator+(const sf::Vector2<type>&, const sf::Vector2<type>&); \
+    template sf::Vector2<type>  sf::operator*(const sf::Vector2<type>&, type);                     \
+    template sf::Vector2<type>  sf::operator*(type, const sf::Vector2<type>&);                     \
+    template sf::Vector2<type>& sf::operator*=(sf::Vector2<type>&, type);                          \
+    template sf::Vector2<type>  sf::operator/(const sf::Vector2<type>&, type);                     \
+    template sf::Vector2<type>& sf::operator/=(sf::Vector2<type>&, type);
+
+#define SFML_INSTANTIATE_VECTOR2_SIGNED_NUMERICAL_NON_MEMBER_FUNCTIONS(type) \
+    template sf::Vector2<type> sf::operator-(const sf::Vector2<type>&);
+
+SFML_INSTANTIATE_VECTOR2_BASIC_NON_MEMBER_FUNCTIONS(float)
+SFML_INSTANTIATE_VECTOR2_BASIC_NON_MEMBER_FUNCTIONS(double)
+SFML_INSTANTIATE_VECTOR2_BASIC_NON_MEMBER_FUNCTIONS(long double)
+SFML_INSTANTIATE_VECTOR2_BASIC_NON_MEMBER_FUNCTIONS(bool)
+SFML_INSTANTIATE_VECTOR2_BASIC_NON_MEMBER_FUNCTIONS(int)
+SFML_INSTANTIATE_VECTOR2_BASIC_NON_MEMBER_FUNCTIONS(unsigned int)
+
+SFML_INSTANTIATE_VECTOR2_NUMERICAL_NON_MEMBER_FUNCTIONS(float)
+SFML_INSTANTIATE_VECTOR2_NUMERICAL_NON_MEMBER_FUNCTIONS(double)
+SFML_INSTANTIATE_VECTOR2_NUMERICAL_NON_MEMBER_FUNCTIONS(long double)
+SFML_INSTANTIATE_VECTOR2_NUMERICAL_NON_MEMBER_FUNCTIONS(int)
+SFML_INSTANTIATE_VECTOR2_NUMERICAL_NON_MEMBER_FUNCTIONS(unsigned int)
+
+SFML_INSTANTIATE_VECTOR2_SIGNED_NUMERICAL_NON_MEMBER_FUNCTIONS(float)
+SFML_INSTANTIATE_VECTOR2_SIGNED_NUMERICAL_NON_MEMBER_FUNCTIONS(double)
+SFML_INSTANTIATE_VECTOR2_SIGNED_NUMERICAL_NON_MEMBER_FUNCTIONS(long double)
+SFML_INSTANTIATE_VECTOR2_SIGNED_NUMERICAL_NON_MEMBER_FUNCTIONS(int)
+
+
+////////////////////////////////////////////////////////////
+// Explicit instantiation definitions -- member functions
+////////////////////////////////////////////////////////////
 
 #define SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(type)                \
     template /*                   */ sf::Vector2<type>::Vector2();           \
@@ -128,13 +174,16 @@ template class sf::Vector2<long double>;
     template const sf::Vector2<type> sf::Vector2<type>::UnitX;               \
     template const sf::Vector2<type> sf::Vector2<type>::UnitY;
 
-#define SFML_INSTANTIATE_VECTOR2_INTEGRAL_MEMBER_FUNCTIONS(type)                      \
-    template type              sf::Vector2<type>::lengthSq() const;                   \
-    template sf::Vector2<type> sf::Vector2<type>::perpendicular() const;              \
-    template type              sf::Vector2<type>::dot(const Vector2& rhs) const;      \
-    template type              sf::Vector2<type>::cross(const Vector2& rhs) const;    \
-    template sf::Vector2<type> sf::Vector2<type>::cwiseMul(const Vector2& rhs) const; \
-    template sf::Vector2<type> sf::Vector2<type>::cwiseDiv(const Vector2& rhs) const;
+#define SFML_INSTANTIATE_VECTOR2_INTEGRAL_MEMBER_FUNCTIONS(type)                            \
+    template type              sf::Vector2<type>::lengthSq() const;                         \
+    template type              sf::Vector2<type>::dot(const sf::Vector2<type>&) const;      \
+    template type              sf::Vector2<type>::cross(const sf::Vector2<type>&) const;    \
+    template sf::Vector2<type> sf::Vector2<type>::cwiseMul(const sf::Vector2<type>&) const; \
+    template sf::Vector2<type> sf::Vector2<type>::cwiseDiv(const sf::Vector2<type>&) const;
+
+#define SFML_INSTANTIATE_VECTOR2_SIGNED_INTEGRAL_MEMBER_FUNCTIONS(type) \
+    template sf::Vector2<type> sf::Vector2<type>::perpendicular() const;
+
 
 SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(bool)
 SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(int)
@@ -142,3 +191,5 @@ SFML_INSTANTIATE_VECTOR2_BASIC_MEMBER_FUNCTIONS(unsigned int)
 
 SFML_INSTANTIATE_VECTOR2_INTEGRAL_MEMBER_FUNCTIONS(int)
 SFML_INSTANTIATE_VECTOR2_INTEGRAL_MEMBER_FUNCTIONS(unsigned int)
+
+SFML_INSTANTIATE_VECTOR2_SIGNED_INTEGRAL_MEMBER_FUNCTIONS(int)

--- a/src/SFML/System/Vector3.cpp
+++ b/src/SFML/System/Vector3.cpp
@@ -56,9 +56,27 @@ T Vector3<T>::length() const
 
 
 ////////////////////////////////////////////////////////////
-// Explicit template instantiations
+// Explicit instantiation definitions
 ////////////////////////////////////////////////////////////
 
 template class sf::Vector3<float>;
 template class sf::Vector3<double>;
 template class sf::Vector3<long double>;
+
+#define SFML_INSTANTIATE_VECTOR3_BASIC_MEMBER_FUNCTIONS(type) \
+    template /*             */ sf::Vector3<type>::Vector3();  \
+    template /*             */ sf::Vector3<type>::Vector3(type, type, type);
+
+#define SFML_INSTANTIATE_VECTOR3_INTEGRAL_MEMBER_FUNCTIONS(type)                      \
+    template type              sf::Vector3<type>::lengthSq() const;                   \
+    template type              sf::Vector3<type>::dot(const Vector3& rhs) const;      \
+    template sf::Vector3<type> sf::Vector3<type>::cross(const Vector3& rhs) const;    \
+    template sf::Vector3<type> sf::Vector3<type>::cwiseMul(const Vector3& rhs) const; \
+    template sf::Vector3<type> sf::Vector3<type>::cwiseDiv(const Vector3& rhs) const;
+
+SFML_INSTANTIATE_VECTOR3_BASIC_MEMBER_FUNCTIONS(bool)
+SFML_INSTANTIATE_VECTOR3_BASIC_MEMBER_FUNCTIONS(int)
+SFML_INSTANTIATE_VECTOR3_BASIC_MEMBER_FUNCTIONS(unsigned int)
+
+SFML_INSTANTIATE_VECTOR3_INTEGRAL_MEMBER_FUNCTIONS(int)
+SFML_INSTANTIATE_VECTOR3_INTEGRAL_MEMBER_FUNCTIONS(unsigned int)


### PR DESCRIPTION
Prevent instantiating commonly used template specializations over and over again, both for SFML and for SFML users.