### PR TITLE
Fix how we specify `CATCH_CONFIG_FAST_COMPILE`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 add_subdirectory(install)
 set_target_warnings(test-sfml-install)
 
-set(CATCH_CONFIG_FAST_COMPILE ON)
+set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
 FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG v3.3.2)


### PR DESCRIPTION
## Description

After we switched to Catch2 the following configuration warning appeared:
```
CMake Warning (dev) at build/_deps/catch2-src/CMake/CatchConfigOptions.cmake:24 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'CATCH_CONFIG_FAST_COMPILE'.
Call Stack (most recent call first):
  build/_deps/catch2-src/CMake/CatchConfigOptions.cmake:69 (AddConfigOption)
  build/_deps/catch2-src/CMakeLists.txt:55 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This PR fixes that warning. You can confirm this is working by inspection the CMakeCache.txt and seeing that on the `master` branch, this option is still OFF after configuration finishes but it is ON when using this patch.

Build times when configuring with `cmake -B build -DCMAKE_BUILD_TYPE=Debug -DSFML_BUILD_TEST_SUITE=ON`
`master`:
```
Benchmark 1: ninja clean && ninja
  Time (mean ± σ):     11.302 s ±  0.065 s    [User: 79.109 s, System: 11.552 s]
  Range (min … max):   11.245 s … 11.455 s    10 runs
```

This PR:
```
Benchmark 1: ninja clean && ninja
  Time (mean ± σ):     11.237 s ±  0.040 s    [User: 79.111 s, System: 11.551 s]
  Range (min … max):   11.188 s … 11.309 s    10 runs
```

Saves us a whopping tenth of a second lol but I'll take what I can get. At least we get rid of that annoying CMake warning.