### PR TITLE
Remove brew update until GitHub fixes the issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,8 @@ jobs:
     - name: Install macOS Tools
       if: runner.os == 'macOS'
       run: |
-        brew update
+        # Do not run updates until GitHub has fixed all the issues: https://github.com/orgs/Homebrew/discussions/4612
+        # brew update
         brew install gcovr ninja || true
 
     - name: Install OpenCppCoverage and add to PATH
@@ -238,7 +239,8 @@ jobs:
     - name: Install macOS Dependencies
       if: runner.os == 'macOS'
       run: |
-        brew update
+        # Do not run updates until GitHub has fixed all the issues: https://github.com/orgs/Homebrew/discussions/4612
+        # brew update
         brew install llvm || true
         echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
 


### PR DESCRIPTION
## Description

Our pipelines have been failing of the past days, due to some issue with GitHub's homebrew-core and homebrew-cask repositories. The maintainers are in contact with GitHub, but it's unclear how long it takes, until it's fixed.

https://github.com/orgs/Homebrew/discussions/4612

This PR just removes the `brew update` call for now, so we won't run into those issues anymore.

Alternatively, we could also just wait it out.