### PR TITLE
Create a symlink to force gpgv to use the correct source of trusted keys on mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
         if [ "$platform" == "windows" ]; then CODECOV_BINARY="codecov.exe"; else CODECOV_BINARY="codecov"; fi
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
         curl -s --remote-name-all "https://uploader.codecov.io/latest/$platform/{$CODECOV_BINARY,$CODECOV_BINARY.SHA256SUM,$CODECOV_BINARY.SHA256SUM.sig}"
+        ln -s ~/.gnupg/trustdb.gpg ~/.gnupg/trustedkeys.kbx
         gpgv "$CODECOV_BINARY.SHA256SUM.sig" "$CODECOV_BINARY.SHA256SUM"
         if [ "$platform" == "windows" ]; then powershell 'If ($(Compare-Object -ReferenceObject $(($(certUtil -hashfile codecov.exe SHA256)[1], "codecov.exe") -join "  ") -DifferenceObject $(Get-Content codecov.exe.SHA256SUM)).length -eq 0) {echo "codecov: OK"} Else {exit 1}';
         else shasum -a 256 -c codecov.SHA256SUM; fi


### PR DESCRIPTION
## Description

This PR adds creates a symlink to target the correct source of trusted keys for gpgv. It has no impact on Linux and is ignored on Windows, causing no issues.

This was discussed in Discord with @ChrisThrasher 
