### PR TITLE
Clean up namespace usage

### DIFF
--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -122,7 +122,7 @@ void Music::setLoopPoints(TimeSpan timePoints)
     // Check our state. This averts a divide-by-zero. GetChannelCount() is cheap enough to use often
     if (getChannelCount() == 0 || m_file.getSampleCount() == 0)
     {
-        sf::err() << "Music is not in a valid state to assign Loop Points." << std::endl;
+        err() << "Music is not in a valid state to assign Loop Points." << std::endl;
         return;
     }
 
@@ -135,12 +135,12 @@ void Music::setLoopPoints(TimeSpan timePoints)
     // Validate
     if (samplePoints.offset >= m_file.getSampleCount())
     {
-        sf::err() << "LoopPoints offset val must be in range [0, Duration)." << std::endl;
+        err() << "LoopPoints offset val must be in range [0, Duration)." << std::endl;
         return;
     }
     if (samplePoints.length == 0)
     {
-        sf::err() << "LoopPoints length val must be nonzero." << std::endl;
+        err() << "LoopPoints length val must be nonzero." << std::endl;
         return;
     }
 

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -70,13 +70,13 @@ VertexBuffer::VertexBuffer(PrimitiveType type) : m_primitiveType(type)
 
 
 ////////////////////////////////////////////////////////////
-VertexBuffer::VertexBuffer(VertexBuffer::Usage usage) : m_usage(usage)
+VertexBuffer::VertexBuffer(Usage usage) : m_usage(usage)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-VertexBuffer::VertexBuffer(PrimitiveType type, VertexBuffer::Usage usage) : m_primitiveType(type), m_usage(usage)
+VertexBuffer::VertexBuffer(PrimitiveType type, Usage usage) : m_primitiveType(type), m_usage(usage)
 {
 }
 
@@ -314,7 +314,7 @@ PrimitiveType VertexBuffer::getPrimitiveType() const
 
 
 ////////////////////////////////////////////////////////////
-void VertexBuffer::setUsage(VertexBuffer::Usage usage)
+void VertexBuffer::setUsage(Usage usage)
 {
     m_usage = usage;
 }

--- a/src/SFML/Main/SFMLActivity.cpp
+++ b/src/SFML/Main/SFMLActivity.cpp
@@ -67,7 +67,7 @@ const char* getLibraryName(JNIEnv* lJNIEnv, jobject& objectActivityInfo)
     if (valueString == nullptr)
     {
         LOGE("No meta-data 'sfml.app.lib_name' found in AndroidManifest.xml file");
-        exit(1);
+        std::exit(1);
     }
 
     // Convert the application name to a C++ string and return it
@@ -77,7 +77,7 @@ const char* getLibraryName(JNIEnv* lJNIEnv, jobject& objectActivityInfo)
     if (applicationNameLength >= 256)
     {
         LOGE("The value of 'sfml.app.lib_name' must not be longer than 255 characters.");
-        exit(1);
+        std::exit(1);
     }
 
     strncpy(name, applicationName, static_cast<std::size_t>(applicationNameLength));
@@ -123,7 +123,7 @@ void* loadLibrary(const char* libraryName, JNIEnv* lJNIEnv, jobject& ObjectActiv
     if (!handle)
     {
         LOGE("dlopen(\"%s\"): %s", libraryPath, dlerror());
-        exit(1);
+        std::exit(1);
     }
 
     // Release the Java string
@@ -217,7 +217,7 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
     if (!ANativeActivity_onCreate)
     {
         LOGE("sfml-activity: Undefined symbol ANativeActivity_onCreate");
-        exit(1);
+        std::exit(1);
     }
 
     ANativeActivity_onCreate(activity, savedState, savedStateSize);


### PR DESCRIPTION
## Description

I found a few places where we were not obeying our own rules for namespaces. For those unaware, we always omit `sf::` where possible, always use `std::` where possible, and always omit a class's namespace within the class.