### PR TITLE
Fixed texture being upside down on Android when copying the texture of a RenderTexture

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -35,6 +35,7 @@
 
 #include <SFML/System/Err.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <ostream>
 #include <utility>
@@ -400,6 +401,22 @@ Image Texture::copyToImage() const
         glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
 
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, static_cast<GLuint>(previousFrameBuffer)));
+
+        if (m_pixelsFlipped)
+        {
+            // Flip the texture vertically
+            const auto stride             = static_cast<std::ptrdiff_t>(m_size.x * 4);
+            auto       currentRowIterator = pixels.begin();
+            auto       nextRowIterator    = pixels.begin() + stride;
+            auto       reverseRowIterator = pixels.begin() + (stride * static_cast<std::ptrdiff_t>(m_size.y - 1));
+            for (unsigned int i = 0; i < m_size.y / 2; ++i)
+            {
+                std::swap_ranges(currentRowIterator, nextRowIterator, reverseRowIterator);
+                currentRowIterator = nextRowIterator;
+                nextRowIterator += stride;
+                reverseRowIterator -= stride;
+            }
+        }
     }
 
 #else


### PR DESCRIPTION
## Description

RenderTexture was flipped on Android after the texture was copied, as described in https://github.com/SFML/SFML/issues/2419

This PR fixes https://github.com/SFML/SFML/issues/2419

## Platforms

The affected code is only compiled when `SFML_OPENGL_ES` is defined. The code was only tested on Android, but the bug should have existed on other platforms that use OpenGL ES. This was however not tested.

## How to test this PR?

The following code is supposed to render a green circle in the top left corner of the screen.
On Android, before the change from this PR is applied, the green circle will appear in the bottom left corner instead.

```cpp
#include <SFML/Graphics.hpp>
int main()
{
    sf::RenderWindow window(sf::VideoMode::getDesktopMode(), "SFML works!", sf::Style::Fullscreen);

    sf::CircleShape circle(400.f);
    circle.setFillColor(sf::Color::Green);

    sf::RenderTexture texture;
    texture.create({window.getSize().x, window.getSize().y});

    texture.clear();
    texture.draw(circle);
    texture.display();

    sf::Texture copiedTexture = texture.getTexture();
    sf::Sprite sprite(copiedTexture);

    bool active = window.hasFocus();
    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            switch (event.type)
            {
            case sf::Event::Closed:
                window.close();
                break;
            case sf::Event::LostFocus:
                window.setActive(0);
                active = 0;
                break;
            case sf::Event::GainedFocus:
                window.setActive(1);
                active = 1;
                break;
            case sf::Event::KeyReleased:
                if (event.key.code == sf::Keyboard::Escape)
                    window.close();
                break;
            }
        }
        if (!active)
            continue;

        window.clear();
        window.draw(sprite);
        window.display();
    }
}
```