### PR TITLE
Remove C++11 header

### DIFF
--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -55,7 +55,7 @@
 #include <SFML/System/Err.hpp>
 #include <algorithm>
 #include <cstring>
-#include <cstdint>
+#include <stdint.h>
 
 
 namespace
@@ -66,7 +66,7 @@ std::size_t readCallback(void* ptr, std::size_t size, void* data)
     return static_cast<std::size_t>(stream->read(ptr, static_cast<sf::Int64>(size)));
 }
 
-int seekCallback(std::uint64_t offset, void* data)
+int seekCallback(uint64_t offset, void* data)
 {
     sf::InputStream* stream = static_cast<sf::InputStream*>(data);
     sf::Int64 position = stream->seek(static_cast<sf::Int64>(offset));


### PR DESCRIPTION
## Description

This was caught by someone writing a Conan package for SFML 2.6.0.

https://github.com/conan-io/conan-center-index/pull/18069#discussion_r1243817430

In practice this is a meaningless change but I'm fixing it for the sake of pedantry. Because C99 already provides fixed-width integers, we can rely on them. We can't use `sf::Uint64` here since it's an `unsigned long` on some platforms and `unsigned long long` on others which apparently causes issues with using it as a parameter in a function pointer as is the case on line 112.