### PR TITLE
Add Intel oneAPI CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         - { name: Windows MinGW,          os: windows-2022, flags: -DSFML_USE_MESA3D=TRUE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
         - { name: Linux GCC,            os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
         - { name: Linux Clang,          os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
+        - { name: Linux Intel oneAPI,   os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -GNinja }
         - { name: MacOS,                os: macos-12, flags: -GNinja }
         - { name: MacOS Xcode,          os: macos-12, flags: -GXcode }
         - { name: iOS,                  os: macos-12, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
@@ -88,6 +89,17 @@ jobs:
         CLANG_VERSION=$(clang++ --version | sed -n 's/.*version \([0-9]\+\)\..*/\1/p')
         echo "CLANG_VERSION=$CLANG_VERSION" >> $GITHUB_ENV
         sudo apt-get install gcovr ${{ matrix.platform.name == 'Linux Clang' && 'llvm-$CLANG_VERSION' || '' }}
+
+    - name: Install Intel oneAPI
+      if: matrix.platform.name == 'Linux Intel oneAPI'
+      run: |
+        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+          | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+        sudo apt-get install intel-oneapi-compiler-dpcpp-cpp
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
 
     - name: Install macOS Tools
       if: runner.os == 'macOS'

--- a/test/Graphics/ConvexShape.test.cpp
+++ b/test/Graphics/ConvexShape.test.cpp
@@ -3,6 +3,7 @@
 // Other 1st party headers
 #include <SFML/Graphics/CircleShape.hpp>
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <SystemUtil.hpp>
@@ -103,7 +104,8 @@ TEST_CASE("[Graphics] sf::ConvexShape")
         convex.setPoint(0, {-100000.f, 0.f});
         convex.setPoint(1, {100000.f, 0.f});
         convex.setPoint(2, {100000.f, 0.000001f});
-        CHECK(convex.getGeometricCenter() == Approx(sf::Vector2f(100000.f / 3.f, 0.f)));
+        CHECK(convex.getGeometricCenter().x == Catch::Approx(100000. / 3.).margin(1e-2));
+        CHECK(convex.getGeometricCenter().y == Catch::Approx(0).margin(1e-5));
     }
 
     SECTION("Geometric center for aligned points")


### PR DESCRIPTION
## Description

https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compiler.html

This is a pretty unique CI job since so few CI pipelines use compilers that aren't from the MSVC, GCC, or Clang family of compilers. The Intel oneAPI compiler is relatively new and not the same Intel compiler from years past. Getting it installed requires a chunk of shell code but that's as far as the additional complexity goes. It does a perfectly fine job compiling the library.

The only change I had to make was a slightly tweak to some floating point related tests. This isn't entirely surprising. This compiler produced results just slightly outside of the 1*10^-5 margin we apply to all floating point comparisons so I had to increase the margin for that one test. 

If this new job gives us trouble then I don't mind removing it but in light of issues like #2583 I'm eager to add it and see how well it works for us.