### PR TITLE
Remove unnecessary export() call

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -429,9 +429,6 @@ function(sfml_export_targets)
     endif()
     set(targets_config_filename "SFML${config_name}Targets.cmake")
 
-    export(EXPORT SFMLConfigExport
-           FILE "${CMAKE_CURRENT_BINARY_DIR}/${targets_config_filename}")
-
     if(SFML_BUILD_FRAMEWORKS)
         set(config_package_location "SFML.framework/Resources/CMake")
     else()
@@ -441,7 +438,6 @@ function(sfml_export_targets)
         INSTALL_DESTINATION "${config_package_location}")
     configure_package_config_file("${CURRENT_DIR}/SFMLConfigDependencies.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/SFMLConfigDependencies.cmake"
         INSTALL_DESTINATION "${config_package_location}")
-
 
     install(EXPORT SFMLConfigExport
             FILE ${targets_config_filename}


### PR DESCRIPTION
## Description

This call appears to be redundant with the below lines which already generate this file.

https://github.com/SFML/SFML/blob/00b6488c3e9350bda573e9a82a06a1d855fa494b/cmake/Macros.cmake#L446-L448

The install interface tests should confirm that this is a valid change.