### PR TITLE
Fix spacing of comment

### DIFF
--- a/include/SFML/Graphics/PrimitiveType.hpp
+++ b/include/SFML/Graphics/PrimitiveType.hpp
@@ -42,7 +42,7 @@ enum class PrimitiveType
     LineStrip,     //!< List of connected lines, a point uses the previous point to form a line
     Triangles,     //!< List of individual triangles
     TriangleStrip, //!< List of connected triangles, a point uses the two previous points to form a triangle
-    TriangleFan //!< List of connected triangles, a point uses the common center and the previous point to form a triangle
+    TriangleFan    //!< List of connected triangles, a point uses the common center and the previous point to form a triangle
 };
 
 } // namespace sf


### PR DESCRIPTION
I was reading the primitives header file to see what v3 deems deprecated. Noticed this out of line comment. Just wanted to fix it