### PR TITLE
WglContext: Caching pixel formats for a massive speed boost in multiple context programs.

### DIFF
--- a/include/SFML/Window/ContextSettings.hpp
+++ b/include/SFML/Window/ContextSettings.hpp
@@ -26,6 +26,7 @@
 #define SFML_CONTEXTSETTINGS_HPP
 
 #include <SFML/Config.hpp>
+#include <tuple>
 
 namespace sf
 {
@@ -69,6 +70,11 @@ struct ContextSettings
     sRgbCapable      (sRgb)
     {
     }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Comparison operator. Used in the WGL pixel format cache.
+    ////////////////////////////////////////////////////////////
+    auto operator<(const ContextSettings& rhs) const { return std::tie(depthBits, stencilBits, antialiasingLevel, majorVersion, minorVersion, attributeFlags, sRgbCapable) < std::tie(rhs.depthBits, rhs.stencilBits, rhs.antialiasingLevel, rhs.majorVersion, rhs.minorVersion, rhs.attributeFlags, rhs.sRgbCapable); }
 
     ////////////////////////////////////////////////////////////
     // Member data


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description
Hello! My program creates lots of worker OpenGL contexts and it was taking 20+ seconds to start. The bottleneck was trying to find the best WGL pixel format. Since all my contexts use the same pixel format, it made sense to cache the pixel format. Creating 64 contexts could then happen in under 1 second.

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android