### PR TITLE
Assert against division by zero in public APIs

### DIFF
--- a/include/SFML/System/Angle.inl
+++ b/include/SFML/System/Angle.inl
@@ -191,6 +191,7 @@ constexpr Angle& operator*=(Angle& left, float right)
 ////////////////////////////////////////////////////////////
 constexpr Angle operator/(Angle left, float right)
 {
+    assert(right != 0 && "Angle::operator/ cannot divide by 0");
     return degrees(left.asDegrees() / right);
 }
 
@@ -198,6 +199,7 @@ constexpr Angle operator/(Angle left, float right)
 ////////////////////////////////////////////////////////////
 constexpr Angle& operator/=(Angle& left, float right)
 {
+    assert(right != 0 && "Angle::operator/= cannot divide by 0");
     return left = left / right;
 }
 
@@ -205,6 +207,7 @@ constexpr Angle& operator/=(Angle& left, float right)
 ////////////////////////////////////////////////////////////
 constexpr float operator/(Angle left, Angle right)
 {
+    assert(right.asDegrees() != 0 && "Angle::operator/ cannot divide by 0");
     return left.asDegrees() / right.asDegrees();
 }
 
@@ -212,6 +215,7 @@ constexpr float operator/(Angle left, Angle right)
 ////////////////////////////////////////////////////////////
 constexpr Angle operator%(Angle left, Angle right)
 {
+    assert(right.asDegrees() != 0 && "Angle::operator% cannot divide by 0");
     return degrees(priv::positiveRemainder(left.asDegrees(), right.asDegrees()));
 }
 
@@ -219,6 +223,7 @@ constexpr Angle operator%(Angle left, Angle right)
 ////////////////////////////////////////////////////////////
 constexpr Angle& operator%=(Angle& left, Angle right)
 {
+    assert(right.asDegrees() != 0 && "Angle::operator%= cannot modulus by 0");
     return left = left % right;
 }
 

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <ratio>
 
+#include <cassert>
 #include <cstdint>
 
 

--- a/include/SFML/System/Time.inl
+++ b/include/SFML/System/Time.inl
@@ -213,6 +213,7 @@ constexpr Time& operator*=(Time& left, std::int64_t right)
 ////////////////////////////////////////////////////////////
 constexpr Time operator/(Time left, float right)
 {
+    assert(right != 0 && "Time::operator/ cannot divide by 0");
     return seconds(left.asSeconds() / right);
 }
 
@@ -220,6 +221,7 @@ constexpr Time operator/(Time left, float right)
 ////////////////////////////////////////////////////////////
 constexpr Time operator/(Time left, std::int64_t right)
 {
+    assert(right != 0 && "Time::operator/ cannot divide by 0");
     return microseconds(left.asMicroseconds() / right);
 }
 
@@ -227,6 +229,7 @@ constexpr Time operator/(Time left, std::int64_t right)
 ////////////////////////////////////////////////////////////
 constexpr Time& operator/=(Time& left, float right)
 {
+    assert(right != 0 && "Time::operator/= cannot divide by 0");
     return left = left / right;
 }
 
@@ -234,6 +237,7 @@ constexpr Time& operator/=(Time& left, float right)
 ////////////////////////////////////////////////////////////
 constexpr Time& operator/=(Time& left, std::int64_t right)
 {
+    assert(right != 0 && "Time::operator/= cannot divide by 0");
     return left = left / right;
 }
 
@@ -241,6 +245,7 @@ constexpr Time& operator/=(Time& left, std::int64_t right)
 ////////////////////////////////////////////////////////////
 constexpr float operator/(Time left, Time right)
 {
+    assert(right.asMicroseconds() != 0 && "Time::operator/ cannot divide by 0");
     return left.asSeconds() / right.asSeconds();
 }
 
@@ -248,6 +253,7 @@ constexpr float operator/(Time left, Time right)
 ////////////////////////////////////////////////////////////
 constexpr Time operator%(Time left, Time right)
 {
+    assert(right.asMicroseconds() != 0 && "Time::operator% cannot modulus by 0");
     return microseconds(left.asMicroseconds() % right.asMicroseconds());
 }
 
@@ -255,6 +261,7 @@ constexpr Time operator%(Time left, Time right)
 ////////////////////////////////////////////////////////////
 constexpr Time& operator%=(Time& left, Time right)
 {
+    assert(right.asMicroseconds() != 0 && "Time::operator%= cannot modulus by 0");
     return left = left % right;
 }
 

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -177,6 +177,7 @@ constexpr Vector2<T>& operator*=(Vector2<T>& left, T right)
 template <typename T>
 constexpr Vector2<T> operator/(const Vector2<T>& left, T right)
 {
+    assert(right != 0 && "Vector2::operator/ cannot divide by 0");
     return Vector2<T>(left.x / right, left.y / right);
 }
 
@@ -185,6 +186,7 @@ constexpr Vector2<T> operator/(const Vector2<T>& left, T right)
 template <typename T>
 constexpr Vector2<T>& operator/=(Vector2<T>& left, T right)
 {
+    assert(right != 0 && "Vector2::operator/= cannot divide by 0");
     left.x /= right;
     left.y /= right;
 

--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -176,6 +176,7 @@ constexpr Vector3<T>& operator*=(Vector3<T>& left, T right)
 template <typename T>
 constexpr Vector3<T> operator/(const Vector3<T>& left, T right)
 {
+    assert(right != 0 && "Vector3::operator/ cannot divide by 0");
     return Vector3<T>(left.x / right, left.y / right, left.z / right);
 }
 
@@ -184,6 +185,7 @@ constexpr Vector3<T> operator/(const Vector3<T>& left, T right)
 template <typename T>
 constexpr Vector3<T>& operator/=(Vector3<T>& left, T right)
 {
+    assert(right != 0 && "Vector3::operator/= cannot divide by 0");
     left.x /= right;
     left.y /= right;
     left.z /= right;


### PR DESCRIPTION
## Description

Yet another class of UB we can eliminate in debug builds. I'm not concerned about the case where users provide the literal `0` but rather the cases where the divisor is the result of some calculation and may be zero in some cases.