### PR TITLE
Added support for running the GitHub actions workflow using CCache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
     name: ${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}
     runs-on: ${{ matrix.platform.os }}
 
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache # Use ccache to cache C compiler output
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache # Use ccache to cache C++ compiler output
+
     strategy:
       fail-fast: false
       matrix:
@@ -72,9 +76,12 @@ jobs:
         cmakeVersion: ${{ runner.os == 'Windows' && '3.24' || '3.22' }} # Set to minimum required version (3.24 on Windows and 3.22 elsewhere) as specified in CMakeLists.txt to test compatibility
         ninjaVersion: latest
 
-    - name: Install Linux Dependencies
+    - name: Install Linux Dependencies and Tools
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev xvfb fluxbox
+      run: |
+        CLANG_VERSION=$(clang++ --version | sed -n 's/.*version \([0-9]\+\)\..*/\1/p')
+        echo "CLANG_VERSION=$CLANG_VERSION" >> $GITHUB_ENV
+        sudo apt-get update && sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev xvfb fluxbox ccache gcovr ${{ matrix.platform.name == 'Linux Clang' && 'llvm-$CLANG_VERSION' || '' }}
 
     - name: Install Android Components
       if: matrix.platform.name == 'Android'
@@ -82,19 +89,20 @@ jobs:
         wget -nv https://dl.google.com/android/repository/android-ndk-r23b-linux.zip -P $GITHUB_WORKSPACE
         unzip -qq -d $GITHUB_WORKSPACE android-ndk-r23b-linux.zip
 
-    - name: Install Linux Tools
-      if: matrix.type.name == 'Debug' && runner.os == 'Linux'
-      run: |
-        CLANG_VERSION=$(clang++ --version | sed -n 's/.*version \([0-9]\+\)\..*/\1/p')
-        echo "CLANG_VERSION=$CLANG_VERSION" >> $GITHUB_ENV
-        sudo apt-get install gcovr ${{ matrix.platform.name == 'Linux Clang' && 'llvm-$CLANG_VERSION' || '' }}
-
     - name: Install macOS Tools
       if: runner.os == 'macOS'
       run: |
         # Do not run updates until GitHub has fixed all the issues: https://github.com/orgs/Homebrew/discussions/4612
         # brew update
-        brew install gcovr || true
+        brew install gcovr ccache || true
+
+    # In addition to installing a known working version of CCache, this action also takes care of saving and restoring the cache for us
+    # Additionally it outputs information at the end of each job that helps us to verify if the cache is working properly
+    - name: Setup CCache
+      uses: hendrikmuhs/ccache-action@v1.2.10
+      with:
+        verbose: 2
+        key: ${{ matrix.platform.name }}-${{ matrix.config.name }}-${{ matrix.type.name }}
 
     - name: Cache OpenCppCoverage
       if: matrix.type.name == 'Debug' && runner.os == 'Windows'
@@ -126,11 +134,14 @@ jobs:
         curl -Lo mingw64.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/12.2.0-16.0.0-10.0.0-msvcrt-r5/winlibs-x86_64-posix-seh-gcc-12.2.0-llvm-16.0.0-mingw-w64msvcrt-10.0.0-r5.zip
         unzip -qq -d "C:\Program Files" mingw64.zip
 
-    - name: Add OpenCppCoverage and MinGW to PATH
+    - name: Add OpenCppCoverage and MinGW to PATH and remove MinGW-supplied CCache
       if: runner.os == 'Windows'
       run: |
         echo "C:\Program Files\OpenCppCoverage" >> $GITHUB_PATH
         echo "C:\Program Files\mingw64\bin" >> $GITHUB_PATH
+        rm -f "C:\Program Files\mingw64\bin\ccache.exe"
+        echo "Using $(which ccache)"
+        ccache --version
 
     - name: Configure CMake
       run: cmake --preset dev -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,6 @@ project(SFML VERSION 3.0.0)
 
 set(VERSION_IS_RELEASE OFF)
 
-# use ccache if available
-find_program(CCACHE_PROGRAM ccache)
-if(CCACHE_PROGRAM)
-    message(STATUS "Found ccache in ${CCACHE_PROGRAM}")
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-endif()
-
 # include the configuration file
 include(cmake/Config.cmake)
 


### PR DESCRIPTION
Title.

This changeset adds `ccache` support to speed up building by caching the produced object files whenever possible. Because it works by instructing the chosen CMake generator to insert it as the compiler launcher it won't be supported on vendor-specific generators like MSBuild or Xcode. MSVC support can be added later if we decide to move most of it over to Ninja.