### PR TITLE
Clamp window height on macOS

### DIFF
--- a/src/SFML/Window/macOS/SFWindowController.mm
+++ b/src/SFML/Window/macOS/SFWindowController.mm
@@ -457,8 +457,14 @@
         // Add titlebar height.
         height += static_cast<unsigned int>([self titlebarHeight]);
 
-        // Send resize event if size has changed
-        if (sf::Vector2u(width, height) != m_requester->getSize())
+        // Corner case: don't set the window height bigger than the screen height
+        // or the view will be resized _later_ without generating a resize event.
+        NSRect  screenFrame      = [[NSScreen mainScreen] visibleFrame];
+        CGFloat maxVisibleHeight = screenFrame.size.height;
+        if (height > maxVisibleHeight)
+            height = static_cast<unsigned int>(maxVisibleHeight);
+
+        if (m_requester != nil)
             m_requester->windowResized({width, height - static_cast<unsigned int>([self titlebarHeight])});
 
         NSRect frame = NSMakeRect([m_window frame].origin.x, [m_window frame].origin.y, width, height);


### PR DESCRIPTION
## Description

When calling `setSize` with height bigger than available height on macOS, the windowing system clamps the window height to available height on screen.
By doing the clamping ourselves, we can emit an event with the correct size.

This PR is related to the PRs #2538, #2611, #2618

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    auto window                 = sf::RenderWindow{sf::VideoMode{{800, 600}}, "800,600"};
    auto worldSize              = sf::Vector2f{window.getSize()};
    auto gradient               = sf::VertexArray{sf::PrimitiveType::TriangleFan, 4};
    auto updateGradientVertices = [&gradient, &worldSize]()
    {
        constexpr auto padding = 64.f;
        gradient[0]            = {{padding, padding}, sf::Color::Red};
        gradient[1]            = {{worldSize.x - padding, padding}, sf::Color::Yellow};
        gradient[2]            = {{worldSize.x - padding, worldSize.y - padding}, sf::Color::Green};
        gradient[3]            = {{padding, worldSize.y - padding}, sf::Color::Blue};
    };
    updateGradientVertices();

    while (window.isOpen())
    {
        for (auto event = sf::Event{}; window.pollEvent(event);)
        {
            switch (event.type)
            {
                case sf::Event::Closed:
                    window.close();
                    break;
                case sf::Event::Resized:
                {
                    const auto windowSize = sf::Vector2u{event.size.width, event.size.height};
                    worldSize             = sf::Vector2f{windowSize};
                    window.setTitle(std::to_string(windowSize.x) + ',' + std::to_string(windowSize.y));
                    window.setView(sf::View{{{0, 0}, worldSize}});
                    updateGradientVertices();
                    break;
                }
                case sf::Event::KeyPressed:
                    switch (event.key.scancode)
                    {
                        case sf::Keyboard::Scan::Q:
                            window.setSize({800, 600});
                            break;
                        case sf::Keyboard::Scan::W:
                            window.setSize({1200, 600});
                            break;
                        case sf::Keyboard::Scan::E:
                            window.setSize({1600, 600});
                            break;
                        case sf::Keyboard::Scan::A:
                            window.setSize({800, 900});
                            break;
                        case sf::Keyboard::Scan::S:
                            window.setSize({1200, 900});
                            break;
                        case sf::Keyboard::Scan::D:
                            window.setSize({1600, 900});
                            break;
                        case sf::Keyboard::Scan::Z:
                            window.setSize({800, 1200});
                            break;
                        case sf::Keyboard::Scan::X:
                            window.setSize({1200, 1200});
                            break;
                        case sf::Keyboard::Scan::C:
                            window.setSize({1600, 1200});
                            break;
                        default:
                            break;
                    }
                    break;
                default:
                    break;
            }
        }

        window.clear(sf::Color{64, 64, 64});
        window.draw(gradient);
        window.display();
    }
}
```
