### PR TITLE
Fixed compiling on Linux with SFML_OPENGL_ES

### DIFF
--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -427,7 +427,7 @@ XVisualInfo EglContext::selectBestVisual(::Display* XDisplay, unsigned int bitsP
 
     // Get X11 visuals compatible with this EGL config
     int  visualCount      = 0;
-    auto availableVisuals = X11Ptr<XVisualInfo[]> XGetVisualInfo(XDisplay, VisualIDMask, &vTemplate, &visualCount));
+    auto availableVisuals = X11Ptr<XVisualInfo[]>(XGetVisualInfo(XDisplay, VisualIDMask, &vTemplate, &visualCount));
 
     if (visualCount == 0)
     {


### PR DESCRIPTION
A typo was made in `EglContext::selectBestVisual` in [#2540](https://github.com/SFML/SFML/pull/2540) which breaks compilation on Linux when SFML_OPENGL_ES=ON

This PR adds the missing bracket to make the code compile again.