### PR TITLE
Allow for manually triggering CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
## Description

This is a useful thing to have. It lets us manually trigger CI when we want to observe something about it like build times or log messages since the logs for a given CI run expire after a certain amount of time.
