### PR TITLE
Fixed $GITHUB_WORKSPACE backslashes being escaped by bash when passed to the sh command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,8 @@ jobs:
           set -e
           if [ "${{ runner.os }}" == "Windows" ]; then
             # Make use of a test to print OpenGL vendor/renderer/version info to the console
-            find $GITHUB_WORKSPACE/build/bin -name test-sfml-window.exe -exec sh -c "{} --test-case=\"[Window] sf::Context\" --subcase=\"Version String\" | grep OpenGL" \;
+            # We have to convert the backslashes in $GITHUB_WORKSPACE to (forward) slashes so bash doesn't try to escape them in the sh command
+            find $(echo $GITHUB_WORKSPACE | sed 's/\\\\/\\//g')/build/bin -name test-sfml-window.exe -exec sh -c "{} --test-case=\"[Window] sf::Context\" --subcase=\"Version String\" | grep OpenGL" \;
             # Run the tests
             cmake --build $GITHUB_WORKSPACE/build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
             # Coverage is already generated on Windows when running tests.


### PR DESCRIPTION
The path in $GITHUB_WORKSPACE when running on a Windows runner uses backslashes as directory separators. Because we use bash, when passing a path constructed using $GITHUB_WORKSPACE as a string to another command, the backslashes are treated as escape characters and removed, breaking the complete path. This currently only happens with the find command we use to output the OpenGL information before testing.

This fix uses sed to replace the backslashes with Unix (forward) slashes in the path passed to find so that find runs exec using a path that only contains (forward) slashes.