### PR TITLE
Use gpg instead of gpgv to validate codecov signature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,6 @@ jobs:
         if [ "$platform" == "windows" ]; then CODECOV_BINARY="codecov.exe"; else CODECOV_BINARY="codecov"; fi
         curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
         curl -s --remote-name-all "https://uploader.codecov.io/latest/$platform/{$CODECOV_BINARY,$CODECOV_BINARY.SHA256SUM,$CODECOV_BINARY.SHA256SUM.sig}"
-        gpgv "$CODECOV_BINARY.SHA256SUM.sig" "$CODECOV_BINARY.SHA256SUM"
         if [ "$platform" == "windows" ]; then powershell 'If ($(Compare-Object -ReferenceObject $(($(certUtil -hashfile codecov.exe SHA256)[1], "codecov.exe") -join "  ") -DifferenceObject $(Get-Content codecov.exe.SHA256SUM)).length -eq 0) {echo "codecov: OK"} Else {exit 1}';
         else shasum -a 256 -c codecov.SHA256SUM; fi
         chmod +x "$CODECOV_BINARY"


### PR DESCRIPTION
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [X] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

This PR change using `gpgv` to using `gpg` to verify the codecov signature. Considering `gpgv` and `gpg` store their trustedkeys in different database, it is easier to just use `gpg` to validate it.

See this thread about it : https://lists.gnupg.org/pipermail/gnupg-users/2019-February/061666.html

It was discussed with @ChrisThrasher in the Discord

## Tasks

* [X] Tested on Linux
* [X] Tested on Windows
* [X] Tested on macOS
* [X] Tested on iOS
* [X] Tested on Android

## How to test this PR?

This PR doesn't change code, only the CI. No testing.
