### PR TITLE
Updated the test for the maximum antialiasing level of render texture

### DIFF
--- a/test/Graphics/RenderTexture.test.cpp
+++ b/test/Graphics/RenderTexture.test.cpp
@@ -36,7 +36,7 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
 
     SECTION("getMaximumAntialiasingLevel()")
     {
-        CHECK(sf::RenderTexture::getMaximumAntialiasingLevel() < 32);
+        CHECK(sf::RenderTexture::getMaximumAntialiasingLevel() <= 64);
     }
 
     SECTION("Set/get smooth")


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

The test would fail on my machine because sf::RenderTexture::getMaximumAntialiasingLevel() returns 32 on my system.
64 should still be a reasonable value.

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->

<!-- Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start: -->

Run the tests