### PR TITLE
Fix warnings in Linux OpenGL ES codepaths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         - { name: Windows VS2022 Clang, os: windows-2022, flags: -T ClangCL }
         - { name: Linux GCC,      os: ubuntu-20.04  }
         - { name: Linux Clang,    os: ubuntu-20.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: Linux GCC OpenGL ES, os: ubuntu-20.04, flags: -DSFML_OPENGL_ES=ON }
         - { name: MacOS XCode,    os: macos-11   }
         config:
         - { name: Shared,       flags: -DBUILD_SHARED_LIBS=TRUE }

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@ Also available on the website: https://www.sfml-dev.org/changelog.php#sfml-2.6.1
 **Bugfixes**
 
 -   Ensure OpenGL extensions are loaded before querying maximum texture size (#2603)
+-   Fix warnings in Linux OpenGL ES codepaths (#2747)
 
 ### Audio
 

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -387,7 +387,7 @@ bool RenderTextureImplFBO::create(unsigned int width, unsigned int height, unsig
     if (createFrameBuffer())
     {
         // Restore previously bound framebuffer
-        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, frameBuffer));
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, static_cast<GLuint>(frameBuffer)));
 
         return true;
     }

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -38,6 +38,10 @@
 #include <cstring>
 #include <climits>
 
+#if defined(__GNUC__)
+    #pragma GCC diagnostic ignored "-Wduplicated-branches"
+#endif
+
 
 namespace
 {
@@ -346,10 +350,16 @@ Image Texture::copyToImage() const
 
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, frameBuffer));
         glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0));
-        glCheck(glReadPixels(0, 0, m_size.x, m_size.y, GL_RGBA, GL_UNSIGNED_BYTE, &pixels[0]));
+        glCheck(glReadPixels(0,
+                             0,
+                             static_cast<GLsizei>(m_size.x),
+                             static_cast<GLsizei>(m_size.y),
+                             GL_RGBA,
+                             GL_UNSIGNED_BYTE,
+                             &pixels[0]));
         glCheck(GLEXT_glDeleteFramebuffers(1, &frameBuffer));
 
-        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, previousFrameBuffer));
+        glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, static_cast<GLuint>(previousFrameBuffer)));
 
         if (m_pixelsFlipped)
         {


### PR DESCRIPTION
## Description

Closes #2744 

Because CI wasn't covering this code (at least in the 2.6.x branch) we didn't know there were warnings to fix.

I don't think any of this is relevant to SFML 3 so it will get removed during the next back merge but it's easy enough to fix in 2.6.1 so we might as well.