### PR TITLE
Added 'm_cacheId' getter to sf::Texture

### DIFF
--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -548,6 +548,20 @@ public:
     unsigned int getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the unique number that identifies the texture to
+    /// the render target's cache
+    ///
+    /// Can be stored in classes that utilize the sf::Texture class
+    /// and compared on subsequent calls to member functions of
+    /// that class to determine if the texture has fundamentally
+    /// changed.
+    ///
+    /// \return Unique number of the texture
+    ///
+    ////////////////////////////////////////////////////////////
+    std::uint64_t getCacheId() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Bind a texture for rendering
     ///
     /// This function is not part of the graphics API, it mustn't be
@@ -593,7 +607,6 @@ public:
     static unsigned int getMaximumSize();
 
 private:
-    friend class Text;
     friend class RenderTexture;
     friend class RenderTarget;
 

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -369,11 +369,11 @@ void Text::draw(RenderTarget& target, const RenderStates& states) const
 void Text::ensureGeometryUpdate() const
 {
     // Do nothing, if geometry has not changed and the font texture has not changed
-    if (!m_geometryNeedUpdate && m_font->getTexture(m_characterSize).m_cacheId == m_fontTextureId)
+    if (!m_geometryNeedUpdate && m_font->getTexture(m_characterSize).getCacheId() == m_fontTextureId)
         return;
 
     // Save the current fonts texture id
-    m_fontTextureId = m_font->getTexture(m_characterSize).m_cacheId;
+    m_fontTextureId = m_font->getTexture(m_characterSize).getCacheId();
 
     // Mark geometry as updated
     m_geometryNeedUpdate = false;

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -938,6 +938,13 @@ unsigned int Texture::getNativeHandle() const
 
 
 ////////////////////////////////////////////////////////////
+std::uint64_t Texture::getCacheId() const
+{
+    return m_cacheId;
+}
+
+
+////////////////////////////////////////////////////////////
 unsigned int Texture::getValidSize(unsigned int size)
 {
     if (GLEXT_texture_non_power_of_two)


### PR DESCRIPTION
## Description
This member function would be very useful for checking whether a sf::Texture has been swapped/created between calls to a class that contains it.  An example would be custom font or text classes that operate on some format not supported directly by the SFML API, e.g., SVG files or some custom raster font.  My use case was a font class that loaded individual PNG files from an existing application (Super Mario 64 port) and built a dynamically sized texture from them, mapping their texture rects to characters. These could then be rendered to the screen via a custom text class with a vertex buffer, minimizing draw calls. I need a way to check whether the texture has been resized between calls the the custom text object, which may not be accessed every frame. I don't need direct access to an internal variable like m_cacheId; that would be stupid, but I don't see a reason to preclude someone from utilizing its value, and the additional code is pretty minuscule.  I've searched for this topic online and found one example of someone bringing it up, but it didn't seem like they made a very good case for it, and I believe they even suggested making the variable public, which again, like I said, is pretty silly.