### PR TITLE
Adding reserve() to VertexArray

### DIFF
--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -123,10 +123,10 @@ public:
     /// used to reduce the number of memory allocations when
     /// a high number of vertices is appended.
     ///
-    /// \param maxVertexCount New capacity of the array (number of vertices)
+    /// \param capacity New capacity of the array (number of vertices)
     ///
     ////////////////////////////////////////////////////////////
-    void reserve(std::size_t maxVertexCount);
+    void reserve(std::size_t capacity);
 
     ////////////////////////////////////////////////////////////
     /// \brief Resize the vertex array

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -115,6 +115,20 @@ public:
     void clear();
 
     ////////////////////////////////////////////////////////////
+    /// \brief Reserve memory space for the vertex array
+    ///
+    /// Allocates enough memory so that at least the given number
+    /// of vertices can be stored, without another memory allocation.
+    /// No vertices are added or removed. This function is solely
+    /// used to reduce the number of memory allocations when
+    /// a high number of vertices is appended.
+    ///
+    /// \param maxVertexCount New capacity of the array (number of vertices)
+    ///
+    ////////////////////////////////////////////////////////////
+    void reserve(std::size_t maxVertexCount);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Resize the vertex array
     ///
     /// If \a vertexCount is greater than the current size, the previous

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -70,6 +70,13 @@ void VertexArray::clear()
 
 
 ////////////////////////////////////////////////////////////
+void VertexArray::reserve(std::size_t maxVertexCount)
+{
+    m_vertices.reserve(maxVertexCount);
+}
+
+
+////////////////////////////////////////////////////////////
 void VertexArray::resize(std::size_t vertexCount)
 {
     m_vertices.resize(vertexCount);

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -70,9 +70,9 @@ void VertexArray::clear()
 
 
 ////////////////////////////////////////////////////////////
-void VertexArray::reserve(std::size_t maxVertexCount)
+void VertexArray::reserve(std::size_t capacity)
 {
-    m_vertices.reserve(maxVertexCount);
+    m_vertices.reserve(capacity);
 }
 
 

--- a/test/Graphics/VertexArray.test.cpp
+++ b/test/Graphics/VertexArray.test.cpp
@@ -69,6 +69,12 @@ TEST_CASE("[Graphics] sf::VertexArray")
         CHECK(vertexArray.getVertexCount() == 0);
     }
 
+    SECTION("Reserve array")
+    {
+        sf::VertexArray vertexArray;
+        vertexArray.reserve(3);
+    }
+
     SECTION("Append to array")
     {
         sf::VertexArray  vertexArray;


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Hi there, thank you so much for this amazing library!
I am trying to implement a Batch Renderer and therefore need all the performance I can get. I added a small change to also expose the `reserve()` function besides the `resize()` function. Any problems with that? :)

I also added a unit test, although we cannot really check if the allocation works, we can only check that the function is callable.

## Tasks

* [ ] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

```cpp
void resize() {
    sf::VertexArray va;
    va.reserve(50000);       // Thanks to this function all 50000 elements are dynamically appended, with only a single heap allocation
    for (int i = 0; i < 50000; i++) {
        va.append(sf::Vertex(sf::Vector2f(0, 0), sf::Color::Red));
    }
}
```
