### PR TITLE
Remove sound default constructor

### DIFF
--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -47,12 +47,6 @@ class SFML_AUDIO_API Sound : public SoundSource
 {
 public:
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    Sound();
-
-    ////////////////////////////////////////////////////////////
     /// \brief Construct the sound with a buffer
     ///
     /// \param buffer Sound buffer containing the audio data to play with the sound
@@ -213,18 +207,27 @@ public:
     ////////////////////////////////////////////////////////////
     Sound& operator=(const Sound& right);
 
-    ////////////////////////////////////////////////////////////
-    /// \brief Reset the internal buffer of the sound
-    ///
-    /// This function is for internal use only, you don't have
-    /// to use it. It is called by the sf::SoundBuffer that
-    /// this sound uses, when it is destroyed in order to prevent
-    /// the sound from using a dead buffer.
-    ///
-    ////////////////////////////////////////////////////////////
-    void resetBuffer();
-
 private:
+    friend class SoundBuffer;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Detach sound from its internal buffer
+    ///
+    /// This allows the sound buffer to temporarily detach the
+    /// sounds that use it when the sound buffer gets updated.
+    ///
+    ////////////////////////////////////////////////////////////
+    void detachBuffer();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Re-attach sound to its internal buffer
+    ///
+    /// This allows the sound buffer to attach back the sounds
+    /// that use it after the sound buffer has been updated.
+    ///
+    ////////////////////////////////////////////////////////////
+    void reattachBuffer();
+
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
@@ -252,7 +255,7 @@ private:
 ///
 /// In order to work, a sound must be given a buffer of audio
 /// data to play. Audio data (samples) is stored in sf::SoundBuffer,
-/// and attached to a sound with the setBuffer() function.
+/// and attached to a sound when it is created or with the setBuffer() function.
 /// The buffer object attached to a sound must remain alive
 /// as long as the sound uses it. Note that multiple sounds
 /// can use the same sound buffer at the same time.
@@ -265,8 +268,7 @@ private:
 ///     // Handle error...
 /// }
 ///
-/// sf::Sound sound;
-/// sound.setBuffer(buffer);
+/// sf::Sound sound(buffer);
 /// sound.play();
 /// \endcode
 ///

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -164,10 +164,10 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the audio buffer attached to the sound
     ///
-    /// \return Sound buffer attached to the sound (can be a null pointer)
+    /// \return Sound buffer attached to the sound
     ///
     ////////////////////////////////////////////////////////////
-    const SoundBuffer* getBuffer() const;
+    const SoundBuffer& getBuffer() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether or not the sound is in loop mode

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -331,16 +331,14 @@ private:
 ///     // error...
 /// }
 ///
-/// // Create a sound source and bind it to the buffer
-/// sf::Sound sound1;
-/// sound1.setBuffer(buffer);
+/// // Create a sound source bound to the buffer
+/// sf::Sound sound1(buffer);
 ///
 /// // Play the sound
 /// sound1.play();
 ///
 /// // Create another sound source bound to the same buffer
-/// sf::Sound sound2;
-/// sound2.setBuffer(buffer);
+/// sf::Sound sound2(buffer);
 ///
 /// // Play it with a higher pitch -- the first sound remains unchanged
 /// sound2.setPitch(2);

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -110,9 +110,9 @@ void Sound::setPlayingOffset(Time timeOffset)
 
 
 ////////////////////////////////////////////////////////////
-const SoundBuffer* Sound::getBuffer() const
+const SoundBuffer& Sound::getBuffer() const
 {
-    return m_buffer;
+    return *m_buffer;
 }
 
 

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -35,10 +35,9 @@
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Time.hpp>
 
+#include <exception>
 #include <memory>
 #include <ostream>
-
-#include <cassert>
 
 #if defined(__APPLE__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -70,7 +69,12 @@ SoundBuffer::SoundBuffer(const SoundBuffer& copy) : m_samples(copy.m_samples), m
 ////////////////////////////////////////////////////////////
 SoundBuffer::~SoundBuffer()
 {
-    assert(m_sounds.empty() && "sf::SoundBuffer must not be destructed while it is used by a sf::Sound");
+    // Make sure no sound is attached to this buffer
+    if (!m_sounds.empty())
+    {
+        err() << "Failed to destruct sound buffer because it is used by " << m_sounds.size() << " sound(s)" << std::endl;
+        std::terminate();
+    }
 
     // Destroy the buffer
     if (m_buffer)

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -11,7 +11,6 @@ int main()
     [[maybe_unused]] const sf::InputSoundFile      inputSoundFile;
     [[maybe_unused]] const sf::SoundBufferRecorder soundBufferRecorder;
     [[maybe_unused]] const sf::Music               music;
-    [[maybe_unused]] const sf::Sound               sound;
 
     // Graphics
     [[maybe_unused]] const sf::Color          color;


### PR DESCRIPTION
## Description

This PR is related to the issue #2507.

By removing `Sound` default constructor, we make sure it is always bound to some `SoundBuffer`.

Doing some operations on an OpenAL sound buffer while OpenAL Sources are attached to it triggers error messages, so we have to keep track of `Sound` instances which are bound to a given `SoundBuffer` so that we can detach and attach sounds when needed.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

- Running SFML audio examples `voip`, `sound`, `sound_capture` and `tennis`.
- Playing around with the following program:

```c++
#include <SFML/Graphics.hpp>
#include <SFML/Audio.hpp>

int main()
{
    auto window = sf::RenderWindow{sf::VideoMode{{200, 200}}, "Test"};
    window.setFramerateLimit(60);

    auto buffer1 = sf::SoundBuffer{};
    if (!buffer1.loadFromFile("resources/jingles_SAX02.ogg"))
        return EXIT_FAILURE;

    auto buffer2 = sf::SoundBuffer{};
    if (!buffer2.loadFromFile("resources/jingles_SAX07.ogg"))
        return EXIT_FAILURE;

    auto buffer = buffer1;

    auto sound1 = sf::Sound{buffer};
    auto sound2 = sound1;
    sound2.setPitch(0.5f);

    while (window.isOpen())
    {
        for (auto event = sf::Event{}; window.pollEvent(event);)
        {
            switch (event.type)
            {
                case sf::Event::Closed:
                    window.close();
                    break;
                case sf::Event::KeyPressed:
                    switch (event.key.scancode)
                    {
                        case sf::Keyboard::Scan::Num1:
                            sound1.play();
                            break;
                        case sf::Keyboard::Scan::Num2:
                            sound2.play();
                            break;
                        case sf::Keyboard::Scan::Q:
                            buffer = buffer1;
                            break;
                        case sf::Keyboard::Scan::W:
                            buffer = buffer2;
                            break;
                        case sf::Keyboard::Scan::E:
                        {
                            auto buffer3 = sf::SoundBuffer{};
                            if (!buffer3.loadFromFile("resources/jingles_SAX03.ogg"))
                                return EXIT_FAILURE;
                            buffer = buffer3;
                            break;
                        }
                        case sf::Keyboard::Scan::A:
                            sound1.setBuffer(buffer1);
                            sound2 = sound1;
                            sound2.setPitch(0.5f);
                            break;
                        case sf::Keyboard::Scan::S:
                            sound1.setBuffer(buffer);
                            sound2 = sound1;
                            sound2.setPitch(0.5f);
                            break;
                        default:
                            break;
                    }
                    break;
                default:
                    break;
            }
        }

        window.clear();
        window.display();
    }
}
```

[resources.zip](https://github.com/SFML/SFML/files/12270235/resources.zip)
Sounds are from [kenney.nl](https://kenney.nl/assets/music-jingles)