### PR TITLE
Fix `sf::Image` tests

### DIFF
--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -196,10 +196,8 @@ TEST_CASE("[Graphics] sf::Image")
 
             sf::Image loadedImage;
             REQUIRE(loadedImage.loadFromFile(filename));
-            CHECK(image.getPixel({0, 0}) == sf::Color::Magenta);
-            CHECK(image.getPixel({255, 255}) == sf::Color::Magenta);
-            CHECK(image.getSize() == sf::Vector2u(256, 256));
-            CHECK(image.getPixelsPtr() != nullptr);
+            CHECK(loadedImage.getSize() == sf::Vector2u(256, 256));
+            CHECK(loadedImage.getPixelsPtr() != nullptr);
 
             CHECK(std::filesystem::remove(filename));
         }


### PR DESCRIPTION

## Description

Bitten by a copy pasta error. We can't test for exact pixel values since jpeg compression changes pixel values slightly.
