### PR TITLE
Add `cppcoreguidelines-pro-type-member-init` clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,7 +42,6 @@ Checks: >
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-const-cast,
-  -cppcoreguidelines-pro-type-member-init,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-static-cast-downcast,
   -cppcoreguidelines-pro-type-union-access,

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -2595,7 +2595,7 @@ private:
     VkImageView                     depthImageView{};
     VkShaderModule                  vertexShaderModule{};
     VkShaderModule                  fragmentShaderModule{};
-    VkPipelineShaderStageCreateInfo shaderStages[2];
+    VkPipelineShaderStageCreateInfo shaderStages[2]{};
     VkDescriptorSetLayout           descriptorSetLayout{};
     VkPipelineLayout                pipelineLayout{};
     VkRenderPass                    renderPass{};

--- a/include/SFML/Audio/SoundFileFactory.inl
+++ b/include/SFML/Audio/SoundFileFactory.inl
@@ -51,9 +51,7 @@ void SoundFileFactory::registerReader()
     unregisterReader<T>();
 
     // Create a new factory with the functions provided by the class
-    ReaderFactory factory;
-    factory.check  = &T::check;
-    factory.create = &priv::createReader<T>;
+    const ReaderFactory factory{&T::check, &priv::createReader<T>};
 
     // Add it
     s_readers.push_back(factory);
@@ -82,9 +80,7 @@ void SoundFileFactory::registerWriter()
     unregisterWriter<T>();
 
     // Create a new factory with the functions provided by the class
-    WriterFactory factory;
-    factory.check  = &T::check;
-    factory.create = &priv::createWriter<T>;
+    const WriterFactory factory{&T::check, &priv::createWriter<T>};
 
     // Add it
     s_writers.push_back(factory);

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -290,7 +290,7 @@ protected:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int m_source; //!< OpenAL source identifier
+    unsigned int m_source{}; //!< OpenAL source identifier
 };
 
 // NOLINTEND(readability-make-member-function-const)

--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -81,7 +81,7 @@ struct Matrix
         copyMatrix(transform, *this);
     }
 
-    float array[Columns * Rows]; //!< Array holding matrix data
+    float array[Columns * Rows]{}; //!< Array holding matrix data
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -177,12 +177,12 @@ public:
         ////////////////////////////////////////////////////////////
         // Member data
         ////////////////////////////////////////////////////////////
-        FieldTable   m_fields;       //!< Fields of the header associated to their value
-        Method       m_method;       //!< Method to use for the request
-        std::string  m_uri;          //!< Target URI of the request
-        unsigned int m_majorVersion; //!< Major HTTP version
-        unsigned int m_minorVersion; //!< Minor HTTP version
-        std::string  m_body;         //!< Body of the request
+        FieldTable   m_fields;          //!< Fields of the header associated to their value
+        Method       m_method;          //!< Method to use for the request
+        std::string  m_uri;             //!< Target URI of the request
+        unsigned int m_majorVersion{1}; //!< Major HTTP version
+        unsigned int m_minorVersion{};  //!< Minor HTTP version
+        std::string  m_body;            //!< Body of the request
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -35,6 +35,8 @@
 #include <SFML/Window/Sensor.hpp>
 
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
+
 namespace sf
 {
 ////////////////////////////////////////////////////////////
@@ -200,7 +202,7 @@ struct Event
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    EventType type; //!< Type of the event
+    EventType type{}; //!< Type of the event
 
     union
     {
@@ -219,6 +221,8 @@ struct Event
 };
 
 } // namespace sf
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/TextureSaver.hpp
+++ b/src/SFML/Graphics/TextureSaver.hpp
@@ -59,7 +59,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    GLint m_textureBinding; //!< Texture binding to restore
+    GLint m_textureBinding{}; //!< Texture binding to restore
 };
 
 } // namespace sf::priv

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -39,11 +39,9 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Http::Request::Request(const std::string& uri, Method method, const std::string& body)
+Http::Request::Request(const std::string& uri, Method method, const std::string& body) : m_method(method)
 {
-    setMethod(method);
     setUri(uri);
-    setHttpVersion(1, 0);
     setBody(body);
 }
 

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -73,7 +73,7 @@ std::optional<IpAddress> IpAddress::resolve(std::string_view address)
     addrinfo* result = nullptr;
     if (getaddrinfo(address.data(), nullptr, &hints, &result) == 0 && result != nullptr)
     {
-        sockaddr_in sin;
+        sockaddr_in sin{};
         std::memcpy(&sin, result->ai_addr, sizeof(*result->ai_addr));
 
         const std::uint32_t ip = sin.sin_addr.s_addr;
@@ -102,7 +102,7 @@ IpAddress::IpAddress(std::uint32_t address) : m_address(htonl(address))
 ////////////////////////////////////////////////////////////
 std::string IpAddress::toString() const
 {
-    in_addr address;
+    in_addr address{};
     address.s_addr = m_address;
 
     return inet_ntoa(address);

--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -171,7 +171,7 @@ void SocketSelector::clear()
 bool SocketSelector::wait(Time timeout)
 {
     // Setup the timeout
-    timeval time;
+    timeval time{};
     time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1000000);
     time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1000000);
 

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -48,7 +48,7 @@ unsigned short TcpListener::getLocalPort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the local end of the socket
-        sockaddr_in                  address;
+        sockaddr_in                  address{};
         priv::SocketImpl::AddrLength size = sizeof(address);
         if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
         {
@@ -114,7 +114,7 @@ Socket::Status TcpListener::accept(TcpSocket& socket)
     }
 
     // Accept a new connection
-    sockaddr_in                  address;
+    sockaddr_in                  address{};
     priv::SocketImpl::AddrLength length = sizeof(address);
     const SocketHandle           remote = ::accept(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &length);
 

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -66,7 +66,7 @@ unsigned short TcpSocket::getLocalPort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the local end of the socket
-        sockaddr_in                  address;
+        sockaddr_in                  address{};
         priv::SocketImpl::AddrLength size = sizeof(address);
         if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
         {
@@ -85,7 +85,7 @@ std::optional<IpAddress> TcpSocket::getRemoteAddress() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the remote end of the socket
-        sockaddr_in                  address;
+        sockaddr_in                  address{};
         priv::SocketImpl::AddrLength size = sizeof(address);
         if (getpeername(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
         {
@@ -104,7 +104,7 @@ unsigned short TcpSocket::getRemotePort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the remote end of the socket
-        sockaddr_in                  address;
+        sockaddr_in                  address{};
         priv::SocketImpl::AddrLength size = sizeof(address);
         if (getpeername(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
         {
@@ -175,7 +175,7 @@ Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short
             FD_SET(getNativeHandle(), &selector);
 
             // Setup the timeout
-            timeval time;
+            timeval time{};
             time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1000000);
             time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1000000);
 

--- a/src/SFML/Network/UdpSocket.cpp
+++ b/src/SFML/Network/UdpSocket.cpp
@@ -51,7 +51,7 @@ unsigned short UdpSocket::getLocalPort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the local end of the socket
-        sockaddr_in                  address;
+        sockaddr_in                  address{};
         priv::SocketImpl::AddrLength size = sizeof(address);
         if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
         {

--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -61,31 +61,31 @@ struct ActivityStates
     AInputQueue*    inputQueue{};
     AConfiguration* config{};
 
-    EGLDisplay  display;
-    EglContext* context;
+    EGLDisplay  display{};
+    EglContext* context{};
 
-    void*       savedState;
-    std::size_t savedStateSize;
+    void*       savedState{};
+    std::size_t savedStateSize{};
 
     std::recursive_mutex mutex;
 
-    void (*forwardEvent)(const Event& event);
-    int (*processEvent)(int fd, int events, void* data);
+    void (*forwardEvent)(const Event& event){};
+    int (*processEvent)(int fd, int events, void* data){};
 
     std::unordered_map<int, Vector2i> touchEvents;
     Vector2i                          mousePosition;
-    bool                              isButtonPressed[Mouse::ButtonCount];
+    bool                              isButtonPressed[Mouse::ButtonCount]{};
 
-    bool mainOver;
+    bool mainOver{};
 
     Vector2i screenSize;
 
-    bool initialized;
-    bool terminated;
+    bool initialized{};
+    bool terminated{};
 
-    bool fullscreen;
+    bool fullscreen{};
 
-    bool updated;
+    bool updated{};
 
     LogcatStream logcat;
 };

--- a/src/SFML/System/Android/SuspendAwareClock.cpp
+++ b/src/SFML/System/Android/SuspendAwareClock.cpp
@@ -34,7 +34,7 @@ namespace sf
 
 SuspendAwareClock::time_point SuspendAwareClock::now() noexcept
 {
-    ::timespec ts;
+    ::timespec ts{};
 #ifdef CLOCK_BOOTTIME
     clock_gettime(CLOCK_BOOTTIME, &ts);
 #else

--- a/src/SFML/System/Unix/SleepImpl.cpp
+++ b/src/SFML/System/Unix/SleepImpl.cpp
@@ -40,7 +40,7 @@ void sleepImpl(Time time)
     const std::int64_t usecs = time.asMicroseconds();
 
     // Construct the time to wait
-    timespec ti;
+    timespec ti{};
     ti.tv_sec  = static_cast<time_t>(usecs / 1000000);
     ti.tv_nsec = static_cast<long>((usecs % 1000000) * 1000);
 

--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -377,7 +377,7 @@ bool eventProcess(sf::Event& event)
     // Check all the open file descriptors for the next event
     for (auto& fileDescriptor : fileDescriptors)
     {
-        input_event inputEvent;
+        input_event inputEvent{};
         bytesRead = read(fileDescriptor, &inputEvent, sizeof(inputEvent));
 
         while (bytesRead > 0)
@@ -509,7 +509,7 @@ bool eventProcess(sf::Event& event)
     newTerminalConfig.c_lflag &= ~static_cast<tcflag_t>(ICANON);
     tcsetattr(STDIN_FILENO, TCSANOW, &newTerminalConfig);
 
-    timeval timeout;
+    timeval timeout{};
     timeout.tv_sec  = 0;
     timeout.tv_usec = 0;
 

--- a/src/SFML/Window/DRM/WindowImplDRM.cpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.cpp
@@ -186,9 +186,9 @@ bool WindowImplDRM::hasFocus() const
 
 void WindowImplDRM::processEvents()
 {
-    sf::Event ev;
-    while (sf::priv::InputImpl::checkEvent(ev))
-        pushEvent(ev);
+    sf::Event event;
+    while (sf::priv::InputImpl::checkEvent(event))
+        pushEvent(event);
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/SensorManager.hpp
+++ b/src/SFML/Window/SensorManager.hpp
@@ -124,10 +124,10 @@ private:
     ////////////////////////////////////////////////////////////
     struct Item
     {
-        bool       available; //!< Is the sensor available on this device?
-        bool       enabled;   //!< Current enable state of the sensor
-        SensorImpl sensor;    //!< Sensor implementation
-        Vector3f   value;     //!< The current sensor value
+        bool       available{}; //!< Is the sensor available on this device?
+        bool       enabled{};   //!< Current enable state of the sensor
+        SensorImpl sensor{};    //!< Sensor implementation
+        Vector3f   value;       //!< The current sensor value
     };
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -50,7 +50,7 @@ struct JoystickRecord
 {
     std::string deviceNode;
     std::string systemPath;
-    bool        plugged;
+    bool        plugged{};
 };
 
 using JoystickList = std::vector<JoystickRecord>;
@@ -639,7 +639,7 @@ JoystickState JoystickImpl::JoystickImpl::update()
     }
 
     // pop events from the joystick file
-    js_event joyState;
+    js_event joyState{};
     ssize_t  result = read(m_file, &joyState, sizeof(joyState));
     while (result > 0)
     {

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -790,8 +790,7 @@ bool JoystickImpl::openDInput(unsigned int index)
                     {
                         if (m_identification.vendorId && m_identification.productId)
                         {
-                            JoystickBlacklistEntry entry;
-
+                            JoystickBlacklistEntry entry{};
                             entry.vendorId  = m_identification.vendorId;
                             entry.productId = m_identification.productId;
 

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -212,15 +212,15 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int          m_index;        //!< Index of the joystick
-    JOYCAPS               m_caps;         //!< Joystick capabilities
-    IDirectInputDevice8W* m_device;       //!< DirectInput 8.x device
-    DIDEVCAPS             m_deviceCaps;   //!< DirectInput device capabilities
-    int m_axes[Joystick::AxisCount];      //!< Offsets to the bytes containing the axes states, -1 if not available
-    int m_buttons[Joystick::ButtonCount]; //!< Offsets to the bytes containing the button states, -1 if not available
+    unsigned int          m_index{};        //!< Index of the joystick
+    JOYCAPS               m_caps{};         //!< Joystick capabilities
+    IDirectInputDevice8W* m_device{};       //!< DirectInput 8.x device
+    DIDEVCAPS             m_deviceCaps{};   //!< DirectInput device capabilities
+    int m_axes[Joystick::AxisCount]{};      //!< Offsets to the bytes containing the axes states, -1 if not available
+    int m_buttons[Joystick::ButtonCount]{}; //!< Offsets to the bytes containing the button states, -1 if not available
     Joystick::Identification m_identification; //!< Joystick identification
     JoystickState            m_state;          //!< Buffered joystick state
-    bool                     m_buffered;       //!< true if the device uses buffering, false if the device uses polling
+    bool                     m_buffered{};     //!< true if the device uses buffering, false if the device uses polling
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -334,7 +334,7 @@ private:
     std::unique_ptr<JoystickStatesImpl> m_joystickStatesImpl;         //!< Previous state of the joysticks (PImpl)
     Vector3f                            m_sensorValue[Sensor::Count]; //!< Previous value of the sensors
     float m_joystickThreshold{0.1f}; //!< Joystick threshold (minimum motion for "move" event to be generated)
-    float m_previousAxes[Joystick::Count][Joystick::AxisCount]; //!< Position of each axis last time a move event triggered, in range [-100, 100]
+    float m_previousAxes[Joystick::Count][Joystick::AxisCount]{}; //!< Position of each axis last time a move event triggered, in range [-100, 100]
     std::optional<Vector2u> m_minimumSize; //!< Minimum window size
     std::optional<Vector2u> m_maximumSize; //!< Maximum window size
 };

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -232,11 +232,11 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    UIWindow*         m_window;         ///< Pointer to the internal UIKit window
-    SFView*           m_view;           ///< OpenGL view of the window
-    SFViewController* m_viewController; ///< Controller attached to the view
-    bool              m_hasFocus;       ///< Current focus state of the window
-    float             m_backingScale;   ///< Converts from points to pixels and vice versa
+    UIWindow*         m_window{};         ///< Pointer to the internal UIKit window
+    SFView*           m_view{};           ///< OpenGL view of the window
+    SFViewController* m_viewController{}; ///< Controller attached to the view
+    bool              m_hasFocus{};       ///< Current focus state of the window
+    float             m_backingScale{};   ///< Converts from points to pixels and vice versa
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -288,8 +288,8 @@ private:
     ////////////////////////////////////////////////////////////
     IOHIDManagerRef m_manager{};                                                   ///< Underlying HID Manager
     IOHIDElements m_keys[static_cast<std::size_t>(Keyboard::Scan::ScancodeCount)]; ///< All the keys on any connected keyboard
-    Keyboard::Scancode m_keyToScancodeMapping[Keyboard::KeyCount];                 ///< Mapping from Key to Scancode
-    Keyboard::Key m_scancodeToKeyMapping[static_cast<std::size_t>(Keyboard::Scan::ScancodeCount)]; ///< Mapping from Scancode to Key
+    Keyboard::Scancode m_keyToScancodeMapping[Keyboard::KeyCount]{};               ///< Mapping from Key to Scancode
+    Keyboard::Key m_scancodeToKeyMapping[static_cast<std::size_t>(Keyboard::Scan::ScancodeCount)]{}; ///< Mapping from Scancode to Key
 
     ////////////////////////////////////////////////////////////
     /// m_keys' index corresponds to sf::Keyboard::Scancode enum.

--- a/src/SFML/Window/macOS/JoystickImpl.hpp
+++ b/src/SFML/Window/macOS/JoystickImpl.hpp
@@ -115,9 +115,9 @@ private:
     using ButtonsVector = std::vector<IOHIDElementRef>;
 
     AxisMap                  m_axis;           ///< Axes (but not POV/Hat) of the joystick
-    IOHIDElementRef          m_hat;            ///< POV/Hat axis of the joystick
+    IOHIDElementRef          m_hat{};          ///< POV/Hat axis of the joystick
     ButtonsVector            m_buttons;        ///< Buttons of the joystick
-    unsigned int             m_index;          ///< SFML index
+    unsigned int             m_index{};        ///< SFML index
     Joystick::Identification m_identification; ///< Joystick identification
 
     // NOLINTNEXTLINE(readability-identifier-naming)

--- a/src/SFML/Window/macOS/SFKeyboardModifiersHelper.mm
+++ b/src/SFML/Window/macOS/SFKeyboardModifiersHelper.mm
@@ -153,7 +153,7 @@ void initialiseKeyboardHelper()
 ////////////////////////////////////////////////////////
 sf::Event::KeyEvent keyEventWithModifiers(NSUInteger modifiers, sf::Keyboard::Key key, sf::Keyboard::Scancode code)
 {
-    sf::Event::KeyEvent event;
+    sf::Event::KeyEvent event{};
     event.code     = key;
     event.scancode = code;
     event.alt      = modifiers & NSAlternateKeyMask;

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -61,7 +61,7 @@ TEST_CASE("[Graphics] sf::Image")
         SECTION("create(Vector2, std::uint8_t*)")
         {
             // 10 x 10, with 4 colour channels array
-            std::array<std::uint8_t, 400> pixels;
+            std::array<std::uint8_t, 400> pixels{};
             for (std::size_t i = 0; i < pixels.size(); i += 4)
             {
                 pixels[i]     = 255; // r


### PR DESCRIPTION
## Description

https://releases.llvm.org/16.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html

This marks another good step towards systematically rooting out undefined behavior in the form of reading uninitialized memory.

> The check takes assignment of fields in the constructor body into account but generates false positives for fields initialized in methods invoked in the constructor body.

I noticed a few of these false positives but found satisfactory workarounds.