### PR TITLE
Annotate PRs with clang-tidy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,13 +238,22 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew update
-        brew install llvm || true
+        brew install llvm pyyaml || true
         echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
+
+    - name: Install PyYAML
+      run: python3 -m pip install pyyaml
 
     - name: Configure
       shell: bash
-      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_UNITY_BUILD=ON -DSFML_BUILD_EXAMPLES=TRUE -DSFML_BUILD_TEST_SUITE=TRUE ${{matrix.platform.flags}}
+      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_UNITY_BUILD=ON -DSFML_BUILD_EXAMPLES=TRUE -DSFML_BUILD_TEST_SUITE=TRUE -DCLANG_TIDY_EXPORT_FIXES=TRUE ${{matrix.platform.flags}}
 
     - name: Analyze Code
       shell: bash
       run: cmake --build $GITHUB_WORKSPACE/build --target tidy
+
+    - name: Process clang-tidy Warnings
+      if: always()
+      uses: asarium/clang-tidy-action@v1
+      with:
+        fixesFile: clang-tidy-fixes.yaml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,10 @@ add_custom_target(format
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)
 
 sfml_set_option(CLANG_TIDY_EXECUTABLE clang-tidy STRING "Override clang-tidy executable, requires minimum version 14")
+sfml_set_option(CLANG_TIDY_EXPORT_FIXES OFF BOOL "TRUE to export clang-tidy fixes")
 add_custom_target(tidy
-    COMMAND ${CMAKE_COMMAND} -DCLANG_TIDY_EXECUTABLE=${CLANG_TIDY_EXECUTABLE} -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} -P ./cmake/Tidy.cmake
+    COMMAND ${CMAKE_COMMAND} -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
+                             -DCLANG_TIDY_EXECUTABLE=${CLANG_TIDY_EXECUTABLE}
+                             -DCLANG_TIDY_EXPORT_FIXES=${CLANG_TIDY_EXPORT_FIXES}
+                             -P ./cmake/Tidy.cmake
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)

--- a/cmake/Tidy.cmake
+++ b/cmake/Tidy.cmake
@@ -28,7 +28,10 @@ if(NOT RUN_CLANG_TIDY)
 endif()
 
 # Run
-execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
+if(CLANG_TIDY_EXPORT_FIXES)
+    set(EXPORT_FIXES -export-fixes clang-tidy-fixes.yaml)
+endif()
+execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -p ${PROJECT_BINARY_DIR} ${EXPORT_FIXES} RESULTS_VARIABLE EXIT_CODE)
 if(NOT EXIT_CODE STREQUAL 0)
     message(FATAL_ERROR "Analysis failed")
 endif()

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -16,7 +16,7 @@ int main()
     // Graphics
     [[maybe_unused]] const sf::Color          color;
     [[maybe_unused]] const sf::Font           font;
-    [[maybe_unused]] const sf::RenderWindow   renderWindow;
+    [[maybe_unused]] const sf::RenderWindow   render_window;
     [[maybe_unused]] const sf::RectangleShape rectangleShape;
     [[maybe_unused]] const sf::Vertex         vertex;
 


### PR DESCRIPTION
## Description

https://github.com/marketplace/actions/clang-tidy-action

I'm experimenting with a new GitHub Action for annotating PRs with any clang-tidy failures so it's a lot easier to find and fix the things it detects. The annotations only appear on PRs so I'm submitting this draft PR so I can see if it's working.

