### PR TITLE
Clean up clang-tidy output

### DIFF
--- a/cmake/Tidy.cmake
+++ b/cmake/Tidy.cmake
@@ -28,7 +28,7 @@ if(NOT RUN_CLANG_TIDY)
 endif()
 
 # Run
-execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
+execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -quiet -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
 if(NOT EXIT_CODE STREQUAL 0)
     message(FATAL_ERROR "Analysis failed")
 endif()


### PR DESCRIPTION
## Description

From the official documentation:

> This suppresses printing statistics about ignored warnings and warnings treated as errors if the respective options are specified.

Example output, before:
```
Enabled checks:
    bugprone-argument-comment
    bugprone-assert-side-effect
    bugprone-bad-signal-to-kill-thread
[...]
/usr/bin/clang-tidy -p=/path/to/SFML/build /path/to/SFML/src/SFML/System/Clock.cpp
2883 warnings generated.
Suppressed 2884 warnings (2883 in non-user code, 1 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
/usr/bin/clang-tidy -p=/path/to/SFML/build /path/to/SFML/src/SFML/Audio/AlResource.cpp
13213 warnings generated.
Suppressed 13213 warnings (13213 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```

After:
```
/usr/bin/clang-tidy -p=/path/to/SFML/build -quiet /path/to/SFML/src/SFML/System/Clock.cpp
2883 warnings generated.
/usr/bin/clang-tidy -p=/path/to/SFML/build -quiet /path/to/SFML/src/SFML/Audio/SoundFileReaderFlac.cpp
13808 warnings generated.
```

Non-ignored warnings & errors still correctly show, as before, example:
```
/usr/bin/clang-tidy -p=/path/to/SFML/build -quiet /path/to/SFML/src/SFML/System/Clock.cpp
/path/to/SFML/src/SFML/System/Clock.cpp:41:9: error: invalid case style for variable 'test_test' [readability-identifier-naming,-warnings-as-errors]
    int test_test;
        ^~~~~~~~~
        testTest
2885 warnings generated.
```

In the future, clang-tidy may also omit the unnecessary "warnings generated" message (https://github.com/llvm/llvm-project/issues/47042)