### PR TITLE
Shallow clone Catch2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,8 @@ set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
 set(CATCH_CONFIG_NO_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT ON CACHE BOOL "")
 FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.4.0)
+    GIT_TAG v3.4.0
+    GIT_SHALLOW ON)
 FetchContent_MakeAvailable(Catch2)
 include(Catch)
 


### PR DESCRIPTION
## Description

This takes a 4 second configuration time for the entire project with examples and tests and turns that into 3! Whopping 25% reduction in configuration time. This effect is likely to be even larger on machines without exceptionally good internet connections.

Before:
```
  $ hyperfine 'rm -rf build && cmake --preset dev'
  Benchmark 1: rm -rf build && cmake --preset dev
    Time (mean ± σ):      4.076 s ±  0.130 s    [User: 2.148 s, System: 1.376 s]
    Range (min … max):    3.963 s …  4.321 s    10 runs
```

After:
```
  $ hyperfine 'rm -rf build && cmake --preset dev'
  Benchmark 1: rm -rf build && cmake --preset dev
    Time (mean ± σ):      3.007 s ±  0.313 s    [User: 1.061 s, System: 1.160 s]
    Range (min … max):    2.783 s …  3.805 s    10 runs
```

---

Lifted from #2685. I wanted to test this change in isolation and was shocked at how affective it was.