### PR TITLE
Fixed GL_SCISSOR_TEST affecting sf::Font internals

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -57,6 +57,28 @@ std::uint64_t getUniqueId() noexcept
 
     return id.fetch_add(1);
 }
+
+// Automatic wrapper for temporarily disabling GL_SCISSOR_TEST
+class ScissorSaver
+{
+public:
+	ScissorSaver() :
+		m_wasEnabled(glIsEnabled(GL_SCISSOR_TEST))
+	{
+		if(m_wasEnabled)
+			glCheck(glDisable(GL_SCISSOR_TEST));
+	}
+
+	~ScissorSaver()
+	{
+		if(m_wasEnabled)
+			glCheck(glEnable(GL_SCISSOR_TEST));
+	}
+
+private:
+	bool m_wasEnabled;
+};
+
 } // namespace TextureImpl
 } // namespace
 
@@ -515,6 +537,7 @@ void Texture::update(const Texture& texture, const Vector2u& dest)
     if (GLEXT_framebuffer_object && GLEXT_framebuffer_blit)
     {
         const TransientContextLock lock;
+        const TextureImpl::ScissorSaver scissorSaver;
 
         // Save the current bindings so we can restore them after we are done
         GLint readFramebuffer = 0;


### PR DESCRIPTION
## Description

Added a sentry object for disabling and re-enabling `GL_SCISSOR_TEST`, if it was enabled when calling `Texture::update`. This may be called from within `sf::Font` when new glyph is rendered. 

This PR is related to the issue #2588

## Tasks

* [ ] Tested on Linux
* [X] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Following code shows missing or corrupted glyphs when `okno.draw(text)` is called with `GL_SCISSOR_TEST` enabled. Tweaking font size or number of unique characters in definition of `text` may be required for reproduction, in case there are other factors I am not aware of.

```cpp
#include <SFML/Graphics.hpp>
#include <SFML/OpenGL.hpp>

int main()
{
    sf::RenderWindow okno( sf::VideoMode( {320, 240 }), "Scissors" );
    sf::Font font;
    // https://fonts.google.com/specimen/Charis+SIL/about
    if(!font.loadFromFile("CharisSIL-Regular.ttf"))
        return 0;

    sf::Text text(font, "0123456789ABCDEFGHIJKLMNOPQ", 30);
    text.setFillColor(sf::Color::White);

    glEnable(GL_SCISSOR_TEST);
    glScissor(0, 0, 30, 30);
    okno.draw(text); // Trigger caching several glyphs with GL_SCISSOR_TEST active.
    glDisable(GL_SCISSOR_TEST);

    while( okno.isOpen() )
    {
        sf::Event event;
        while( okno.pollEvent( event ) )
        {
            if( event.type == sf::Event::Closed )
                    okno.close();

        } //while
        okno.clear();
        okno.draw(text);
        okno.display();
    }
}
```
