### PR TITLE
Replace `std::memcpy` with a more expressive alternative

### DIFF
--- a/examples/voip/Server.cpp
+++ b/examples/voip/Server.cpp
@@ -133,11 +133,9 @@ private:
                 // (so we protect any operation on it with the mutex)
                 {
                     const std::lock_guard lock(m_mutex);
-                    const std::size_t     oldSize = m_samples.size();
-                    m_samples.resize(oldSize + sampleCount);
-                    std::memcpy(&(m_samples[oldSize]),
-                                static_cast<const char*>(packet.getData()) + 1,
-                                sampleCount * sizeof(std::int16_t));
+                    const auto*           begin = static_cast<const char*>(packet.getData()) + 1;
+                    const auto*           end   = begin + sampleCount * sizeof(std::int16_t);
+                    m_samples.insert(m_samples.end(), begin, end);
                 }
             }
             else if (id == serverEndOfStream)

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -66,9 +66,9 @@ void Packet::append(const void* data, std::size_t sizeInBytes)
 {
     if (data && (sizeInBytes > 0))
     {
-        const std::size_t start = m_data.size();
-        m_data.resize(start + sizeInBytes);
-        std::memcpy(&m_data[start], data, sizeInBytes);
+        const auto* begin = reinterpret_cast<const std::byte*>(data);
+        const auto* end   = begin + sizeInBytes;
+        m_data.insert(m_data.end(), begin, end);
     }
 }
 


### PR DESCRIPTION
## Description

Use `std::vector` member functions is easier to read and maintain.