### PR TITLE
Update Catch2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,9 +4,10 @@ add_subdirectory(install)
 set_target_warnings(test-sfml-install)
 
 set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
+set(CATCH_CONFIG_NO_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT ON CACHE BOOL "")
 FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.3.2)
+    GIT_TAG v3.4.0)
 FetchContent_MakeAvailable(Catch2)
 include(Catch)
 


### PR DESCRIPTION
## Description

https://github.com/catchorg/Catch2/releases/tag/v3.4.0

I had to disable some experimental static analysis support. Keeping it enabled causes a false positive clang-tidy about an unused function.