### PR TITLE
Remove irrelevant entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,45 +1,7 @@
-# Prerequisites
-*.d
-
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
-
-# Build folders
-build/
-cmake-build-*/
-
-# Cache/IDE folders
 .cache/
-.vscode/
 .idea/
 .vs/
-
-# User configuration
+.vscode/
+build/
+cmake-build-*/
 CMakeUserPresets.json


### PR DESCRIPTION
## Description

https://github.com/github/gitignore/blob/main/C%2B%2B.gitignore

Our .gitignore file originated from this .gitignore template. This template is made to be general-purpose and thus includes many things we don't care about. We know that the SFML build won't produce files with any of these patterns outside of the binary dir. This is the reality of any CMake-based project. CMake does a good job compartmentalizing the build products so that our .gitignore can be very short.

I alphabetized the list while I was at it.

See https://github.com/SFML/SFML/pull/1866 for the original discussion on the .gitignore file. There was little conversation when originally added so I doubt anyone feels strongly about keeping all the things I removed.