### PR TITLE
Test for correct network ordering of packets

### DIFF
--- a/test/Network/Packet.test.cpp
+++ b/test/Network/Packet.test.cpp
@@ -5,6 +5,9 @@
 #include <array>
 #include <limits>
 #include <type_traits>
+#include <vector>
+
+#include <cstddef>
 
 #define CHECK_PACKET_STREAM_OPERATORS(expected)              \
     do                                                       \
@@ -65,6 +68,54 @@ TEST_CASE("[Network] sf::Packet")
         CHECK(packet.getDataSize() == 0);
         CHECK(packet.endOfPacket());
         CHECK(static_cast<bool>(packet));
+    }
+
+    SECTION("Network ordering")
+    {
+        sf::Packet packet;
+
+        SECTION("16 bit int")
+        {
+            packet << std::uint16_t{12'345};
+            const auto*       dataPtr = static_cast<const std::byte*>(packet.getData());
+            const std::vector bytes(dataPtr, dataPtr + packet.getDataSize());
+            const std::vector expectedBytes{std::byte{0x30}, std::byte{0x39}};
+            CHECK(bytes == expectedBytes);
+        }
+
+        SECTION("32 bit int")
+        {
+            packet << std::uint32_t{1'234'567'890};
+            const auto*       dataPtr = static_cast<const std::byte*>(packet.getData());
+            const std::vector bytes(dataPtr, dataPtr + packet.getDataSize());
+            const std::vector expectedBytes{std::byte{0x49}, std::byte{0x96}, std::byte{0x02}, std::byte{0xD2}};
+            CHECK(bytes == expectedBytes);
+        }
+
+        SECTION("float")
+        {
+            packet << 123.456f;
+            const auto*       dataPtr = static_cast<const std::byte*>(packet.getData());
+            const std::vector bytes(dataPtr, dataPtr + packet.getDataSize());
+            const std::vector expectedBytes{std::byte{0x79}, std::byte{0xe9}, std::byte{0xf6}, std::byte{0x42}};
+            CHECK(bytes == expectedBytes);
+        }
+
+        SECTION("double")
+        {
+            packet << 789.123;
+            const auto*       dataPtr = static_cast<const std::byte*>(packet.getData());
+            const std::vector bytes(dataPtr, dataPtr + packet.getDataSize());
+            const std::vector expectedBytes{std::byte{0x44},
+                                            std::byte{0x8b},
+                                            std::byte{0x6c},
+                                            std::byte{0xe7},
+                                            std::byte{0xfb},
+                                            std::byte{0xa8},
+                                            std::byte{0x88},
+                                            std::byte{0x40}};
+            CHECK(bytes == expectedBytes);
+        }
     }
 
     SECTION("Stream operators")


### PR DESCRIPTION
## Description

We were previously testing for round-trip correctness after serialization and deserialization but we were not testing that the serialized forms matches network order. It's a safe assumption that all of our development machines and CI runners are Little Endian so these tests won't be truly meaningful until we can run on Big Endian hardware. Given how rare BE hardware is, arguably it doesn't even matter whether we honor network ordering but as it stands now, the API promises as such so it's a good idea to test it.

These tests will give us more feedback on the changes made in https://github.com/SFML/SFML/pull/2380. 