### PR TITLE
Fix CMake minimum required version being too low

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
-cmake_minimum_required(VERSION 3.22)
+if(CMAKE_HOST_WIN32)
+    # We require a CMake version greater than or equal to 3.24 on Windows in order to
+    # support specifying target_include_directories with SYSTEM for Visual Studio Generators
+    # see: https://cmake.org/cmake/help/latest/release/3.24.html#generators
+    cmake_minimum_required(VERSION 3.24)
+else()
+    # For all other systems, 3.22 will suffice
+    cmake_minimum_required(VERSION 3.22)
+endif()
 
 # define a macro that helps defining an option
 macro(sfml_set_option var default type docstring)


### PR DESCRIPTION
Support for specifying `SYSTEM` in `target_include_directories` for Visual Studio generators when using VS 2019 Update 11 or later was only [added in CMake 3.24](https://cmake.org/cmake/help/latest/release/3.24.html#generators). Building with a CMake version that is older will cause stbi warnings generated by MSVC to fail the build, see [this job which was run with CMake 3.23](https://github.com/SFML/SFML/actions/runs/6387751178/job/17336532042).