### PR TITLE
Fix 2.6.x failing to compile on gcc 13.1.1 because of missing headers

### DIFF
--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -55,6 +55,7 @@
 #include <SFML/System/Err.hpp>
 #include <algorithm>
 #include <cstring>
+#include <cstdint>
 
 
 namespace


### PR DESCRIPTION
I was getting this error until I added this header: /home/dogunbound/SFML/SFML/src/SFML/Audio/SoundFileReaderMp3.cpp:68:23: error: ‘uint64_t’ is not a member of ‘std’;

This is a fix

Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [x] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

There is a bug where compile sfml 2.6.x fails because of missing stdint library. This pull request fixes this bug. This is probably a GCC v13 issue and probably why some have yet to encounter it.

Fix is just to include the header in this file.

https://github.com/SFML/SFML/issues/2552

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Run this command to compile SFML 2.6.x:
```
cmake -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build -j20
sudo cmake --install build
```