### PR TITLE
Fix clang-tidy-16 failures

### DIFF
--- a/examples/X11/X11.cpp
+++ b/examples/X11/X11.cpp
@@ -49,7 +49,7 @@
     // Setup a perspective projection
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    float extent = std::tan(sf::degrees(45).asRadians());
+    const float extent = std::tan(sf::degrees(45).asRadians());
 
 #ifdef SFML_OPENGL_ES
     glFrustumf(-extent, extent, -extent, extent, 1.0f, 500.0f);
@@ -166,24 +166,24 @@ int main()
         return EXIT_FAILURE;
 
     // Get the default screen
-    int screen = DefaultScreen(display);
+    const int screen = DefaultScreen(display);
 
     // Let's create the main window
     XSetWindowAttributes attributes;
     attributes.background_pixel = BlackPixel(display, screen);
     attributes.event_mask       = KeyPressMask;
-    Window window               = XCreateWindow(display,
-                                  RootWindow(display, screen),
-                                  0,
-                                  0,
-                                  650,
-                                  330,
-                                  0,
-                                  DefaultDepth(display, screen),
-                                  InputOutput,
-                                  DefaultVisual(display, screen),
-                                  CWBackPixel | CWEventMask,
-                                  &attributes);
+    const Window window         = XCreateWindow(display,
+                                        RootWindow(display, screen),
+                                        0,
+                                        0,
+                                        650,
+                                        330,
+                                        0,
+                                        DefaultDepth(display, screen),
+                                        InputOutput,
+                                        DefaultVisual(display, screen),
+                                        CWBackPixel | CWEventMask,
+                                        &attributes);
     if (!window)
         return EXIT_FAILURE;
 
@@ -191,30 +191,30 @@ int main()
     XStoreName(display, window, "SFML Window");
 
     // Let's create the windows which will serve as containers for our SFML views
-    Window view1 = XCreateWindow(display,
-                                 window,
-                                 10,
-                                 10,
-                                 310,
-                                 310,
-                                 0,
-                                 DefaultDepth(display, screen),
-                                 InputOutput,
-                                 DefaultVisual(display, screen),
-                                 0,
-                                 nullptr);
-    Window view2 = XCreateWindow(display,
-                                 window,
-                                 330,
-                                 10,
-                                 310,
-                                 310,
-                                 0,
-                                 DefaultDepth(display, screen),
-                                 InputOutput,
-                                 DefaultVisual(display, screen),
-                                 0,
-                                 nullptr);
+    const Window view1 = XCreateWindow(display,
+                                       window,
+                                       10,
+                                       10,
+                                       310,
+                                       310,
+                                       0,
+                                       DefaultDepth(display, screen),
+                                       InputOutput,
+                                       DefaultVisual(display, screen),
+                                       0,
+                                       nullptr);
+    const Window view2 = XCreateWindow(display,
+                                       window,
+                                       330,
+                                       10,
+                                       310,
+                                       310,
+                                       0,
+                                       DefaultDepth(display, screen),
+                                       InputOutput,
+                                       DefaultVisual(display, screen),
+                                       0,
+                                       nullptr);
 
     // Show our windows
     XMapWindow(display, window);
@@ -225,7 +225,7 @@ int main()
     sf::Window sfmlView2(view2);
 
     // Create a clock for measuring elapsed time
-    sf::Clock clock;
+    const sf::Clock clock;
 
     // Load OpenGL or OpenGL ES entry points using glad
     if (!sfmlView1.setActive())

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -136,8 +136,8 @@ void cleanup()
 
 void drmFbDestroyCallback(gbm_bo* bo, void* data)
 {
-    int   drmFd = gbm_device_get_fd(gbm_bo_get_device(bo));
-    auto* fb    = static_cast<DrmFb*>(data);
+    const int drmFd = gbm_device_get_fd(gbm_bo_get_device(bo));
+    auto*     fb    = static_cast<DrmFb*>(data);
 
     if (fb->fbId)
         drmModeRmFB(drmFd, fb->fbId);
@@ -147,8 +147,8 @@ void drmFbDestroyCallback(gbm_bo* bo, void* data)
 
 DrmFb* drmFbGetFromBo(gbm_bo& bo)
 {
-    int   drmFd = gbm_device_get_fd(gbm_bo_get_device(&bo));
-    auto* fb    = static_cast<DrmFb*>(gbm_bo_get_user_data(&bo));
+    const int drmFd = gbm_device_get_fd(gbm_bo_get_device(&bo));
+    auto*     fb    = static_cast<DrmFb*>(gbm_bo_get_user_data(&bo));
     if (fb)
         return fb;
 
@@ -549,7 +549,7 @@ DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, cons
     // Create EGL context
     createContext(shared);
 
-    Vector2u size = owner.getSize();
+    const Vector2u size = owner.getSize();
     createSurface(size, bitsPerPixel, true);
 }
 

--- a/src/SFML/Window/DRM/InputImplUDev.cpp
+++ b/src/SFML/Window/DRM/InputImplUDev.cpp
@@ -117,15 +117,15 @@ bool keepFileDescriptor(int fileDesc)
     // This is the keyboard test used by SDL.
     // The first 32 bits are ESC, numbers and Q to D;  If we have any of those,
     // consider it a keyboard device; do not test for KEY_RESERVED, though
-    bool isKeyboard = (bitmaskKey[0] & 0xFFFFFFFE);
+    const bool isKeyboard = (bitmaskKey[0] & 0xFFFFFFFE);
 
-    bool isAbs = TEST_BIT(EV_ABS, bitmaskEv) && TEST_BIT(ABS_X, bitmaskAbs) && TEST_BIT(ABS_Y, bitmaskAbs);
+    const bool isAbs = TEST_BIT(EV_ABS, bitmaskEv) && TEST_BIT(ABS_X, bitmaskAbs) && TEST_BIT(ABS_Y, bitmaskAbs);
 
-    bool isRel = TEST_BIT(EV_REL, bitmaskEv) && TEST_BIT(REL_X, bitmaskRel) && TEST_BIT(REL_Y, bitmaskRel);
+    const bool isRel = TEST_BIT(EV_REL, bitmaskEv) && TEST_BIT(REL_X, bitmaskRel) && TEST_BIT(REL_Y, bitmaskRel);
 
-    bool isMouse = (isAbs || isRel) && TEST_BIT(BTN_MOUSE, bitmaskKey);
+    const bool isMouse = (isAbs || isRel) && TEST_BIT(BTN_MOUSE, bitmaskKey);
 
-    bool isTouch = isAbs && (TEST_BIT(BTN_TOOL_FINGER, bitmaskKey) || TEST_BIT(BTN_TOUCH, bitmaskKey));
+    const bool isTouch = isAbs && (TEST_BIT(BTN_TOOL_FINGER, bitmaskKey) || TEST_BIT(BTN_TOUCH, bitmaskKey));
 
     return isKeyboard || isMouse || isTouch;
 }
@@ -145,7 +145,7 @@ void initFileDescriptors()
         stream << i;
         name += stream.str();
 
-        int tempFD = open(name.c_str(), O_RDONLY | O_NONBLOCK);
+        const int tempFD = open(name.c_str(), O_RDONLY | O_NONBLOCK);
 
         if (tempFD < 0)
         {
@@ -355,7 +355,7 @@ void processSlots()
 
 bool eventProcess(sf::Event& event)
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
 
     // Ensure that we are initialized
     initFileDescriptors();
@@ -383,7 +383,7 @@ bool eventProcess(sf::Event& event)
         {
             if (inputEvent.type == EV_KEY)
             {
-                sf::Mouse::Button mb = toMouseButton(inputEvent.code);
+                const sf::Mouse::Button mb = toMouseButton(inputEvent.code);
                 if (mb != sf::Mouse::ButtonCount)
                 {
                     event.type = inputEvent.value ? sf::Event::MouseButtonPressed : sf::Event::MouseButtonReleased;
@@ -396,7 +396,7 @@ bool eventProcess(sf::Event& event)
                 }
                 else
                 {
-                    sf::Keyboard::Key kb = toKey(inputEvent.code);
+                    const sf::Keyboard::Key kb = toKey(inputEvent.code);
 
                     unsigned int special = 0;
                     if ((kb == sf::Keyboard::Delete) || (kb == sf::Keyboard::Backspace))
@@ -571,7 +571,7 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 bool InputImpl::isKeyPressed(Keyboard::Key key)
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
     if ((key < 0) || (key >= static_cast<int>(keyMap.size())))
         return false;
 
@@ -625,7 +625,7 @@ void InputImpl::setVirtualKeyboardVisible(bool /*visible*/)
 ////////////////////////////////////////////////////////////
 bool InputImpl::isMouseButtonPressed(Mouse::Button button)
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
     if ((button < 0) || (button >= static_cast<int>(mouseMap.size())))
         return false;
 
@@ -637,7 +637,7 @@ bool InputImpl::isMouseButtonPressed(Mouse::Button button)
 ////////////////////////////////////////////////////////////
 Vector2i InputImpl::getMousePosition()
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
     return mousePos;
 }
 
@@ -652,7 +652,7 @@ Vector2i InputImpl::getMousePosition(const WindowBase& /*relativeTo*/)
 ////////////////////////////////////////////////////////////
 void InputImpl::setMousePosition(const Vector2i& position)
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
     mousePos = position;
 }
 
@@ -696,7 +696,7 @@ Vector2i InputImpl::getTouchPosition(unsigned int finger, const WindowBase& /*re
 ////////////////////////////////////////////////////////////
 bool InputImpl::checkEvent(sf::Event& event)
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
     if (!eventQueue.empty())
     {
         event = eventQueue.front();
@@ -730,7 +730,7 @@ bool InputImpl::checkEvent(sf::Event& event)
 ////////////////////////////////////////////////////////////
 void InputImpl::setTerminalConfig()
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
     initFileDescriptors();
 
     tcgetattr(STDIN_FILENO, &newTerminalConfig);               // get current terminal config
@@ -747,7 +747,7 @@ void InputImpl::setTerminalConfig()
 ////////////////////////////////////////////////////////////
 void InputImpl::restoreTerminalConfig()
 {
-    std::lock_guard lock(inputMutex);
+    const std::lock_guard lock(inputMutex);
     initFileDescriptors();
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldTerminalConfig); // restore terminal config

--- a/src/SFML/Window/DRM/VideoModeImpl.cpp
+++ b/src/SFML/Window/DRM/VideoModeImpl.cpp
@@ -38,7 +38,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 {
     std::vector<VideoMode> modes;
 
-    Drm&                drm  = sf::priv::DRMContext::getDRM();
+    const Drm&          drm  = sf::priv::DRMContext::getDRM();
     drmModeConnectorPtr conn = drm.savedConnector;
 
     if (conn)
@@ -56,7 +56,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 ////////////////////////////////////////////////////////////
 VideoMode VideoModeImpl::getDesktopMode()
 {
-    Drm&               drm = sf::priv::DRMContext::getDRM();
+    const Drm&         drm = sf::priv::DRMContext::getDRM();
     drmModeModeInfoPtr ptr = drm.mode;
     if (ptr)
         return VideoMode({ptr->hdisplay, ptr->vdisplay});

--- a/src/SFML/Window/DRM/WindowImplDRM.cpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.cpp
@@ -61,7 +61,7 @@ WindowImplDRM::~WindowImplDRM()
 ////////////////////////////////////////////////////////////
 WindowHandle WindowImplDRM::getSystemHandle() const
 {
-    Drm& drm = sf::priv::DRMContext::getDRM();
+    const Drm& drm = sf::priv::DRMContext::getDRM();
     return static_cast<WindowHandle>(drm.fileDescriptor);
 }
 

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -43,7 +43,7 @@ void eglCheckError(const std::filesystem::path& file, unsigned int line, std::st
 {
     // Obtain information about the success or failure of the most recent EGL
     // function called in the current thread
-    EGLint errorCode = eglGetError();
+    const EGLint errorCode = eglGetError();
 
     if (errorCode != EGL_SUCCESS)
     {

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -138,7 +138,7 @@ String ClipboardImpl::getStringImpl()
     // if UTF-8 is not available) and written to our window property
     XConvertSelection(m_display, m_clipboard, (m_utf8String != None) ? m_utf8String : XA_STRING, m_targetProperty, m_window, CurrentTime);
 
-    Clock clock;
+    const Clock clock;
 
     // Wait for a response for up to 1000ms
     while (!m_requestResponded && (clock.getElapsedTime().asMilliseconds() < 1000))
@@ -204,7 +204,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
             // Notification that the current selection owner
             // has responded to our request
 
-            XSelectionEvent& selectionEvent = windowEvent.xselection;
+            const XSelectionEvent& selectionEvent = windowEvent.xselection;
 
             m_clipboardContents.clear();
 
@@ -222,18 +222,18 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
 
             // The selection owner should have wrote the selection
             // data to the specified window property
-            int result = XGetWindowProperty(m_display,
-                                            m_window,
-                                            m_targetProperty,
-                                            0,
-                                            0x7fffffff,
-                                            False,
-                                            AnyPropertyType,
-                                            &type,
-                                            &format,
-                                            &items,
-                                            &remainingBytes,
-                                            &data);
+            const int result = XGetWindowProperty(m_display,
+                                                  m_window,
+                                                  m_targetProperty,
+                                                  0,
+                                                  0x7fffffff,
+                                                  False,
+                                                  AnyPropertyType,
+                                                  &type,
+                                                  &format,
+                                                  &items,
+                                                  &remainingBytes,
+                                                  &data);
 
             if (result == Success)
             {
@@ -267,7 +267,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
         case SelectionRequest:
         {
             // Respond to a request for our clipboard contents
-            XSelectionRequestEvent& selectionRequestEvent = windowEvent.xselectionrequest;
+            const XSelectionRequestEvent& selectionRequestEvent = windowEvent.xselectionrequest;
 
             // Our reply
             XSelectionEvent selectionEvent;
@@ -316,7 +316,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
                          ((m_utf8String == None) && (selectionRequestEvent.target == m_text)))
                 {
                     // Respond to a request for conversion to a Latin-1 string
-                    std::string data = m_clipboardContents.toAnsiString();
+                    const std::string data = m_clipboardContents.toAnsiString();
 
                     XChangeProperty(m_display,
                                     selectionRequestEvent.requestor,
@@ -343,7 +343,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
                 {
                     // Respond to a request for conversion to a UTF-8 string
                     // or an encoding of our choosing (we always choose UTF-8)
-                    std::basic_string<std::uint8_t> data = m_clipboardContents.toUtf8();
+                    const std::basic_string<std::uint8_t> data = m_clipboardContents.toUtf8();
 
                     XChangeProperty(m_display,
                                     selectionRequestEvent.requestor,

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -101,8 +101,8 @@ bool CursorImpl::loadFromPixelsMonochrome(const std::uint8_t* pixels, Vector2u s
     // The bit data is stored packed into bytes. If the number of pixels on each row of the image
     // does not fit exactly into (width/8) bytes, one extra byte is allocated at the end of each
     // row to store the extra pixels.
-    std::size_t               packedWidth = (size.x + 7) / 8;
-    std::size_t               bytes       = packedWidth * size.y;
+    const std::size_t         packedWidth = (size.x + 7) / 8;
+    const std::size_t         bytes       = packedWidth * size.y;
     std::vector<std::uint8_t> mask(bytes, 0); // Defines which pixel is opaque (1) or transparent (0).
     std::vector<std::uint8_t> data(bytes, 0); // Defines which pixel is white (1) or black (0).
 
@@ -110,33 +110,33 @@ bool CursorImpl::loadFromPixelsMonochrome(const std::uint8_t* pixels, Vector2u s
     {
         for (std::size_t i = 0; i < size.x; ++i)
         {
-            std::size_t pixelIndex = i + j * size.x;
-            std::size_t byteIndex  = i / 8 + j * packedWidth;
-            std::size_t bitIndex   = i % 8;
+            const std::size_t pixelIndex = i + j * size.x;
+            const std::size_t byteIndex  = i / 8 + j * packedWidth;
+            const std::size_t bitIndex   = i % 8;
 
             // Turn on pixel that are not transparent
-            std::uint8_t opacity = pixels[pixelIndex * 4 + 3] > 0 ? 1 : 0;
+            const std::uint8_t opacity = pixels[pixelIndex * 4 + 3] > 0 ? 1 : 0;
             mask[byteIndex] |= static_cast<std::uint8_t>(opacity << bitIndex);
 
             // Choose between black/background & white/foreground color for each pixel,
             // based on the pixel color intensity: on average, if a channel is "active"
             // at 50%, the bit is white.
-            int intensity = (pixels[pixelIndex * 4 + 0] + pixels[pixelIndex * 4 + 1] + pixels[pixelIndex * 4 + 2]) / 3;
-            std::uint8_t bit = intensity > 128 ? 1 : 0;
+            const int intensity = (pixels[pixelIndex * 4 + 0] + pixels[pixelIndex * 4 + 1] + pixels[pixelIndex * 4 + 2]) / 3;
+            const std::uint8_t bit = intensity > 128 ? 1 : 0;
             data[byteIndex] |= static_cast<std::uint8_t>(bit << bitIndex);
         }
     }
 
-    Pixmap maskPixmap = XCreateBitmapFromData(m_display,
-                                              XDefaultRootWindow(m_display),
-                                              reinterpret_cast<char*>(mask.data()),
-                                              size.x,
-                                              size.y);
-    Pixmap dataPixmap = XCreateBitmapFromData(m_display,
-                                              XDefaultRootWindow(m_display),
-                                              reinterpret_cast<char*>(data.data()),
-                                              size.x,
-                                              size.y);
+    const Pixmap maskPixmap = XCreateBitmapFromData(m_display,
+                                                    XDefaultRootWindow(m_display),
+                                                    reinterpret_cast<char*>(mask.data()),
+                                                    size.x,
+                                                    size.y);
+    const Pixmap dataPixmap = XCreateBitmapFromData(m_display,
+                                                    XDefaultRootWindow(m_display),
+                                                    reinterpret_cast<char*>(data.data()),
+                                                    size.x,
+                                                    size.y);
 
     // Define the foreground color as white and the background as black.
     XColor fg;

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -57,7 +57,7 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 Display* openDisplay()
 {
-    std::lock_guard lock(mutex);
+    const std::lock_guard lock(mutex);
 
     if (referenceCount == 0)
     {
@@ -80,7 +80,7 @@ Display* openDisplay()
 ////////////////////////////////////////////////////////////
 void closeDisplay(Display* display)
 {
-    std::lock_guard lock(mutex);
+    const std::lock_guard lock(mutex);
 
     assert(display == sharedDisplay);
 
@@ -92,7 +92,7 @@ void closeDisplay(Display* display)
 ////////////////////////////////////////////////////////////
 XIM openXim()
 {
-    std::lock_guard lock(mutex);
+    const std::lock_guard lock(mutex);
 
     assert(sharedDisplay != nullptr);
 
@@ -103,9 +103,9 @@ XIM openXim()
         // We need the default (environment) locale and X locale for opening
         // the IM and properly receiving text
         // First save the previous ones (this might be able to be written more elegantly?)
-        const char* p;
-        std::string prevLoc((p = setlocale(LC_ALL, nullptr)) ? p : "");
-        std::string prevXLoc((p = XSetLocaleModifiers(nullptr)) ? p : "");
+        const char*       p;
+        const std::string prevLoc((p = setlocale(LC_ALL, nullptr)) ? p : "");
+        const std::string prevXLoc((p = XSetLocaleModifiers(nullptr)) ? p : "");
 
         // Set the locales from environment
         setlocale(LC_ALL, "");
@@ -130,7 +130,7 @@ XIM openXim()
 ////////////////////////////////////////////////////////////
 void closeXim(XIM xim)
 {
-    std::lock_guard lock(mutex);
+    const std::lock_guard lock(mutex);
 
     assert(xim == sharedXIM);
 
@@ -148,7 +148,7 @@ Atom getAtom(const std::string& name, bool onlyIfExists)
 
     Display* display = openDisplay();
 
-    Atom atom = XInternAtom(display, name.c_str(), onlyIfExists ? True : False);
+    const Atom atom = XInternAtom(display, name.c_str(), onlyIfExists ? True : False);
 
     closeDisplay(display);
 

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -371,18 +371,18 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
             }
 
             // TODO: Replace this with proper acceleration detection
-            bool accelerated = true;
+            const bool accelerated = true;
 
             // Evaluate the visual
-            int color = red + green + blue + alpha;
-            int score = evaluateFormat(bitsPerPixel,
-                                       settings,
-                                       color,
-                                       depth,
-                                       stencil,
-                                       multiSampling ? samples : 0,
-                                       accelerated,
-                                       sRgb == True);
+            const int color = red + green + blue + alpha;
+            const int score = evaluateFormat(bitsPerPixel,
+                                             settings,
+                                             color,
+                                             depth,
+                                             stencil,
+                                             multiSampling ? samples : 0,
+                                             accelerated,
+                                             sRgb == True);
 
             // If it's better than the current best, make it the new best
             if (score < bestScore)
@@ -489,7 +489,7 @@ void GlxContext::createSurface(GlxContext* shared, const Vector2u& size, unsigne
         glXQueryVersion(m_display, &major, &minor);
 
         // Check if glXCreatePbuffer is available (requires GLX 1.3 or greater)
-        bool hasCreatePbuffer = ((major > 1) || (minor >= 3));
+        const bool hasCreatePbuffer = ((major > 1) || (minor >= 3));
 
         if (hasCreatePbuffer)
         {
@@ -539,7 +539,7 @@ void GlxContext::createSurface(GlxContext* shared, const Vector2u& size, unsigne
     }
 
     // If pbuffers are not available we use a hidden window as the off-screen surface to draw to
-    int screen = DefaultScreen(m_display);
+    const int screen = DefaultScreen(m_display);
 
     // Define the window attributes
     XSetWindowAttributes attributes;
@@ -581,7 +581,7 @@ void GlxContext::createSurface(::Window window)
 void GlxContext::createContext(GlxContext* shared)
 {
     // Get a working copy of the context settings
-    ContextSettings settings = m_settings;
+    const ContextSettings settings = m_settings;
 
     XVisualInfo* visualInfo = nullptr;
 
@@ -637,7 +637,7 @@ void GlxContext::createContext(GlxContext* shared)
         err() << "Failed to query GLX version, limited to legacy context creation" << std::endl;
 
     // Check if glXCreateContextAttribsARB is available (requires GLX 1.3 or greater)
-    bool hasCreateContextArb = SF_GLAD_GLX_ARB_create_context && ((major > 1) || (minor >= 3));
+    const bool hasCreateContextArb = SF_GLAD_GLX_ARB_create_context && ((major > 1) || (minor >= 3));
 
     // Create the OpenGL context -- first try using glXCreateContextAttribsARB
     if (hasCreateContextArb)
@@ -687,10 +687,10 @@ void GlxContext::createContext(GlxContext* shared)
             // Check if setting the profile is supported
             if (SF_GLAD_GLX_ARB_create_context_profile)
             {
-                int profile = (m_settings.attributeFlags & ContextSettings::Core)
-                                  ? GLX_CONTEXT_CORE_PROFILE_BIT_ARB
-                                  : GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
-                int debug   = (m_settings.attributeFlags & ContextSettings::Debug) ? GLX_CONTEXT_DEBUG_BIT_ARB : 0;
+                const int profile = (m_settings.attributeFlags & ContextSettings::Core)
+                                        ? GLX_CONTEXT_CORE_PROFILE_BIT_ARB
+                                        : GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB;
+                const int debug = (m_settings.attributeFlags & ContextSettings::Debug) ? GLX_CONTEXT_DEBUG_BIT_ARB : 0;
 
                 attributes.push_back(GLX_CONTEXT_PROFILE_MASK_ARB);
                 attributes.push_back(profile);
@@ -713,7 +713,7 @@ void GlxContext::createContext(GlxContext* shared)
 
             // RAII GLX error handler (we simply ignore errors here)
             // On an error, glXCreateContextAttribsARB will return 0 anyway
-            GlxErrorHandler handler(m_display);
+            const GlxErrorHandler handler(m_display);
 
             if (toShare)
             {

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -145,7 +145,7 @@ Vector2i InputImpl::getMousePosition()
 ////////////////////////////////////////////////////////////
 Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
 {
-    WindowHandle handle = relativeTo.getSystemHandle();
+    const WindowHandle handle = relativeTo.getSystemHandle();
     if (handle)
     {
         // Open a connection with the X server
@@ -194,7 +194,7 @@ void InputImpl::setMousePosition(const Vector2i& position, const WindowBase& rel
     // Open a connection with the X server
     Display* display = openDisplay();
 
-    WindowHandle handle = relativeTo.getSystemHandle();
+    const WindowHandle handle = relativeTo.getSystemHandle();
     if (handle)
     {
         XWarpPointer(display, None, handle, 0, 0, 0, 0, position.x, position.y);

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -253,7 +253,7 @@ void updatePluggedList(udev_device* udevDevice = nullptr)
 bool hasMonitorEvent()
 {
     // This will not fail since we make sure udevMonitor is valid
-    int monitorFd = udev_monitor_get_fd(udevMonitor);
+    const int monitorFd = udev_monitor_get_fd(udevMonitor);
 
     pollfd fds{monitorFd, POLLIN, 0};
 
@@ -392,17 +392,17 @@ unsigned int getJoystickProductId(unsigned int index)
 // Get the joystick name
 std::string getJoystickName(unsigned int index)
 {
-    std::string devnode = joystickList[index].deviceNode;
+    const std::string devnode = joystickList[index].deviceNode;
 
     // First try using ioctl with JSIOCGNAME
-    int fd = ::open(devnode.c_str(), O_RDONLY | O_NONBLOCK);
+    const int fd = ::open(devnode.c_str(), O_RDONLY | O_NONBLOCK);
 
     if (fd >= 0)
     {
         // Get the name
         char name[128] = {};
 
-        int result = ioctl(fd, JSIOCGNAME(sizeof(name)), name);
+        const int result = ioctl(fd, JSIOCGNAME(sizeof(name)), name);
 
         ::close(fd);
 
@@ -539,7 +539,7 @@ bool JoystickImpl::open(unsigned int index)
 
     if (joystickList[index].plugged)
     {
-        std::string devnode = joystickList[index].deviceNode;
+        const std::string devnode = joystickList[index].deviceNode;
 
         // Open the joystick's file descriptor (read-only and non-blocking)
         m_file = ::open(devnode.c_str(), O_RDONLY | O_NONBLOCK);
@@ -648,7 +648,7 @@ JoystickState JoystickImpl::JoystickImpl::update()
             // An axis was moved
             case JS_EVENT_AXIS:
             {
-                float value = joyState.value * 100.f / 32767.f;
+                const float value = joyState.value * 100.f / 32767.f;
 
                 if (joyState.number < ABS_MAX + 1)
                 {

--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -549,12 +549,12 @@ sf::Keyboard::Scancode keyCodeToScancode(KeyCode code)
 ////////////////////////////////////////////////////////////
 KeyCode keyToKeyCode(sf::Keyboard::Key key)
 {
-    KeySym keysym = sf::priv::keyToKeySym(key);
+    const KeySym keysym = sf::priv::keyToKeySym(key);
 
     if (keysym != NoSymbol)
     {
-        Display* display = sf::priv::openDisplay();
-        KeyCode  keycode = XKeysymToKeycode(display, keysym);
+        Display*      display = sf::priv::openDisplay();
+        const KeyCode keycode = XKeysymToKeycode(display, keysym);
         sf::priv::closeDisplay(display);
 
         if (keycode != nullKeyCode)
@@ -574,8 +574,8 @@ KeySym scancodeToKeySym(sf::Keyboard::Scancode code)
 {
     Display* display = sf::priv::openDisplay();
 
-    KeySym  keysym  = NoSymbol;
-    KeyCode keycode = scancodeToKeyCode(code);
+    KeySym        keysym  = NoSymbol;
+    const KeyCode keycode = scancodeToKeyCode(code);
 
     if (keycode != nullKeyCode) // ensure that this Scancode is mapped to keycode
         keysym = XkbKeycodeToKeysym(display, keycode, 0, 0);
@@ -614,7 +614,7 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 bool KeyboardImpl::isKeyPressed(Keyboard::Key key)
 {
-    KeyCode keycode = keyToKeyCode(key);
+    const KeyCode keycode = keyToKeyCode(key);
     return isKeyPressedImpl(keycode);
 }
 
@@ -622,7 +622,7 @@ bool KeyboardImpl::isKeyPressed(Keyboard::Key key)
 ////////////////////////////////////////////////////////////
 bool KeyboardImpl::isKeyPressed(Keyboard::Scancode code)
 {
-    KeyCode keycode = scancodeToKeyCode(code);
+    const KeyCode keycode = scancodeToKeyCode(code);
     return isKeyPressedImpl(keycode);
 }
 
@@ -630,7 +630,7 @@ bool KeyboardImpl::isKeyPressed(Keyboard::Scancode code)
 ////////////////////////////////////////////////////////////
 Keyboard::Scancode KeyboardImpl::delocalize(Keyboard::Key key)
 {
-    KeyCode keycode = keyToKeyCode(key);
+    const KeyCode keycode = keyToKeyCode(key);
     return keyCodeToScancode(keycode);
 }
 
@@ -638,7 +638,7 @@ Keyboard::Scancode KeyboardImpl::delocalize(Keyboard::Key key)
 ////////////////////////////////////////////////////////////
 Keyboard::Key KeyboardImpl::localize(Keyboard::Scancode code)
 {
-    KeySym keysym = scancodeToKeySym(code);
+    const KeySym keysym = scancodeToKeySym(code);
     return keySymToKey(keysym);
 }
 
@@ -673,8 +673,8 @@ String KeyboardImpl::getDescription(Keyboard::Scancode code)
 
     if (checkInput)
     {
-        KeySym   keysym  = scancodeToKeySym(code);
-        char32_t unicode = keysymToUnicode(keysym);
+        const KeySym   keysym  = scancodeToKeySym(code);
+        const char32_t unicode = keysymToUnicode(keysym);
 
         if (unicode != 0)
             return String(unicode);
@@ -805,8 +805,8 @@ Keyboard::Key KeyboardImpl::getKeyFromEvent(XKeyEvent& event)
     for (int i = 0; i < 4; ++i)
     {
         // Get the SFML keyboard code from the keysym of the key that has been pressed
-        KeySym        keysym = XLookupKeysym(&event, i);
-        Keyboard::Key key    = keySymToKey(keysym);
+        const KeySym        keysym = XLookupKeysym(&event, i);
+        const Keyboard::Key key    = keySymToKey(keysym);
         if (key != Keyboard::Unknown)
             return key;
     }

--- a/src/SFML/Window/Unix/VideoModeImpl.cpp
+++ b/src/SFML/Window/Unix/VideoModeImpl.cpp
@@ -49,7 +49,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     if (display)
     {
         // Retrieve the default screen number
-        int screen = DefaultScreen(display);
+        const int screen = DefaultScreen(display);
 
         // Check if the XRandR extension is present
         int version;
@@ -135,7 +135,7 @@ VideoMode VideoModeImpl::getDesktopMode()
     if (display)
     {
         // Retrieve the default screen number
-        int screen = DefaultScreen(display);
+        const int screen = DefaultScreen(display);
 
         // Check if the XRandR extension is present
         int version;
@@ -146,8 +146,8 @@ VideoMode VideoModeImpl::getDesktopMode()
             if (config)
             {
                 // Get the current video mode
-                Rotation currentRotation;
-                int      currentMode = XRRConfigCurrentConfiguration(config, &currentRotation);
+                Rotation  currentRotation;
+                const int currentMode = XRRConfigCurrentConfiguration(config, &currentRotation);
 
                 // Get the available screen sizes
                 int            nbSizes;

--- a/src/SFML/Window/Unix/VulkanImplX11.cpp
+++ b/src/SFML/Window/Unix/VulkanImplX11.cpp
@@ -203,7 +203,7 @@ bool VulkanImplX11::createVulkanSurface(const VkInstance&            instance,
     surfaceCreateInfo.dpy                        = openDisplay();
     surfaceCreateInfo.window                     = windowHandle;
 
-    bool result = (vkCreateXlibSurfaceKHR(instance, &surfaceCreateInfo, allocator, &surface) == VK_SUCCESS);
+    const bool result = (vkCreateXlibSurfaceKHR(instance, &surfaceCreateInfo, allocator, &surface) == VK_SUCCESS);
 
     closeDisplay(surfaceCreateInfo.dpy);
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -108,7 +108,7 @@ std::filesystem::path findExecutableName()
 {
     // We use /proc/self/cmdline to get the command line
     // the user used to invoke this instance of the application
-    int file = ::open("/proc/self/cmdline", O_RDONLY | O_NONBLOCK);
+    const int file = ::open("/proc/self/cmdline", O_RDONLY | O_NONBLOCK);
 
     if (file < 0)
         return "sfml";
@@ -148,8 +148,8 @@ bool ewmhSupported()
 
     checked = true;
 
-    Atom netSupportingWmCheck = sf::priv::getAtom("_NET_SUPPORTING_WM_CHECK", true);
-    Atom netSupported         = sf::priv::getAtom("_NET_SUPPORTED", true);
+    const Atom netSupportingWmCheck = sf::priv::getAtom("_NET_SUPPORTING_WM_CHECK", true);
+    const Atom netSupported         = sf::priv::getAtom("_NET_SUPPORTED", true);
 
     if (!netSupportingWmCheck || !netSupported)
         return false;
@@ -186,7 +186,7 @@ bool ewmhSupported()
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
-    ::Window rootWindow = *reinterpret_cast<::Window*>(data);
+    const ::Window rootWindow = *reinterpret_cast<::Window*>(data);
 #pragma GCC diagnostic pop
 
     XFree(data);
@@ -221,7 +221,7 @@ bool ewmhSupported()
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
-    ::Window childWindow = *reinterpret_cast<::Window*>(data);
+    const ::Window childWindow = *reinterpret_cast<::Window*>(data);
 #pragma GCC diagnostic pop
 
     XFree(data);
@@ -243,7 +243,7 @@ bool ewmhSupported()
 
     // We try to get the name of the window manager
     // for window manager specific workarounds
-    Atom netWmName = sf::priv::getAtom("_NET_WM_NAME", true);
+    const Atom netWmName = sf::priv::getAtom("_NET_WM_NAME", true);
 
     if (!netWmName)
     {
@@ -310,7 +310,7 @@ bool getEWMHFrameExtents(::Display* disp, ::Window win, long& xFrameExtent, long
     if (!ewmhSupported())
         return false;
 
-    Atom frameExtents = sf::priv::getAtom("_NET_FRAME_EXTENTS", true);
+    const Atom frameExtents = sf::priv::getAtom("_NET_FRAME_EXTENTS", true);
 
     if (frameExtents == None)
         return false;
@@ -322,7 +322,18 @@ bool getEWMHFrameExtents(::Display* disp, ::Window win, long& xFrameExtent, long
     unsigned long  numBytesLeft;
     unsigned char* data = nullptr;
 
-    int result = XGetWindowProperty(disp, win, frameExtents, 0, 4, False, XA_CARDINAL, &actualType, &actualFormat, &numItems, &numBytesLeft, &data);
+    const int result = XGetWindowProperty(disp,
+                                          win,
+                                          frameExtents,
+                                          0,
+                                          4,
+                                          False,
+                                          XA_CARDINAL,
+                                          &actualType,
+                                          &actualFormat,
+                                          &numItems,
+                                          &numBytesLeft,
+                                          &data);
 
     if ((result == Success) && (actualType == XA_CARDINAL) && (actualFormat == 32) && (numItems == 4) &&
         (numBytesLeft == 0) && (data != nullptr))
@@ -424,8 +435,8 @@ m_cursorGrabbed(m_fullscreen)
         windowPosition = displaySize - Vector2i(mode.size) / 2;
     }
 
-    unsigned int width  = mode.size.x;
-    unsigned int height = mode.size.y;
+    const unsigned int width  = mode.size.x;
+    const unsigned int height = mode.size.y;
 
     Visual* visual = nullptr;
     int     depth  = 0;
@@ -440,7 +451,7 @@ m_cursorGrabbed(m_fullscreen)
     else
     {
         // Choose the visual according to the context settings
-        XVisualInfo visualInfo = ContextType::selectBestVisual(m_display, mode.bitsPerPixel, settings);
+        const XVisualInfo visualInfo = ContextType::selectBestVisual(m_display, mode.bitsPerPixel, settings);
 
         visual = visualInfo.visual;
         depth  = visualInfo.depth;
@@ -485,7 +496,7 @@ m_cursorGrabbed(m_fullscreen)
     // change our window's decorations and functions according to the requested style)
     if (!m_fullscreen)
     {
-        Atom wmHintsAtom = getAtom("_MOTIF_WM_HINTS", false);
+        const Atom wmHintsAtom = getAtom("_MOTIF_WM_HINTS", false);
         if (wmHintsAtom)
         {
             // NOLINTBEGIN(readability-identifier-naming)
@@ -651,7 +662,7 @@ WindowImplX11::~WindowImplX11()
     closeDisplay(m_display);
 
     // Remove this window from the global list of windows (required for focus request)
-    std::lock_guard lock(allWindowsMutex);
+    const std::lock_guard lock(allWindowsMutex);
     allWindows.erase(std::find(allWindows.begin(), allWindows.end(), this));
 }
 
@@ -869,10 +880,10 @@ void WindowImplX11::setTitle(const String& title)
     std::basic_string<std::uint8_t> utf8Title;
     Utf32::toUtf8(title.begin(), title.end(), std::back_inserter(utf8Title));
 
-    Atom useUtf8 = getAtom("UTF8_STRING", false);
+    const Atom useUtf8 = getAtom("UTF8_STRING", false);
 
     // Set the _NET_WM_NAME atom, which specifies a UTF-8 encoded window title.
-    Atom wmName = getAtom("_NET_WM_NAME", false);
+    const Atom wmName = getAtom("_NET_WM_NAME", false);
     XChangeProperty(m_display,
                     m_window,
                     wmName,
@@ -883,7 +894,7 @@ void WindowImplX11::setTitle(const String& title)
                     static_cast<int>(utf8Title.size()));
 
     // Set the _NET_WM_ICON_NAME atom, which specifies a UTF-8 encoded window title.
-    Atom wmIconName = getAtom("_NET_WM_ICON_NAME", false);
+    const Atom wmIconName = getAtom("_NET_WM_ICON_NAME", false);
     XChangeProperty(m_display,
                     m_window,
                     wmIconName,
@@ -958,7 +969,7 @@ void WindowImplX11::setIcon(const Vector2u& size, const std::uint8_t* pixels)
     XDestroyImage(iconImage);
 
     // Create the mask pixmap (must have 1 bit depth)
-    std::size_t               pitch = (size.x + 7) / 8;
+    const std::size_t         pitch = (size.x + 7) / 8;
     std::vector<std::uint8_t> maskPixels(pitch * size.y, 0);
     for (std::size_t j = 0; j < size.y; ++j)
     {
@@ -968,7 +979,7 @@ void WindowImplX11::setIcon(const Vector2u& size, const std::uint8_t* pixels)
             {
                 if (i * 8 + k < size.x)
                 {
-                    std::uint8_t opacity = (pixels[(i * 8 + k + j * size.x) * 4 + 3] > 0) ? 1 : 0;
+                    const std::uint8_t opacity = (pixels[(i * 8 + k + j * size.x) * 4 + 3] > 0) ? 1 : 0;
                     maskPixels[i + j * pitch] |= static_cast<std::uint8_t>(opacity << k);
                 }
             }
@@ -1008,7 +1019,7 @@ void WindowImplX11::setIcon(const Vector2u& size, const std::uint8_t* pixels)
             (pixels[i * 4 + 2] << 0) | (pixels[i * 4 + 1] << 8) | (pixels[i * 4 + 0] << 16) | (pixels[i * 4 + 3] << 24));
     }
 
-    Atom netWmIcon = getAtom("_NET_WM_ICON");
+    const Atom netWmIcon = getAtom("_NET_WM_ICON");
 
     XChangeProperty(m_display,
                     m_window,
@@ -1085,7 +1096,7 @@ void WindowImplX11::setMouseCursorGrabbed(bool grabbed)
         // Try multiple times to grab the cursor
         for (unsigned int trial = 0; trial < maxTrialsCount; ++trial)
         {
-            int result = XGrabPointer(m_display, m_window, True, None, GrabModeAsync, GrabModeAsync, m_window, None, CurrentTime);
+            const int result = XGrabPointer(m_display, m_window, True, None, GrabModeAsync, GrabModeAsync, m_window, None, CurrentTime);
 
             if (result == GrabSuccess)
             {
@@ -1127,7 +1138,7 @@ void WindowImplX11::requestFocus()
     bool sfmlWindowFocused = false;
 
     {
-        std::lock_guard lock(allWindowsMutex);
+        const std::lock_guard lock(allWindowsMutex);
         for (sf::priv::WindowImplX11* windowPtr : allWindows)
         {
             if (windowPtr->hasFocus())
@@ -1147,7 +1158,7 @@ void WindowImplX11::requestFocus()
         return; // error getting attribute
     }
 
-    bool windowViewable = (attributes.map_state == IsViewable);
+    const bool windowViewable = (attributes.map_state == IsViewable);
 
     if (sfmlWindowFocused && windowViewable)
     {
@@ -1211,11 +1222,11 @@ void WindowImplX11::grabFocus()
         event.xclient.data.l[1]    = static_cast<long>(m_lastInputTime);
         event.xclient.data.l[2]    = 0; // We don't know the currently active window
 
-        int result = XSendEvent(m_display,
-                                DefaultRootWindow(m_display),
-                                False,
-                                SubstructureNotifyMask | SubstructureRedirectMask,
-                                &event);
+        const int result = XSendEvent(m_display,
+                                      DefaultRootWindow(m_display),
+                                      False,
+                                      SubstructureNotifyMask | SubstructureRedirectMask,
+                                      &event);
 
         XFlush(m_display);
 
@@ -1403,7 +1414,7 @@ void WindowImplX11::switchToFullscreen()
 
     if (ewmhSupported())
     {
-        Atom netWmBypassCompositor = getAtom("_NET_WM_BYPASS_COMPOSITOR");
+        const Atom netWmBypassCompositor = getAtom("_NET_WM_BYPASS_COMPOSITOR");
 
         if (netWmBypassCompositor)
         {
@@ -1419,8 +1430,8 @@ void WindowImplX11::switchToFullscreen()
                             1);
         }
 
-        Atom netWmState           = getAtom("_NET_WM_STATE", true);
-        Atom netWmStateFullscreen = getAtom("_NET_WM_STATE_FULLSCREEN", true);
+        const Atom netWmState           = getAtom("_NET_WM_STATE", true);
+        const Atom netWmStateFullscreen = getAtom("_NET_WM_STATE_FULLSCREEN", true);
 
         if (!netWmState || !netWmStateFullscreen)
         {
@@ -1438,11 +1449,11 @@ void WindowImplX11::switchToFullscreen()
         event.xclient.data.l[2]    = 0; // No second property
         event.xclient.data.l[3]    = 1; // Normal window
 
-        int result = XSendEvent(m_display,
-                                DefaultRootWindow(m_display),
-                                False,
-                                SubstructureNotifyMask | SubstructureRedirectMask,
-                                &event);
+        const int result = XSendEvent(m_display,
+                                      DefaultRootWindow(m_display),
+                                      False,
+                                      SubstructureNotifyMask | SubstructureRedirectMask,
+                                      &event);
 
         if (!result)
             err() << "Setting fullscreen failed, could not send \"_NET_WM_STATE\" event" << std::endl;
@@ -1455,8 +1466,8 @@ void WindowImplX11::setProtocols()
 {
     using namespace WindowsImplX11Impl;
 
-    Atom wmProtocols    = getAtom("WM_PROTOCOLS");
-    Atom wmDeleteWindow = getAtom("WM_DELETE_WINDOW");
+    const Atom wmProtocols    = getAtom("WM_PROTOCOLS");
+    const Atom wmDeleteWindow = getAtom("WM_DELETE_WINDOW");
 
     if (!wmProtocols)
     {
@@ -1546,8 +1557,8 @@ void WindowImplX11::initialize()
         err() << "Failed to create input context for window -- TextEntered event won't be able to return unicode"
               << std::endl;
 
-    Atom wmWindowType       = getAtom("_NET_WM_WINDOW_TYPE", false);
-    Atom wmWindowTypeNormal = getAtom("_NET_WM_WINDOW_TYPE_NORMAL", false);
+    const Atom wmWindowType       = getAtom("_NET_WM_WINDOW_TYPE", false);
+    Atom       wmWindowTypeNormal = getAtom("_NET_WM_WINDOW_TYPE_NORMAL", false);
 
     if (wmWindowType && wmWindowTypeNormal)
     {
@@ -1574,7 +1585,7 @@ void WindowImplX11::initialize()
     XFlush(m_display);
 
     // Add this window to the global list of windows (required for focus request)
-    std::lock_guard lock(allWindowsMutex);
+    const std::lock_guard lock(allWindowsMutex);
     allWindows.push_back(this);
 }
 
@@ -1584,7 +1595,7 @@ void WindowImplX11::updateLastInputTime(::Time time)
 {
     if (time && (time != m_lastInputTime))
     {
-        Atom netWmUserTime = getAtom("_NET_WM_USER_TIME", true);
+        const Atom netWmUserTime = getAtom("_NET_WM_USER_TIME", true);
 
         if (netWmUserTime)
         {
@@ -1607,8 +1618,8 @@ void WindowImplX11::updateLastInputTime(::Time time)
 void WindowImplX11::createHiddenCursor()
 {
     // Create the cursor's pixmap (1x1 pixels)
-    Pixmap cursorPixmap    = XCreatePixmap(m_display, m_window, 1, 1, 1);
-    GC     graphicsContext = XCreateGC(m_display, cursorPixmap, 0, nullptr);
+    const Pixmap cursorPixmap    = XCreatePixmap(m_display, m_window, 1, 1, 1);
+    GC           graphicsContext = XCreateGC(m_display, cursorPixmap, 0, nullptr);
     XDrawPoint(m_display, cursorPixmap, graphicsContext, 0, 0);
     XFreeGC(m_display, graphicsContext);
 
@@ -1663,7 +1674,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 // Try multiple times to grab the cursor
                 for (unsigned int trial = 0; trial < maxTrialsCount; ++trial)
                 {
-                    int result = XGrabPointer(m_display, m_window, True, None, GrabModeAsync, GrabModeAsync, m_window, None, CurrentTime);
+                    const int result = XGrabPointer(m_display, m_window, True, None, GrabModeAsync, GrabModeAsync, m_window, None, CurrentTime);
 
                     if (result == GrabSuccess)
                     {
@@ -1737,13 +1748,13 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
             // Input methods might want random ClientMessage events
             if (!XFilterEvent(&windowEvent, None))
             {
-                static Atom wmProtocols = getAtom("WM_PROTOCOLS");
+                static const Atom wmProtocols = getAtom("WM_PROTOCOLS");
 
                 // Handle window manager protocol messages we support
                 if (windowEvent.xclient.message_type == wmProtocols)
                 {
-                    static Atom wmDeleteWindow = getAtom("WM_DELETE_WINDOW");
-                    static Atom netWmPing      = ewmhSupported() ? getAtom("_NET_WM_PING", true) : None;
+                    static const Atom wmDeleteWindow = getAtom("WM_DELETE_WINDOW");
+                    static const Atom netWmPing      = ewmhSupported() ? getAtom("_NET_WM_PING", true) : None;
 
                     if ((windowEvent.xclient.format == 32) &&
                         (windowEvent.xclient.data.l[0]) == static_cast<long>(wmDeleteWindow))
@@ -1814,12 +1825,12 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                     Status       status;
                     std::uint8_t keyBuffer[64];
 
-                    int length = Xutf8LookupString(m_inputContext,
-                                                   &windowEvent.xkey,
-                                                   reinterpret_cast<char*>(keyBuffer),
-                                                   sizeof(keyBuffer),
-                                                   nullptr,
-                                                   &status);
+                    const int length = Xutf8LookupString(m_inputContext,
+                                                         &windowEvent.xkey,
+                                                         reinterpret_cast<char*>(keyBuffer),
+                                                         sizeof(keyBuffer),
+                                                         nullptr,
+                                                         &status);
 
                     if (status == XBufferOverflow)
                         err() << "A TextEntered event has more than 64 bytes of UTF-8 input, and "
@@ -1886,7 +1897,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
         case ButtonPress:
         {
             // Buttons 4 and 5 are the vertical wheel and 6 and 7 the horizontal wheel.
-            unsigned int button = windowEvent.xbutton.button;
+            const unsigned int button = windowEvent.xbutton.button;
             if ((button == Button1) || (button == Button2) || (button == Button3) || (button == 8) || (button == 9))
             {
                 Event event;
@@ -1916,7 +1927,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
         // Mouse button released
         case ButtonRelease:
         {
-            unsigned int button = windowEvent.xbutton.button;
+            const unsigned int button = windowEvent.xbutton.button;
             if ((button == Button1) || (button == Button2) || (button == Button3) || (button == 8) || (button == 9))
             {
                 Event event;
@@ -2083,7 +2094,7 @@ RROutput WindowImplX11::getOutputPrimary(::Window& rootWindow, XRRScreenResource
     // if xRandR version >= 1.3 get the primary screen else take the first screen
     if ((xRandRMajor == 1 && xRandRMinor >= 3) || xRandRMajor > 1)
     {
-        RROutput output = XRRGetOutputPrimary(m_display, rootWindow);
+        const RROutput output = XRRGetOutputPrimary(m_display, rootWindow);
 
         // Check if returned output is valid, otherwise use the first screen
         if (output == None)
@@ -2119,7 +2130,7 @@ Vector2i WindowImplX11::getPrimaryMonitorPosition()
     if (!checkXRandR(xRandRMajor, xRandRMinor))
         xRandRMajor = xRandRMinor = 0;
 
-    RROutput output = getOutputPrimary(rootWindow, res, xRandRMajor, xRandRMinor);
+    const RROutput output = getOutputPrimary(rootWindow, res, xRandRMajor, xRandRMinor);
 
     // Get output info from output
     XRROutputInfo* outputInfo = XRRGetOutputInfo(m_display, res, output);


### PR DESCRIPTION
## Description

I recently started using Fedora 38 which ships clang-tidy-16. That means for the first time we used something newer than clang-tidy-14 on the Linux (and Linux DRM) code. Turns out the `misc-const-correctness` check has improved since then so it caught a lot of places we're missing `const`.
