### PR TITLE
Reenable `sf::Cursor` tests

### DIFF
--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -6,8 +6,7 @@
 #include <array>
 #include <type_traits>
 
-// Skip these tests with [.display] because they fail when using DRM which hasn't implemented sf::Cursor
-TEST_CASE("[Window] sf::Cursor", "[.display]")
+TEST_CASE("[Window] sf::Cursor", runDisplayTests())
 {
     SECTION("Type traits")
     {


### PR DESCRIPTION
## Description

A fun thing about `runDisplayTests()` is that it means that the tests won't get run in CI on the DRM code. Technically you can run the display tests locally when buidling with DRM so these tests will still fail under those circumstances. Regardless I think it is a net positive to run the tests in CI.

We're already using this workaround for other tests that fail in the DRM config. A more proper fix would require making `SFML_USE_DRM` a public symbol which I've advocated for before. If our tests are broken due to that symbol being private the that's a good sign that it maybe ought to be public. Then we can correctly disable these tests for DRM builds isn't of using `runDisplayTests()` as a workaround.