### PR TITLE
Add tests for `sf::Image::saveToFile`

### DIFF
--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <ostream>
 
+#include <cassert>
 #include <cstring>
 
 
@@ -263,7 +264,9 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
 ////////////////////////////////////////////////////////////
 void Image::setPixel(const Vector2u& coords, const Color& color)
 {
-    std::uint8_t* pixel = &m_pixels[(coords.x + coords.y * m_size.x) * 4];
+    const auto index = (coords.x + coords.y * m_size.x) * 4;
+    assert(index < m_pixels.size() && "Image::setPixel() cannot access out of bounds pixel");
+    std::uint8_t* pixel = &m_pixels[index];
     *pixel++            = color.r;
     *pixel++            = color.g;
     *pixel++            = color.b;
@@ -274,7 +277,9 @@ void Image::setPixel(const Vector2u& coords, const Color& color)
 ////////////////////////////////////////////////////////////
 Color Image::getPixel(const Vector2u& coords) const
 {
-    const std::uint8_t* pixel = &m_pixels[(coords.x + coords.y * m_size.x) * 4];
+    const auto index = (coords.x + coords.y * m_size.x) * 4;
+    assert(index < m_pixels.size() && "Image::getPixel() cannot access out of bounds pixel");
+    const std::uint8_t* pixel = &m_pixels[index];
     return {pixel[0], pixel[1], pixel[2], pixel[3]};
 }
 

--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -269,6 +269,10 @@ bool ImageLoader::saveImageToFile(const std::filesystem::path&     filename,
             if (stbi_write_jpg(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, pixels.data(), 90))
                 return true;
         }
+        else
+        {
+            err() << "Image file extension " << extension << " not supported\n";
+        }
     }
 
     err() << "Failed to save image\n" << formatDebugPathInfo(filename) << std::endl;

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -129,6 +129,82 @@ TEST_CASE("[Graphics] sf::Image")
         CHECK(image.getPixelsPtr() != nullptr);
     }
 
+    SECTION("saveToFile()")
+    {
+        sf::Image image;
+
+        SECTION("Empty")
+        {
+            CHECK(!image.saveToFile("test.jpg"));
+        }
+
+        SECTION("Invalid size")
+        {
+            image.create({10, 0}, sf::Color::Magenta);
+            CHECK(!image.saveToFile("test.jpg"));
+            image.create({0, 10}, sf::Color::Magenta);
+            CHECK(!image.saveToFile("test.jpg"));
+        }
+
+        image.create({256, 256}, sf::Color::Magenta);
+
+        SECTION("No extension")
+        {
+            CHECK(!image.saveToFile("wheresmyextension"));
+            CHECK(!image.saveToFile("pls/add/extension"));
+        }
+
+        SECTION("Invalid extension")
+        {
+            CHECK(!image.saveToFile("test.ps"));
+            CHECK(!image.saveToFile("test.foo"));
+        }
+
+        SECTION("Successful save")
+        {
+            auto filename = std::filesystem::temp_directory_path();
+
+            SECTION("To .bmp")
+            {
+                filename /= "test.bmp";
+                CHECK(image.saveToFile(filename));
+            }
+
+            SECTION("To .tga")
+            {
+                filename /= "test.tga";
+                CHECK(image.saveToFile(filename));
+            }
+
+            SECTION("To .png")
+            {
+                filename /= "test.png";
+                CHECK(image.saveToFile(filename));
+            }
+
+            SECTION("To .jpg")
+            {
+                filename /= "test.jpg";
+                CHECK(image.saveToFile(filename));
+            }
+
+            SECTION("To .jpeg")
+            {
+                filename /= "test.jpeg";
+                CHECK(image.saveToFile(filename));
+            }
+
+            sf::Image loadedImage;
+            REQUIRE(loadedImage.loadFromFile(filename));
+            CHECK(image.getPixel({0, 0}) == sf::Color::Magenta);
+            CHECK(image.getPixel({255, 255}) == sf::Color::Magenta);
+            CHECK(image.getSize() == sf::Vector2u(256, 256));
+            CHECK(image.getPixelsPtr() != nullptr);
+
+            CHECK(std::filesystem::remove(filename));
+        }
+    }
+
     SECTION("Set/get pixel")
     {
         sf::Image image;


### PR DESCRIPTION
## Description

The `<filesystem>` library makes it feasible to create and clean up temporary files so this didnt' end up being too difficult. It's not entirely exception-safe since `std::filesystem::remove` is not called within a destructor but (1) SFML does not throw exceptions and (2) it's not a big deal if a few files litter up someone's temporary directory.

While I was at it, I found 3 places to improve diagnostics when users incorrectly use the `sf::Image` API including 2 more instances of `assert`ing against UB.

Codecov confirms that this PR has perfect coverage of `sf::Image::saveToFile` and the other internal functions it calls into.