### PR TITLE
Add `sf::Rect<T>::getCenter()`

### DIFF
--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -109,7 +109,7 @@ public:
     ///
     /// \return Position of rectangle
     ///
-    /// \see getSize
+    /// \see getSize, getCenter
     ///
     ////////////////////////////////////////////////////////////
     constexpr Vector2<T> getPosition() const;
@@ -119,10 +119,20 @@ public:
     ///
     /// \return Size of rectangle
     ///
-    /// \see getPosition
+    /// \see getPosition, getCenter
     ///
     ////////////////////////////////////////////////////////////
     constexpr Vector2<T> getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the position of the center of the rectangle
+    ///
+    /// \return Center of rectangle
+    ///
+    /// \see getSize, getPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    constexpr Vector2<T> getCenter() const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -129,6 +129,14 @@ constexpr Vector2<T> Rect<T>::getSize() const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
+constexpr Vector2<T> Rect<T>::getCenter() const
+{
+    return getPosition() + getSize() / T{2};
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
 constexpr bool operator==(const Rect<T>& left, const Rect<T>& right)
 {
     return (left.left == right.left) && (left.width == right.width) && (left.top == right.top) &&

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -221,7 +221,7 @@ void Shape::update()
     m_insideBounds = m_vertices.getBounds();
 
     // Compute the center and make it the first vertex
-    m_vertices[0].position = m_insideBounds.getPosition() + m_insideBounds.getSize() / 2.f;
+    m_vertices[0].position = m_insideBounds.getCenter();
 
     // Color
     updateFillColors();

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -90,7 +90,7 @@ void View::setViewport(const FloatRect& viewport)
 ////////////////////////////////////////////////////////////
 void View::reset(const FloatRect& rectangle)
 {
-    m_center   = rectangle.getPosition() + rectangle.getSize() / 2.f;
+    m_center   = rectangle.getCenter();
     m_size     = rectangle.getSize();
     m_rotation = Angle::Zero;
 

--- a/test/Graphics/Rect.test.cpp
+++ b/test/Graphics/Rect.test.cpp
@@ -103,6 +103,12 @@ TEST_CASE("[Graphics] sf::Rect")
         STATIC_CHECK(sf::IntRect({1, 2}, {3, 4}).getSize() == sf::Vector2i(3, 4));
     }
 
+    SECTION("getCenter()")
+    {
+        STATIC_CHECK(sf::IntRect({}, {}).getCenter() == sf::Vector2i());
+        STATIC_CHECK(sf::IntRect({1, 2}, {4, 6}).getCenter() == sf::Vector2i(3, 5));
+    }
+
     SECTION("Operators")
     {
         SECTION("operator==")


### PR DESCRIPTION
## Description

Inspired by a comment from Bromeon: https://github.com/SFML/SFML/pull/2692#discussion_r1329828733

I think this is a good convenience to give users. There are ever 2 places we needed it internally.

---

> Why not add `sf::Rect<T>::getEnd()` too?
I'm not opposed to this, but I could not find anywhere inside this repo that we would use it so I decided to hold off. I'm open to adding it if others think it's worth having.