### PR TITLE
Fix broken `sf::swap` overloads

### DIFF
--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -637,7 +637,7 @@ private:
 /// \param right Second instance to swap
 ///
 ////////////////////////////////////////////////////////////
-void swap(Texture& left, Texture& right) noexcept;
+SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 
 } // namespace sf
 

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -346,7 +346,7 @@ private:
 /// \param right Second instance to swap
 ///
 ////////////////////////////////////////////////////////////
-void swap(VertexBuffer& left, VertexBuffer& right) noexcept;
+SFML_GRAPHICS_API void swap(VertexBuffer& left, VertexBuffer& right) noexcept;
 
 } // namespace sf
 

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -196,7 +196,7 @@ TEST_CASE("[Graphics] sf::Texture" * doctest::skip(skipDisplayTests))
         texture2.setSmooth(true);
         texture2.setRepeated(false);
 
-        std::swap(texture1, texture2);
+        sf::swap(texture1, texture2);
         CHECK_FALSE(texture1.isSrgb());
         CHECK(texture1.isSmooth());
         CHECK_FALSE(texture1.isRepeated());

--- a/test/Graphics/VertexBuffer.test.cpp
+++ b/test/Graphics/VertexBuffer.test.cpp
@@ -149,7 +149,7 @@ TEST_CASE("[Graphics] sf::VertexBuffer" * doctest::skip(true))
         sf::VertexBuffer vertexBuffer2(sf::PrimitiveType::TriangleStrip, sf::VertexBuffer::Stream);
         CHECK(vertexBuffer2.create(60));
 
-        std::swap(vertexBuffer1, vertexBuffer2);
+        sf::swap(vertexBuffer1, vertexBuffer2);
 
         CHECK(vertexBuffer1.getVertexCount() == 60);
         CHECK(vertexBuffer1.getNativeHandle() != 0);


### PR DESCRIPTION
## Description

`std::swap` won't call any overloads of `swap` in other namespaces which means these two overloads never got called. Since they never got called, their lack of linker visibility went unnoticed. Discovered while writing #2280.