### PR TITLE
Fixed RenderTexture being upside down on Android in SFML 2.6 (backport of #2719)

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -350,6 +350,22 @@ Image Texture::copyToImage() const
         glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
 
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, previousFrameBuffer));
+
+        if (m_pixelsFlipped)
+        {
+            // Flip the texture vertically
+            const int stride        = static_cast<int>(m_size.x * 4);
+            Uint8*    currentRowPtr = pixels.data();
+            Uint8*    nextRowPtr    = pixels.data() + stride;
+            Uint8*    reverseRowPtr = pixels.data() + (stride * static_cast<int>(m_size.y - 1));
+            for (unsigned int y = 0; y < m_size.y / 2; ++y)
+            {
+                std::swap_ranges(currentRowPtr, nextRowPtr, reverseRowPtr);
+                currentRowPtr = nextRowPtr;
+                nextRowPtr += stride;
+                reverseRowPtr -= stride;
+            }
+        }
     }
 
 #else


### PR DESCRIPTION
This fixes https://github.com/SFML/SFML/issues/2419 on the 2.6.x branch

The fix was already merged in the master branch with https://github.com/SFML/SFML/pull/2719, this is a backport for the 2.6.x branch

## How to test this PR?

The following code is supposed to render a green circle in the top left corner of the screen.
On Android, before the change from this PR is applied, the green circle will appear in the bottom left corner instead.

```cpp
#include <SFML/Graphics.hpp>
int main()
{
    sf::RenderWindow window(sf::VideoMode::getDesktopMode(), "SFML works!", sf::Style::Fullscreen);

    sf::CircleShape circle(400.f);
    circle.setFillColor(sf::Color::Green);

    sf::RenderTexture texture;
    texture.create(window.getSize().x, window.getSize().y);

    texture.clear();
    texture.draw(circle);
    texture.display();

    sf::Texture copiedTexture = texture.getTexture();
    sf::Sprite sprite(copiedTexture);

    bool active = window.hasFocus();
    while (window.isOpen())
    {
        sf::Event event;
        while (window.pollEvent(event))
        {
            switch (event.type)
            {
            case sf::Event::Closed:
                window.close();
                break;
            case sf::Event::LostFocus:
                window.setActive(0);
                active = 0;
                break;
            case sf::Event::GainedFocus:
                window.setActive(1);
                active = 1;
                break;
            case sf::Event::KeyReleased:
                if (event.key.code == sf::Keyboard::Escape)
                    window.close();
                break;
            }
        }
        if (!active)
            continue;

        window.clear();
        window.draw(sprite);
        window.display();
    }
}
```