### PR TITLE
Use `std::filesystem::path` for paths

### DIFF
--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -27,6 +27,8 @@
 
 #import "NSString+stdstring.h"
 
+#include <filesystem>
+
 // These define are used for converting the color of the NSPopUpButton
 #define BLUE  @"Blue"
 #define GREEN @"Green"
@@ -39,8 +41,8 @@ struct SFMLmainWindow
 {
     SFMLmainWindow(sf::WindowHandle win) : renderWindow(win), text(font), sprite(logo), background(sf::Color::Blue)
     {
-        std::string resPath = [[[NSBundle mainBundle] resourcePath] tostdstring];
-        if (!logo.loadFromFile(resPath + "/logo.png"))
+        std::filesystem::path resPath = [[[NSBundle mainBundle] resourcePath] tostdstring];
+        if (!logo.loadFromFile(resPath / "logo.png"))
             NSLog(@"Couldn't load the logo image");
 
         logo.setSmooth(true);
@@ -54,7 +56,7 @@ struct SFMLmainWindow
         unsigned int wh = renderWindow.getSize().y;
         sprite.setPosition(sf::Vector2f(ww, wh) / 2.f);
 
-        if (!font.loadFromFile(resPath + "/tuffy.ttf"))
+        if (!font.loadFromFile(resPath / "tuffy.ttf"))
             NSLog(@"Couldn't load the font");
 
         text.setFillColor(sf::Color::White);

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -502,10 +502,10 @@ public:
     /// \see download
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Response upload(const std::string& localFile,
-                                  const std::string& remotePath,
-                                  TransferMode       mode   = TransferMode::Binary,
-                                  bool               append = false);
+    [[nodiscard]] Response upload(const std::filesystem::path& localFile,
+                                  const std::filesystem::path& remotePath,
+                                  TransferMode                 mode   = TransferMode::Binary,
+                                  bool                         append = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a command to the FTP server

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -322,23 +322,15 @@ Ftp::Response Ftp::download(const std::filesystem::path& remoteFile, const std::
 
 
 ////////////////////////////////////////////////////////////
-Ftp::Response Ftp::upload(const std::string& localFile, const std::string& remotePath, TransferMode mode, bool append)
+Ftp::Response Ftp::upload(const std::filesystem::path& localFile,
+                          const std::filesystem::path& remotePath,
+                          TransferMode                 mode,
+                          bool                         append)
 {
     // Get the contents of the file to send
     std::ifstream file(localFile, std::ios_base::binary);
     if (!file)
         return Response(Response::Status::InvalidFile);
-
-    // Extract the filename from the file path
-    std::string                  filename = localFile;
-    const std::string::size_type pos      = filename.find_last_of("/\\");
-    if (pos != std::string::npos)
-        filename = filename.substr(pos + 1);
-
-    // Make sure the destination path ends with a slash
-    std::string path = remotePath;
-    if (!path.empty() && (path[path.size() - 1] != '\\') && (path[path.size() - 1] != '/'))
-        path += "/";
 
     // Open a data channel using the given transfer mode
     DataChannel data(*this);
@@ -346,7 +338,7 @@ Ftp::Response Ftp::upload(const std::string& localFile, const std::string& remot
     if (response.isOk())
     {
         // Tell the server to start the transfer
-        response = sendCommand(append ? "APPE" : "STOR", path + filename);
+        response = sendCommand(append ? "APPE" : "STOR", (remotePath / localFile.filename()).string());
         if (response.isOk())
         {
             // Send the file data

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -12,7 +12,7 @@
 
 namespace
 {
-std::string getTemporaryFilePath()
+std::filesystem::path getTemporaryFilePath()
 {
     static int counter = 0;
 
@@ -24,13 +24,13 @@ std::string getTemporaryFilePath()
     result /= std::filesystem::temp_directory_path();
     result /= oss.str();
 
-    return result.string();
+    return result;
 }
 
 class TemporaryFile
 {
 private:
-    std::string m_path;
+    std::filesystem::path m_path;
 
 public:
     // Create a temporary file with a randomly generated path, containing 'contents'.
@@ -56,7 +56,7 @@ public:
     TemporaryFile& operator=(const TemporaryFile&) = delete;
 
     // Return the randomly generated path.
-    const std::string& getPath() const
+    const std::filesystem::path& getPath() const
     {
         return m_path;
     }


### PR DESCRIPTION
## Description

Finishes the transition started in #1964

https://github.com/SFML/SFML/pull/1964#discussion_r788403832

The above comment called into question whether this is appropriate to use in `sf::Ftp` but upon further inspection, construction of a `std::filesystem::path` does not seem to modify the string from which it was constructed which makes me more confident that we can replace `std::string` with `std::filesystem` without issue. I do think we should run some quick tests, ~~but I'm not actually sure how to test this out so hopefully someone can help explain how we might do that.~~

EDIT: See https://github.com/SFML/SFML/pull/2142 for some tips on how to test the FTP example.