### PR TITLE
Moved most variables in sfml-graphics, GlResource and GlContext out of namespace scope

### DIFF
--- a/include/SFML/Window/GlResource.hpp
+++ b/include/SFML/Window/GlResource.hpp
@@ -29,6 +29,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
 
+#include <memory>
+
 
 namespace sf
 {
@@ -48,23 +50,24 @@ protected:
     GlResource();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Destructor
-    ///
-    ////////////////////////////////////////////////////////////
-    ~GlResource();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Register a function to be called when a context is destroyed
+    /// \brief Register an OpenGL object to be destroyed when its containing context is destroyed
     ///
     /// This is used for internal purposes in order to properly
     /// clean up OpenGL resources that cannot be shared between
     /// contexts.
     ///
-    /// \param callback Function to be called when a context is destroyed
-    /// \param arg      Argument to pass when calling the function
+    /// \param object Object to be destroyed when its containing context is destroyed
     ///
     ////////////////////////////////////////////////////////////
-    static void registerContextDestroyCallback(ContextDestroyCallback callback, void* arg);
+    static void registerUnsharedGlObject(std::shared_ptr<void> object);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Unregister an OpenGL object from its containing context
+    ///
+    /// \param object Object to be unregistered
+    ///
+    ////////////////////////////////////////////////////////////
+    static void unregisterUnsharedGlObject(std::shared_ptr<void> object);
 
     ////////////////////////////////////////////////////////////
     /// \brief RAII helper class to temporarily lock an available context for use
@@ -97,6 +100,12 @@ protected:
         ////////////////////////////////////////////////////////////
         TransientContextLock& operator=(const TransientContextLock&) = delete;
     };
+
+private:
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::shared_ptr<void> m_sharedContext; //!< Shared context used to link all contexts together for resource sharing
 };
 
 } // namespace sf

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -137,8 +137,12 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::unordered_map<std::uint64_t, unsigned int> m_frameBuffers; //!< OpenGL frame buffer objects per context
-    std::unordered_map<std::uint64_t, unsigned int> m_multisampleFrameBuffers; //!< Optional per-context OpenGL frame buffer objects with multisample attachments
+    struct FrameBufferObject;
+
+    using FrameBufferObjectMap = std::unordered_map<std::uint64_t, std::weak_ptr<FrameBufferObject>>;
+
+    FrameBufferObjectMap m_frameBuffers; //!< OpenGL frame buffer objects per context
+    FrameBufferObjectMap m_multisampleFrameBuffers; //!< Optional per-context OpenGL frame buffer objects with multisample attachments
     unsigned int             m_depthStencilBuffer{}; //!< Optional depth/stencil buffer attached to the frame buffer
     unsigned int             m_colorBuffer{};        //!< Optional multisample color buffer attached to the frame buffer
     Vector2u                 m_size;                 //!< Width and height of the attachments

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -71,6 +71,7 @@ Texture::Texture() : m_cacheId(TextureImpl::getUniqueId())
 
 ////////////////////////////////////////////////////////////
 Texture::Texture(const Texture& copy) :
+GlResource(copy),
 m_isSmooth(copy.m_isSmooth),
 m_sRgb(copy.m_sRgb),
 m_isRepeated(copy.m_isRepeated),

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -84,7 +84,10 @@ VertexBuffer::VertexBuffer(PrimitiveType type, Usage usage) : m_primitiveType(ty
 
 
 ////////////////////////////////////////////////////////////
-VertexBuffer::VertexBuffer(const VertexBuffer& copy) : m_primitiveType(copy.m_primitiveType), m_usage(copy.m_usage)
+VertexBuffer::VertexBuffer(const VertexBuffer& copy) :
+GlResource(copy),
+m_primitiveType(copy.m_primitiveType),
+m_usage(copy.m_usage)
 {
     if (copy.m_buffer && copy.m_size)
     {

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -50,38 +50,32 @@ class GlContext
 {
 public:
     ////////////////////////////////////////////////////////////
-    /// \brief Perform resource initialization
+    /// \brief Get a shared_ptr to the shared context
     ///
-    /// This function is called every time an OpenGL resource is
-    /// created. When the first resource is initialized, it makes
-    /// sure that everything is ready for contexts to work properly.
+    /// \return shared_ptr to the shared context
     ///
     ////////////////////////////////////////////////////////////
-    static void initResource();
+    static std::shared_ptr<void> getSharedContext();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Perform resource cleanup
-    ///
-    /// This function is called every time an OpenGL resource is
-    /// destroyed. When the last resource is destroyed, it makes
-    /// sure that everything that was created by initResource()
-    /// is properly released.
-    ///
-    ////////////////////////////////////////////////////////////
-    static void cleanupResource();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Register a function to be called when a context is destroyed
+    /// \brief Register an OpenGL object to be destroyed when its containing context is destroyed
     ///
     /// This is used for internal purposes in order to properly
     /// clean up OpenGL resources that cannot be shared bwteen
     /// contexts.
     ///
-    /// \param callback Function to be called when a context is destroyed
-    /// \param arg      Argument to pass when calling the function
+    /// \param object Object to be destroyed when its containing context is destroyed
     ///
     ////////////////////////////////////////////////////////////
-    static void registerContextDestroyCallback(ContextDestroyCallback callback, void* arg);
+    static void registerUnsharedGlObject(std::shared_ptr<void> object);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Unregister an OpenGL object from its containing context
+    ///
+    /// \param object Object to be unregister
+    ///
+    ////////////////////////////////////////////////////////////
+    static void unregisterUnsharedGlObject(std::shared_ptr<void> object);
 
     ////////////////////////////////////////////////////////////
     /// \brief Acquires a context for short-term use on the current thread
@@ -300,6 +294,10 @@ protected:
     ContextSettings m_settings; //!< Creation settings of the context
 
 private:
+    struct TransientContext;
+    struct SharedContext;
+    struct Impl;
+
     ////////////////////////////////////////////////////////////
     /// \brief Perform various initializations after the context construction
     /// \param requestedSettings Requested settings during context creation
@@ -317,7 +315,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    const std::uint64_t m_id; //!< Unique number that identifies the context
+    const std::unique_ptr<Impl> m_impl; //!< Implementation details
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/GlResource.cpp
+++ b/src/SFML/Window/GlResource.cpp
@@ -32,23 +32,22 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-GlResource::GlResource()
+GlResource::GlResource() : m_sharedContext(priv::GlContext::getSharedContext())
 {
-    priv::GlContext::initResource();
 }
 
 
 ////////////////////////////////////////////////////////////
-GlResource::~GlResource()
+void GlResource::registerUnsharedGlObject(std::shared_ptr<void> object)
 {
-    priv::GlContext::cleanupResource();
+    priv::GlContext::registerUnsharedGlObject(std::move(object));
 }
 
 
 ////////////////////////////////////////////////////////////
-void GlResource::registerContextDestroyCallback(ContextDestroyCallback callback, void* arg)
+void GlResource::unregisterUnsharedGlObject(std::shared_ptr<void> object)
 {
-    priv::GlContext::registerContextDestroyCallback(callback, arg);
+    priv::GlContext::unregisterUnsharedGlObject(std::move(object));
 }
 
 

--- a/test/Window/GlResource.test.cpp
+++ b/test/Window/GlResource.test.cpp
@@ -3,7 +3,7 @@
 #include <type_traits>
 
 static_assert(!std::is_constructible_v<sf::GlResource>);
-static_assert(!std::is_copy_constructible_v<sf::GlResource>);
+static_assert(std::is_copy_constructible_v<sf::GlResource>);
 static_assert(std::is_copy_assignable_v<sf::GlResource>);
-static_assert(!std::is_nothrow_move_constructible_v<sf::GlResource>);
+static_assert(std::is_nothrow_move_constructible_v<sf::GlResource>);
 static_assert(std::is_nothrow_move_assignable_v<sf::GlResource>);


### PR DESCRIPTION
Everybody knows the age-old explanation of why things might go wrong with some code: "don't create global SFML objects".

Due to historical reasons, it was very difficult (although not impossible), effort-wise to implement working context management without the use of objects living in namespace scope. With the additions from modern C++ this has become much easier.

Having objects living in namespace scope introduces construction ordering requirements between translation units which has never been guaranteed by C++, this essentially makes this code broken. Saying users shouldn't put their stuff in namespace scope is just a workaround for something we can and really should fix. While we still shouldn't recommend this practice, we have to be realistic, it is still going to happen, and we have better things to do than to play code police. Standard library objects support this usage without causing undefined behaviour and SFML classes should strive to be that robust as well.

The changes in this changeset also set up a better facility to manage other types of OpenGL resources that can't be shared between contexts. This might be necessary in the future.

This code would have broken in so many ways without these changes:
```cpp
#include <SFML/Graphics.hpp>

sf::RenderWindow  window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
sf::Texture       texture;
sf::VertexBuffer  vbo;
sf::Shader        shader;
sf::RenderTexture renderTexture;

int main()
{
    window.setFramerateLimit(60);

    if (!texture.create(sf::Vector2u(1, 1)))
        return -1;

    if (!vbo.create(1))
        return -1;

    if (!shader.loadFromMemory("void main() {}", sf::Shader::Vertex))
        return -1;

    if (!renderTexture.create(sf::Vector2u(1, 1)))
        return -1;

    while (window.isOpen())
    {
        for (sf::Event event; window.pollEvent(event);)
        {
            if (event.type == sf::Event::Closed)
                window.close();
        }

        window.clear();
        window.display();
    }
}
```