### PR TITLE
Add tests for `sf::RenderTarget` and `sf::RenderTexture`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           config: { name: OpenGL ES, flags: -DSFML_USE_MESA3D=TRUE -DBUILD_SHARED_LIBS=TRUE -DSFML_OPENGL_ES=ON }
           type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
         - platform: { name: Windows MinGW, os: windows-2022 }
-          config: { name: Static Standard Libraries, flags: -GNinja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DSFML_USE_STATIC_STD_LIBS=TRUE }
+          config: { name: Static Standard Libraries, flags: -GNinja -DSFML_USE_MESA3D=TRUE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DSFML_USE_STATIC_STD_LIBS=TRUE }
         - platform: { name: macOS, os: macos-12 }
           config: { name: Frameworks, flags: -GNinja -DSFML_BUILD_FRAMEWORKS=TRUE -DBUILD_SHARED_LIBS=TRUE }
         - platform: { name: Android, os: ubuntu-22.04 }

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -170,6 +170,7 @@ Vector2u RenderTexture::getSize() const
 ////////////////////////////////////////////////////////////
 bool RenderTexture::isSrgb() const
 {
+    assert(m_impl && "Must call RenderTexture::create first");
     return m_impl->isSrgb();
 }
 

--- a/test/Graphics/RenderTarget.test.cpp
+++ b/test/Graphics/RenderTarget.test.cpp
@@ -1,9 +1,133 @@
 #include <SFML/Graphics/RenderTarget.hpp>
 
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <SystemUtil.hpp>
 #include <type_traits>
 
-static_assert(!std::is_constructible_v<sf::RenderTarget>);
-static_assert(!std::is_copy_constructible_v<sf::RenderTarget>);
-static_assert(!std::is_copy_assignable_v<sf::RenderTarget>);
-static_assert(!std::is_nothrow_move_constructible_v<sf::RenderTarget>);
-static_assert(!std::is_nothrow_move_assignable_v<sf::RenderTarget>);
+class RenderTarget : public sf::RenderTarget
+{
+    sf::Vector2u getSize() const override
+    {
+        return {640, 480};
+    }
+};
+
+TEST_CASE("[Graphics] sf::RenderTarget")
+{
+    SECTION("Type traits")
+    {
+        STATIC_CHECK(!std::is_constructible_v<sf::RenderTarget>);
+        STATIC_CHECK(!std::is_copy_constructible_v<sf::RenderTarget>);
+        STATIC_CHECK(!std::is_copy_assignable_v<sf::RenderTarget>);
+        STATIC_CHECK(!std::is_nothrow_move_constructible_v<sf::RenderTarget>);
+        STATIC_CHECK(!std::is_nothrow_move_assignable_v<sf::RenderTarget>);
+    }
+
+    SECTION("Construction")
+    {
+        const RenderTarget renderTarget;
+        CHECK(renderTarget.getView().getCenter() == sf::Vector2f(500, 500));
+        CHECK(renderTarget.getView().getSize() == sf::Vector2f(1000, 1000));
+        CHECK(renderTarget.getView().getRotation() == sf::Angle::Zero);
+        CHECK(renderTarget.getView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
+        CHECK(renderTarget.getView().getTransform() == sf::Transform(.002f, 0, -1, 0, -.002f, 1, 0, 0, 1));
+        CHECK(renderTarget.getDefaultView().getCenter() == sf::Vector2f(500, 500));
+        CHECK(renderTarget.getDefaultView().getSize() == sf::Vector2f(1000, 1000));
+        CHECK(renderTarget.getDefaultView().getRotation() == sf::Angle::Zero);
+        CHECK(renderTarget.getDefaultView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
+        CHECK(renderTarget.getDefaultView().getTransform() == sf::Transform(.002f, 0, -1, 0, -.002f, 1, 0, 0, 1));
+        CHECK(!renderTarget.isSrgb());
+    }
+
+    SECTION("Set/get view")
+    {
+        RenderTarget renderTarget;
+        renderTarget.setView({{1, 2}, {3, 4}});
+        CHECK(renderTarget.getView().getCenter() == sf::Vector2f(1, 2));
+        CHECK(renderTarget.getView().getSize() == sf::Vector2f(3, 4));
+    }
+
+    SECTION("setActive()")
+    {
+        RenderTarget renderTarget;
+        CHECK(renderTarget.setActive());
+        CHECK(renderTarget.setActive(false));
+        CHECK(renderTarget.setActive(true));
+    }
+
+    SECTION("getViewport(const View&)")
+    {
+        const auto makeView = [](const auto& viewport)
+        {
+            sf::View view;
+            view.setViewport(viewport);
+            return view;
+        };
+
+        const RenderTarget renderTarget;
+        CHECK(renderTarget.getViewport(makeView(sf::FloatRect({0, 0}, {1, 1}))) == sf::IntRect({0, 0}, {640, 480}));
+        CHECK(renderTarget.getViewport(makeView(sf::FloatRect({1, 1}, {.5f, .25f}))) ==
+              sf::IntRect({640, 480}, {320, 120}));
+        CHECK(renderTarget.getViewport(makeView(sf::FloatRect({.5f, .5f}, {.25f, .75f}))) ==
+              sf::IntRect({320, 240}, {160, 360}));
+    }
+
+    SECTION("mapPixelToCoords(const Vector2i&)")
+    {
+        sf::View view;
+        view.move({5, 5});
+        view.setViewport(sf::FloatRect({0, 0}, {.5f, 1}));
+        RenderTarget renderTarget;
+        renderTarget.setView(view);
+        const auto [x1, y1] = renderTarget.mapPixelToCoords({0, 0});
+        CHECK_THAT(x1, Catch::Matchers::WithinRel(5, 1e-4));
+        CHECK_THAT(y1, Catch::Matchers::WithinRel(5, 1e-4));
+        const auto [x2, y2] = renderTarget.mapPixelToCoords({1, 1});
+        CHECK_THAT(x2, Catch::Matchers::WithinRel(8.125, 1e-4));
+        CHECK_THAT(y2, Catch::Matchers::WithinRel(7.0833, 1e-4));
+        const auto [x3, y3] = renderTarget.mapPixelToCoords({320, 240});
+        CHECK_THAT(x3, Catch::Matchers::WithinRel(1005, 1e-5));
+        CHECK_THAT(y3, Catch::Matchers::WithinRel(505, 1e-5));
+    }
+
+    SECTION("mapPixelToCoords(const Vector2i&, const View&)")
+    {
+        sf::View view;
+        view.move({5, 5});
+        view.setViewport(sf::FloatRect({.5f, .5f}, {.5f, 1}));
+        const RenderTarget renderTarget;
+        const auto [x1, y1] = renderTarget.mapPixelToCoords({0, 0}, view);
+        CHECK_THAT(x1, Catch::Matchers::WithinRel(-995, 1e-5));
+        CHECK_THAT(y1, Catch::Matchers::WithinRel(-495, 1e-5));
+        const auto [x2, y2] = renderTarget.mapPixelToCoords({320, 480}, view);
+        CHECK_THAT(x2, Catch::Matchers::WithinAbs(5, 1e-4));
+        CHECK_THAT(y2, Catch::Matchers::WithinRel(505, 1e-5));
+    }
+
+    SECTION("mapCoordsToPixel(const Vector2f&)")
+    {
+        sf::View view;
+        view.move({5, 5});
+        view.setViewport(sf::FloatRect({.25f, 0}, {1, 1}));
+        RenderTarget renderTarget;
+        renderTarget.setView(view);
+        CHECK(renderTarget.mapCoordsToPixel({0, 0}) == sf::Vector2i(156, -2));
+        CHECK(renderTarget.mapCoordsToPixel({-500, 0}) == sf::Vector2i(-163, -2));
+        CHECK(renderTarget.mapCoordsToPixel({0, -250}) == sf::Vector2i(156, -122));
+    }
+
+    SECTION("mapCoordsToPixel(const Vector2f&, const View&)")
+    {
+        sf::View view;
+        view.move({5, 5});
+        view.setViewport(sf::FloatRect({0, 0}, {.5, .25f}));
+        RenderTarget renderTarget;
+        renderTarget.setView(view);
+        CHECK(renderTarget.mapCoordsToPixel({0, 0}) == sf::Vector2i(-1, 0));
+        CHECK(renderTarget.mapCoordsToPixel({320, 0}) == sf::Vector2i(100, 0));
+        CHECK(renderTarget.mapCoordsToPixel({0, 480}) == sf::Vector2i(-1, 57));
+        CHECK(renderTarget.mapCoordsToPixel({640, 480}) == sf::Vector2i(203, 57));
+    }
+}

--- a/test/Graphics/RenderTexture.test.cpp
+++ b/test/Graphics/RenderTexture.test.cpp
@@ -1,8 +1,79 @@
 #include <SFML/Graphics/RenderTexture.hpp>
 
+#include <catch2/catch_test_macros.hpp>
+
+#include <WindowUtil.hpp>
 #include <type_traits>
 
-static_assert(!std::is_copy_constructible_v<sf::RenderTexture>);
-static_assert(!std::is_copy_assignable_v<sf::RenderTexture>);
-static_assert(!std::is_nothrow_move_constructible_v<sf::RenderTexture>);
-static_assert(!std::is_nothrow_move_assignable_v<sf::RenderTexture>);
+TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
+{
+    SECTION("Type traits")
+    {
+        STATIC_CHECK(!std::is_copy_constructible_v<sf::RenderTexture>);
+        STATIC_CHECK(!std::is_copy_assignable_v<sf::RenderTexture>);
+        STATIC_CHECK(!std::is_nothrow_move_constructible_v<sf::RenderTexture>);
+        STATIC_CHECK(!std::is_nothrow_move_assignable_v<sf::RenderTexture>);
+    }
+
+    SECTION("Construction")
+    {
+        const sf::RenderTexture renderTexture;
+        CHECK(!renderTexture.isSmooth());
+        CHECK(!renderTexture.isRepeated());
+        CHECK(renderTexture.getSize() == sf::Vector2u(0, 0));
+    }
+
+    SECTION("create()")
+    {
+        sf::RenderTexture renderTexture;
+        CHECK(!renderTexture.create({1'000'000, 1'000'000}));
+        CHECK(renderTexture.create({480, 360}));
+        CHECK(!renderTexture.isSmooth());
+        CHECK(!renderTexture.isRepeated());
+        CHECK(renderTexture.getSize() == sf::Vector2u(480, 360));
+        CHECK(!renderTexture.isSrgb());
+    }
+
+    SECTION("getMaximumAntialiasingLevel()")
+    {
+        CHECK(sf::RenderTexture::getMaximumAntialiasingLevel() < 32);
+    }
+
+    SECTION("Set/get smooth")
+    {
+        sf::RenderTexture renderTexture;
+        renderTexture.setSmooth(true);
+        CHECK(renderTexture.isSmooth());
+    }
+
+    SECTION("Set/get repeated")
+    {
+        sf::RenderTexture renderTexture;
+        renderTexture.setRepeated(true);
+        CHECK(renderTexture.isRepeated());
+    }
+
+    SECTION("generateMipmap()")
+    {
+        sf::RenderTexture renderTexture;
+        CHECK(!renderTexture.generateMipmap());
+        CHECK(renderTexture.create({480, 360}));
+        CHECK(renderTexture.generateMipmap());
+    }
+
+    SECTION("setActive()")
+    {
+        sf::RenderTexture renderTexture;
+        CHECK(!renderTexture.setActive());
+        CHECK(renderTexture.create({480, 360}));
+        CHECK(renderTexture.setActive());
+    }
+
+    SECTION("getTexture()")
+    {
+        sf::RenderTexture renderTexture;
+        CHECK(renderTexture.getTexture().getSize() == sf::Vector2u(0, 0));
+        CHECK(renderTexture.create({480, 360}));
+        CHECK(renderTexture.getTexture().getSize() == sf::Vector2u(480, 360));
+    }
+}

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -191,6 +191,14 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         CHECK(!texture.isRepeated());
     }
 
+    SECTION("generateMipmap()")
+    {
+        sf::Texture texture;
+        CHECK(!texture.generateMipmap());
+        CHECK(texture.create({100, 100}));
+        CHECK(texture.generateMipmap());
+    }
+
     SECTION("swap()")
     {
         constexpr std::uint8_t blue[]  = {0x00, 0x00, 0xFF, 0xFF};


### PR DESCRIPTION
## Description

We're close to 50 test cases!
<img width="310" alt="Screenshot 2023-09-01 at 9 58 13 PM" src="https://github.com/SFML/SFML/assets/39244355/0163ef2b-1699-45cf-bab9-e10074bbe214">


I could use a hand with the `sf::RenderTarget::mapPixelToCoords` and `sf::RenderTarget::mapCoordsToPixel` if anyone has a better idea for what inputs are the most meaningful for testing. I just pulled out some random numbers for the sake of covering those code paths but I don't understand these functions well enough to test them any better than that.

These two classes should be the last two Graphics module classes without tests.