### PR TITLE
Modernize memory management of X11 types

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -123,6 +123,7 @@ elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
             ${SRCROOT}/Unix/SensorImpl.hpp
             ${SRCROOT}/Unix/Display.cpp
             ${SRCROOT}/Unix/Display.hpp
+            ${SRCROOT}/Unix/Utils.hpp
             ${SRCROOT}/Unix/VideoModeImpl.cpp
             ${SRCROOT}/Unix/VulkanImplX11.cpp
             ${SRCROOT}/Unix/VulkanImplX11.hpp

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -39,6 +39,8 @@
 #include <SFML/System/Android/Activity.hpp>
 #endif
 #if defined(SFML_SYSTEM_LINUX) && !defined(SFML_USE_DRM)
+#include <SFML/Window/Unix/Utils.hpp>
+
 #include <X11/Xlib.h>
 #endif
 
@@ -424,10 +426,8 @@ XVisualInfo EglContext::selectBestVisual(::Display* XDisplay, unsigned int bitsP
     vTemplate.visualid = static_cast<VisualID>(nativeVisualId);
 
     // Get X11 visuals compatible with this EGL config
-    XVisualInfo *availableVisuals, bestVisual;
-    int          visualCount = 0;
-
-    availableVisuals = XGetVisualInfo(XDisplay, VisualIDMask, &vTemplate, &visualCount);
+    int  visualCount      = 0;
+    auto availableVisuals = X11Ptr<XVisualInfo[]> XGetVisualInfo(XDisplay, VisualIDMask, &vTemplate, &visualCount));
 
     if (visualCount == 0)
     {
@@ -438,10 +438,7 @@ XVisualInfo EglContext::selectBestVisual(::Display* XDisplay, unsigned int bitsP
     }
 
     // Pick up the best one
-    bestVisual = availableVisuals[0];
-    XFree(availableVisuals);
-
-    return bestVisual;
+    return availableVisuals[0];
 }
 #endif
 

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Unix/CursorImpl.hpp>
 #include <SFML/Window/Unix/Display.hpp>
+#include <SFML/Window/Unix/Utils.hpp>
 
 #include <X11/Xcursor/Xcursor.h>
 #include <X11/Xutil.h>
@@ -39,6 +40,15 @@
 
 namespace sf::priv
 {
+template <>
+struct XDeleter<XcursorImage>
+{
+    void operator()(XcursorImage* cursorImage) const
+    {
+        XcursorImageDestroy(cursorImage);
+    }
+};
+
 
 ////////////////////////////////////////////////////////////
 CursorImpl::CursorImpl() : m_display(openDisplay())
@@ -71,9 +81,9 @@ bool CursorImpl::loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vecto
 bool CursorImpl::loadFromPixelsARGB(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot)
 {
     // Create cursor image, convert from RGBA to ARGB.
-    XcursorImage* cursorImage = XcursorImageCreate(static_cast<int>(size.x), static_cast<int>(size.y));
-    cursorImage->xhot         = hotspot.x;
-    cursorImage->yhot         = hotspot.y;
+    auto cursorImage  = X11Ptr<XcursorImage>(XcursorImageCreate(static_cast<int>(size.x), static_cast<int>(size.y)));
+    cursorImage->xhot = hotspot.x;
+    cursorImage->yhot = hotspot.y;
 
     const std::size_t numPixels = static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y);
     for (std::size_t pixelIndex = 0; pixelIndex < numPixels; ++pixelIndex)
@@ -84,10 +94,7 @@ bool CursorImpl::loadFromPixelsARGB(const std::uint8_t* pixels, Vector2u size, V
     }
 
     // Create the cursor.
-    m_cursor = XcursorImageLoadCursor(m_display, cursorImage);
-
-    // Free the resources
-    XcursorImageDestroy(cursorImage);
+    m_cursor = XcursorImageLoadCursor(m_display, cursorImage.get());
 
     // We assume everything went fine...
     return true;

--- a/src/SFML/Window/Unix/Utils.hpp
+++ b/src/SFML/Window/Unix/Utils.hpp
@@ -1,0 +1,61 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2023 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <X11/Xlib.h>
+
+#include <memory>
+#include <type_traits>
+
+
+namespace sf::priv
+{
+////////////////////////////////////////////////////////////
+/// \brief Class template for freeing X11 pointers
+///
+/// Specialized elsewhere for types that are freed through
+/// other means than XFree(). XFree() is the most common use
+/// case though so it is the default.
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+struct XDeleter
+{
+    void operator()(T* data) const
+    {
+        XFree(data);
+    }
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Class template for wrapping owning raw pointers from X11
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+using X11Ptr = std::unique_ptr<T, XDeleter<std::remove_all_extents_t<T>>>;
+} // namespace sf::priv


### PR DESCRIPTION
## Description

This PR does two main things:

1. Remove unnecessary heap allocations
2. Manage necessary heap allocations with smart pointers

The goal at the start was to get rid of as many uses of `XFree` as possible. I quickly realized that often times we're freeing something that was heap allocated for no reason other than we chose to use an X11 factory function that happens to heap allocate the type. `XAllocWMHints` is a good example of this. It just `calloc`s a `XWMHints` the gives you a pointer to that allocation which it expects you to free. There are a few other `XAlloc` functions which all do the same thing. It initializes all members to zero which may be convenient to C programmers but we can use `T t{}` to zero-initialize all members of `T` so that's not useful to use in C++ land.

https://github.com/mirror/libX11/blob/ff8706a5eae25b8bafce300527079f68a201d27f/src/PropAlloc.c#L52-L55

Along the way I realized that a lot of other `XFree`s are cleaning up owning raw pointers that we're forced to deal with. Those are fixed by using `std::unique_ptr` to automatically clean up the allocation. In a few places X11 is actually returning a pointer to an array in which case I used `std::unique_ptr<T[]>`.

(This will get squashed. I'm keeping the verbose history in case I need to remove or revert anything.)