### PR TITLE
Use C++ headers

### DIFF
--- a/src/SFML/Main/SFMLActivity.cpp
+++ b/src/SFML/Main/SFMLActivity.cpp
@@ -29,10 +29,11 @@
 #include <jni.h>
 
 #include <dlfcn.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
 #include <string>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 
 #define LOGE(...) ((void)__android_log_print(ANDROID_LOG_INFO, "sfml-activity", __VA_ARGS__))
 


### PR DESCRIPTION
## Description

Some Android code was still using C headers. I searched around for a few different patterns to detect remaining uses of C headers in lieu of their C++ equivalent but couldn't find any more so these may be the last. I think there's a clang-tidy check for this but we don't analyze Android code so it's prone to have these issues.