### PR TITLE
Specify `CMAKE_RUNTIME_OUTPUT_DIRECTORY` from outside of the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,9 +216,6 @@ if(SFML_OS_MACOS)
     endif()
 endif()
 
-# set the output directory for SFML DLLs and executables
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
-
 # enable project folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,6 +8,7 @@
       "cacheVariables": {
         "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": "${sourceDir}/build/bin",
         "SFML_BUILD_EXAMPLES": "ON",
         "SFML_BUILD_TEST_SUITE": "ON",
         "SFML_WARNINGS_AS_ERRORS": "ON"


### PR DESCRIPTION
## Description

Hardcoding this into the library itself means that outside consumers cannot choose a different value. This in particular breaks the CMake template project of ours which also tries to set this value. It resulted in the DLLs not being placed in build/bin as expected but rather build/_deps/sfml-build/bin.

As conventional wisdom dictates, it's best to not touch `CMAKE_` variables unless necessary. Luckily our use of presents means we can easy move this into the development preset so there are no ergonomics disadvantages to this.

This problem is not present in SFML 2 because that version does not manipulate `CMAKE_RUNTIME_OUTPUT_DIRECTORY`. Luckily now that the template project defaults to static libs these DLL issues are harder to run into.

Thanks to @Bambo-Borris for reporting this.