### PR TITLE
Prefer C++ standard lib over C standard lib

### DIFF
--- a/src/SFML/Graphics/ImageLoader.cpp
+++ b/src/SFML/Graphics/ImageLoader.cpp
@@ -40,6 +40,8 @@
 #include <iterator>
 #include <ostream>
 
+#include <cstring>
+
 
 namespace
 {
@@ -109,7 +111,7 @@ bool ImageLoader::loadImageFromFile(const std::filesystem::path& filename, std::
         {
             // Copy the loaded pixels to the pixel buffer
             pixels.resize(static_cast<std::size_t>(width * height * 4));
-            memcpy(pixels.data(), ptr, pixels.size());
+            std::memcpy(pixels.data(), ptr, pixels.size());
         }
 
         // Free the loaded pixels (they are now in our own pixel buffer)
@@ -154,7 +156,7 @@ bool ImageLoader::loadImageFromMemory(const void* data, std::size_t dataSize, st
             {
                 // Copy the loaded pixels to the pixel buffer
                 pixels.resize(static_cast<std::size_t>(width * height * 4));
-                memcpy(pixels.data(), ptr, pixels.size());
+                std::memcpy(pixels.data(), ptr, pixels.size());
             }
 
             // Free the loaded pixels (they are now in our own pixel buffer)
@@ -213,7 +215,7 @@ bool ImageLoader::loadImageFromStream(InputStream& stream, std::vector<std::uint
         {
             // Copy the loaded pixels to the pixel buffer
             pixels.resize(static_cast<std::size_t>(width * height * 4));
-            memcpy(pixels.data(), ptr, pixels.size());
+            std::memcpy(pixels.data(), ptr, pixels.size());
         }
 
         // Free the loaded pixels (they are now in our own pixel buffer)

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -500,7 +500,7 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
 
     if (savedState != nullptr)
     {
-        states->savedState     = malloc(savedStateSize);
+        states->savedState     = std::malloc(savedStateSize);
         states->savedStateSize = savedStateSize;
         std::memcpy(states->savedState, savedState, savedStateSize);
     }

--- a/src/SFML/Window/Win32/ClipboardImpl.cpp
+++ b/src/SFML/Window/Win32/ClipboardImpl.cpp
@@ -33,6 +33,8 @@
 
 #include <ostream>
 
+#include <cstring>
+
 
 namespace sf::priv
 {
@@ -91,7 +93,7 @@ void ClipboardImpl::setString(const String& text)
 
     if (stringHandle)
     {
-        memcpy(GlobalLock(stringHandle), text.toWideString().data(), stringSize);
+        std::memcpy(GlobalLock(stringHandle), text.toWideString().data(), stringSize);
         GlobalUnlock(stringHandle);
         SetClipboardData(CF_UNICODETEXT, stringHandle);
     }


### PR DESCRIPTION
## Description

There are still a few places we're using C standard library functions over their C++ standard library alternatives. I can't find any other instances of this but please point out any more so we can fix them in this PR.