### PR TITLE
Remove unnecessary CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,9 +214,6 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v3
 
-    - name: Install Dependencies
-      run: sudo apt-get install clang-format-14
-
     - name: Format Code
       run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-14 -P cmake/Format.cmake
 


### PR DESCRIPTION
## Description

https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#language-and-runtime
<img width="351" alt="Screenshot 2023-09-17 at 5 26 23 PM" src="https://github.com/SFML/SFML/assets/39244355/1ef1b797-e80a-4a11-8198-673d8dc13d4d">

GitHub already advertises that `clang-format-14` is present by default so there's no need for us to include this `apt-get` call. It was doing nothing. It only took like 1s to run though so it's not like it had a noticeable impact this whole time.