### PR TITLE
Add doc strings to remaining assertions

### DIFF
--- a/examples/shader/Effect.hpp
+++ b/examples/shader/Effect.hpp
@@ -62,7 +62,7 @@ protected:
 
     static const sf::Font& getFont()
     {
-        assert(s_font != nullptr);
+        assert(s_font != nullptr && "Cannot get font until setFont() is called");
         return *s_font;
     }
 

--- a/include/SFML/System/Angle.inl
+++ b/include/SFML/System/Angle.inl
@@ -28,7 +28,7 @@ constexpr float pi = 3.141592654f;
 
 constexpr float positiveRemainder(float a, float b)
 {
-    assert(b > 0.0f);
+    assert(b > 0.0f && "Cannot calculate remainder with non-positive divisor");
     const float val = a - static_cast<float>(static_cast<int>(a / b)) * b;
     if (val >= 0.f)
         return val;

--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -141,7 +141,7 @@ FLAC__StreamDecoderWriteStatus streamWrite(const FLAC__StreamDecoder*,
                     sample = static_cast<std::int16_t>(buffer[j][i] >> 16);
                     break;
                 default:
-                    assert(false);
+                    assert(false && "Invalid bits per sample. Must be 8, 16, 24, or 32.");
                     break;
             }
 
@@ -271,7 +271,7 @@ bool SoundFileReaderFlac::open(InputStream& stream, Info& info)
 ////////////////////////////////////////////////////////////
 void SoundFileReaderFlac::seek(std::uint64_t sampleOffset)
 {
-    assert(m_decoder);
+    assert(m_decoder && "No decoder available. Call SoundFileReaderFlac::open() to create a new one.");
 
     // Reset the callback data (the "write" callback will be called)
     m_clientData.buffer    = nullptr;
@@ -300,7 +300,7 @@ void SoundFileReaderFlac::seek(std::uint64_t sampleOffset)
 ////////////////////////////////////////////////////////////
 std::uint64_t SoundFileReaderFlac::read(std::int16_t* samples, std::uint64_t maxCount)
 {
-    assert(m_decoder);
+    assert(m_decoder && "No decoder available. Call SoundFileReaderFlac::open() to create a new one.");
 
     // If there are leftovers from previous call, use it first
     const std::size_t left = m_clientData.leftovers.size();

--- a/src/SFML/Audio/SoundFileReaderOgg.cpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.cpp
@@ -128,7 +128,7 @@ bool SoundFileReaderOgg::open(InputStream& stream, Info& info)
 ////////////////////////////////////////////////////////////
 void SoundFileReaderOgg::seek(std::uint64_t sampleOffset)
 {
-    assert(m_vorbis.datasource);
+    assert(m_vorbis.datasource && "Vorbis datasource is missing. Call SoundFileReaderOgg::open() to initialize it.");
 
     ov_pcm_seek(&m_vorbis, static_cast<ogg_int64_t>(sampleOffset / m_channelCount));
 }
@@ -137,7 +137,7 @@ void SoundFileReaderOgg::seek(std::uint64_t sampleOffset)
 ////////////////////////////////////////////////////////////
 std::uint64_t SoundFileReaderOgg::read(std::int16_t* samples, std::uint64_t maxCount)
 {
-    assert(m_vorbis.datasource);
+    assert(m_vorbis.datasource && "Vorbis datasource is missing. Call SoundFileReaderOgg::open() to initialize it.");
 
     // Try to read the requested number of samples, stop only on error or end of file
     std::uint64_t count = 0;

--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -141,7 +141,7 @@ bool SoundFileReaderWav::open(InputStream& stream, Info& info)
 ////////////////////////////////////////////////////////////
 void SoundFileReaderWav::seek(std::uint64_t sampleOffset)
 {
-    assert(m_stream);
+    assert(m_stream && "Input stream cannot be null. Call SoundFileReaderWav::open() to initialize it.");
 
     if (m_stream->seek(static_cast<std::int64_t>(m_dataStart + sampleOffset * m_bytesPerSample) == -1))
         err() << "Failed to seek WAV sound stream" << std::endl;
@@ -151,7 +151,7 @@ void SoundFileReaderWav::seek(std::uint64_t sampleOffset)
 ////////////////////////////////////////////////////////////
 std::uint64_t SoundFileReaderWav::read(std::int16_t* samples, std::uint64_t maxCount)
 {
-    assert(m_stream);
+    assert(m_stream && "Input stream cannot be null. Call SoundFileReaderWav::open() to initialize it.");
 
     std::uint64_t count    = 0;
     const auto    startPos = static_cast<std::uint64_t>(m_stream->tell());
@@ -204,7 +204,7 @@ std::uint64_t SoundFileReaderWav::read(std::int16_t* samples, std::uint64_t maxC
 
             default:
             {
-                assert(false);
+                assert(false && "Invalid bytes per sample. Must be 1, 2, 3, or 4.");
                 return 0;
             }
         }
@@ -219,7 +219,7 @@ std::uint64_t SoundFileReaderWav::read(std::int16_t* samples, std::uint64_t maxC
 ////////////////////////////////////////////////////////////
 bool SoundFileReaderWav::parseHeader(Info& info)
 {
-    assert(m_stream);
+    assert(m_stream && "Input stream cannot be null. Call SoundFileReaderWav::open() to initialize it.");
 
     // If we are here, it means that the first part of the header
     // (the format) has already been checked

--- a/src/SFML/Audio/SoundFileWriterOgg.cpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.cpp
@@ -138,7 +138,7 @@ void SoundFileWriterOgg::write(const std::int16_t* samples, std::uint64_t count)
     {
         // Prepare a buffer to hold our samples
         float** buffer = vorbis_analysis_buffer(&m_state, bufferSize);
-        assert(buffer);
+        assert(buffer && "Vorbis buffer failed to allocate");
 
         // Write the samples to the buffer, converted to float
         for (int i = 0; i < std::min(frameCount, bufferSize); ++i)

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -110,7 +110,7 @@ bool SoundFileWriterWav::open(const std::filesystem::path& filename, unsigned in
 ////////////////////////////////////////////////////////////
 void SoundFileWriterWav::write(const std::int16_t* samples, std::uint64_t count)
 {
-    assert(m_file.good());
+    assert(m_file.good() && "Most recent I/O operation failed");
 
     while (count--)
         encode(m_file, *samples++);
@@ -120,7 +120,7 @@ void SoundFileWriterWav::write(const std::int16_t* samples, std::uint64_t count)
 ////////////////////////////////////////////////////////////
 bool SoundFileWriterWav::writeHeader(unsigned int sampleRate, unsigned int channelCount)
 {
-    assert(m_file.good());
+    assert(m_file.good() && "Most recent I/O operation failed");
 
     // Write the main chunk ID
     char mainChunkId[4] = {'R', 'I', 'F', 'F'};

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -332,7 +332,7 @@ void SoundRecorder::launchCapturingThread()
 {
     m_isCapturing = true;
 
-    assert(!m_thread.joinable());
+    assert(!m_thread.joinable() && "Capture thread is already running");
     m_thread = std::thread(&SoundRecorder::record, this);
 }
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -508,7 +508,7 @@ void SoundStream::launchStreamingThread(Status threadStartState)
         m_threadStartState = threadStartState;
     }
 
-    assert(!m_thread.joinable());
+    assert(!m_thread.joinable() && "Background thread is still running");
     m_thread = std::thread(&SoundStream::streamData, this);
 }
 

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -137,7 +137,7 @@ Vector2f Shape::getGeometricCenter() const
     switch (count)
     {
         case 0:
-            assert(false);
+            assert(false && "Cannot calculate geometric center of shape with no points");
             return Vector2f{};
         case 1:
             return getPoint(0);

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -130,7 +130,7 @@ FloatRect Sprite::getGlobalBounds() const
 ////////////////////////////////////////////////////////////
 void Sprite::draw(RenderTarget& target, const RenderStates& states) const
 {
-    assert(m_texture);
+    assert(m_texture && "Cannot use null texture. Call Sprite::setTexture() to initialize it.");
 
     RenderStates statesCopy(states);
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -453,8 +453,8 @@ void Texture::update(const std::uint8_t* pixels)
 ////////////////////////////////////////////////////////////
 void Texture::update(const std::uint8_t* pixels, const Vector2u& size, const Vector2u& dest)
 {
-    assert(dest.x + size.x <= m_size.x);
-    assert(dest.y + size.y <= m_size.y);
+    assert(dest.x + size.x <= m_size.x && "Destination x coordinate is outside of texture");
+    assert(dest.y + size.y <= m_size.y && "Destination y coordinate is outside of texture");
 
     if (pixels && m_texture)
     {
@@ -497,8 +497,8 @@ void Texture::update(const Texture& texture)
 ////////////////////////////////////////////////////////////
 void Texture::update(const Texture& texture, const Vector2u& dest)
 {
-    assert(dest.x + texture.m_size.x <= m_size.x);
-    assert(dest.y + texture.m_size.y <= m_size.y);
+    assert(dest.x + texture.m_size.x <= m_size.x && "Destination x coordinate is outside of texture");
+    assert(dest.y + texture.m_size.y <= m_size.y && "Destination y coordinate is outside of texture");
 
     if (!m_texture || !texture.m_texture)
         return;
@@ -630,8 +630,8 @@ void Texture::update(const Window& window)
 ////////////////////////////////////////////////////////////
 void Texture::update(const Window& window, const Vector2u& dest)
 {
-    assert(dest.x + window.getSize().x <= m_size.x);
-    assert(dest.y + window.getSize().y <= m_size.y);
+    assert(dest.x + window.getSize().x <= m_size.x && "Destination x coordinate is outside of texture");
+    assert(dest.y + window.getSize().y <= m_size.y && "Destination y coordinate is outside of texture");
 
     if (m_texture && window.setActive(true))
     {

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -84,7 +84,7 @@ int getAndroidApiLevel(ANativeActivity* activity)
 ////////////////////////////////////////////////////////////
 ActivityStates* retrieveStates(ANativeActivity* activity)
 {
-    assert(activity != nullptr);
+    assert(activity != nullptr && "Activity cannot be null");
 
     // Hide the ugly cast we find in each callback function
     return static_cast<ActivityStates*>(activity->instance);

--- a/src/SFML/System/Android/Activity.cpp
+++ b/src/SFML/System/Android/Activity.cpp
@@ -71,7 +71,8 @@ void resetActivity(ActivityStates* initializedStates)
 ActivityStates& getActivity()
 {
     ActivityStates* const states = getActivityStatesPtr();
-    assert(states != nullptr);
+    assert(states != nullptr &&
+           "Cannot dereference null activity states pointer. Call priv::resetActivity() to initialize it.");
     return *states;
 }
 

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -355,7 +355,7 @@ EGLConfig EglContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
         }
     }
 
-    assert(bestScore < 0x7FFFFFFF);
+    assert(bestScore < 0x7FFFFFFF && "Failed to calculate best config");
 
     return bestConfig;
 }

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -82,7 +82,7 @@ void closeDisplay(Display* display)
 {
     const std::lock_guard lock(mutex);
 
-    assert(display == sharedDisplay);
+    assert(display == sharedDisplay && "Display must match shared display");
 
     --referenceCount;
     if (referenceCount == 0)
@@ -94,7 +94,7 @@ XIM openXim()
 {
     const std::lock_guard lock(mutex);
 
-    assert(sharedDisplay != nullptr);
+    assert(sharedDisplay != nullptr && "Shared display is null. Call priv::openDisplay() to initialize it.");
 
     if (referenceCountXIM == 0)
     {
@@ -132,7 +132,7 @@ void closeXim(XIM xim)
 {
     const std::lock_guard lock(mutex);
 
-    assert(xim == sharedXIM);
+    assert(xim == sharedXIM && "XIM must match shared XIM");
 
     --referenceCountXIM;
 

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -199,7 +199,8 @@ WglContext::~WglContext()
 ////////////////////////////////////////////////////////////
 GlFunctionPointer WglContext::getFunction(const char* name)
 {
-    assert(WglContextImpl::currentContext != nullptr);
+    assert(WglContextImpl::currentContext != nullptr &&
+           "Current WGL context cannot be null. Call WglContext::makeCurrent() to initialize it.");
 
     // If we are using the generic GDI implementation, skip to loading directly from OpenGL32.dll since it doesn't support extensions
     if (!WglContextImpl::currentContext->m_isGeneric)

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -37,17 +37,17 @@ public:
     TemporaryFile(const std::string& contents) : m_path(getTemporaryFilePath())
     {
         std::ofstream ofs(m_path);
-        assert(ofs);
+        assert(ofs && "Stream encountered an error");
 
         ofs << contents;
-        assert(ofs);
+        assert(ofs && "Stream encountered an error");
     }
 
     // Close and delete the generated file.
     ~TemporaryFile()
     {
         [[maybe_unused]] const bool removed = std::filesystem::remove(m_path);
-        assert(removed);
+        assert(removed && "m_path failed to be removed from filesystem");
     }
 
     // Prevent copies.

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -19,7 +19,7 @@ namespace
 template <typename T>
 auto select(const std::basic_string<T>& string16, const std::basic_string<T>& string32)
 {
-    assert(string16 != string32);
+    assert(string16 != string32 && "Invalid to select between identical inputs");
     if constexpr (sizeof(wchar_t) == 2)
         return string16;
     else


### PR DESCRIPTION
## Description

Inspired by #2595 and #2596

The main rationale behind this PR is that if an assertion fails, it's often not obvious what went wrong. At best you can see _that_ something failed but unless you're already familiar with SFML's source code, chances are you won't immediately understand _why_ something failed.

I'm sure these messages will need some refining since I myself struggled to understand what some of these assertions mean since they were present in code I don't already understand.

One outstanding question I have is whether we bother including the function name in the assertion message. We did that in the `sf::Vector` assertions but that's not a pattern we've used elsewhere before. Is that a precedent we want to set across the codebase? Is it worth the effort?