### PR TITLE
Remove reference to deleted file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 * text=auto eol=lf
 
 extlibs/**/* -text -eol linguist-vendored
-cmake/toolchains/android.toolchain.cmake -text -eol
 
 *.png -text -eol
 *.jpg -text -eol


### PR DESCRIPTION
## Description

cmake/toolchains/android.toolchain.cmake was removed [here](https://github.com/SFML/SFML/commit/195f5d7409b52a256149c24b7bb19d600971fe3f) back in 2019.