### PR TITLE
Revert "Disable faulty Windows Clang job"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         - { name: Windows VS2022 x86,     os: windows-2022, flags: -DSFML_USE_MESA3D=TRUE -A Win32 }
         - { name: Windows VS2022 x64,     os: windows-2022, flags: -DSFML_USE_MESA3D=TRUE -A x64 }
         - { name: Windows VS2022 ClangCL, os: windows-2022, flags: -DSFML_USE_MESA3D=TRUE -T ClangCL }
-        # - { name: Windows VS2022 Clang,   os: windows-2022, flags: -DSFML_USE_MESA3D=TRUE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
+        - { name: Windows VS2022 Clang,   os: windows-2022, flags: -DSFML_USE_MESA3D=TRUE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
         - { name: Windows MinGW,          os: windows-2022, flags: -DSFML_USE_MESA3D=TRUE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
         - { name: Linux GCC,            os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
         - { name: Linux Clang,          os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
@@ -231,7 +231,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        # - { name: Windows,   os: windows-2022, flags: -GNinja }
+        - { name: Windows,   os: windows-2022, flags: -GNinja }
         - { name: Linux,     os: ubuntu-22.04 }
         - { name: Linux DRM, os: ubuntu-22.04, flags: -DSFML_USE_DRM=TRUE }
         - { name: macOS,     os: macos-12 }


### PR DESCRIPTION
## Description

Closes #2664 

This reverts commit bbb6f60dda95a1c63372ab60061f60cf3fa4f9c7.

They're finally shipping Clang 16 in these images so we can restore these jobs.