### PR TITLE
Enable clang-tidy `modernize-pass-by-value` check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,7 +30,6 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,
   -modernize-macro-to-enum,
-  -modernize-pass-by-value,
   -modernize-return-braced-init-list,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,

--- a/examples/shader/Effect.hpp
+++ b/examples/shader/Effect.hpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <string>
+#include <utility>
 
 
 ////////////////////////////////////////////////////////////
@@ -54,7 +55,7 @@ public:
     }
 
 protected:
-    Effect(const std::string& name) : m_name(name)
+    Effect(std::string name) : m_name(std::move(name))
     {
     }
 

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -77,13 +77,13 @@ public:
     /// \param characterSize  Base size of characters, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Text(const Font& font, const String& string = "", unsigned int characterSize = 30);
+    Text(const Font& font, String string = "", unsigned int characterSize = 30);
 
     ////////////////////////////////////////////////////////////
     /// \brief Disallow construction from a temporary font
     ///
     ////////////////////////////////////////////////////////////
-    Text(Font&& font, const String& string = "", unsigned int characterSize = 30) = delete;
+    Text(Font&& font, String string = "", unsigned int characterSize = 30) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -142,7 +142,7 @@ public:
         /// \param message Response message
         ///
         ////////////////////////////////////////////////////////////
-        explicit Response(Status code = Status::InvalidResponse, const std::string& message = "");
+        explicit Response(Status code = Status::InvalidResponse, std::string message = "");
 
         ////////////////////////////////////////////////////////////
         /// \brief Check if the status code means a success

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -149,7 +149,7 @@ public:
     /// \param utf32String UTF-32 string to assign
     ///
     ////////////////////////////////////////////////////////////
-    String(const std::u32string& utf32String);
+    String(std::u32string utf32String);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new sf::String from a UTF-8 encoded string

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 
 namespace
@@ -94,8 +95,8 @@ void addGlyphQuad(sf::VertexArray& vertices, sf::Vector2f position, const sf::Co
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Text::Text(const Font& font, const String& string, unsigned int characterSize) :
-m_string(string),
+Text::Text(const Font& font, String string, unsigned int characterSize) :
+m_string(std::move(string)),
 m_font(&font),
 m_characterSize(characterSize)
 {

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -36,6 +36,7 @@
 #include <iterator>
 #include <ostream>
 #include <sstream>
+#include <utility>
 
 
 namespace sf
@@ -78,7 +79,7 @@ private:
 
 
 ////////////////////////////////////////////////////////////
-Ftp::Response::Response(Status code, const std::string& message) : m_status(code), m_message(message)
+Ftp::Response::Response(Status code, std::string message) : m_status(code), m_message(std::move(message))
 {
 }
 

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -30,6 +30,7 @@
 
 #include <cstring>
 #include <iterator>
+#include <utility>
 
 
 namespace sf
@@ -118,7 +119,7 @@ String::String(const char32_t* utf32String)
 
 
 ////////////////////////////////////////////////////////////
-String::String(const std::u32string& utf32String) : m_string(utf32String)
+String::String(std::u32string utf32String) : m_string(std::move(utf32String))
 {
 }
 


### PR DESCRIPTION
## Description

https://clang.llvm.org/extra/clang-tidy/checks/modernize/pass-by-value.html

This ensures that we're not copying potentially large types more often than necessary.