### PR TITLE
Use native CMake support for detecting architecture size

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -5,12 +5,10 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     # don't use the OpenGL ES implementation on Windows
     set(OPENGL_ES 0)
 
-    # detect the architecture (note: this test won't work for cross-compilation)
-    include(CheckTypeSize)
-    check_type_size(void* SIZEOF_VOID_PTR)
-    if(${SIZEOF_VOID_PTR} STREQUAL "4")
+    # detect the architecture
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         set(ARCH_32BITS 1)
-    elseif(${SIZEOF_VOID_PTR} STREQUAL "8")
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
         set(ARCH_64BITS 1)
     else()
         message(FATAL_ERROR "Unsupported architecture")


### PR DESCRIPTION
## Description

https://cmake.org/cmake/help/v3.22/variable/CMAKE_SIZEOF_VOID_P.html

This has existed since CMake 3.0.