### PR TITLE
Add tests for `sf::Joystick`

### DIFF
--- a/src/SFML/Window/Joystick.cpp
+++ b/src/SFML/Window/Joystick.cpp
@@ -28,6 +28,8 @@
 #include <SFML/Window/Joystick.hpp>
 #include <SFML/Window/JoystickManager.hpp>
 
+#include <cassert>
+
 
 namespace sf
 {
@@ -55,6 +57,7 @@ bool Joystick::hasAxis(unsigned int joystick, Axis axis)
 ////////////////////////////////////////////////////////////
 bool Joystick::isButtonPressed(unsigned int joystick, unsigned int button)
 {
+    assert(button < Joystick::ButtonCount && "Button must be less than Joystick::ButtonCount");
     return priv::JoystickManager::getInstance().getState(joystick).buttons[button];
 }
 

--- a/src/SFML/Window/JoystickManager.cpp
+++ b/src/SFML/Window/JoystickManager.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/JoystickManager.hpp>
 
+#include <cassert>
+
 
 namespace sf::priv
 {
@@ -41,6 +43,7 @@ JoystickManager& JoystickManager::getInstance()
 ////////////////////////////////////////////////////////////
 const JoystickCaps& JoystickManager::getCapabilities(unsigned int joystick) const
 {
+    assert(joystick < Joystick::Count && "Joystick index must be less than Joystick::Count");
     return m_joysticks[joystick].capabilities;
 }
 
@@ -48,6 +51,7 @@ const JoystickCaps& JoystickManager::getCapabilities(unsigned int joystick) cons
 ////////////////////////////////////////////////////////////
 const JoystickState& JoystickManager::getState(unsigned int joystick) const
 {
+    assert(joystick < Joystick::Count && "Joystick index must be less than Joystick::Count");
     return m_joysticks[joystick].state;
 }
 
@@ -55,6 +59,7 @@ const JoystickState& JoystickManager::getState(unsigned int joystick) const
 ////////////////////////////////////////////////////////////
 const Joystick::Identification& JoystickManager::getIdentification(unsigned int joystick) const
 {
+    assert(joystick < Joystick::Count && "Joystick index must be less than Joystick::Count");
     return m_joysticks[joystick].identification;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,6 +66,7 @@ set(WINDOW_SRC
     Window/Cursor.test.cpp
     Window/Event.test.cpp
     Window/GlResource.test.cpp
+    Window/Joystick.test.cpp
     Window/Keyboard.test.cpp
     Window/VideoMode.test.cpp
     Window/Window.test.cpp

--- a/test/Window/Joystick.test.cpp
+++ b/test/Window/Joystick.test.cpp
@@ -1,0 +1,76 @@
+#include <SFML/Window/Joystick.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+TEST_CASE("[Window] sf::Joystick")
+{
+    SECTION("Constants")
+    {
+        STATIC_CHECK(sf::Joystick::Count == 8);
+        STATIC_CHECK(sf::Joystick::ButtonCount == 32);
+        STATIC_CHECK(sf::Joystick::AxisCount == 8);
+    }
+
+    SECTION("Identification")
+    {
+        const sf::Joystick::Identification identification;
+        CHECK(identification.name == "No Joystick");
+        CHECK(identification.vendorId == 0);
+        CHECK(identification.productId == 0);
+    }
+
+    // By avoiding calling sf::Joystick::update() we can guarantee that
+    // no joysticks will be detected. This is how we can ensure these
+    // tests are portable and reliable.
+
+    const auto joystick = GENERATE(range(0u, sf::Joystick::Count - 1));
+
+    SECTION("isConnected()")
+    {
+        CHECK(!sf::Joystick::isConnected(joystick));
+    }
+
+    SECTION("getButtonCount()")
+    {
+        CHECK(sf::Joystick::getButtonCount(joystick) == 0);
+    }
+
+    SECTION("hasAxis()")
+    {
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::X));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Y));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Z));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::R));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::U));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::V));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::PovX));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::PovY));
+    }
+
+    SECTION("isButtonPressed()")
+    {
+        const auto button = GENERATE(range(0u, sf::Joystick::ButtonCount - 1));
+        CHECK(!sf::Joystick::isButtonPressed(joystick, button));
+    }
+
+    SECTION("getAxisPosition")
+    {
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::X) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Y) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Z) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::R) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::U) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::V) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::PovX) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::PovY) == 0);
+    }
+
+    SECTION("getIdentification()")
+    {
+        const auto identification = sf::Joystick::getIdentification(joystick);
+        CHECK(identification.name == "No Joystick");
+        CHECK(identification.vendorId == 0);
+        CHECK(identification.productId == 0);
+    }
+}


### PR DESCRIPTION
## Description

See a comment I wrote in Joystick.test.cpp about why we can reliably test `sf::Joystick` even if someone currently has a joystick connected. I confirmed this locally by connecting an Xbox controller and observing the tests passing. If I added a call to `sf::Joystick::update()` I can confirm it fails as one would expect.

While I was at it, I also added some more assertion to catch invalid user inputs to public APIs. This expands on what I did in https://github.com/SFML/SFML/pull/2682. Yay for more checks against UB!