### PR TITLE
Assert that a video mode exists before trying to use it

### DIFF
--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -34,6 +34,8 @@
 
 #include <ostream>
 
+#include <cassert>
+
 
 namespace sf
 {
@@ -90,6 +92,7 @@ void Window::create(VideoMode mode, const String& title, std::uint32_t style, co
             if (!mode.isValid())
             {
                 err() << "The requested video mode is not available, switching to a valid mode" << std::endl;
+                assert(!VideoMode::getFullscreenModes().empty() && "No video modes available");
                 mode = VideoMode::getFullscreenModes()[0];
             }
 


### PR DESCRIPTION
## Description

This converts a segfault into a more predictable failure, at least in debug builds.

One small step towards addressing #2300.