### PR TITLE
Disable `SFML_WARNINGS_AS_ERRORS` by default

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,8 @@
         "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "SFML_BUILD_EXAMPLES": "ON",
-        "SFML_BUILD_TEST_SUITE": "ON"
+        "SFML_BUILD_TEST_SUITE": "ON",
+        "SFML_WARNINGS_AS_ERRORS": "ON"
       }
     }
   ]

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -4,7 +4,7 @@
 
 # Helper function to enable compiler warnings for a specific target
 function(set_target_warnings target)
-    option(SFML_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
+    option(SFML_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" FALSE)
 
     if(SFML_COMPILER_MSVC)
         target_compile_options(${target} PRIVATE


### PR DESCRIPTION
## Description

This is not the best default value because it imposes additional requirements on user builds that are not strictly necessary. This has caused complaints in the past as people encounter build failures that are merely due to warnings and not hard compiler errors. Changing this default value makes it more likely that someone trying to use SFML can use it without issue.

Here are some issues caused by us enabling `-Werror`/`/WX` by default:

 * https://github.com/conan-io/conan-center-index/pull/18069
 * https://github.com/microsoft/vcpkg/pull/32944
 * https://github.com/SFML/SFML/issues/2100
 * https://github.com/SFML/SFML/issues/2575
 * https://github.com/SFML/SFML/issues/2217
 * https://github.com/SFML/SFML/issues/2046
 * https://github.com/SFML/SFML/issues/1998 

None of these warnings were revealing true issues with the code. If we did fix any of these warnings it was done as a service to users so that they're not forced to see the warnings. It's exceptional that issues or PRs about warnings are catching legit bugs. Our CI pipeline with its static analysis already does a great job catching such things before users can detect them.

It's critical that developers and CI continue to use `-Werror`/`/WX` and luckily it's trivial to keep doing that thanks to us now using CMake presets. We stand to benefit by not requiring users build SFML in this overly strict manner. 

---

We should consider back porting this change to SFML 2 as well since it's easy enough to do. It only requires changing 2 lines of code.