### PR TITLE
Emit resize event any time size changes

### DIFF
--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -471,18 +471,9 @@
         // Add titlebar height.
         height += static_cast<unsigned int>([self titlebarHeight]);
 
-        // Corner case: don't set the window height bigger than the screen height
-        // or the view will be resized _later_ without generating a resize event.
-        NSRect screenFrame = [[NSScreen mainScreen] visibleFrame];
-        CGFloat maxVisibleHeight = screenFrame.size.height;
-        if (height > maxVisibleHeight)
-        {
-            height = static_cast<unsigned int>(maxVisibleHeight);
-
-            // The size is not the requested one, we fire an event
-            if (m_requester != 0)
-                m_requester->windowResized(width, height - static_cast<unsigned int>([self titlebarHeight]));
-        }
+        // Send resize event if size has changed
+        if (sf::Vector2u(width, height) != m_requester->getSize())
+            m_requester->windowResized(width, height - static_cast<unsigned int>([self titlebarHeight]));
 
         NSRect frame = NSMakeRect([m_window frame].origin.x,
                                   [m_window frame].origin.y,


### PR DESCRIPTION
Fixes bug where resize events only got triggered upon manual window resizing OR if one called setSize with a height that was too large.

Extension of https://github.com/SFML/SFML/pull/2538 

Thrasher wanted me to put up a PR for 2.6.x fixes for this. I agree that such a simple bug fix should also be included in 2.6.x