### PR TITLE
Added missing doxygen tag \return and comments related to SFML documentation style.

### DIFF
--- a/src/SFML/Audio/ALCheck.cpp
+++ b/src/SFML/Audio/ALCheck.cpp
@@ -43,7 +43,7 @@ namespace
 namespace AlCheckImpl
 {
 thread_local ALenum lastError(AL_NO_ERROR);
-}
+} // namespace AlCheckImpl
 } // namespace
 
 namespace sf::priv

--- a/src/SFML/Audio/SoundFileReaderWav.hpp
+++ b/src/SFML/Audio/SoundFileReaderWav.hpp
@@ -61,6 +61,8 @@ public:
     /// \param stream Stream to open
     /// \param info   Structure to fill with the attributes of the loaded sound
     ///
+    /// \return True if the file was successfully opened
+    ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(sf::InputStream& stream, Info& info) override;
 

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -44,7 +44,7 @@ namespace
 namespace WindowsBaseImpl
 {
 const sf::WindowBase* fullscreenWindow = nullptr;
-}
+} // namespace WindowsBaseImpl
 } // namespace
 
 


### PR DESCRIPTION
Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

* [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php?topic=29052.0) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

- The PR addresses small changes in the doxygen documentation.
- While examining the source code, I identified a missing doxygen tag \return in a function marked with [[nodiscard]].
- Additionally, there were missing comments // namespace NAME that did not adhere to the style recommended in the SFML documentation style guide (https://www.sfml-dev.org/style.php).
- Creating an issue for these changes was not necessary. The fixes were considered straightforward.

forum discussion : https://en.sfml-dev.org/forums/index.php?topic=29052.0

## Tasks
Not applicable

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android
