### PR TITLE
Embed MSVC debugging information when building using a compiler launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,14 @@ jobs:
       with:
         arch: ${{ contains(matrix.platform.name, 'x86') && 'x86' || 'x64' }}
 
+    # Although the CMake configuration will run with 3.24 on Windows and 3.22
+    # elsewhere, we install 3.25 on Windows in order to support specifying
+    # CMAKE_MSVC_DEBUG_INFORMATION_FORMAT which allows CCache to cache MSVC object
+    # files, see: https://cmake.org/cmake/help/latest/release/3.25.html#variables
     - name: Get CMake and Ninja
       uses: lukka/get-cmake@latest
       with:
-        cmakeVersion: ${{ runner.os == 'Windows' && '3.24' || '3.22' }} # Set to minimum required version (3.24 on Windows and 3.22 elsewhere) as specified in CMakeLists.txt to test compatibility
+        cmakeVersion: ${{ runner.os == 'Windows' && '3.25' || '3.22' }}
         ninjaVersion: latest
 
     - name: Install Linux Dependencies and Tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ endmacro()
 
 # these options have to be set before CMake detects/configures the toolchain
 
+# use new MSVC debug information format specification mechanism if available
+# we use this mechanism to embed debug information into the object file to allow ccache to cache it
+if(POLICY CMP0141)
+    cmake_policy(SET CMP0141 NEW)
+endif()
+
 # determine whether to create a debug or release build
 sfml_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
 sfml_set_option(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" STRING "The minimal iOS version that will be able to run the built binaries. Cannot be lower than 13.0")
@@ -155,10 +161,14 @@ if(SFML_USE_SYSTEM_DEPS)
     list(REMOVE_DUPLICATES CMAKE_IGNORE_PATH)
 endif()
 
-# Visual C++: remove warnings regarding SL security and algorithms on pointers
 if(SFML_COMPILER_MSVC)
     # add an option to choose whether PDB debug symbols should be generated (defaults to true when possible)
     sfml_set_option(SFML_GENERATE_PDB TRUE BOOL "True to generate PDB debug symbols, FALSE otherwise.")
+
+    # if building using a compiler launcher, embed the MSVC debugging information to allow for caching
+    if(CMAKE_CXX_COMPILER_LAUNCHER)
+        set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
+    endif()
 endif()
 
 # define SFML_OPENGL_ES if needed


### PR DESCRIPTION
Embed MSVC debugging information when building using a compiler launcher in order to allow ccache to cache MSVC compiler output when running a CI workflow.