### PR TITLE
Run clang-tidy on OpenGL ES codepaths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,12 +222,13 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows,   os: windows-2022, flags: -GNinja }
-        - { name: Linux,     os: ubuntu-22.04 }
-        - { name: Linux DRM, os: ubuntu-22.04, flags: -DSFML_USE_DRM=TRUE }
-        - { name: macOS,     os: macos-12 }
-        - { name: iOS,       os: macos-12,     flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
-        - { name: Android,   os: ubuntu-22.04, flags: -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r23b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
+        - { name: Windows,         os: windows-2022, flags: -GNinja }
+        - { name: Linux,           os: ubuntu-22.04 }
+        - { name: Linux DRM,       os: ubuntu-22.04, flags: -DSFML_USE_DRM=TRUE }
+        - { name: Linux OpenGL ES, os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON }
+        - { name: macOS,           os: macos-12 }
+        - { name: iOS,             os: macos-12,     flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
+        - { name: Android,         os: ubuntu-22.04, flags: -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r23b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
 
     steps:
     - name: Checkout Code

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -399,7 +399,7 @@ void EglContext::updateSettings()
 
 #if defined(SFML_SYSTEM_LINUX) && !defined(SFML_USE_DRM)
 ////////////////////////////////////////////////////////////
-XVisualInfo EglContext::selectBestVisual(::Display* XDisplay, unsigned int bitsPerPixel, const ContextSettings& settings)
+XVisualInfo EglContext::selectBestVisual(::Display* xDisplay, unsigned int bitsPerPixel, const ContextSettings& settings)
 {
     EglContextImpl::ensureInit();
 
@@ -419,7 +419,7 @@ XVisualInfo EglContext::selectBestVisual(::Display* XDisplay, unsigned int bitsP
         // Should never happen...
         err() << "No EGL visual found. You should check your graphics driver" << std::endl;
 
-        return XVisualInfo();
+        return {};
     }
 
     XVisualInfo vTemplate;
@@ -427,14 +427,14 @@ XVisualInfo EglContext::selectBestVisual(::Display* XDisplay, unsigned int bitsP
 
     // Get X11 visuals compatible with this EGL config
     int  visualCount      = 0;
-    auto availableVisuals = X11Ptr<XVisualInfo[]>(XGetVisualInfo(XDisplay, VisualIDMask, &vTemplate, &visualCount));
+    auto availableVisuals = X11Ptr<XVisualInfo[]>(XGetVisualInfo(xDisplay, VisualIDMask, &vTemplate, &visualCount));
 
     if (visualCount == 0)
     {
         // Can't happen...
         err() << "No X11 visual found. Bug in your EGL implementation ?" << std::endl;
 
-        return XVisualInfo();
+        return {};
     }
 
     // Pick up the best one


### PR DESCRIPTION
## Description

We don't have tons of OpenGL ES code but we have enough to justify statically analyzing it.