### PR TITLE
Fix macOS Window Resizing Bug

### DIFF
--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -457,18 +457,9 @@
         // Add titlebar height.
         height += static_cast<unsigned int>([self titlebarHeight]);
 
-        // Corner case: don't set the window height bigger than the screen height
-        // or the view will be resized _later_ without generating a resize event.
-        NSRect  screenFrame      = [[NSScreen mainScreen] visibleFrame];
-        CGFloat maxVisibleHeight = screenFrame.size.height;
-        if (height > maxVisibleHeight)
-        {
-            height = static_cast<unsigned int>(maxVisibleHeight);
-
-            // The size is not the requested one, we fire an event
-            if (m_requester != nil)
-                m_requester->windowResized({width, height - static_cast<unsigned int>([self titlebarHeight])});
-        }
+        // Send resize event if size has changed
+        if (sf::Vector2u(width, height) != m_requester->getSize())
+            m_requester->windowResized({width, height - static_cast<unsigned int>([self titlebarHeight])});
 
         NSRect frame = NSMakeRect([m_window frame].origin.x, [m_window frame].origin.y, width, height);
 


### PR DESCRIPTION
## Description

Fixes bug where resize events only got triggered upon manual window resizing OR if one called `sf::WindowBase::setSize` with a height that was too large. This was caught during the testing of #2519. The reason we think it's a bug is that other windowing backends like X11 do emit a resize event when `setSize` is called.

Brief testing proves that this works but I'm not sure if this has any unintended side effects so I'm not eager to merge until I understand the code better. This bug is present on 2.6.x as well in case we choose to backport this.