### PR TITLE
Support for `std::string_view` in `sf::String`

### DIFF
--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -33,6 +33,7 @@
 
 #include <locale>
 #include <string>
+#include <string_view>
 
 #include <cstddef>
 #include <cstdint>
@@ -171,6 +172,18 @@ public:
     String(const std::string& ansiString, const std::locale& locale = {});
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct from an ANSI string view and a locale
+    ///
+    /// The source string is converted to UTF-32 according
+    /// to the given locale.
+    ///
+    /// \param ansiString ANSI string to convert
+    /// \param locale     Locale to use for conversion
+    ///
+    ////////////////////////////////////////////////////////////
+    String(std::string_view ansiString, const std::locale& locale = {});
+
+    ////////////////////////////////////////////////////////////
     /// \brief Construct from null-terminated C-style wide string
     ///
     /// \param wideString Wide string to convert
@@ -187,6 +200,14 @@ public:
     String(const std::wstring& wideString);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct from a wide string view
+    ///
+    /// \param wideString Wide string to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    String(std::wstring_view wideString);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Construct from a null-terminated C-style UTF-32 string
     ///
     /// \param utf32String UTF-32 string to assign
@@ -201,6 +222,14 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     String(std::u32string utf32String);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from an UTF-32 string view
+    ///
+    /// \param utf32String UTF-32 string to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    String(std::u32string_view utf32String);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new `sf::String` from a UTF-8 encoded string

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -173,7 +173,13 @@ String::String(const char* ansiString, const std::locale& locale)
 
 
 ////////////////////////////////////////////////////////////
-String::String(const std::string& ansiString, const std::locale& locale)
+String::String(const std::string& ansiString, const std::locale& locale) : String(std::string_view(ansiString), locale)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+String::String(std::string_view ansiString, const std::locale& locale)
 {
     m_string.reserve(ansiString.length() + 1);
     Utf32::fromAnsi(ansiString.begin(), ansiString.end(), std::back_inserter(m_string), locale);
@@ -196,7 +202,13 @@ String::String(const wchar_t* wideString)
 
 
 ////////////////////////////////////////////////////////////
-String::String(const std::wstring& wideString)
+String::String(const std::wstring& wideString) : String(std::wstring_view(wideString))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+String::String(std::wstring_view wideString)
 {
     m_string.reserve(wideString.length() + 1);
     Utf32::fromWide(wideString.begin(), wideString.end(), std::back_inserter(m_string));
@@ -211,6 +223,12 @@ String::String(const char32_t* utf32String) : m_string(utf32String ? utf32String
 
 ////////////////////////////////////////////////////////////
 String::String(std::u32string utf32String) : m_string(std::move(utf32String))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+String::String(std::u32string_view utf32String) : m_string(utf32String)
 {
 }
 

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -286,6 +286,21 @@ TEST_CASE("[System] sf::String")
             CHECK(string.getData() != nullptr);
         }
 
+        SECTION("ANSI string view constructor")
+        {
+            const sf::String string = "Csiga"sv;
+            CHECK(std::string(string) == "Csiga"s);
+            CHECK(std::wstring(string) == L"Csiga"s);
+            CHECK(string.toAnsiString() == "Csiga"s);
+            CHECK(string.toWideString() == L"Csiga"s);
+            CHECK(string.toUtf8() == sf::U8String{'C', 's', 'i', 'g', 'a'});
+            CHECK(string.toUtf16() == u"Csiga"s);
+            CHECK(string.toUtf32() == U"Csiga"s);
+            CHECK(string.getSize() == 5);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
+        }
+
         SECTION("Wide character constructor")
         {
             {
@@ -362,6 +377,21 @@ TEST_CASE("[System] sf::String")
             CHECK(string.getData() != nullptr);
         }
 
+        SECTION("Wide string view constructor")
+        {
+            const sf::String string = L"Полжав"sv;
+            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::wstring(string) == L"Полжав"s);
+            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toWideString() == L"Полжав"s);
+            CHECK(string.toUtf8() == sf::U8String{0xD0, 0x9F, 0xD0, 0xBE, 0xD0, 0xBB, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB2});
+            CHECK(string.toUtf16() == u"Полжав"s);
+            CHECK(string.toUtf32() == U"Полжав"s);
+            CHECK(string.getSize() == 6);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
+        }
+
         SECTION("UTF-32 character constructor")
         {
             const sf::String string = U'🐌';
@@ -424,6 +454,21 @@ TEST_CASE("[System] sf::String")
         SECTION("UTF-32 string constructor")
         {
             const sf::String string = U"گھونگا"s;
+            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::wstring(string) == L"گھونگا"s);
+            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toWideString() == L"گھونگا"s);
+            CHECK(string.toUtf8() == sf::U8String{0xDA, 0xAF, 0xDA, 0xBE, 0xD9, 0x88, 0xD9, 0x86, 0xDA, 0xAF, 0xD8, 0xA7});
+            CHECK(string.toUtf16() == u"گھونگا"s);
+            CHECK(string.toUtf32() == U"گھونگا"s);
+            CHECK(string.getSize() == 6);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
+        }
+
+        SECTION("UTF-32 string view constructor")
+        {
+            const sf::String string = U"گھونگا"sv;
             CHECK(std::string(string) == "\0\0\0\0\0\0"s);
             CHECK(std::wstring(string) == L"گھونگا"s);
             CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);


### PR DESCRIPTION
## Description

Revision of https://github.com/SFML/SFML/pull/2451

This is in a new branch and up to date with the origin's master as of this post.

Closes #2445

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?
Test driver (modified to match changes in sf::Text):

```cpp
#include <SFML/Main.hpp>
#include <SFML/Graphics.hpp>
#include <SFML/Window.hpp>

#include <string_view>

int main() {
  sf::RenderWindow window(sf::VideoMode(sf::Vector2u(800, 600)), "SFML Testbed");
  window.setFramerateLimit(60);

  sf::Font font;
  bool derp = font.loadFromFile("c:/Windows/Fonts/arial.ttf");
  
  const char data[] = "derpdurr";
  const wchar_t wdata[] = L"herpboing";

  std::string str(data + 4, 4);
  std::string_view sv(data, 4);
  std::wstring wstr(wdata, 4);
  std::wstring_view wsv(wdata + 4);

  std::vector<sf::Text> texts;
  texts.emplace_back(font, wstr);
  texts.back().setPosition(sf::Vector2f(10, 0));
  texts.emplace_back(font, sv);
  texts.back().setPosition(sf::Vector2f(10, 40));
  texts.emplace_back(font, str);
  texts.back().setPosition(sf::Vector2f(10, 80));
  texts.emplace_back(font, wsv);
  texts.back().setPosition(sf::Vector2f(10, 120));
  
  for(bool run = true; run;) {
    window.clear();
    for(auto& text : texts) {
      window.draw(text);
    }
    window.display();

    sf::Event event;
    while(window.pollEvent(event)) {
      if(event.type == sf::Event::Closed) { run = false; break; }
    }
  }
}
```
