### PR TITLE
Replace C++ int types with SFML ones

### DIFF
--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -69,7 +69,7 @@ m_valid  (false)
 
 ////////////////////////////////////////////////////////////
 IpAddress::IpAddress(Uint8 byte0, Uint8 byte1, Uint8 byte2, Uint8 byte3) :
-m_address(htonl(static_cast<uint32_t>((byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3))),
+m_address(htonl(static_cast<Uint32>((byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3))),
 m_valid  (true)
 {
 }

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -150,7 +150,7 @@ Packet& Packet::operator >>(Int16& data)
     if (checkSize(sizeof(data)))
     {
         std::memcpy(&data, &m_data[m_readPos], sizeof(data));
-        data = static_cast<Int16>(ntohs(static_cast<uint16_t>(data)));
+        data = static_cast<Int16>(ntohs(static_cast<Uint16>(data)));
         m_readPos += sizeof(data);
     }
 
@@ -178,7 +178,7 @@ Packet& Packet::operator >>(Int32& data)
     if (checkSize(sizeof(data)))
     {
         std::memcpy(&data, &m_data[m_readPos], sizeof(data));
-        data = static_cast<Int32>(ntohl(static_cast<uint32_t>(data)));
+        data = static_cast<Int32>(ntohl(static_cast<Uint32>(data)));
         m_readPos += sizeof(data);
     }
 
@@ -412,7 +412,7 @@ Packet& Packet::operator <<(Uint8 data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator <<(Int16 data)
 {
-    Int16 toWrite = static_cast<Int16>(htons(static_cast<uint16_t>(data)));
+    Int16 toWrite = static_cast<Int16>(htons(static_cast<Uint16>(data)));
     append(&toWrite, sizeof(toWrite));
     return *this;
 }
@@ -430,7 +430,7 @@ Packet& Packet::operator <<(Uint16 data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator <<(Int32 data)
 {
-    Int32 toWrite = static_cast<Int32>(htonl(static_cast<uint32_t>(data)));
+    Int32 toWrite = static_cast<Int32>(htonl(static_cast<Uint32>(data)));
     append(&toWrite, sizeof(toWrite));
     return *this;
 }


### PR DESCRIPTION
## Description

Looks like we had accidentally sneaked in some C++11 int types, when fixing conversion warnings.

## How to test this PR?

Build this PR