### PR TITLE
Added assert messages to Vector3 functions

### DIFF
--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -89,9 +89,9 @@ constexpr Vector3<T> Vector3<T>::cwiseMul(const Vector3<T>& rhs) const
 template <typename T>
 constexpr Vector3<T> Vector3<T>::cwiseDiv(const Vector3<T>& rhs) const
 {
-    assert(rhs.x != 0);
-    assert(rhs.y != 0);
-    assert(rhs.z != 0);
+    assert(rhs.x != 0 && "Vector3::cwiseDiv() cannot divide by 0");
+    assert(rhs.y != 0 && "Vector3::cwiseDiv() cannot divide by 0");
+    assert(rhs.z != 0 && "Vector3::cwiseDiv() cannot divide by 0");
     return Vector3<T>(x / rhs.x, y / rhs.y, z / rhs.z);
 }
 

--- a/src/SFML/System/Vector3.cpp
+++ b/src/SFML/System/Vector3.cpp
@@ -38,7 +38,7 @@ Vector3<T> Vector3<T>::normalized() const
 {
     static_assert(std::is_floating_point_v<T>, "Vector3::normalized() is only supported for floating point types");
 
-    assert(*this != Vector3<T>());
+    assert(*this != Vector3<T>() && "Vector3::normalized() cannot normalize a zero vector");
     return (*this) / length();
 }
 


### PR DESCRIPTION
## Description
Adds some assert messages to 2 Vector3 functions to make why the program is failing clearer.

## Tasks

* [x] Tested on Windows

## Test

```cpp
void Test() {
	sf::Vector3f v1(0.f, 0.f, 0.f);
	v1.normalized();
	sf::Vector3f v2(1.f, 1.f, 1.f);
	v2.cwiseDiv({ 0.f, 0.f, 0.f });
	v2.cwiseDiv({ 1.f, 0.f, 0.f });
	v2.cwiseDiv({ 1.f, 1.f, 0.f });
}

// Errors:
Assertion failed: *this != Vector3<T>() && "Vector3::normalized() cannot normalize a zero vector", file C:\Users\erikf\dev\LIBRARIES\SFML3\src\SFML\System\Vector3.cpp, line 41
Assertion failed: rhs.x != 0 && "Vector3::cwiseDiv() cannot divide by 0", file C:\Users\erikf\dev\LIBRARIES\SFML3\include\SFML\System\Vector3.inl, line 92
Assertion failed: rhs.y != 0 && "Vector3::cwiseDiv() cannot divide by 0", file C:\Users\erikf\dev\LIBRARIES\SFML3\include\SFML\System\Vector3.inl, line 93
Assertion failed: rhs.z != 0 && "Vector3::cwiseDiv() cannot divide by 0", file C:\Users\erikf\dev\LIBRARIES\SFML3\include\SFML\System\Vector3.inl, line 94
```
