### PR TITLE
Remove redundant link library

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ set(SYSTEM_SRC
     System/Vector2.test.cpp
     System/Vector3.test.cpp
 )
-sfml_add_test(test-sfml-system "${SYSTEM_SRC}" SFML::System)
+sfml_add_test(test-sfml-system "${SYSTEM_SRC}" "")
 target_compile_definitions(test-sfml-system PRIVATE
     EXPECTED_SFML_VERSION_MAJOR=${SFML_VERSION_MAJOR}
     EXPECTED_SFML_VERSION_MINOR=${SFML_VERSION_MINOR}


### PR DESCRIPTION
## Description
Clang 16 started warning about this
```
  ld: warning: ignoring duplicate libraries: 'lib/libsfml-system-s-d.a'
  ```
test-sfml-system links to sfml-test-main which already links to `SFML::System`.