### PR TITLE
Assert Messages For Vector2 Functions

### DIFF
--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -94,8 +94,8 @@ constexpr Vector2<T> Vector2<T>::cwiseMul(const Vector2<T>& rhs) const
 template <typename T>
 constexpr Vector2<T> Vector2<T>::cwiseDiv(const Vector2<T>& rhs) const
 {
-    assert(rhs.x != 0);
-    assert(rhs.y != 0);
+    assert(rhs.x != 0 && "Vector2::cwiseDiv() cannot divide by 0");
+    assert(rhs.y != 0 && "Vector2::cwiseDiv() cannot divide by 0");
     return Vector2<T>(x / rhs.x, y / rhs.y);
 }
 

--- a/src/SFML/System/Vector2.cpp
+++ b/src/SFML/System/Vector2.cpp
@@ -38,7 +38,7 @@ Vector2<T> Vector2<T>::normalized() const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::normalized() is only supported for floating point types");
 
-    assert(*this != Vector2<T>());
+    assert(*this != Vector2<T>() && "Vector2::normalized() cannot normalize a zero vector");
     return (*this) / length();
 }
 
@@ -49,8 +49,8 @@ Angle Vector2<T>::angleTo(const Vector2<T>& rhs) const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::angleTo() is only supported for floating point types");
 
-    assert(*this != Vector2<T>());
-    assert(rhs != Vector2<T>());
+    assert(*this != Vector2<T>() && "Vector2::angleTo() cannot calculate angle from a zero vector");
+    assert(rhs != Vector2<T>() && "Vector2::angleTo() cannot calculate angle to a zero vector");
     return radians(static_cast<float>(std::atan2(cross(rhs), dot(rhs))));
 }
 
@@ -61,7 +61,7 @@ Angle Vector2<T>::angle() const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::angle() is only supported for floating point types");
 
-    assert(*this != Vector2<T>());
+    assert(*this != Vector2<T>() && "Vector2::angle() cannot calculate angle from a zero vector");
     return radians(static_cast<float>(std::atan2(y, x)));
 }
 
@@ -87,7 +87,7 @@ Vector2<T> Vector2<T>::projectedOnto(const Vector2<T>& axis) const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::projectedOnto() is only supported for floating point types");
 
-    assert(axis != Vector2<T>());
+    assert(axis != Vector2<T>() && "Vector2::projectedOnto() cannot project onto a zero vector");
     return dot(axis) / axis.lengthSq() * axis;
 }
 


### PR DESCRIPTION
## Description

My pull request adds some assert messages into the new Vector2 functions from SFML3 that make it clearer that using a zero vector with these functions will cause an error.

This PR is related to the issue #2592

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## Testing

```cpp
#include <SFML/Graphics.hpp>

void Test() {
	sf::Vector2<float> v1;
	sf::Vector2<float> v2(1.0f, 1.0f);
	v1.normalized();
	v1.angleTo({ 1.0f, 1.0f });
	v2.angleTo({ 0.0f, 0.0f });
	v1.angle();
	v2.projectedOnto({ 0.0f, 0.0f });
}
```
### Resulting Errors
```c++
Assertion failed: ("Vector2::normalized() cannot normalize a zero vector", *this != Vector2<T>()), file C:\Users\erikf\dev\LIBRARIES\SFML3\src\SFML\System\Vector2.cpp, line 41
Assertion failed: ("Vector2::angleTo() cannot calculate angle from a zero vector", *this != Vector2<T>()), file C:\Users\erikf\dev\LIBRARIES\SFML3\src\SFML\System\Vector2.cpp, line 52
Assertion failed: ("Vector2::angleTo() cannot calculate angle to a zero vector", rhs != Vector2<T>()), file C:\Users\erikf\dev\LIBRARIES\SFML3\src\SFML\System\Vector2.cpp, line 53
Assertion failed: ("Vector2::angle() cannot calculate angle from a zero vector", *this != Vector2<T>()), file C:\Users\erikf\dev\LIBRARIES\SFML3\src\SFML\System\Vector2.cpp, line 64
Assertion failed: ("Vector2::projectedOnto() cannot project onto a zero vector", axis != Vector2<T>()), file C:\Users\erikf\dev\LIBRARIES\SFML3\src\SFML\System\Vector2.cpp, line 90
```

