### PR TITLE
Provide an option to specify the number of parallel jobs clang-tidy should be run with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,6 +549,7 @@ add_custom_target(format
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)
 
 sfml_set_option(CLANG_TIDY_EXECUTABLE clang-tidy STRING "Override clang-tidy executable, requires minimum version 14")
+sfml_set_option(CLANG_TIDY_JOBS "0" STRING "Specify the number of clang-tidy jobs to run in parallel, 0 means determine based on CPU count")
 add_custom_target(tidy
-    COMMAND ${CMAKE_COMMAND} -DCLANG_TIDY_EXECUTABLE=${CLANG_TIDY_EXECUTABLE} -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} -P ./cmake/Tidy.cmake
+    COMMAND ${CMAKE_COMMAND} -DCLANG_TIDY_EXECUTABLE=${CLANG_TIDY_EXECUTABLE} -DCLANG_TIDY_JOBS=${CLANG_TIDY_JOBS} -DPROJECT_BINARY_DIR=${PROJECT_BINARY_DIR} -P ./cmake/Tidy.cmake
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)

--- a/cmake/Tidy.cmake
+++ b/cmake/Tidy.cmake
@@ -27,8 +27,13 @@ if(NOT RUN_CLANG_TIDY)
     message(FATAL_ERROR "Failed to find run-clang-tidy script")
 endif()
 
+# Set job count to 0 (the default) if it is not set
+if(NOT CLANG_TIDY_JOBS)
+   set(CLANG_TIDY_JOBS "0")
+endif()
+
 # Run
-execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -quiet -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
+execute_process(COMMAND ${Python_EXECUTABLE} ${RUN_CLANG_TIDY} -j ${CLANG_TIDY_JOBS} -clang-tidy-binary ${CLANG_TIDY_EXECUTABLE} -quiet -p ${PROJECT_BINARY_DIR} RESULTS_VARIABLE EXIT_CODE)
 if(NOT EXIT_CODE STREQUAL 0)
     message(FATAL_ERROR "Analysis failed")
 endif()


### PR DESCRIPTION
Title.

This would allow me to get rid of the patching step necessary to limit CPU usage when running CI using Buildbot.