### PR TITLE
Add more `readability-identifier-naming` rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -75,6 +75,10 @@ CheckOptions:
   - { key: readability-identifier-naming.FunctionCase,        value: camelBack }
   - { key: readability-identifier-naming.VariableCase,        value: camelBack }
   - { key: readability-identifier-naming.ParameterCase,       value: camelBack }
+  - { key: readability-identifier-naming.MemberCase,          value: camelBack }
+  - { key: readability-identifier-naming.PrivateMemberCase,   value: camelBack }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,   value: m_ }
 HeaderFilterRegex: '.*'
 WarningsAsErrors: '*'
 UseColor: true

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -2569,6 +2569,7 @@ public:
     }
 
 private:
+    // NOLINTBEGIN(readability-identifier-naming)
     sf::WindowBase window{sf::VideoMode({800, 600}), "SFML window with Vulkan", sf::Style::Default};
 
     bool vulkanAvailable{sf::Vulkan::isAvailable()};
@@ -2618,6 +2619,7 @@ private:
     std::vector<VkSemaphore>        imageAvailableSemaphores;
     std::vector<VkSemaphore>        renderFinishedSemaphores;
     std::vector<VkFence>            fences;
+    // NOLINTEND(readability-identifier-naming)
 };
 
 

--- a/include/SFML/Network/TcpSocket.hpp
+++ b/include/SFML/Network/TcpSocket.hpp
@@ -221,9 +221,9 @@ private:
     ////////////////////////////////////////////////////////////
     struct PendingPacket
     {
-        std::uint32_t          Size{};         //!< Data of packet size
-        std::size_t            SizeReceived{}; //!< Number of size bytes received so far
-        std::vector<std::byte> Data;           //!< Data of the packet
+        std::uint32_t          size{};         //!< Data of packet size
+        std::size_t            sizeReceived{}; //!< Number of size bytes received so far
+        std::vector<std::byte> data;           //!< Data of the packet
     };
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -97,7 +97,7 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 struct WindowImpl::JoystickStatesImpl
 {
-    JoystickState m_states[Joystick::Count]; //!< Previous state of the joysticks
+    JoystickState states[Joystick::Count]; //!< Previous state of the joysticks
 };
 
 ////////////////////////////////////////////////////////////
@@ -121,7 +121,7 @@ WindowImpl::WindowImpl() : m_joystickStatesImpl(std::make_unique<JoystickStatesI
     JoystickManager::getInstance().update();
     for (unsigned int i = 0; i < Joystick::Count; ++i)
     {
-        m_joystickStatesImpl->m_states[i] = JoystickManager::getInstance().getState(i);
+        m_joystickStatesImpl->states[i] = JoystickManager::getInstance().getState(i);
         std::fill_n(m_previousAxes[i], static_cast<std::size_t>(Joystick::AxisCount), 0.f);
     }
 
@@ -226,11 +226,11 @@ void WindowImpl::processJoystickEvents()
     for (unsigned int i = 0; i < Joystick::Count; ++i)
     {
         // Copy the previous state of the joystick and get the new one
-        const JoystickState previousState = m_joystickStatesImpl->m_states[i];
-        m_joystickStatesImpl->m_states[i] = JoystickManager::getInstance().getState(i);
+        const JoystickState previousState = m_joystickStatesImpl->states[i];
+        m_joystickStatesImpl->states[i]   = JoystickManager::getInstance().getState(i);
 
         // Connection state
-        const bool connected = m_joystickStatesImpl->m_states[i].connected;
+        const bool connected = m_joystickStatesImpl->states[i].connected;
         if (previousState.connected ^ connected)
         {
             Event event;
@@ -254,7 +254,7 @@ void WindowImpl::processJoystickEvents()
                 {
                     const auto  axis    = static_cast<Joystick::Axis>(j);
                     const float prevPos = m_previousAxes[i][axis];
-                    const float currPos = m_joystickStatesImpl->m_states[i].axes[axis];
+                    const float currPos = m_joystickStatesImpl->states[i].axes[axis];
                     if (std::abs(currPos - prevPos) >= m_joystickThreshold)
                     {
                         Event event;
@@ -273,7 +273,7 @@ void WindowImpl::processJoystickEvents()
             for (unsigned int j = 0; j < caps.buttonCount; ++j)
             {
                 const bool prevPressed = previousState.buttons[j];
-                const bool currPressed = m_joystickStatesImpl->m_states[i].buttons[j];
+                const bool currPressed = m_joystickStatesImpl->states[i].buttons[j];
 
                 if (prevPressed ^ currPressed)
                 {

--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -43,6 +43,7 @@ std::vector<sf::Vector2i> touchPositions;
 
 @interface SFAppDelegate ()
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 @property (nonatomic) CMMotionManager* motionManager;
 
 @end

--- a/src/SFML/Window/iOS/SFView.mm
+++ b/src/SFML/Window/iOS/SFView.mm
@@ -38,6 +38,7 @@
 
 @interface SFView ()
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 @property (nonatomic) NSMutableArray* touches;
 
 @end

--- a/src/SFML/Window/macOS/AutoreleasePoolWrapper.hpp
+++ b/src/SFML/Window/macOS/AutoreleasePoolWrapper.hpp
@@ -66,7 +66,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    NSAutoreleasePoolRef pool; ///< The autorelease pool.
+    NSAutoreleasePoolRef m_pool; ///< The autorelease pool.
 };
 
 } // namespace sf

--- a/src/SFML/Window/macOS/AutoreleasePoolWrapper.mm
+++ b/src/SFML/Window/macOS/AutoreleasePoolWrapper.mm
@@ -37,14 +37,14 @@ namespace sf
 ////////////////////////////////////////////////////////
 AutoreleasePool::AutoreleasePool()
 {
-    pool = [[NSAutoreleasePool alloc] init];
+    m_pool = [[NSAutoreleasePool alloc] init];
 }
 
 
 ////////////////////////////////////////////////////////
 AutoreleasePool::~AutoreleasePool()
 {
-    [pool drain];
+    [m_pool drain];
 }
 
 } // namespace sf

--- a/src/SFML/Window/macOS/SFOpenGLView.h
+++ b/src/SFML/Window/macOS/SFOpenGLView.h
@@ -68,6 +68,7 @@ class WindowImplCocoa;
 /// the cursor (that was disconnected from the system).
 ///
 ////////////////////////////////////////////////////////////
+// NOLINTBEGIN(readability-identifier-naming)
 @interface SFOpenGLView : NSOpenGLView
 {
     sf::priv::WindowImplCocoa* m_requester;     ///< View's requester
@@ -87,6 +88,7 @@ class WindowImplCocoa;
     SFSilentResponder* m_silentResponder;
     NSTextView*        m_hiddenTextView;
 }
+// NOLINTEND(readability-identifier-naming)
 
 ////////////////////////////////////////////////////////////
 /// \brief Create the SFML OpenGL view

--- a/src/SFML/Window/macOS/SFViewController.h
+++ b/src/SFML/Window/macOS/SFViewController.h
@@ -37,13 +37,14 @@
 /// \brief Implementation of WindowImplDelegateProtocol for view management
 ///
 ////////////////////////////////////////////////////////////
-
+// NOLINTBEGIN(readability-identifier-naming)
 @interface SFViewController : NSObject<WindowImplDelegateProtocol>
 {
     NSView*                    m_view;      ///< Underlying Cocoa view
     SFOpenGLView*              m_oglView;   ///< OpenGL view
     sf::priv::WindowImplCocoa* m_requester; ///< View's requester
 }
+// NOLINTEND(readability-identifier-naming)
 
 ////////////////////////////////////////////////////////////
 /// \brief Initialize the view controller

--- a/src/SFML/Window/macOS/SFWindowController.h
+++ b/src/SFML/Window/macOS/SFWindowController.h
@@ -53,6 +53,7 @@ class WindowImplCocoa;
 /// style is restored.
 ///
 ////////////////////////////////////////////////////////////
+// NOLINTBEGIN(readability-identifier-naming)
 @interface SFWindowController : NSResponder<WindowImplDelegateProtocol, NSWindowDelegate>
 {
     NSWindow*                  m_window;        ///< Underlying Cocoa window to be controlled
@@ -62,6 +63,7 @@ class WindowImplCocoa;
     BOOL                       m_restoreResize; ///< See note above
     BOOL                       m_highDpi;       ///< Support high-DPI rendering or not
 }
+// NOLINTEND(readability-identifier-naming)
 
 ////////////////////////////////////////////////////////////
 /// \brief Create the SFML window with an external Cocoa window


### PR DESCRIPTION
## Description

There are more things we can enforce with clang-tidy's `readability-identifier-naming` check.

I had to add some exceptions to Objective-C++ code since clang-tidy was giving me warnings that I did not think were correct. In general clang-tidy struggles with Objective-C++ code so this is nothing new.