### PR TITLE
Add CMakeUserPresets to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ cmake-build-*/
 .vscode/
 .idea/
 .vs/
+
+# User configuration
+CMakeUserPresets.json


### PR DESCRIPTION
Now that we use a CMakePresets.json file for CI, it makes sense to support users having their own presets in a CMakeUserPresets.json file.

From CMake documentation:

> CMakePresets.json may be checked into a version control system, and
> CMakeUserPresets.json should NOT be checked in. For example, if a
> project is using Git, CMakePresets.json may be tracked, and
> CMakeUserPresets.json should be added to the .gitignore.
