### PR TITLE
Only install MinGW when necessary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,14 @@ jobs:
         max_attempts: 10
         timeout_minutes: 3
         command: |
-          choco uninstall mingw
-          choco install mingw --version 11.2.0
           choco install ninja OpenCppCoverage -y
           echo "C:\Program Files\OpenCppCoverage" >> $env:GITHUB_PATH
+
+    - name: Install MinGW
+      if: matrix.platform.name == 'Windows MinGW'
+      run: |
+        choco uninstall mingw
+        choco install mingw --version 11.2.0
 
     - name: Configure CMake
       shell: bash


### PR DESCRIPTION
## Description

Installing MinGW 11 takes way too long to tolerate doing this in all Windows jobs. This was an oversight when writing #2710.
