### PR TITLE
Add minimum and maximum window size implementation

### DIFF
--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -244,6 +244,22 @@ public:
     void setSize(const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Sets a minimum window rendering region size
+    ///
+    /// \param minimumSize New minimum size, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMinimumSize(const Vector2u& minimumSize);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets a maximum window rendering region size
+    ///
+    /// \param maximumSize New maximum size, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMaximumSize(const Vector2u& maximumSize);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Change the title of the window
     ///
     /// \param title New title

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -115,6 +115,22 @@ public:
     virtual void setSize(const Vector2u& size);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Sets a minimum window rendering region size
+    ///
+    /// \param minimumSize New minimum size, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMinimumSize(const Vector2u& minimumSize);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets a maximum window rendering region size
+    ///
+    /// \param maximumSize New maximum size, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMaximumSize(const Vector2u& maximumSize);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Change the title of the window
     ///
     /// \param title New title
@@ -312,6 +328,8 @@ private:
     ::Cursor   m_lastCursor;     ///< Last cursor used -- this data is not owned by the window and is required to be always valid
     bool       m_keyRepeat;      ///< Is the KeyRepeat feature enabled?
     Vector2i   m_previousSize;   ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
+    Vector2u   m_minimumSize;    ///< Minimum size the rendering region of the window can be
+    Vector2u   m_maximumSize;    ///< Maximum size the rendering region of the window can be
     bool       m_useSizeHints;   ///< Is the size of the window fixed with size hints?
     bool       m_fullscreen;     ///< Is the window in fullscreen?
     bool       m_cursorGrabbed;  ///< Is the mouse cursor trapped?

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -225,6 +225,23 @@ void WindowBase::setSize(const Vector2u& size)
     }
 }
 
+////////////////////////////////////////////////////////////
+void WindowBase::setMinimumSize(const Vector2u &minimumSize)
+{
+    if (m_impl)
+    {
+        m_impl->setMinimumSize(minimumSize);
+    }
+}
+
+////////////////////////////////////////////////////////////
+void WindowBase::setMaximumSize(const Vector2u &maximumSize)
+{
+    if (m_impl)
+    {
+        m_impl->setMaximumSize(maximumSize);
+    }
+}
 
 ////////////////////////////////////////////////////////////
 void WindowBase::setTitle(const String& title)

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -155,6 +155,22 @@ public:
     virtual void setSize(const Vector2u& size) = 0;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Sets a minimum window rendering region size
+    ///
+    /// \param minimumSize New minimum size, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMinimumSize(const Vector2u& minimumSize) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets a maximum window rendering region size
+    ///
+    /// \param maximumSize New maximum size, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void setMaximumSize(const Vector2u& maximumSize) = 0;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Change the title of the window
     ///
     /// \param title New title


### PR DESCRIPTION
## Description

My PR is to allow users to set the minimum and maximum size. Right now it only implements it for X11, but the plan is to do this for all other OS.

Related actions:
https://github.com/SFML/SFML/pull/2378
https://github.com/SFML/SFML/issues/2124

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Just run and compile this code bellow and try and the window to be bigger or smaller than the defined sizes.
```cpp
#include <SFML/Graphics.hpp>
#include <SFML/Window.hpp>

int main() {
  sf::RenderWindow window(sf::VideoMode(200, 200), "SFML works!");
  window.setMinimumSize(sf::Vector2u(200, 200));
  window.setMaximumSize(sf::Vector2u(800, 800));

  while (window.isOpen()) {
    sf::Event event;
    while (window.pollEvent(event)) {
      if (event.type == sf::Event::Closed)
        window.close();
    }

    window.clear();
    window.display();
  }

  return 0;
}
```
