### PR TITLE
Assorted Fixes for Testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 env:
+  DISPLAY: ":99" # Display number to use for the X server
   GALLIUM_DRIVER: llvmpipe # Use Mesa 3D software OpenGL renderer
 
 jobs:
@@ -104,6 +105,20 @@ jobs:
     - name: Build
       shell: bash
       run: cmake --build $GITHUB_WORKSPACE/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
+      
+    - name: Prepare Test
+      shell: bash
+      run: |
+        set -e
+        # Start up Xvfb and fluxbox to host display tests
+        if [ "${{ runner.os }}" == "Linux" ]; then
+          Xvfb $DISPLAY -screen 0 1920x1080x24 &
+          sleep 5
+          fluxbox > /dev/null 2>&1 &
+          sleep 5
+        fi
+        # Make sure the build/bin directory exists so that the find command does not fail if no executables are built
+        mkdir -p $GITHUB_WORKSPACE/build/bin
 
     - name: Test
       uses: nick-fields/retry@v2
@@ -122,14 +137,6 @@ jobs:
             cmake --build $GITHUB_WORKSPACE/build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
             # Coverage is already generated on Windows when running tests.
           else
-            # Start up Xvfb and fluxbox to host display tests on DISPLAY :99
-            if [ "${{ runner.os }}" == "Linux" ]; then
-              export DISPLAY=":99"
-              Xvfb $DISPLAY -screen 0 1920x1080x24 &
-              sleep 5
-              fluxbox > /dev/null 2>&1 &
-              sleep 5
-            fi
             # Make use of a test to print OpenGL vendor/renderer/version info to the console
             find $GITHUB_WORKSPACE/build/bin -name test-sfml-window -exec {} --test-case="[Window] sf::Context" --subcase="Version String" \; | grep OpenGL
             # Run the tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
         warning_on_retry: false
         shell: bash
         command: |
+          set -e
           if [ "${{ runner.os }}" == "Windows" ]; then
             # Make use of a test to print OpenGL vendor/renderer/version info to the console
             find $GITHUB_WORKSPACE/build/bin -name test-sfml-window.exe -exec {} --test-case="[Window] sf::Context" --subcase="Version String" \; | grep OpenGL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
             # Make use of a test to print OpenGL vendor/renderer/version info to the console
             find $GITHUB_WORKSPACE/build/bin -name test-sfml-window -exec {} --test-case="[Window] sf::Context" --subcase="Version String" \; | grep OpenGL
             # Run the tests
-            ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+            ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure -C ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
             # Run gcovr to extract coverage information from the test run
             if [ "${{ matrix.type.name }}" == "Debug" ]; then
               gcovr -r $GITHUB_WORKSPACE -x $GITHUB_WORKSPACE/build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,13 @@ jobs:
           set -e
           if [ "${{ runner.os }}" == "Windows" ]; then
             # Make use of a test to print OpenGL vendor/renderer/version info to the console
-            find $GITHUB_WORKSPACE/build/bin -name test-sfml-window.exe -exec {} --test-case="[Window] sf::Context" --subcase="Version String" \; | grep OpenGL
+            find $GITHUB_WORKSPACE/build/bin -name test-sfml-window.exe -exec sh -c "{} --test-case=\"[Window] sf::Context\" --subcase=\"Version String\" | grep OpenGL" \;
             # Run the tests
             cmake --build $GITHUB_WORKSPACE/build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
             # Coverage is already generated on Windows when running tests.
           else
             # Make use of a test to print OpenGL vendor/renderer/version info to the console
-            find $GITHUB_WORKSPACE/build/bin -name test-sfml-window -exec {} --test-case="[Window] sf::Context" --subcase="Version String" \; | grep OpenGL
+            find $GITHUB_WORKSPACE/build/bin -name test-sfml-window -exec sh -c "{} --test-case=\"[Window] sf::Context\" --subcase=\"Version String\" | grep OpenGL" \;
             # Run the tests
             ctest --test-dir $GITHUB_WORKSPACE/build --output-on-failure -C ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
             # Run gcovr to extract coverage information from the test run


### PR DESCRIPTION
## Description

Each commit fixes something separate

1. The lack of `set -e` in the test job allowed the `ctest` call to fail without the entire job failing. I didn't think GitHub Actions behaved this way but apparently so. See false positive [here](https://github.com/ChrisThrasher/SFML/actions/runs/4642877317/jobs/8217128705).
2. This hid the fact that the `find` call failed on iOS and Android. It's fine if this fails though so we can ignore this failure. See where it failed on me [here](https://github.com/ChrisThrasher/SFML/actions/runs/4643516748/jobs/8218214753).
3. We were using the wrong flag for specify which config to test. This is probably my fault since I think I originally added that. I'm not sure why using `--config` doesn't cause CTest to fail but it doesn't so this problem went unnoticed for a while. See failing CI run [here](https://github.com/ChrisThrasher/SFML/actions/runs/4642982091/jobs/8217315593).

See links for CI runs that demonstrate what each commit is fixing.

We can squash these tiny commits if you'd like.