### PR TITLE
Add clang-tidy `modernize-return-braced-init-list` check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,7 +29,6 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,
   -modernize-macro-to-enum,
-  -modernize-return-braced-init-list,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -performance-inefficient-string-concatenation,

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -341,7 +341,7 @@ float getMoisture(unsigned int x, unsigned int y)
 ////////////////////////////////////////////////////////////
 sf::Color colorFromFloats(float r, float g, float b)
 {
-    return sf::Color(static_cast<std::uint8_t>(r), static_cast<std::uint8_t>(g), static_cast<std::uint8_t>(b));
+    return {static_cast<std::uint8_t>(r), static_cast<std::uint8_t>(g), static_cast<std::uint8_t>(b)};
 }
 
 sf::Color getLowlandsTerrainColor(float moisture)
@@ -451,7 +451,7 @@ sf::Vector2f computeNormal(float left, float right, float bottom, float top)
     crossProduct /= crossProduct.z;
 
     // Return "compressed" normal
-    return sf::Vector2f(crossProduct.x, crossProduct.y);
+    return {crossProduct.x, crossProduct.y};
 }
 
 

--- a/include/SFML/Graphics/Color.inl
+++ b/include/SFML/Graphics/Color.inl
@@ -77,10 +77,10 @@ constexpr Color operator+(const Color& left, const Color& right)
         return static_cast<std::uint8_t>(intResult < 255 ? intResult : 255);
     };
 
-    return Color(clampedAdd(left.r, right.r),
-                 clampedAdd(left.g, right.g),
-                 clampedAdd(left.b, right.b),
-                 clampedAdd(left.a, right.a));
+    return {clampedAdd(left.r, right.r),
+            clampedAdd(left.g, right.g),
+            clampedAdd(left.b, right.b),
+            clampedAdd(left.a, right.a)};
 }
 
 
@@ -93,10 +93,10 @@ constexpr Color operator-(const Color& left, const Color& right)
         return static_cast<std::uint8_t>(intResult > 0 ? intResult : 0);
     };
 
-    return Color(clampedSub(left.r, right.r),
-                 clampedSub(left.g, right.g),
-                 clampedSub(left.b, right.b),
-                 clampedSub(left.a, right.a));
+    return {clampedSub(left.r, right.r),
+            clampedSub(left.g, right.g),
+            clampedSub(left.b, right.b),
+            clampedSub(left.a, right.a)};
 }
 
 
@@ -109,10 +109,7 @@ constexpr Color operator*(const Color& left, const Color& right)
         return static_cast<std::uint8_t>(uint16Result / 255u);
     };
 
-    return Color(scaledMul(left.r, right.r),
-                 scaledMul(left.g, right.g),
-                 scaledMul(left.b, right.b),
-                 scaledMul(left.a, right.a));
+    return {scaledMul(left.r, right.r), scaledMul(left.g, right.g), scaledMul(left.b, right.b), scaledMul(left.a, right.a)};
 }
 
 

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -63,15 +63,15 @@ constexpr Transform Transform::getInverse() const
     if (det != 0.f)
     {
         // clang-format off
-        return Transform( (m_matrix[15] * m_matrix[5] - m_matrix[7] * m_matrix[13]) / det,
-                         -(m_matrix[15] * m_matrix[4] - m_matrix[7] * m_matrix[12]) / det,
-                          (m_matrix[13] * m_matrix[4] - m_matrix[5] * m_matrix[12]) / det,
-                         -(m_matrix[15] * m_matrix[1] - m_matrix[3] * m_matrix[13]) / det,
-                          (m_matrix[15] * m_matrix[0] - m_matrix[3] * m_matrix[12]) / det,
-                         -(m_matrix[13] * m_matrix[0] - m_matrix[1] * m_matrix[12]) / det,
-                          (m_matrix[7]  * m_matrix[1] - m_matrix[3] * m_matrix[5])  / det,
-                         -(m_matrix[7]  * m_matrix[0] - m_matrix[3] * m_matrix[4])  / det,
-                          (m_matrix[5]  * m_matrix[0] - m_matrix[1] * m_matrix[4])  / det);
+        return {(m_matrix[15] * m_matrix[5] - m_matrix[7] * m_matrix[13]) / det,
+               -(m_matrix[15] * m_matrix[4] - m_matrix[7] * m_matrix[12]) / det,
+                (m_matrix[13] * m_matrix[4] - m_matrix[5] * m_matrix[12]) / det,
+               -(m_matrix[15] * m_matrix[1] - m_matrix[3] * m_matrix[13]) / det,
+                (m_matrix[15] * m_matrix[0] - m_matrix[3] * m_matrix[12]) / det,
+               -(m_matrix[13] * m_matrix[0] - m_matrix[1] * m_matrix[12]) / det,
+                (m_matrix[7]  * m_matrix[1] - m_matrix[3] * m_matrix[5])  / det,
+               -(m_matrix[7]  * m_matrix[0] - m_matrix[3] * m_matrix[4])  / det,
+                (m_matrix[5]  * m_matrix[0] - m_matrix[1] * m_matrix[4])  / det};
         // clang-format on
     }
     else
@@ -84,8 +84,8 @@ constexpr Transform Transform::getInverse() const
 ////////////////////////////////////////////////////////////
 constexpr Vector2f Transform::transformPoint(const Vector2f& point) const
 {
-    return Vector2f(m_matrix[0] * point.x + m_matrix[4] * point.y + m_matrix[12],
-                    m_matrix[1] * point.x + m_matrix[5] * point.y + m_matrix[13]);
+    return {m_matrix[0] * point.x + m_matrix[4] * point.y + m_matrix[12],
+            m_matrix[1] * point.x + m_matrix[5] * point.y + m_matrix[13]};
 }
 
 
@@ -115,7 +115,7 @@ constexpr FloatRect Transform::transformRect(const FloatRect& rectangle) const
         // clang-format on
     }
 
-    return FloatRect({left, top}, {right - left, bottom - top});
+    return {{left, top}, {right - left, bottom - top}};
 }
 
 

--- a/include/SFML/System/Time.inl
+++ b/include/SFML/System/Time.inl
@@ -73,21 +73,21 @@ constexpr Time::operator std::chrono::duration<Rep, Period>() const
 ////////////////////////////////////////////////////////////
 constexpr Time seconds(float amount)
 {
-    return Time(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::duration<float>(amount)));
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::duration<float>(amount));
 }
 
 
 ////////////////////////////////////////////////////////////
 constexpr Time milliseconds(std::int32_t amount)
 {
-    return Time(std::chrono::milliseconds(amount));
+    return std::chrono::milliseconds(amount);
 }
 
 
 ////////////////////////////////////////////////////////////
 constexpr Time microseconds(std::int64_t amount)
 {
-    return Time(std::chrono::microseconds(amount));
+    return std::chrono::microseconds(amount);
 }
 
 

--- a/src/SFML/Graphics/CircleShape.cpp
+++ b/src/SFML/Graphics/CircleShape.cpp
@@ -79,7 +79,7 @@ Vector2f CircleShape::getPoint(std::size_t index) const
 ////////////////////////////////////////////////////////////
 Vector2f CircleShape::getGeometricCenter() const
 {
-    return Vector2f(m_radius, m_radius);
+    return {m_radius, m_radius};
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -755,7 +755,7 @@ IntRect Font::findGlyphRect(Page& page, const Vector2u& size) const
                 if (!newTexture.create(textureSize * 2u))
                 {
                     err() << "Failed to create new page texture" << std::endl;
-                    return IntRect({0, 0}, {2, 2});
+                    return {{0, 0}, {2, 2}};
                 }
 
                 newTexture.setSmooth(m_isSmooth);
@@ -767,7 +767,7 @@ IntRect Font::findGlyphRect(Page& page, const Vector2u& size) const
                 // Oops, we've reached the maximum texture size...
                 err() << "Failed to add a new character to the font: the maximum texture size has been reached"
                       << std::endl;
-                return IntRect({0, 0}, {2, 2});
+                return {{0, 0}, {2, 2}};
             }
         }
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -275,7 +275,7 @@ void Image::setPixel(const Vector2u& coords, const Color& color)
 Color Image::getPixel(const Vector2u& coords) const
 {
     const std::uint8_t* pixel = &m_pixels[(coords.x + coords.y * m_size.x) * 4];
-    return Color(pixel[0], pixel[1], pixel[2], pixel[3]);
+    return {pixel[0], pixel[1], pixel[2], pixel[3]};
 }
 
 

--- a/src/SFML/Graphics/RectangleShape.cpp
+++ b/src/SFML/Graphics/RectangleShape.cpp
@@ -68,13 +68,13 @@ Vector2f RectangleShape::getPoint(std::size_t index) const
     {
         default:
         case 0:
-            return Vector2f(0, 0);
+            return {0, 0};
         case 1:
-            return Vector2f(m_size.x, 0);
+            return {m_size.x, 0};
         case 2:
-            return Vector2f(m_size.x, m_size.y);
+            return {m_size.x, m_size.y};
         case 3:
-            return Vector2f(0, m_size.y);
+            return {0, m_size.y};
     }
 }
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -116,7 +116,7 @@ FloatRect Sprite::getLocalBounds() const
     const auto width  = static_cast<float>(std::abs(m_textureRect.width));
     const auto height = static_cast<float>(std::abs(m_textureRect.height));
 
-    return FloatRect({0.f, 0.f}, {width, height});
+    return {{0.f, 0.f}, {width, height}};
 }
 
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -365,7 +365,7 @@ Image Texture::copyToImage() const
 {
     // Easy case: empty texture
     if (!m_texture)
-        return Image();
+        return {};
 
     const TransientContextLock lock;
 

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -124,12 +124,12 @@ FloatRect VertexArray::getBounds() const
                 bottom = position.y;
         }
 
-        return FloatRect({left, top}, {right - left, bottom - top});
+        return {{left, top}, {right - left, bottom - top}};
     }
     else
     {
         // Array is empty
-        return FloatRect();
+        return {};
     }
 }
 

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -209,7 +209,7 @@ Ftp::Response Ftp::keepAlive()
 ////////////////////////////////////////////////////////////
 Ftp::DirectoryResponse Ftp::getWorkingDirectory()
 {
-    return DirectoryResponse(sendCommand("PWD"));
+    return {sendCommand("PWD")};
 }
 
 
@@ -234,7 +234,7 @@ Ftp::ListingResponse Ftp::getDirectoryListing(const std::string& directory)
         }
     }
 
-    return ListingResponse(response, directoryData.str());
+    return {response, directoryData.str()};
 }
 
 

--- a/src/SFML/Window/Android/ClipboardImpl.cpp
+++ b/src/SFML/Window/Android/ClipboardImpl.cpp
@@ -39,7 +39,7 @@ namespace sf::priv
 String ClipboardImpl::getString()
 {
     sf::err() << "Clipboard API not implemented for Android.\n";
-    return String();
+    return {};
 }
 
 

--- a/src/SFML/Window/Android/JoystickImpl.cpp
+++ b/src/SFML/Window/Android/JoystickImpl.cpp
@@ -71,7 +71,7 @@ void JoystickImpl::close()
 JoystickCaps JoystickImpl::getCapabilities() const
 {
     // To implement
-    return JoystickCaps();
+    return {};
 }
 
 
@@ -86,7 +86,7 @@ Joystick::Identification JoystickImpl::getIdentification() const
 JoystickState JoystickImpl::update()
 {
     // To implement
-    return JoystickState();
+    return {};
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -125,7 +125,7 @@ void WindowImplAndroid::processEvents()
 Vector2i WindowImplAndroid::getPosition() const
 {
     // Not applicable
-    return Vector2i(0, 0);
+    return {};
 }
 
 

--- a/src/SFML/Window/DRM/InputImplUDev.cpp
+++ b/src/SFML/Window/DRM/InputImplUDev.cpp
@@ -682,7 +682,7 @@ Vector2i InputImpl::getTouchPosition(unsigned int finger)
             return slot.pos;
     }
 
-    return Vector2i();
+    return {};
 }
 
 

--- a/src/SFML/Window/DRM/WindowImplDRM.cpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.cpp
@@ -68,7 +68,7 @@ WindowHandle WindowImplDRM::getNativeHandle() const
 ////////////////////////////////////////////////////////////
 Vector2i WindowImplDRM::getPosition() const
 {
-    return Vector2i(0, 0);
+    return {0, 0};
 }
 
 

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -400,7 +400,7 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
         // Should never happen...
         err() << "No GLX visual found. You should check your graphics driver" << std::endl;
 
-        return XVisualInfo();
+        return {};
     }
 }
 

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -138,7 +138,7 @@ Vector2i InputImpl::getMousePosition()
     // Close the connection with the X server
     closeDisplay(display);
 
-    return Vector2i(gx, gy);
+    return {gx, gy};
 }
 
 
@@ -165,11 +165,11 @@ Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
         // Close the connection with the X server
         closeDisplay(display);
 
-        return Vector2i(x, y);
+        return {x, y};
     }
     else
     {
-        return Vector2i();
+        return {};
     }
 }
 
@@ -218,7 +218,7 @@ bool InputImpl::isTouchDown(unsigned int /*finger*/)
 Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/)
 {
     // Not applicable
-    return Vector2i();
+    return {};
 }
 
 
@@ -226,7 +226,7 @@ Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/)
 Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/, const WindowBase& /*relativeTo*/)
 {
     // Not applicable
-    return Vector2i();
+    return {};
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -407,7 +407,7 @@ std::string getJoystickName(unsigned int index)
         ::close(fd);
 
         if (result >= 0)
-            return std::string(name);
+            return name;
     }
 
     // Fall back to manual USB chain walk via udev
@@ -421,13 +421,13 @@ std::string getJoystickName(unsigned int index)
             udev_device_unref(udevDevice);
 
             if (product)
-                return std::string(product);
+                return {product};
         }
     }
 
     sf::err() << "Unable to get name for joystick " << devnode << std::endl;
 
-    return std::string("Unknown Joystick");
+    return "Unknown Joystick";
 }
 } // namespace
 

--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -677,7 +677,7 @@ String KeyboardImpl::getDescription(Keyboard::Scancode code)
         const char32_t unicode = keysymToUnicode(keysym);
 
         if (unicode != 0)
-            return String(unicode);
+            return {unicode};
     }
 
     // Fallback to our best guess for the keys that are known to be independent of the layout.

--- a/src/SFML/Window/Unix/SensorImpl.cpp
+++ b/src/SFML/Window/Unix/SensorImpl.cpp
@@ -71,7 +71,7 @@ void SensorImpl::close()
 Vector3f SensorImpl::update()
 {
     // To be implemented
-    return Vector3f(0, 0, 0);
+    return {0, 0, 0};
 }
 
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -818,7 +818,7 @@ Vector2i WindowImplX11::getPosition() const
     // it to, even with decorations and such, which get shifted back.
     // In these rare cases, we can use the absolute value directly.
     if (isWMAbsolutePositionGood())
-        return Vector2i(xAbsRelToRoot, yAbsRelToRoot);
+        return {xAbsRelToRoot, yAbsRelToRoot};
 
     // CASE 2: most modern WMs support EWMH and can define _NET_FRAME_EXTENTS
     // with the exact frame size to subtract, so if present, we prefer it and
@@ -830,7 +830,7 @@ Vector2i WindowImplX11::getPosition() const
     {
         // Get final X/Y coordinates: subtract EWMH frame extents from
         // absolute window position.
-        return Vector2i((xAbsRelToRoot - static_cast<int>(xFrameExtent)), (yAbsRelToRoot - static_cast<int>(yFrameExtent)));
+        return {(xAbsRelToRoot - static_cast<int>(xFrameExtent)), (yAbsRelToRoot - static_cast<int>(yFrameExtent))};
     }
 
     // CASE 3: EWMH frame extents were not available, use geometry.
@@ -866,7 +866,7 @@ Vector2i WindowImplX11::getPosition() const
 
     XGetGeometry(m_display, ancestor, &root, &xRelToRoot, &yRelToRoot, &width, &height, &borderWidth, &depth);
 
-    return Vector2i(xRelToRoot, yRelToRoot);
+    return {xRelToRoot, yRelToRoot};
 }
 
 

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -647,7 +647,7 @@ Vector2i InputImpl::getMousePosition()
 {
     POINT point;
     GetCursorPos(&point);
-    return Vector2i(point.x, point.y);
+    return {point.x, point.y};
 }
 
 
@@ -660,11 +660,11 @@ Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
         POINT point;
         GetCursorPos(&point);
         ScreenToClient(handle, &point);
-        return Vector2i(point.x, point.y);
+        return {point.x, point.y};
     }
     else
     {
-        return Vector2i();
+        return {};
     }
 }
 
@@ -701,7 +701,7 @@ bool InputImpl::isTouchDown(unsigned int /*finger*/)
 Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/)
 {
     // Not applicable
-    return Vector2i();
+    return {};
 }
 
 
@@ -709,7 +709,7 @@ Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/)
 Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/, const WindowBase& /*relativeTo*/)
 {
     // Not applicable
-    return Vector2i();
+    return {};
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/Win32/SensorImpl.cpp
+++ b/src/SFML/Window/Win32/SensorImpl.cpp
@@ -71,7 +71,7 @@ void SensorImpl::close()
 Vector3f SensorImpl::update()
 {
     // To be implemented
-    return Vector3f(0, 0, 0);
+    return {};
 }
 
 

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -116,7 +116,7 @@ String getErrorString(DWORD errorCode)
 
     std::ostringstream ss;
     ss << "Error " << errorCode;
-    return String(ss.str());
+    return {ss.str()};
 }
 
 

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -302,7 +302,7 @@ Vector2i WindowImplWin32::getPosition() const
     RECT rect;
     GetWindowRect(m_handle, &rect);
 
-    return Vector2i(rect.left, rect.top);
+    return {rect.left, rect.top};
 }
 
 
@@ -322,7 +322,7 @@ Vector2u WindowImplWin32::getSize() const
     RECT rect;
     GetClientRect(m_handle, &rect);
 
-    return Vector2u(static_cast<unsigned int>(rect.right - rect.left), static_cast<unsigned int>(rect.bottom - rect.top));
+    return Vector2u(Vector2<LONG>(rect.right - rect.left, rect.bottom - rect.top));
 }
 
 

--- a/src/SFML/Window/iOS/ClipboardImpl.mm
+++ b/src/SFML/Window/iOS/ClipboardImpl.mm
@@ -49,7 +49,7 @@ String ClipboardImpl::getString()
     }
     else
     {
-        return String();
+        return {};
     }
 }
 

--- a/src/SFML/Window/iOS/InputImpl.mm
+++ b/src/SFML/Window/iOS/InputImpl.mm
@@ -84,7 +84,7 @@ bool InputImpl::isMouseButtonPressed(Mouse::Button /* button */)
 ////////////////////////////////////////////////////////////
 Vector2i InputImpl::getMousePosition()
 {
-    return Vector2i(0, 0);
+    return {};
 }
 
 

--- a/src/SFML/Window/iOS/JoystickImpl.mm
+++ b/src/SFML/Window/iOS/JoystickImpl.mm
@@ -71,7 +71,7 @@ void JoystickImpl::close()
 JoystickCaps JoystickImpl::getCapabilities() const
 {
     // Not implemented
-    return JoystickCaps();
+    return {};
 }
 
 
@@ -79,7 +79,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
 Joystick::Identification JoystickImpl::getIdentification() const
 {
     // Not implemented
-    return Joystick::Identification();
+    return {};
 }
 
 
@@ -87,7 +87,7 @@ Joystick::Identification JoystickImpl::getIdentification() const
 JoystickState JoystickImpl::update()
 {
     // Not implemented
-    return JoystickState();
+    return {};
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -109,8 +109,8 @@ WindowHandle WindowImplUIKit::getNativeHandle() const
 Vector2i WindowImplUIKit::getPosition() const
 {
     const CGPoint origin = m_window.frame.origin;
-    return Vector2i(static_cast<int>(origin.x * static_cast<double>(m_backingScale)),
-                    static_cast<int>(origin.y * static_cast<double>(m_backingScale)));
+    return {static_cast<int>(origin.x * static_cast<double>(m_backingScale)),
+            static_cast<int>(origin.y * static_cast<double>(m_backingScale))};
 }
 
 
@@ -124,8 +124,8 @@ void WindowImplUIKit::setPosition(const Vector2i& /* position */)
 Vector2u WindowImplUIKit::getSize() const
 {
     const CGRect physicalFrame = m_window.frame;
-    return Vector2u(static_cast<unsigned int>(physicalFrame.size.width * static_cast<double>(m_backingScale)),
-                    static_cast<unsigned int>(physicalFrame.size.height * static_cast<double>(m_backingScale)));
+    return {static_cast<unsigned int>(physicalFrame.size.width * static_cast<double>(m_backingScale)),
+            static_cast<unsigned int>(physicalFrame.size.height * static_cast<double>(m_backingScale))};
 }
 
 

--- a/src/SFML/Window/macOS/HIDInputManager.mm
+++ b/src/SFML/Window/macOS/HIDInputManager.mm
@@ -691,7 +691,7 @@ String HIDInputManager::getDescription(Keyboard::Scancode code)
             // Phase 2: Try to convert the key to unicode
             const UniChar unicode = toUnicode(localize(code));
             if (unicode != 0x00)
-                return String(static_cast<char32_t>(unicode));
+                return {static_cast<char32_t>(unicode)};
         }
 
         // Phase 3: Return final fallback

--- a/src/SFML/Window/macOS/InputImpl.mm
+++ b/src/SFML/Window/macOS/InputImpl.mm
@@ -191,7 +191,7 @@ Vector2i InputImpl::getMousePosition(const WindowBase& relativeTo)
 
     // No view ?
     if (view == nil)
-        return Vector2i();
+        return {};
 
     // Use -cursorPositionFromEvent: with nil.
     const NSPoint pos = [view cursorPositionFromEvent:nil];
@@ -250,7 +250,7 @@ bool InputImpl::isTouchDown(unsigned int /*finger*/)
 Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/)
 {
     // Not applicable
-    return Vector2i();
+    return {};
 }
 
 
@@ -258,7 +258,7 @@ Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/)
 Vector2i InputImpl::getTouchPosition(unsigned int /*finger*/, const WindowBase& /*relativeTo*/)
 {
     // Not applicable
-    return Vector2i();
+    return {};
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/macOS/SensorImpl.cpp
+++ b/src/SFML/Window/macOS/SensorImpl.cpp
@@ -71,7 +71,7 @@ void SensorImpl::close()
 Vector3f SensorImpl::update()
 {
     // To be implemented
-    return Vector3f(0, 0, 0);
+    return {0, 0, 0};
 }
 
 

--- a/test/Graphics/Shape.test.cpp
+++ b/test/Graphics/Shape.test.cpp
@@ -24,11 +24,11 @@ public:
         {
             default:
             case 0:
-                return sf::Vector2f(m_size.x / 2, 0);
+                return {m_size.x / 2, 0};
             case 1:
-                return sf::Vector2f(0, m_size.y);
+                return {0, m_size.y};
             case 2:
-                return sf::Vector2f(m_size.x, m_size.y);
+                return {m_size.x, m_size.y};
         }
     }
 


### PR DESCRIPTION
## Description

Yet another modern C++ feature we can be taking advantage of. The fact that clang-tidy can automatically detect this makes it easier to justify its addition. It's not something we'll have to keep in mind during code reviews.