### PR TITLE
Return reference instead of non-null pointer

### DIFF
--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -139,16 +139,15 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the source texture of the sprite
     ///
-    /// If the sprite has no source texture, a null pointer is returned.
-    /// The returned pointer is const, which means that you can't
+    /// The returned reference is const, which means that you can't
     /// modify the texture when you retrieve it with this function.
     ///
-    /// \return Pointer to the sprite's texture
+    /// \return Reference to the sprite's texture
     ///
     /// \see setTexture
     ///
     ////////////////////////////////////////////////////////////
-    const Texture* getTexture() const;
+    const Texture& getTexture() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the sub-rectangle of the texture displayed by the sprite

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -283,16 +283,15 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the text's font
     ///
-    /// If the text has no font attached, a null pointer is returned.
-    /// The returned pointer is const, which means that you
+    /// The returned reference is const, which means that you
     /// cannot modify the font when you get it from this function.
     ///
-    /// \return Pointer to the text's font
+    /// \return Reference to the text's font
     ///
     /// \see setFont
     ///
     ////////////////////////////////////////////////////////////
-    const Font* getFont() const;
+    const Font& getFont() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the character size

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -55,8 +55,8 @@ Sprite::Sprite(const Texture& texture, const IntRect& rectangle)
 ////////////////////////////////////////////////////////////
 void Sprite::setTexture(const Texture& texture, bool resetRect)
 {
-    // Recompute the texture area if requested, or if there was no valid texture & rect before
-    if (resetRect || (!m_texture && (m_textureRect == sf::IntRect())))
+    // Recompute the texture area if requested
+    if (resetRect)
     {
         setTextureRect(IntRect({0, 0}, Vector2i(texture.getSize())));
     }
@@ -90,9 +90,9 @@ void Sprite::setColor(const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-const Texture* Sprite::getTexture() const
+const Texture& Sprite::getTexture() const
 {
-    return m_texture;
+    return *m_texture;
 }
 
 
@@ -130,8 +130,6 @@ FloatRect Sprite::getGlobalBounds() const
 ////////////////////////////////////////////////////////////
 void Sprite::draw(RenderTarget& target, const RenderStates& states) const
 {
-    assert(m_texture && "Cannot use null texture. Call Sprite::setTexture() to initialize it.");
-
     RenderStates statesCopy(states);
 
     statesCopy.transform *= getTransform();

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -241,9 +241,9 @@ const String& Text::getString() const
 
 
 ////////////////////////////////////////////////////////////
-const Font* Text::getFont() const
+const Font& Text::getFont() const
 {
-    return m_font;
+    return *m_font;
 }
 
 

--- a/test/Graphics/Text.test.cpp
+++ b/test/Graphics/Text.test.cpp
@@ -2,7 +2,7 @@
 
 #include <type_traits>
 
-static_assert(!std::is_constructible_v<sf::Text, sf::String, sf::Font&&, unsigned int>);
+static_assert(!std::is_constructible_v<sf::Text, sf::Font&&, sf::String, unsigned int>);
 static_assert(std::is_copy_constructible_v<sf::Text>);
 static_assert(std::is_copy_assignable_v<sf::Text>);
 static_assert(std::is_nothrow_move_constructible_v<sf::Text>);


### PR DESCRIPTION
Since #2486 and #2494, `Sprite` and `Text` instances cannot hold a null pointer to the corresponding resource.
I suggest that `getTexture` and `getFont` return a reference instead of a pointer to make it clear that it is not null.
What do you think?

Note this is slightly changing `Sprite` constructor behavior. If I understand correctly, `Sprite(texture, IntRect())` is equivalent to `Sprite(texture)` in master, whereas `Sprite(texture, IntRect())` would actually create a Sprite with an empty texture rectangle with this PR. It looks to me this would be the correct behavior one would expect.

I also reviewed corresponding tests and fixed a small inconsistency in `Text` tests while at it.

The same kind of change would apply to `Sound` and `getSoundBuffer` once the default constructor gets removed as planned in #2507.