### PR TITLE
Fixed window tests not accepting a context with better than requested settings

### DIFF
--- a/test/Window/Window.test.cpp
+++ b/test/Window/Window.test.cpp
@@ -45,10 +45,7 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(360, 240));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
-            CHECK(window.getSettings().stencilBits == 0);
-            CHECK(window.getSettings().antialiasingLevel == 0);
             CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
-            CHECK(!window.getSettings().sRgbCapable);
         }
 
         SECTION("Mode, title, and style constructor")
@@ -57,10 +54,7 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(360, 240));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
-            CHECK(window.getSettings().stencilBits == 0);
-            CHECK(window.getSettings().antialiasingLevel == 0);
             CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
-            CHECK(!window.getSettings().sRgbCapable);
         }
 
         SECTION("Mode, title, style, and context settings constructor")
@@ -69,6 +63,9 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(360, 240));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().depthBits >= 1);
+            CHECK(window.getSettings().stencilBits >= 1);
+            CHECK(window.getSettings().antialiasingLevel >= 1);
         }
     }
 
@@ -82,10 +79,7 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(240, 360));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
-            CHECK(window.getSettings().stencilBits == 0);
-            CHECK(window.getSettings().antialiasingLevel == 0);
             CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
-            CHECK(!window.getSettings().sRgbCapable);
         }
 
         SECTION("Mode, title, and style")
@@ -94,10 +88,7 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(240, 360));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
-            CHECK(window.getSettings().stencilBits == 0);
-            CHECK(window.getSettings().antialiasingLevel == 0);
             CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
-            CHECK(!window.getSettings().sRgbCapable);
         }
 
         SECTION("Mode, title, style, and context settings")
@@ -106,6 +97,9 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(240, 360));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().depthBits >= 1);
+            CHECK(window.getSettings().stencilBits >= 1);
+            CHECK(window.getSettings().antialiasingLevel >= 1);
         }
     }
 }


### PR DESCRIPTION
#2695 introduced more tests for `sf::Window` but was too strict with the required context settings. On systems with decent discrete GPUs, it is very likely that the driver will offer pixel formats that are mostly much better than what users will request in order to keep the number of offered pixel formats manageable. Comparing settings for equality, especially when nothing is explicitly requested will almost always fail on such systems.