### PR TITLE
Use more `sf::Vector` operations

### DIFF
--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -279,8 +279,7 @@ public:
             // Spread the coordinates from -480 to +480
             // So they'll always fill the viewport at 800x600
             std::uniform_real_distribution<float> positionDistribution(-480, 480);
-            m_pointCloud[i].position.x = positionDistribution(rng);
-            m_pointCloud[i].position.y = positionDistribution(rng);
+            m_pointCloud[i].position = {positionDistribution(rng), positionDistribution(rng)};
         }
 
         // Load the texture

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -396,8 +396,7 @@ float Font::getKerning(std::uint32_t first, std::uint32_t second, unsigned int c
         const auto secondLsbDelta = static_cast<float>(getGlyph(second, characterSize, bold).lsbDelta);
 
         // Get the kerning vector if present
-        FT_Vector kerning;
-        kerning.x = kerning.y = 0;
+        FT_Vector kerning{0, 0};
         if (FT_HAS_KERNING(face))
             FT_Get_Kerning(face, index1, index2, FT_KERNING_UNFITTED, &kerning);
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -111,8 +111,7 @@ void Image::create(const Vector2u& size, const Color& color)
         std::vector<std::uint8_t>().swap(m_pixels);
 
         // Assign the new size
-        m_size.x = 0;
-        m_size.y = 0;
+        m_size = {};
     }
 }
 
@@ -137,8 +136,7 @@ void Image::create(const Vector2u& size, const std::uint8_t* pixels)
         std::vector<std::uint8_t>().swap(m_pixels);
 
         // Assign the new size
-        m_size.x = 0;
-        m_size.y = 0;
+        m_size = {};
     }
 }
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -211,10 +211,9 @@ Vector2f RenderTarget::mapPixelToCoords(const Vector2i& point) const
 Vector2f RenderTarget::mapPixelToCoords(const Vector2i& point, const View& view) const
 {
     // First, convert from viewport coordinates to homogeneous coordinates
-    Vector2f        normalized;
-    const FloatRect viewport = FloatRect(getViewport(view));
-    normalized.x             = -1.f + 2.f * (static_cast<float>(point.x) - viewport.left) / viewport.width;
-    normalized.y             = 1.f - 2.f * (static_cast<float>(point.y) - viewport.top) / viewport.height;
+    const FloatRect viewport   = FloatRect(getViewport(view));
+    const Vector2f  normalized = Vector2f(-1, 1) +
+                                Vector2f(2, -2).cwiseMul(Vector2f(point) - viewport.getPosition()).cwiseDiv(viewport.getSize());
 
     // Then transform by the inverse of the view matrix
     return view.getInverseTransform().transformPoint(normalized);
@@ -235,12 +234,9 @@ Vector2i RenderTarget::mapCoordsToPixel(const Vector2f& point, const View& view)
     const Vector2f normalized = view.getTransform().transformPoint(point);
 
     // Then convert to viewport coordinates
-    Vector2i        pixel;
     const FloatRect viewport = FloatRect(getViewport(view));
-    pixel.x                  = static_cast<int>((normalized.x + 1.f) / 2.f * viewport.width + viewport.left);
-    pixel.y                  = static_cast<int>((-normalized.y + 1.f) / 2.f * viewport.height + viewport.top);
-
-    return pixel;
+    return Vector2i((normalized.cwiseMul({1, -1}) + sf::Vector2f(1, 1)).cwiseDiv({2, 2}).cwiseMul(viewport.getSize()) +
+                    viewport.getPosition());
 }
 
 

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -221,8 +221,7 @@ void Shape::update()
     m_insideBounds = m_vertices.getBounds();
 
     // Compute the center and make it the first vertex
-    m_vertices[0].position.x = m_insideBounds.left + m_insideBounds.width / 2;
-    m_vertices[0].position.y = m_insideBounds.top + m_insideBounds.height / 2;
+    m_vertices[0].position = m_insideBounds.getPosition() + m_insideBounds.getSize() / 2.f;
 
     // Color
     updateFillColors();
@@ -270,14 +269,14 @@ void Shape::updateTexCoords()
 
     for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
     {
-        const float xratio        = m_insideBounds.width > 0
-                                        ? (m_vertices[i].position.x - m_insideBounds.left) / m_insideBounds.width
-                                        : 0;
-        const float yratio        = m_insideBounds.height > 0
-                                        ? (m_vertices[i].position.y - m_insideBounds.top) / m_insideBounds.height
-                                        : 0;
-        m_vertices[i].texCoords.x = convertedTextureRect.left + convertedTextureRect.width * xratio;
-        m_vertices[i].texCoords.y = convertedTextureRect.top + convertedTextureRect.height * yratio;
+        const float xratio      = m_insideBounds.width > 0
+                                      ? (m_vertices[i].position.x - m_insideBounds.left) / m_insideBounds.width
+                                      : 0;
+        const float yratio      = m_insideBounds.height > 0
+                                      ? (m_vertices[i].position.y - m_insideBounds.top) / m_insideBounds.height
+                                      : 0;
+        m_vertices[i].texCoords = convertedTextureRect.getPosition() +
+                                  convertedTextureRect.getSize().cwiseMul({xratio, yratio});
     }
 }
 

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -90,10 +90,8 @@ void View::setViewport(const FloatRect& viewport)
 ////////////////////////////////////////////////////////////
 void View::reset(const FloatRect& rectangle)
 {
-    m_center.x = rectangle.left + rectangle.width / 2.f;
-    m_center.y = rectangle.top + rectangle.height / 2.f;
-    m_size.x   = rectangle.width;
-    m_size.y   = rectangle.height;
+    m_center   = rectangle.getPosition() + rectangle.getSize() / 2.f;
+    m_size     = rectangle.getSize();
     m_rotation = Angle::Zero;
 
     m_transformUpdated    = false;

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -235,8 +235,8 @@ void WindowImplAndroid::forwardEvent(const Event& event)
 
         if (event.type == Event::GainedFocus)
         {
-            WindowImplAndroid::singleInstance->m_size.x = static_cast<unsigned int>(ANativeWindow_getWidth(states.window));
-            WindowImplAndroid::singleInstance->m_size.y = static_cast<unsigned int>(ANativeWindow_getHeight(states.window));
+            WindowImplAndroid::singleInstance->m_size = Vector2u(
+                Vector2i(ANativeWindow_getWidth(states.window), ANativeWindow_getHeight(states.window)));
             WindowImplAndroid::singleInstance->m_windowBeingCreated = true;
             WindowImplAndroid::singleInstance->m_hasFocus           = true;
         }

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -386,8 +386,7 @@ bool WindowBase::filterEvent(const Event& event)
     if (event.type == Event::Resized)
     {
         // Cache the new size
-        m_size.x = event.size.width;
-        m_size.y = event.size.height;
+        m_size = {event.size.width, event.size.height};
 
         // Notify the derived class
         onResize();


### PR DESCRIPTION
## Description

When dealing with calculations that are fundamentally two dimensional it's helpful to use a 2D data type as much as possible rather than decomposing the calculations into x and y components. The more we use vector operations the better chance we have of easiliy reasoning about what the code is doing.
