### PR TITLE
Added missing SFML_USE_STATIC_STD_LIBS checks to CMake configuration.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,11 @@ target_include_directories(sfml-test-main PUBLIC TestUtilities)
 target_link_libraries(sfml-test-main PUBLIC SFML::System Catch2::Catch2WithMain)
 set_target_warnings(sfml-test-main)
 
+# set the target flags to use the appropriate C++ standard library
+sfml_set_stdlib(Catch2)
+sfml_set_stdlib(Catch2WithMain)
+sfml_set_stdlib(sfml-test-main)
+
 sfml_set_option(SFML_RUN_DISPLAY_TESTS ON BOOL "TRUE to run tests that require a display, FALSE to ignore it")
 if(SFML_RUN_DISPLAY_TESTS)
     target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_DISPLAY_TESTS)

--- a/test/install/CMakeLists.txt
+++ b/test/install/CMakeLists.txt
@@ -18,3 +18,7 @@ endif()
 
 add_executable(test-sfml-install Install.cpp)
 target_link_libraries(test-sfml-install PRIVATE SFML::Graphics SFML::Network SFML::Audio)
+
+if(SFML_USE_STATIC_STD_LIBS)
+    set_target_properties(test-sfml-install PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()


### PR DESCRIPTION
4970af89992951eb2b4973bf32447445e9b38f64 changed to the newer way of linking to the MSVC static runtime, however it left out a few places in the CMake configuration where the check should have also been added. Without these changes, building statically with tests enabled and `SFML_USE_STATIC_STD_LIBS` enabled will fail with MSVC complaining about different runtime library linkage.