### PR TITLE
Add more tests for `sf::Context`

### DIFF
--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -32,6 +32,8 @@
 
 #include <ostream>
 
+#include <cassert>
+
 
 namespace
 {
@@ -107,6 +109,7 @@ std::uint64_t Context::getActiveContextId()
 ////////////////////////////////////////////////////////////
 bool Context::isExtensionAvailable(const char* name)
 {
+    assert(name && "Context::isExtensionAvailable() Extension name cannot be a null pointer");
     return priv::GlContext::isExtensionAvailable(name);
 }
 
@@ -114,6 +117,7 @@ bool Context::isExtensionAvailable(const char* name)
 ////////////////////////////////////////////////////////////
 GlFunctionPointer Context::getFunction(const char* name)
 {
+    assert(name && "Context::getFunction() Function name cannot be a null pointer");
     return priv::GlContext::getFunction(name);
 }
 

--- a/test/Window/Context.test.cpp
+++ b/test/Window/Context.test.cpp
@@ -28,8 +28,29 @@ TEST_CASE("[Window] sf::Context", runDisplayTests())
     SECTION("Construction")
     {
         const sf::Context context;
-
         CHECK(context.getSettings().majorVersion > 0);
+    }
+
+    SECTION("isExtensionAvailable()")
+    {
+        CHECK(!sf::Context::isExtensionAvailable(" "));
+        CHECK(!sf::Context::isExtensionAvailable("this does not exist"));
+    }
+
+    SECTION("getFunction()")
+    {
+        CHECK(sf::Context::getFunction(" ") == nullptr);
+        CHECK(sf::Context::getFunction("this does not exist") == nullptr);
+    }
+
+    SECTION("getActiveContext()")
+    {
+        CHECK(sf::Context::getActiveContext() == nullptr);
+    }
+
+    SECTION("getActiveContextId()")
+    {
+        CHECK(sf::Context::getActiveContextId() == 0);
     }
 
     SECTION("Version String")


### PR DESCRIPTION
## Description

While improving the test coverage of `sf::Context` I found out that certain `nullptr` arguments would cause a crash so I added `assert`s to protect against it.