### PR TITLE
Remove workaround for support old versions of Visual Studio

### DIFF
--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -117,12 +117,6 @@ elseif(SFML_OS_IOS)
     target_link_libraries(sfml-graphics PRIVATE z bz2)
 endif()
 
-# starting from Visual Studio 2015, inline versions of some C functions are used; for compatibility link this library
-# see https://docs.microsoft.com/en-us/cpp/porting/overview-of-potential-upgrade-issues-visual-cpp?view=msvc-160#libraries
-if(SFML_COMPILER_MSVC OR (SFML_COMPILER_CLANG AND SFML_OS_WINDOWS AND NOT MINGW))
-    target_link_libraries(sfml-graphics PRIVATE legacy_stdio_definitions.lib)
-endif()
-
 sfml_find_package(Freetype INCLUDE "FREETYPE_INCLUDE_DIRS" LINK "FREETYPE_LIBRARY")
 target_link_libraries(sfml-graphics PRIVATE Freetype)
 


### PR DESCRIPTION
## Description

This appears to be a backward compatibility fix for support VS 2015 and _older_ versions. Because VS 2019 is the older version you can use and still compile SFML 3, we don't need to worry about this any more.