### PR TITLE
Use CMake Presets to Disambiguate Developer Builds from User Builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
 
     - name: Configure CMake
       shell: bash
-      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install -DSFML_BUILD_EXAMPLES=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_BUILD_TEST_SUITE=TRUE ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
+      run: cmake --preset dev -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
 
     - name: Build
       shell: bash
@@ -204,8 +204,8 @@ jobs:
       if: matrix.platform.name != 'Android'
       shell: bash
       run: |
-        cmake -S $GITHUB_WORKSPACE/test/install -B $GITHUB_WORKSPACE/test/install/build -DSFML_ROOT=$GITHUB_WORKSPACE/install -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
-        cmake --build $GITHUB_WORKSPACE/test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.suffix}}
+        cmake -S $GITHUB_WORKSPACE/test/install -B $GITHUB_WORKSPACE/test/install/build -DSFML_ROOT=$GITHUB_WORKSPACE/build/install -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
+        cmake --build $GITHUB_WORKSPACE/test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
   format:
     name: Formatting
@@ -270,7 +270,7 @@ jobs:
 
     - name: Configure
       shell: bash
-      run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_UNITY_BUILD=ON -DSFML_BUILD_EXAMPLES=TRUE -DSFML_BUILD_TEST_SUITE=TRUE ${{matrix.platform.flags}}
+      run: cmake --preset dev -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_UNITY_BUILD=ON ${{matrix.platform.flags}}
 
     - name: Analyze Code
       shell: bash

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,16 @@
+{
+  "version": 3,
+  "configurePresets":[
+    {
+      "name": "dev",
+      "binaryDir": "build",
+      "installDir": "${sourceDir}/build/install",
+      "cacheVariables": {
+        "CMAKE_CXX_EXTENSIONS": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "SFML_BUILD_EXAMPLES": "ON",
+        "SFML_BUILD_TEST_SUITE": "ON"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

https://cmake.org/cmake/help/v3.22/manual/cmake-presets.7.html

After our [recent upgrade to CMake 3.22](https://github.com/SFML/SFML/pull/2543) we have access to CMake presets, a feature added in CMake 3.19 that is meant to simply the process of adding arguments during configuration. Something important to note about presets is that they're intended to be a developer feature. Users are not expected to use a given project's presets. In CI we can see what this looks like. The diff shows how we can take our most common configuration arguments and encode them in a new CMakePresets.json file.

So why bother with this? Aren't we just shuffling code around for no benefit?

The major benefit here is that presets give us a way of **separating how users build code from how developers build code**. The two parties have very different needs. Users want just the core library. They may specify their own build type or library type but that's about it. Developers meanwhile want the core library and examples and tests and compiler warnings and docs and potentially even more.

As it stands now we're in an awkward place where we want to enable some things by default for the sake of developer convenience but that may get in the way of the user experience. We want devs to have tests and examples enabled for example but that's just unnecessary bloat for users until they figure out how to disable it.

A recent real world problem is the fact that we enable warnings as error by default. [This recently caught out the folks packaging SFML into Vcpkg](https://github.com/microsoft/vcpkg/issues/32574). Conan developers had a [similar issue](https://github.com/SFML/SFML/issues/2594) related to how we enable many compiler warnings by default, something we do for the sake of developer convenience. It would be nice if we could disable warnings-as-errors by default to make users happy while keeping it enabled by default for developers and presets are how we can do that.

This PR takes a neutral stance by maintaining the status quo when it comes to configuration arguments, but if we merge this we'll have the infrastructure to easily change out mind about how developers build SFML versus our how our users do.