### PR TITLE
Add `sf::Window::getFrameTime`

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -174,7 +174,6 @@ int main()
     std::size_t currentSetting = 0;
 
     std::ostringstream osstr;
-    sf::Clock          clock;
 
     while (window.isOpen())
     {
@@ -247,7 +246,7 @@ int main()
 
             // Update and draw the HUD text
             osstr.str("");
-            osstr << "Frame:  " << clock.restart().asMilliseconds() << "ms\n"
+            osstr << "Frame:  " << window.getFrameTime().asMilliseconds() << "ms\n"
                   << "perlinOctaves:  " << perlinOctaves << "\n\n"
                   << "Use the arrow keys to change the values.\nUse the return key to regenerate the terrain.\n\n";
 

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -198,6 +198,20 @@ public:
     const ContextSettings& getSettings() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the duration of the previous frame
+    ///
+    /// Before the first call to display() this will return a
+    /// zero-length duration. After the first call to display()
+    /// it returns the duration since constructing the window.
+    /// After that, it returns the duration between the previous
+    /// two display() calls.
+    ///
+    /// \return Duration of previous frame
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getFrameTime() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Enable or disable vertical synchronization
     ///
     /// Activating vertical synchronization will limit the number
@@ -284,6 +298,7 @@ private:
     std::unique_ptr<priv::GlContext> m_context;        //!< Platform-specific implementation of the OpenGL context
     Clock                            m_clock;          //!< Clock for measuring the elapsed time between frames
     Time                             m_frameTimeLimit; //!< Current framerate limit
+    Time                             m_frameTime;      //!< Current frame time
 };
 
 } // namespace sf

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -165,6 +165,13 @@ const ContextSettings& Window::getSettings() const
 
 
 ////////////////////////////////////////////////////////////
+Time Window::getFrameTime() const
+{
+    return m_frameTime;
+}
+
+
+////////////////////////////////////////////////////////////
 void Window::setVerticalSyncEnabled(bool enabled)
 {
     if (setActive())
@@ -213,10 +220,10 @@ void Window::display()
 
     // Limit the framerate if needed
     if (m_frameTimeLimit != Time::Zero)
-    {
         sleep(m_frameTimeLimit - m_clock.getElapsedTime());
-        m_clock.restart();
-    }
+
+    // Record the latest frame time
+    m_frameTime = m_clock.restart();
 }
 
 

--- a/test/Window/Window.test.cpp
+++ b/test/Window/Window.test.cpp
@@ -27,5 +27,6 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
                                 sf::Style::Default,
                                 sf::ContextSettings());
         CHECK(window.getSize() == sf::Vector2u(256, 256));
+        CHECK(window.getFrameTime() == sf::Time::Zero);
     }
 }


### PR DESCRIPTION
## Description

We already do all the work to calculate the frame time so it's really easy to expose that to users if they want it. This PR is merely finishing a feature that has been mostly complete for many years.

The main use case for this is simplifying how users calculate frame time and thus calculate FPS. While a correct implementation of measuring frame time only requires 1 extra `sf::Clock` (see the Island example in this PR) the bigger cost is in how much time it takes for new users to figure out the correct way to do it. It's a better user experience to be told "here a feature for measuring FPS" then be told how to implement it themselves.