### PR TITLE
Fixed sockets not closing before being moved into

### DIFF
--- a/src/SFML/Network/Socket.cpp
+++ b/src/SFML/Network/Socket.cpp
@@ -65,6 +65,8 @@ Socket& Socket::operator=(Socket&& socket) noexcept
     if (&socket == this)
         return *this;
 
+    close();
+
     m_type       = socket.m_type;
     m_socket     = std::exchange(socket.m_socket, priv::SocketImpl::invalidSocket());
     m_isBlocking = socket.m_isBlocking;


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

When using the move assignment of sf::Socket the previous socket connection is not closed

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->

<!-- Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start: -->

the expected result from his code is 

```
client connected
client disconnected
```

Without the fix I get the following output
```
client connected
```
(presumably the connection might timeout later and I would get the disconnect then or by trying to send data)


The `socket = std::move(otherSocket);` is the main focus here
```cpp
#include <iostream>
#include <thread>

#include <SFML/Network.hpp>

const int port = 60556;

void serverThread()
{
    sf::TcpListener listener;
    if (listener.listen(port) != sf::Socket::Status::Done)
    {
        std::cout << "failed to listen" << std::endl;
        std::terminate();
    }

    listener.setBlocking(false);

    sf::TcpSocket socket;
    while (true)
    {
        if (listener.accept(socket) == sf::Socket::Status::Done)
        {
            std::cout << "client connected" << std::endl;
            break;
        }
    }

    while (true)
    {
        const auto status = socket.send("1", 1);
        if (status == sf::Socket::Status::Error || status == sf::Socket::Status::Disconnected)
        {
            std::cout << "client disconnected" << std::endl;
            break;
        }
    }

}

int main()
{
    std::thread thread(serverThread);

    sf::TcpSocket socket;
    if (socket.connect({ 127, 0, 0, 1 }, port) != sf::Socket::Status::Done)
    {
        std::cout << "failed to connect" << std::endl;
        std::terminate();
    }

    sf::TcpSocket otherSocket;

    socket = std::move(otherSocket);

    std::cin.ignore(10000, '\n');
    std::cin.ignore(10000, '\n');
}
```
