### PR TITLE
Manage memory with higher level constructs

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -500,9 +500,9 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
 
     if (savedState != nullptr)
     {
-        states->savedState     = std::malloc(savedStateSize);
-        states->savedStateSize = savedStateSize;
-        std::memcpy(states->savedState, savedState, savedStateSize);
+        const auto* begin = static_cast<const std::byte*>(savedState);
+        const auto* end   = begin + savedStateSize;
+        states->savedState.assign(begin, end);
     }
 
     states->mainOver = false;

--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -39,6 +39,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <cstddef>
+
 class SFML_SYSTEM_API LogcatStream : public std::streambuf
 {
 public:
@@ -64,8 +66,7 @@ struct ActivityStates
     EGLDisplay  display{};
     EglContext* context{};
 
-    void*       savedState{};
-    std::size_t savedStateSize{};
+    std::vector<std::byte> savedState;
 
     std::recursive_mutex mutex;
 


### PR DESCRIPTION
## Description

`std::vector` provides higher level options for initializing this member. It's worth noting that it appears that `sf::priv::ActivityState::savedState` is not even used so perhaps we can remove it. 

---

While I was looking at this code I realized that I think we can replace
```cpp
auto* states = new sf::priv::ActivityStates();
```
with 
```cpp
static sf::priv::ActivityStates states;
```
with the same effect while getting to remove a `new` which would be nice. If this is function-local static then we can safely pass the address of it around. This is only possible however if it's valid to only have 1 instance of this object alive at a time. If we're supposed to support multiple instances at once then we'll have to stick with the leak-y `new` solution or something like that. As far as I can tell this object is only meant to exist in one place at a time though.
