### PR TITLE
Simplify how tests are ran in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,34 +141,23 @@ jobs:
         fi
         # Make sure the build/bin directory exists so that the find command does not fail if no executables are built
         mkdir -p build/bin
+        # Make use of a test to print OpenGL vendor/renderer/version info to the console
+        find build/bin -name test-sfml-window -or -name test-sfml-window.exe -exec sh -c "{} *sf::Context* --section=\"Version String\" --success | grep OpenGL" \;
 
     - name: Test
-      uses: nick-fields/retry@v2
-      with:
-        max_attempts: 10
-        timeout_minutes: 3
-        retry_wait_seconds: 5
-        warning_on_retry: false
-        shell: bash
-        command: |
-          set -e
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            # Make use of a test to print OpenGL vendor/renderer/version info to the console
-            # We have to convert the backslashes in $GITHUB_WORKSPACE to (forward) slashes so bash doesn't try to escape them in the sh command
-            find $(echo $GITHUB_WORKSPACE | sed 's/\\\\/\\//g')/build/bin -name test-sfml-window.exe -exec sh -c "{} *sf::Context* --section=\"Version String\" --success | grep OpenGL" \;
-            # Run the tests
-            cmake --build build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
-            # Coverage is already generated on Windows when running tests.
-          else
-            # Make use of a test to print OpenGL vendor/renderer/version info to the console
-            find build/bin -name test-sfml-window -exec sh -c "{} *sf::Context* --section=\"Version String\" --success | grep OpenGL" \;
-            # Run the tests
-            ctest --test-dir build --output-on-failure -C ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
-            # Run gcovr to extract coverage information from the test run
-            if [ "${{ matrix.type.name }}" == "Debug" ]; then
-              gcovr -r $GITHUB_WORKSPACE -x build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE
-            fi
-          fi
+      if: runner.os == 'Windows'
+      shell: bash
+      run: cmake --build build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+
+    - name: Test
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        ctest --test-dir build --output-on-failure -C ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --repeat until-pass:3
+        # Run gcovr to extract coverage information from the test run
+        if [ "${{ matrix.type.name }}" == "Debug" ]; then
+          gcovr -r $GITHUB_WORKSPACE -x build/coverage.out -s -f 'src/SFML/.*' -f 'include/SFML/.*' ${{ matrix.platform.gcovr_options }} $GITHUB_WORKSPACE
+        fi
 
     - name: Download Codecov Uploader
       if: matrix.type.name == 'Debug' && github.repository == 'SFML/SFML' # Disable upload in forks


### PR DESCRIPTION
## Description

The flakiness is theoretically limited to Linux where we have to use xvfb-run in CI. Because the tests are ran on Linux via ctest we can more easily use CTest's built-in support for rerunning failed tests. We have yet to actually observe this flakiness after the other changes added in #2474 so it's possible the flakiness has been entirely addressed.

Rerunning the tests was actually contributing to longer CI times in some circumstances. In the event that tests fail for good reason we have to wait another few dozen seconds for the tests to fail 10 times in a row which is inevitable. Now the Windows tests only have to fail once before CI gets to carry on. Non-Windows tests get to fail thrice but they'll fail 3 times in quick succession so we won't spend another ~20 seconds waiting on the final results. It'll only take maybe 1 extra second to re-run them those few more times.

While I was at it I de-duplicated some code for printing OpenGL information. Instead I'm telling `find` to look for two different filenames knowing that one or the other will be found. I find this Bash code tricky to read and maintain so I'm always happy to find ways to reduce how much of it we have.