### PR TITLE
Added missing VS_DEBUGGER_WORKING_DIRECTORY to sfml_add_test macro

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -350,6 +350,9 @@ function(sfml_add_test target SOURCES DEPENDS)
     # set the target flags to use the appropriate C++ standard library
     sfml_set_stdlib(${target})
 
+    # set the Visual Studio startup path for debugging
+    set_target_properties(${target} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
     # link the target to its SFML dependencies
     target_link_libraries(${target} PRIVATE ${DEPENDS} sfml-test-main)
 


### PR DESCRIPTION
Added missing VS_DEBUGGER_WORKING_DIRECTORY to `sfml_add_test` macro since tests now rely on loading file resources.

Recently, tests were added that rely on loading file resources. Running a single test target outside of the test runner would not run it in the right working directory as expected by the paths provided in the test code. Setting `VS_DEBUGGER_WORKING_DIRECTORY` analogous to the examples fixes this problem.