### PR TITLE
Test `SFML_USE_STATIC_STD_LIBS`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
         - platform: { name: Windows VS2022, os: windows-2022 }
           config: { name: OpenGL ES, flags: -DSFML_USE_MESA3D=TRUE -DBUILD_SHARED_LIBS=TRUE -DSFML_OPENGL_ES=ON }
           type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
+        - platform: { name: Windows MinGW, os: windows-2022 }
+          config: { name: Static Standard Libraries, flags: -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=FALSE -DSFML_USE_STATIC_STD_LIBS=TRUE }
         - platform: { name: macOS, os: macos-12 }
           config: { name: Frameworks, flags: -GNinja -DSFML_BUILD_FRAMEWORKS=TRUE -DBUILD_SHARED_LIBS=TRUE }
         - platform: { name: Android, os: ubuntu-22.04 }


### PR DESCRIPTION
## Description

Yet another PR in my journey to testing all these configuration options we have. View the logs to see these flags being applied.

Something weird about this is that in the CI logs you only see this flag appear on the compilation of executables but not on all of SFML's .cpp files. Is that how this is supposed to work? I can't really tell. The other weird thing is that these `-static` flags appear _twice_ in the examples. I believe the problem is that we call `sfml_set_stdlib` when compiling the core library _and_ when compiling the examples. This function is not called when building the tests and the tests don't see this `-static` flag appear twice so that lines up.