### PR TITLE
Make glyph a struct

### DIFF
--- a/include/SFML/Graphics/Glyph.hpp
+++ b/include/SFML/Graphics/Glyph.hpp
@@ -38,12 +38,8 @@ namespace sf
 /// \brief Structure describing a glyph
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Glyph
+struct SFML_GRAPHICS_API Glyph
 {
-public:
-    ////////////////////////////////////////////////////////////
-    // Member data
-    ////////////////////////////////////////////////////////////
     float     advance{};   //!< Offset to move horizontally to the next character
     int       lsbDelta{};  //!< Left offset after forced autohint. Internally used by getKerning()
     int       rsbDelta{};  //!< Right offset after forced autohint. Internally used by getKerning()
@@ -55,7 +51,7 @@ public:
 
 
 ////////////////////////////////////////////////////////////
-/// \class sf::Glyph
+/// \struct sf::Glyph
 /// \ingroup graphics
 ///
 /// A glyph is the visual representation of a character.


### PR DESCRIPTION
## Make Glyph a struct

This is probably the most egregious example of a struct masking as a class. The reason being the coding standard wants to use classes over structs, but do we want to keep following this rule? It's fine if we want to stick to what we are currently doing, but we could at least talk about this coding standard. If anything, we can reference back to here why we don't want to use raw structs for data types.