### PR TITLE
Add tests for `sf::sleep`

### DIFF
--- a/include/SFML/System/Sleep.hpp
+++ b/include/SFML/System/Sleep.hpp
@@ -44,6 +44,11 @@ class Time;
 /// one provides more accurate sleeping time thanks to some
 /// platform-specific tweaks.
 ///
+/// sf::sleep only guarantees millisecond precision. Sleeping
+/// for a duration less than 1 millisecond is prone to result
+/// in the actual sleep duration being less than what is
+/// requested.
+///
 /// \param duration Time to sleep
 ///
 ////////////////////////////////////////////////////////////

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SYSTEM_SRC
     System/Err.test.cpp
     System/FileInputStream.test.cpp
     System/MemoryInputStream.test.cpp
+    System/Sleep.test.cpp
     System/String.test.cpp
     System/Time.test.cpp
     System/Vector2.test.cpp

--- a/test/System/Sleep.test.cpp
+++ b/test/System/Sleep.test.cpp
@@ -1,0 +1,40 @@
+#include <SFML/System/Sleep.hpp>
+
+// Other 1st party headers
+#include <SFML/System/Time.hpp>
+
+#include <doctest/doctest.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+// Specialize StringMaker for std::chrono::duration specializations
+// https://github.com/doctest/doctest/blob/master/doc/markdown/stringification.md#docteststringmakert-specialisation
+namespace doctest
+{
+template <typename Rep, typename Period>
+struct StringMaker<std::chrono::duration<Rep, Period>>
+{
+    static String convert(const std::chrono::duration<Rep, Period>& duration)
+    {
+        return toString(std::chrono::nanoseconds(duration).count()) + "ns";
+    }
+};
+} // namespace doctest
+
+#define CHECK_SLEEP_DURATION(duration)                                     \
+    do                                                                     \
+    {                                                                      \
+        const auto startTime = std::chrono::steady_clock::now();           \
+        sf::sleep((duration));                                             \
+        const auto elapsed = std::chrono::steady_clock::now() - startTime; \
+        CHECK(elapsed >= (duration));                                      \
+    } while (false)
+
+TEST_CASE("[System] sf::sleep")
+{
+    CHECK_SLEEP_DURATION(1ms);
+    CHECK_SLEEP_DURATION(10ms);
+    CHECK_SLEEP_DURATION(100ms);
+}


### PR DESCRIPTION
## Description

While testing `sf::sleep` I tried sleeping for durations less than 1 millisecond and found that on Windows this resulted in the actual sleep duration being _less_ than what was requested. This was odd because sleeping on modern OSes results in sleeping for the duration requested _or longer_ but never a duration shorter than what was requested. I added a sentence to the docs to reflect this fact. One way to mitigate this is to change the function parameter from `sf::Time` to `std::chrono::milliseconds` to make it impossible to request sleeping for some duration between 0 and 1 milliseconds.

I tried a number of ways to reliably test for the upper bound of sleep duration but the nature of OSes is just that there's no meaningful way to test this.

---

https://github.com/SFML/SFML/blob/230c6a4d57353c77ceb06808cb25969ae89f183a/src/SFML/System/Sleep.cpp#L43-L44

If anyone has more insight into this MinGW-w64 bug, please let me know. I can't run MinGW locally so I have little insight into its quirks. I'm curious if newer versions have fixed this because if so, we can remove `sf::sleep` entirely. I couldn't find any documentation on this so I can't gain any insight into whether it was fixed.