### PR TITLE
Add tests for `sf::Vulkan`

### DIFF
--- a/src/SFML/Window/Vulkan.cpp
+++ b/src/SFML/Window/Vulkan.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Vulkan.hpp>
 
+#include <cassert>
+
 #if defined(SFML_SYSTEM_WINDOWS)
 
 #include <SFML/Window/Win32/VulkanImplWin32.hpp>
@@ -73,6 +75,8 @@ bool Vulkan::isAvailable([[maybe_unused]] bool requireGraphics)
 ////////////////////////////////////////////////////////////
 VulkanFunctionPointer Vulkan::getFunction([[maybe_unused]] const char* name)
 {
+    assert(name && "Name cannot be a null pointer");
+
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
     return nullptr;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(WINDOW_SRC
     Window/GlResource.test.cpp
     Window/Keyboard.test.cpp
     Window/VideoMode.test.cpp
+    Window/Vulkan.test.cpp
     Window/Window.test.cpp
     Window/WindowBase.test.cpp
 )

--- a/test/Window/Vulkan.test.cpp
+++ b/test/Window/Vulkan.test.cpp
@@ -1,0 +1,28 @@
+#include <SFML/Window/Vulkan.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[Window] sf::Vulkan")
+{
+    SECTION("getFunction()")
+    {
+        CHECK(sf::Vulkan::getFunction("") == nullptr);
+        CHECK(sf::Vulkan::getFunction(" ") == nullptr);
+        CHECK(sf::Vulkan::getFunction("a string that will never resolve to a Vulkan function") == nullptr);
+
+        CHECKED_IF(sf::Vulkan::isAvailable())
+        {
+            CHECK(sf::Vulkan::getFunction("vkCreateInstance") != nullptr);
+        }
+    }
+
+    SECTION("getGraphicsRequiredInstanceExtensions()")
+    {
+        // If Vulkan is not available this function may or may not return a non-empty vector
+        // If Vulkan is available then it will always return a non-empty vector
+        CHECKED_IF(sf::Vulkan::isAvailable())
+        {
+            CHECK(!sf::Vulkan::getGraphicsRequiredInstanceExtensions().empty());
+        }
+    }
+}


### PR DESCRIPTION
## Description

I added an `assert` to fix a segfault I found in testing. Other than that these tests are pretty straightforward. Some things can be tested on all configs. Other tests only apply if Vulkan is available.