### PR TITLE
Don't enable/disable non-existant GL_FRAMEBUFFER_SRGB on OpenGL ES

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -655,6 +655,9 @@ void RenderTarget::applyShader(const Shader* shader)
 ////////////////////////////////////////////////////////////
 void RenderTarget::setupDraw(bool useVertexCache, const RenderStates& states)
 {
+    // GL_FRAMEBUFFER_SRGB is not available on OpenGL ES
+    // If a framebuffer supports sRGB, it will always be enabled on OpenGL ES
+#ifndef SFML_OPENGL_ES
     // Enable or disable sRGB encoding
     // This is needed for drivers that do not check the format of the surface drawn to before applying sRGB conversion
     if (!m_cache.enable)
@@ -664,6 +667,7 @@ void RenderTarget::setupDraw(bool useVertexCache, const RenderStates& states)
         else
             glCheck(glDisable(GL_FRAMEBUFFER_SRGB));
     }
+#endif
 
     // First set the persistent OpenGL states if it's the very first call
     if (!m_cache.glStatesSet)


### PR DESCRIPTION
The `GL_FRAMEBUFFER_SRGB` enum value doesn't exist in OpenGL ES. Enabling/disabling it isn't required since the implementation will behave as if it is enabled for all sRGB capable targets. Strict OpenGL ES implementations will complain with `GL_INVALID_ENUM` if we try to call `glEnable` or `glDisable` with `GL_FRAMEBUFFER_SRGB`.