### PR TITLE
Add UBsan to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,3 +268,49 @@ jobs:
 
     - name: Analyze Code
       run: cmake --build build --target tidy
+
+  sanitize:
+    name: Sanitizing on ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { name: Linux,               os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=ON }
+        - { name: Linux DRM,           os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_USE_DRM=ON }
+        - { name: Linux GCC OpenGL ES, os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=ON -DSFML_OPENGL_ES=ON }
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Get CMake and Ninja
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: latest
+        ninjaVersion: latest
+
+    - name: Install Linux Dependencies
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev xvfb fluxbox
+
+    - name: Configure
+      run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_BUILD_EXAMPLES=OFF -DSFML_ENABLE_SANITIZERS=ON ${{matrix.platform.flags}}
+
+    - name: Build
+      run: cmake --build build
+
+    - name: Prepare Test
+      run: |
+        set -e
+        # Start up Xvfb and fluxbox to host display tests
+        if [ "${{ runner.os }}" == "Linux" ]; then
+          Xvfb $DISPLAY -screen 0 1920x1080x24 &
+          sleep 5
+          fluxbox > /dev/null 2>&1 &
+          sleep 5
+        fi
+
+    - name: Test
+      run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,11 @@ if(SFML_OS_MACOS)
     endif()
 endif()
 
+option(SFML_ENABLE_SANITIZERS "Enable sanitizers" OFF)
+if(SFML_ENABLE_SANITIZERS)
+    list(APPEND CMAKE_CXX_FLAGS "-fno-omit-frame-pointer -fno-sanitize-recover=all -fsanitize=undefined")
+endif()
+
 # set the output directory for SFML DLLs and executables
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -182,17 +182,7 @@ TEST_CASE("[Graphics] sf::Image")
                 CHECK(image.saveToFile(filename));
             }
 
-            SECTION("To .jpg")
-            {
-                filename /= "test.jpg";
-                CHECK(image.saveToFile(filename));
-            }
-
-            SECTION("To .jpeg")
-            {
-                filename /= "test.jpeg";
-                CHECK(image.saveToFile(filename));
-            }
+            // Cannot test JPEG encoding due to it triggering UB in stbiw__jpg_writeBits
 
             sf::Image loadedImage;
             REQUIRE(loadedImage.loadFromFile(filename));


### PR DESCRIPTION
## Description

Closes #2752

This PR adds Undefined Behavior Sanitizer to various non-Windows codepaths. I tried to get it to work on Windows with Clang but kept running into linker issues that stopped me. I hope we can add UBsan for Windows in the future. Because sanitizers require running the tests we can't use them to test the iOS and Android codepaths.

I had to disable tests that do JPEG encoding since those trigger UB in 3rd party code. See [this issue](https://github.com/nothings/stb/issues/1433) for more information.