### PR TITLE
Don't overwrite module path

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -384,7 +384,7 @@ function(sfml_find_package)
         message(FATAL_ERROR "Unknown arguments when calling sfml_import_library: ${THIS_UNPARSED_ARGUMENTS}")
     endif()
 
-    set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
+    list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
     if (SFML_OS_IOS)
         find_host_package(${target} REQUIRED)
     else()

--- a/src/SFML/CMakeLists.txt
+++ b/src/SFML/CMakeLists.txt
@@ -40,7 +40,7 @@ elseif(SFML_OS_ANDROID)
 endif()
 
 # define the path of our additional CMake modules
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 
 # set the output directory for SFML libraries
 set(LIBRARY_OUTPUT_PATH "${PROJECT_BINARY_DIR}/lib")


### PR DESCRIPTION
## Description

The Conan package for SFML has to fix this so apparently it's a real world problem.

https://github.com/conan-io/conan-center-index/blob/master/recipes/sfml/all/patches/0001-cmake-robust-find-deps.patch
