### PR TITLE
Fix FBO RenderTarget tracking

### DIFF
--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -158,9 +158,22 @@ bool RenderTexture::setActive(bool active)
 ////////////////////////////////////////////////////////////
 void RenderTexture::display()
 {
-    // Update the target texture
-    if (m_impl && (priv::RenderTextureImplFBO::isAvailable() || setActive(true)))
+    if (m_impl)
     {
+        if (priv::RenderTextureImplFBO::isAvailable())
+        {
+            // Perform a RenderTarget-only activation if we are using FBOs
+            if (!RenderTarget::setActive())
+                return;
+        }
+        else
+        {
+            // Perform a full activation if we are not using FBOs
+            if (!setActive())
+                return;
+        }
+
+        // Update the target texture
         m_impl->updateTexture(m_texture.m_texture);
         m_texture.m_pixelsFlipped = true;
         m_texture.invalidateMipmap();


### PR DESCRIPTION
Fixed `RenderTarget` tracking not being notified to update its active target when an FBO `RenderTexture` is `display()`ed.

0adde249ec9fd2012c53b5f57f71989ffd88d16f introduced FBO `RenderTarget` optimizations that reduced the amount of context switching that had to be performed in certain situations. A tracking map was added to `RenderTarget` that kept track of which `RenderTarget` was active in which context. This bug occurs because if the FBO check is successful, not only was the FBO activation skipped, but the updating of the `RenderTarget` map as well. Performing a partial (`RenderTarget`-only) update fixes this issue.

The examples that exhibit broken behaviour can be found in #2630.

Fixes #2630

@danieljpetersen @Bambo-Borris @metaquarx 