### PR TITLE
Ensure OpenGL extensions have been loaded

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -806,6 +806,9 @@ unsigned int Texture::getMaximumSize()
 
         TransientContextLock transientLock;
 
+        // Make sure that extensions are initialized
+        sf::priv::ensureExtensionsInit();
+
         glCheck(glGetIntegerv(GL_MAX_TEXTURE_SIZE, &size));
     }
 


### PR DESCRIPTION
## Description

The OpenGL extensions first need to be loaded, to ensure we're not calling into the void.

This PR is related to the issue #2602

## Tasks

* [ ] Tested on Linux
* [x] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Run the following example:

```cpp
#include <iostream>
#include <SFML/Graphics/Texture.hpp>
int main() {
    std::cout << sf::Texture::getMaximumSize();
}
```
