### PR TITLE
Remove unnecessary `std::string::c_str()` calls

### DIFF
--- a/src/SFML/Audio/SoundFileWriterOgg.cpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.cpp
@@ -80,7 +80,7 @@ bool SoundFileWriterOgg::open(const std::filesystem::path& filename, unsigned in
     vorbis_analysis_init(&m_state, &m_vorbis);
 
     // Open the file after the vorbis setup is ok
-    m_file.open(filename.c_str(), std::ios::binary);
+    m_file.open(filename, std::ios::binary);
     if (!m_file)
     {
         err() << "Failed to write ogg/vorbis file (cannot open file)\n" << formatDebugPathInfo(filename) << std::endl;

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -86,7 +86,7 @@ SoundFileWriterWav::~SoundFileWriterWav()
 bool SoundFileWriterWav::open(const std::filesystem::path& filename, unsigned int sampleRate, unsigned int channelCount)
 {
     // Open the file
-    m_file.open(filename.c_str(), std::ios::binary);
+    m_file.open(filename, std::ios::binary);
     if (!m_file)
     {
         err() << "Failed to open WAV sound file for writing\n" << formatDebugPathInfo(filename) << std::endl;

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -79,7 +79,7 @@ std::size_t getMaxTextureUnits()
 // Read the contents of a file into an array of char
 bool getFileContents(const std::filesystem::path& filename, std::vector<char>& buffer)
 {
-    std::ifstream file(filename.c_str(), std::ios_base::binary);
+    std::ifstream file(filename, std::ios_base::binary);
     if (file)
     {
         file.seekg(0, std::ios_base::end);

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -310,7 +310,7 @@ Ftp::Response Ftp::download(const std::filesystem::path& remoteFile, const std::
 
             // If the download was unsuccessful, delete the partial file
             if (!response.isOk())
-                std::remove(filepath.string().c_str());
+                std::filesystem::remove(filepath);
         }
     }
 
@@ -322,7 +322,7 @@ Ftp::Response Ftp::download(const std::filesystem::path& remoteFile, const std::
 Ftp::Response Ftp::upload(const std::string& localFile, const std::string& remotePath, TransferMode mode, bool append)
 {
     // Get the contents of the file to send
-    std::ifstream file(localFile.c_str(), std::ios_base::binary);
+    std::ifstream file(localFile, std::ios_base::binary);
     if (!file)
         return Response(Response::Status::InvalidFile);
 


### PR DESCRIPTION
## Description

Another random fixup I found while reading code a while ago. We're calling `std::string::c_str()` just to construct another `std::string` in a few places. In one spot I was able to replace it with a `std::filesystem` API call instead which is a lot cleaner.