### PR TITLE
Automatically cancel previous active pipelines when branch is updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: environment-${{github.ref}}
+  cancel-in-progress: true
+
 env:
   DISPLAY: ":99" # Display number to use for the X server
   GALLIUM_DRIVER: llvmpipe # Use Mesa 3D software OpenGL renderer


### PR DESCRIPTION
## Description

Closes #2597 

I hope this will meaningfully cut down on CI time. It should make PR reviews go faster since the latest push to the PR branch will get to start running in CI pretty much immediately instead of us having to wait on a backlog CI runs before that can happen.