### PR TITLE
Assert in-bounds access when using `operator[]`

### DIFF
--- a/src/SFML/Graphics/ConvexShape.cpp
+++ b/src/SFML/Graphics/ConvexShape.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/ConvexShape.hpp>
 
+#include <cassert>
+
 
 namespace sf
 {
@@ -55,6 +57,7 @@ std::size_t ConvexShape::getPointCount() const
 ////////////////////////////////////////////////////////////
 void ConvexShape::setPoint(std::size_t index, const Vector2f& point)
 {
+    assert(index < m_points.size() && "Index is out of bounds");
     m_points[index] = point;
     update();
 }
@@ -63,6 +66,7 @@ void ConvexShape::setPoint(std::size_t index, const Vector2f& point)
 ////////////////////////////////////////////////////////////
 Vector2f ConvexShape::getPoint(std::size_t index) const
 {
+    assert(index < m_points.size() && "Index is out of bounds");
     return m_points[index];
 }
 

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -28,6 +28,8 @@
 #include <SFML/Graphics/RenderTarget.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
 
+#include <cassert>
+
 
 namespace sf
 {
@@ -51,6 +53,7 @@ std::size_t VertexArray::getVertexCount() const
 ////////////////////////////////////////////////////////////
 Vertex& VertexArray::operator[](std::size_t index)
 {
+    assert(index < m_vertices.size() && "Index is out of bounds");
     return m_vertices[index];
 }
 
@@ -58,6 +61,7 @@ Vertex& VertexArray::operator[](std::size_t index)
 ////////////////////////////////////////////////////////////
 const Vertex& VertexArray::operator[](std::size_t index) const
 {
+    assert(index < m_vertices.size() && "Index is out of bounds");
     return m_vertices[index];
 }
 

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -31,6 +31,7 @@
 #include <iterator>
 #include <utility>
 
+#include <cassert>
 #include <cstring>
 
 
@@ -213,6 +214,7 @@ String& String::operator+=(const String& right)
 ////////////////////////////////////////////////////////////
 char32_t String::operator[](std::size_t index) const
 {
+    assert(index < m_string.size() && "Index is out of bounds");
     return m_string[index];
 }
 
@@ -220,6 +222,7 @@ char32_t String::operator[](std::size_t index) const
 ////////////////////////////////////////////////////////////
 char32_t& String::operator[](std::size_t index)
 {
+    assert(index < m_string.size() && "Index is out of bounds");
     return m_string[index];
 }
 


### PR DESCRIPTION
## Description

Out of bounds array access is undefined behavior so let's be sure to catch potential UB in debug builds. It's too easy to accidentally provide an invalid index to one of these public APIs.

`operator[]` is used extensively internally but this PR focused on public APIs where it's particularly easy to accidentally provide an invalid index.

Please let me know if there are any other public APIs doing similar things where we can easily add assertions that catch UB. In general I want to make sure that anywhere that user input to a public API can cause UB we ought to assert against it (assuming doing so is technically feasible). That's a rather broad definition and surely we're missing some places where we could be doing this.