### PR TITLE
Configure doxygen STRIP_FROM_INC_PATH option

### DIFF
--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -193,7 +193,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = "@DOXYGEN_INPUT_DIR@/include"
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't


### PR DESCRIPTION
so that include directives are correct in the generated documentation.

Before:
![Capture d’écran du 2023-04-11 20-34-43](https://user-images.githubusercontent.com/1485306/231257654-b335b274-0251-4825-9e26-8ca7c92a197c.png)

After:
![Capture d’écran du 2023-04-11 20-35-11](https://user-images.githubusercontent.com/1485306/231257688-1ea73b9a-ffb7-49c0-ad31-a33c3bde5f3e.png)

Motivated by this comment: https://github.com/SFML/SFML/pull/2489#issuecomment-1496813153
