### PR TITLE
fix: use non-deprecated form of UDL declaration

### DIFF
--- a/include/SFML/System/Angle.hpp
+++ b/include/SFML/System/Angle.hpp
@@ -435,7 +435,7 @@ namespace Literals
 /// \return \a Angle
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Angle operator"" _deg(long double angle);
+[[nodiscard]] constexpr Angle operator""_deg(long double angle);
 
 ////////////////////////////////////////////////////////////
 /// \relates sf::Angle
@@ -446,7 +446,7 @@ namespace Literals
 /// \return \a Angle
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Angle operator"" _deg(unsigned long long int angle);
+[[nodiscard]] constexpr Angle operator""_deg(unsigned long long int angle);
 
 ////////////////////////////////////////////////////////////
 /// \relates sf::Angle
@@ -457,7 +457,7 @@ namespace Literals
 /// \return \a Angle
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Angle operator"" _rad(long double angle);
+[[nodiscard]] constexpr Angle operator""_rad(long double angle);
 
 ////////////////////////////////////////////////////////////
 /// \relates sf::Angle
@@ -468,7 +468,7 @@ namespace Literals
 /// \return \a Angle
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Angle operator"" _rad(unsigned long long int angle);
+[[nodiscard]] constexpr Angle operator""_rad(unsigned long long int angle);
 
 } // namespace Literals
 

--- a/include/SFML/System/Angle.inl
+++ b/include/SFML/System/Angle.inl
@@ -226,28 +226,28 @@ namespace Literals
 {
 
 ////////////////////////////////////////////////////////////
-constexpr Angle operator"" _deg(long double angle)
+constexpr Angle operator""_deg(long double angle)
 {
     return degrees(static_cast<float>(angle));
 }
 
 
 ////////////////////////////////////////////////////////////
-constexpr Angle operator"" _deg(unsigned long long angle)
+constexpr Angle operator""_deg(unsigned long long angle)
 {
     return degrees(static_cast<float>(angle));
 }
 
 
 ////////////////////////////////////////////////////////////
-constexpr Angle operator"" _rad(long double angle)
+constexpr Angle operator""_rad(long double angle)
 {
     return radians(static_cast<float>(angle));
 }
 
 
 ////////////////////////////////////////////////////////////
-constexpr Angle operator"" _rad(unsigned long long angle)
+constexpr Angle operator""_rad(unsigned long long angle)
 {
     return radians(static_cast<float>(angle));
 }


### PR DESCRIPTION
* [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
* [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
* [ ] Have you provided some example/test code for your changes?
* [ ] If you have additional steps which need to be performed list them as tasks!

----

## Description

Clang 18 issues a deprecation warning,
and is converted to an error with `-Werror`.

This PR is tangentially related to <https://github.com/SFML/SFML/issues/2670#issuecomment-1696061719>.

## Tasks

* [x] Tested on Linux
* [ ] Tested on Windows
* [ ] Tested on macOS
* [ ] Tested on iOS
* [ ] Tested on Android

## How to test this PR?

Taking <https://en.cppreference.com/w/cpp/language/user_literal#Literal_operators> at face value,
the form with a space has always been deprecated,
and the one without has always been supported.
So there should be no issues on conforming C++ implementations.
But I _think_ it may be missing some `(since C++XY)`.