### PR TITLE
Abort looping in SoundStream::streamData if an OpenAL error occurs that would have caused it to never terminate

### DIFF
--- a/src/SFML/Audio/ALCheck.hpp
+++ b/src/SFML/Audio/ALCheck.hpp
@@ -55,11 +55,13 @@ namespace priv
     // If in debug mode, perform a test on every call
     // The do-while loop is needed so that alCheck can be used as a single statement in if/else branches
     #define alCheck(expr) do { expr; sf::priv::alCheckError(__FILE__, __LINE__, #expr); } while (false)
+    #define alGetLastError sf::priv::alGetLastErrorImpl
 
 #else
 
     // Else, we don't add any overhead
     #define alCheck(expr) (expr)
+    #define alGetLastError alGetError
 
 #endif
 
@@ -73,6 +75,15 @@ namespace priv
 ///
 ////////////////////////////////////////////////////////////
 void alCheckError(const char* file, unsigned int line, const char* expression);
+
+
+////////////////////////////////////////////////////////////
+/// Get the last OpenAL error on this thread
+///
+/// \return The last OpenAL error on this thread
+///
+////////////////////////////////////////////////////////////
+ALenum alGetLastErrorImpl();
 
 } // namespace priv
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -404,6 +404,15 @@ void SoundStream::streamData()
             }
         }
 
+        // Check if any error has occurred
+        if (alGetLastError() != AL_NO_ERROR)
+        {
+            // Abort streaming (exit main loop)
+            Lock lock(m_threadMutex);
+            m_isStreaming = false;
+            break;
+        }
+
         // Leave some time for the other threads if the stream is still playing
         if (SoundSource::getStatus() != Stopped)
             sleep(m_processingInterval);


### PR DESCRIPTION
## Description

Backports #2026 and fixes #1831 for SFML 2

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run the sound example and while it's playing, unplug your audio device.

Before it *may* spike in CPU usage and not continue, now it should run through with an error logged in the console.