### PR TITLE
Add clang-tidy `bugprone-incorrect-roundings` check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
-  -bugprone-incorrect-roundings,
   -bugprone-integer-division,
   -bugprone-misplaced-widening-cast,
   -bugprone-narrowing-conversions,

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <iostream>
 #include <mutex>
 #include <ostream>
@@ -193,8 +194,8 @@ IntRect RenderTarget::getViewport(const View& view) const
     const auto [width, height] = Vector2f(getSize());
     const FloatRect& viewport  = view.getViewport();
 
-    return IntRect({static_cast<int>(0.5f + width * viewport.left), static_cast<int>(0.5f + height * viewport.top)},
-                   {static_cast<int>(0.5f + width * viewport.width), static_cast<int>(0.5f + height * viewport.height)});
+    return IntRect(Rect<long>({std::lround(width * viewport.left), std::lround(height * viewport.top)},
+                              {std::lround(width * viewport.width), std::lround(height * viewport.height)}));
 }
 
 


### PR DESCRIPTION
## Description

This issue came up in https://github.com/SFML/SFML/pull/1451. This check lets us automate away yet another small anti-pattern.