### PR TITLE
Test class templates with multiple template types

### DIFF
--- a/test/Graphics/Rect.test.cpp
+++ b/test/Graphics/Rect.test.cpp
@@ -2,26 +2,26 @@
 
 #include <SFML/System/Vector2.hpp>
 
-#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 
 #include <GraphicsUtil.hpp>
 #include <type_traits>
 
-TEST_CASE("[Graphics] sf::Rect")
+TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::IntRect>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::IntRect>);
-        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::IntRect>);
-        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::IntRect>);
+        STATIC_CHECK(std::is_copy_constructible_v<sf::Rect<TestType>>);
+        STATIC_CHECK(std::is_copy_assignable_v<sf::Rect<TestType>>);
+        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Rect<TestType>>);
+        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Rect<TestType>>);
     }
 
     SECTION("Construction")
     {
         SECTION("Default constructor")
         {
-            constexpr sf::IntRect rectangle;
+            constexpr sf::Rect<TestType> rectangle;
             STATIC_CHECK(rectangle.left == 0);
             STATIC_CHECK(rectangle.top == 0);
             STATIC_CHECK(rectangle.width == 0);
@@ -30,7 +30,7 @@ TEST_CASE("[Graphics] sf::Rect")
 
         SECTION("(left, top, width, height) constructor")
         {
-            constexpr sf::IntRect rectangle({1, 2}, {3, 4});
+            constexpr sf::Rect<TestType> rectangle({1, 2}, {3, 4});
             STATIC_CHECK(rectangle.left == 1);
             STATIC_CHECK(rectangle.top == 2);
             STATIC_CHECK(rectangle.width == 3);
@@ -39,9 +39,9 @@ TEST_CASE("[Graphics] sf::Rect")
 
         SECTION("(Vector2, Vector2) constructor")
         {
-            constexpr sf::Vector2i position(1, 2);
-            constexpr sf::Vector2i dimension(3, 4);
-            constexpr sf::IntRect  rectangle(position, dimension);
+            constexpr sf::Vector2<TestType> position(1, 2);
+            constexpr sf::Vector2<TestType> dimension(3, 4);
+            constexpr sf::Rect<TestType>    rectangle(position, dimension);
 
             STATIC_CHECK(rectangle.left == 1);
             STATIC_CHECK(rectangle.top == 2);
@@ -63,22 +63,22 @@ TEST_CASE("[Graphics] sf::Rect")
 
     SECTION("contains(Vector2)")
     {
-        constexpr sf::IntRect rectangle({0, 0}, {10, 10});
+        constexpr sf::Rect<TestType> rectangle({0, 0}, {10, 10});
 
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(0, 0)) == true);
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(9, 0)) == true);
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(0, 9)) == true);
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(9, 9)) == true);
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(9, 10)) == false);
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(10, 9)) == false);
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(10, 10)) == false);
-        STATIC_CHECK(rectangle.contains(sf::Vector2i(15, 15)) == false);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(0, 0)) == true);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(9, 0)) == true);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(0, 9)) == true);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(9, 9)) == true);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(9, 10)) == false);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(10, 9)) == false);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(10, 10)) == false);
+        STATIC_CHECK(rectangle.contains(sf::Vector2<TestType>(15, 15)) == false);
     }
 
     SECTION("findIntersection()")
     {
-        constexpr sf::IntRect rectangle({0, 0}, {10, 10});
-        constexpr sf::IntRect intersectingRectangle({5, 5}, {10, 10});
+        constexpr sf::Rect<TestType> rectangle({0, 0}, {10, 10});
+        constexpr sf::Rect<TestType> intersectingRectangle({5, 5}, {10, 10});
 
         constexpr auto intersectionResult = rectangle.findIntersection(intersectingRectangle);
         STATIC_REQUIRE(intersectionResult.has_value());
@@ -87,50 +87,50 @@ TEST_CASE("[Graphics] sf::Rect")
         STATIC_CHECK(intersectionResult->width == 5);
         STATIC_CHECK(intersectionResult->height == 5);
 
-        constexpr sf::IntRect nonIntersectingRectangle({-5, -5}, {5, 5});
+        constexpr sf::Rect<TestType> nonIntersectingRectangle({-5, -5}, {5, 5});
         STATIC_CHECK_FALSE(rectangle.findIntersection(nonIntersectingRectangle).has_value());
     }
 
     SECTION("getPosition()")
     {
-        STATIC_CHECK(sf::IntRect({}, {}).getPosition() == sf::Vector2i());
-        STATIC_CHECK(sf::IntRect({1, 2}, {3, 4}).getPosition() == sf::Vector2i(1, 2));
+        STATIC_CHECK(sf::Rect<TestType>({}, {}).getPosition() == sf::Vector2<TestType>());
+        STATIC_CHECK(sf::Rect<TestType>({1, 2}, {3, 4}).getPosition() == sf::Vector2<TestType>(1, 2));
     }
 
     SECTION("getSize()")
     {
-        STATIC_CHECK(sf::IntRect({}, {}).getSize() == sf::Vector2i());
-        STATIC_CHECK(sf::IntRect({1, 2}, {3, 4}).getSize() == sf::Vector2i(3, 4));
+        STATIC_CHECK(sf::Rect<TestType>({}, {}).getSize() == sf::Vector2<TestType>());
+        STATIC_CHECK(sf::Rect<TestType>({1, 2}, {3, 4}).getSize() == sf::Vector2<TestType>(3, 4));
     }
 
     SECTION("getCenter()")
     {
-        STATIC_CHECK(sf::IntRect({}, {}).getCenter() == sf::Vector2i());
-        STATIC_CHECK(sf::IntRect({1, 2}, {4, 6}).getCenter() == sf::Vector2i(3, 5));
+        STATIC_CHECK(sf::Rect<TestType>({}, {}).getCenter() == sf::Vector2<TestType>());
+        STATIC_CHECK(sf::Rect<TestType>({1, 2}, {4, 6}).getCenter() == sf::Vector2<TestType>(3, 5));
     }
 
     SECTION("Operators")
     {
         SECTION("operator==")
         {
-            STATIC_CHECK(sf::IntRect() == sf::IntRect());
-            STATIC_CHECK(sf::IntRect({1, 3}, {2, 5}) == sf::IntRect({1, 3}, {2, 5}));
+            STATIC_CHECK(sf::Rect<TestType>() == sf::Rect<TestType>());
+            STATIC_CHECK(sf::Rect<TestType>({1, 3}, {2, 5}) == sf::Rect<TestType>({1, 3}, {2, 5}));
 
-            STATIC_CHECK_FALSE(sf::IntRect({1, 0}, {0, 0}) == sf::IntRect({0, 0}, {0, 0}));
-            STATIC_CHECK_FALSE(sf::IntRect({0, 1}, {0, 0}) == sf::IntRect({0, 0}, {0, 0}));
-            STATIC_CHECK_FALSE(sf::IntRect({0, 0}, {1, 0}) == sf::IntRect({0, 0}, {0, 0}));
-            STATIC_CHECK_FALSE(sf::IntRect({0, 0}, {0, 1}) == sf::IntRect({0, 0}, {0, 0}));
+            STATIC_CHECK_FALSE(sf::Rect<TestType>({1, 0}, {0, 0}) == sf::Rect<TestType>({0, 0}, {0, 0}));
+            STATIC_CHECK_FALSE(sf::Rect<TestType>({0, 1}, {0, 0}) == sf::Rect<TestType>({0, 0}, {0, 0}));
+            STATIC_CHECK_FALSE(sf::Rect<TestType>({0, 0}, {1, 0}) == sf::Rect<TestType>({0, 0}, {0, 0}));
+            STATIC_CHECK_FALSE(sf::Rect<TestType>({0, 0}, {0, 1}) == sf::Rect<TestType>({0, 0}, {0, 0}));
         }
 
         SECTION("operator!=")
         {
-            STATIC_CHECK(sf::IntRect({1, 0}, {0, 0}) != sf::IntRect({0, 0}, {0, 0}));
-            STATIC_CHECK(sf::IntRect({0, 1}, {0, 0}) != sf::IntRect({0, 0}, {0, 0}));
-            STATIC_CHECK(sf::IntRect({0, 0}, {1, 0}) != sf::IntRect({0, 0}, {0, 0}));
-            STATIC_CHECK(sf::IntRect({0, 0}, {0, 1}) != sf::IntRect({0, 0}, {0, 0}));
+            STATIC_CHECK(sf::Rect<TestType>({1, 0}, {0, 0}) != sf::Rect<TestType>({0, 0}, {0, 0}));
+            STATIC_CHECK(sf::Rect<TestType>({0, 1}, {0, 0}) != sf::Rect<TestType>({0, 0}, {0, 0}));
+            STATIC_CHECK(sf::Rect<TestType>({0, 0}, {1, 0}) != sf::Rect<TestType>({0, 0}, {0, 0}));
+            STATIC_CHECK(sf::Rect<TestType>({0, 0}, {0, 1}) != sf::Rect<TestType>({0, 0}, {0, 0}));
 
-            STATIC_CHECK_FALSE(sf::IntRect() != sf::IntRect());
-            STATIC_CHECK_FALSE(sf::IntRect({1, 3}, {2, 5}) != sf::IntRect({1, 3}, {2, 5}));
+            STATIC_CHECK_FALSE(sf::Rect<TestType>() != sf::Rect<TestType>());
+            STATIC_CHECK_FALSE(sf::Rect<TestType>({1, 3}, {2, 5}) != sf::Rect<TestType>({1, 3}, {2, 5}));
         }
     }
 }

--- a/test/System/Vector2.test.cpp
+++ b/test/System/Vector2.test.cpp
@@ -1,6 +1,6 @@
 #include <SFML/System/Vector2.hpp>
 
-#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 
 #include <SystemUtil.hpp>
 #include <type_traits>
@@ -9,31 +9,28 @@
 
 using namespace sf::Literals;
 
-// Use sf::Vector2i for tests (except for float vector algebra).
-// Test coverage is given, as there are no template specializations.
-
-TEST_CASE("[System] sf::Vector2")
+TEMPLATE_TEST_CASE("[System] sf::Vector2", "", int, float)
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Vector2i>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Vector2i>);
-        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector2i>);
-        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector2i>);
+        STATIC_CHECK(std::is_copy_constructible_v<sf::Vector2<TestType>>);
+        STATIC_CHECK(std::is_copy_assignable_v<sf::Vector2<TestType>>);
+        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector2<TestType>>);
+        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector2<TestType>>);
     }
 
     SECTION("Construction")
     {
         SECTION("Default constructor")
         {
-            constexpr sf::Vector2i vector;
+            constexpr sf::Vector2<TestType> vector;
             STATIC_CHECK(vector.x == 0);
             STATIC_CHECK(vector.y == 0);
         }
 
         SECTION("(x, y) coordinate constructor")
         {
-            constexpr sf::Vector2i vector(1, 2);
+            constexpr sf::Vector2<TestType> vector(1, 2);
             STATIC_CHECK(vector.x == 1);
             STATIC_CHECK(vector.y == 2);
         }
@@ -105,8 +102,8 @@ TEST_CASE("[System] sf::Vector2")
     {
         SECTION("-vector")
         {
-            constexpr sf::Vector2i vector(1, 2);
-            constexpr sf::Vector2i negatedVector = -vector;
+            constexpr sf::Vector2<TestType> vector(1, 2);
+            constexpr sf::Vector2<TestType> negatedVector = -vector;
 
             STATIC_CHECK(negatedVector.x == -1);
             STATIC_CHECK(negatedVector.y == -2);
@@ -115,8 +112,8 @@ TEST_CASE("[System] sf::Vector2")
 
     SECTION("Arithmetic operations between two vectors")
     {
-        sf::Vector2i           firstVector(2, 5);
-        constexpr sf::Vector2i secondVector(8, 3);
+        sf::Vector2<TestType>           firstVector(2, 5);
+        constexpr sf::Vector2<TestType> secondVector(8, 3);
 
         SECTION("vector += vector")
         {
@@ -136,7 +133,7 @@ TEST_CASE("[System] sf::Vector2")
 
         SECTION("vector + vector")
         {
-            const sf::Vector2i result = firstVector + secondVector;
+            const sf::Vector2<TestType> result = firstVector + secondVector;
 
             CHECK(result.x == 10);
             CHECK(result.y == 8);
@@ -144,7 +141,7 @@ TEST_CASE("[System] sf::Vector2")
 
         SECTION("vector - vector")
         {
-            const sf::Vector2i result = firstVector - secondVector;
+            const sf::Vector2<TestType> result = firstVector - secondVector;
 
             CHECK(result.x == -6);
             CHECK(result.y == 2);
@@ -153,12 +150,12 @@ TEST_CASE("[System] sf::Vector2")
 
     SECTION("Arithmetic operations between vector and scalar value")
     {
-        sf::Vector2i vector(26, 12);
-        const int    scalar = 2;
+        sf::Vector2<TestType> vector(26, 12);
+        const TestType        scalar = 2;
 
         SECTION("vector * scalar")
         {
-            const sf::Vector2i result = vector * scalar;
+            const sf::Vector2<TestType> result = vector * scalar;
 
             CHECK(result.x == 52);
             CHECK(result.y == 24);
@@ -166,7 +163,7 @@ TEST_CASE("[System] sf::Vector2")
 
         SECTION("scalar * vector")
         {
-            const sf::Vector2i result = scalar * vector;
+            const sf::Vector2<TestType> result = scalar * vector;
 
             CHECK(result.x == 52);
             CHECK(result.y == 24);
@@ -182,7 +179,7 @@ TEST_CASE("[System] sf::Vector2")
 
         SECTION("vector / scalar")
         {
-            const sf::Vector2i result = vector / scalar;
+            const sf::Vector2<TestType> result = vector / scalar;
 
             CHECK(result.x == 13);
             CHECK(result.y == 6);
@@ -199,9 +196,9 @@ TEST_CASE("[System] sf::Vector2")
 
     SECTION("Comparison operations (two equal and one different vector)")
     {
-        constexpr sf::Vector2i firstEqualVector(1, 5);
-        constexpr sf::Vector2i secondEqualVector(1, 5);
-        constexpr sf::Vector2i differentVector(6, 9);
+        constexpr sf::Vector2<TestType> firstEqualVector(1, 5);
+        constexpr sf::Vector2<TestType> secondEqualVector(1, 5);
+        constexpr sf::Vector2<TestType> differentVector(6, 9);
 
         SECTION("vector == vector")
         {
@@ -218,7 +215,7 @@ TEST_CASE("[System] sf::Vector2")
 
     SECTION("Structured bindings")
     {
-        sf::Vector2i vector(1, 2); // NOLINT(misc-const-correctness)
+        sf::Vector2<TestType> vector(1, 2); // NOLINT(misc-const-correctness)
 
         SECTION("destructure by value")
         {
@@ -329,19 +326,19 @@ TEST_CASE("[System] sf::Vector2")
 
     SECTION("Constexpr support")
     {
-        constexpr sf::Vector2i v(1, 2);
-        constexpr sf::Vector2i w(2, -3);
+        constexpr sf::Vector2<TestType> v(1, 2);
+        constexpr sf::Vector2<TestType> w(2, -6);
 
         STATIC_CHECK(v.x == 1);
         STATIC_CHECK(v.y == 2);
-        STATIC_CHECK(v + w == sf::Vector2i(3, -1));
+        STATIC_CHECK(v + w == sf::Vector2<TestType>(3, -4));
 
         STATIC_CHECK(v.lengthSq() == 5);
-        STATIC_CHECK(v.perpendicular() == sf::Vector2i(-2, 1));
+        STATIC_CHECK(v.perpendicular() == sf::Vector2<TestType>(-2, 1));
 
-        STATIC_CHECK(v.dot(w) == -4);
-        STATIC_CHECK(v.cross(w) == -7);
-        STATIC_CHECK(v.cwiseMul(w) == sf::Vector2i(2, -6));
-        STATIC_CHECK(w.cwiseDiv(v) == sf::Vector2i(2, -1));
+        STATIC_CHECK(v.dot(w) == -10);
+        STATIC_CHECK(v.cross(w) == -10);
+        STATIC_CHECK(v.cwiseMul(w) == sf::Vector2<TestType>(2, -12));
+        STATIC_CHECK(w.cwiseDiv(v) == sf::Vector2<TestType>(2, -3));
     }
 }

--- a/test/System/Vector3.test.cpp
+++ b/test/System/Vector3.test.cpp
@@ -1,28 +1,25 @@
 #include <SFML/System/Vector3.hpp>
 
-#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 
 #include <SystemUtil.hpp>
 #include <type_traits>
 
-// Use sf::Vector3i for tests (except for float vector algebra).
-// Test coverage is given, as there are no template specializations.
-
-TEST_CASE("[System] sf::Vector3")
+TEMPLATE_TEST_CASE("[System] sf::Vector3", "", int, float)
 {
     SECTION("Type traits")
     {
         STATIC_CHECK(std::is_copy_constructible_v<sf::Vector3i>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Vector3i>);
-        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector3i>);
-        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector3i>);
+        STATIC_CHECK(std::is_copy_assignable_v<sf::Vector3<TestType>>);
+        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector3<TestType>>);
+        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector3<TestType>>);
     }
 
     SECTION("Construction")
     {
         SECTION("Default constructor")
         {
-            constexpr sf::Vector3i vector;
+            constexpr sf::Vector3<TestType> vector;
             STATIC_CHECK(vector.x == 0);
             STATIC_CHECK(vector.y == 0);
             STATIC_CHECK(vector.z == 0);
@@ -30,7 +27,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SECTION("(x, y, z) coordinate constructor")
         {
-            constexpr sf::Vector3i vector(1, 2, 3);
+            constexpr sf::Vector3<TestType> vector(1, 2, 3);
             STATIC_CHECK(vector.x == 1);
             STATIC_CHECK(vector.y == 2);
             STATIC_CHECK(vector.z == 3);
@@ -51,8 +48,8 @@ TEST_CASE("[System] sf::Vector3")
     {
         SECTION("-vector")
         {
-            constexpr sf::Vector3i vector(1, 2, 3);
-            constexpr sf::Vector3i negatedVector = -vector;
+            constexpr sf::Vector3<TestType> vector(1, 2, 3);
+            constexpr sf::Vector3<TestType> negatedVector = -vector;
 
             STATIC_CHECK(negatedVector.x == -1);
             STATIC_CHECK(negatedVector.y == -2);
@@ -62,8 +59,8 @@ TEST_CASE("[System] sf::Vector3")
 
     SECTION("Arithmetic operations between two vectors")
     {
-        sf::Vector3i           firstVector(2, 5, 6);
-        constexpr sf::Vector3i secondVector(8, 3, 7);
+        sf::Vector3<TestType>           firstVector(2, 5, 6);
+        constexpr sf::Vector3<TestType> secondVector(8, 3, 7);
 
         SECTION("vector += vector")
         {
@@ -85,7 +82,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SECTION("vector + vector")
         {
-            const sf::Vector3i result = firstVector + secondVector;
+            const sf::Vector3<TestType> result = firstVector + secondVector;
 
             CHECK(result.x == 10);
             CHECK(result.y == 8);
@@ -94,7 +91,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SECTION("vector - vector")
         {
-            const sf::Vector3i result = firstVector - secondVector;
+            const sf::Vector3<TestType> result = firstVector - secondVector;
 
             CHECK(result.x == -6);
             CHECK(result.y == 2);
@@ -104,12 +101,12 @@ TEST_CASE("[System] sf::Vector3")
 
     SECTION("Arithmetic operations between vector and scalar value")
     {
-        sf::Vector3i  vector(26, 12, 6);
-        constexpr int scalar = 2;
+        sf::Vector3<TestType> vector(26, 12, 6);
+        constexpr TestType    scalar = 2;
 
         SECTION("vector * scalar")
         {
-            const sf::Vector3i result = vector * scalar;
+            const sf::Vector3<TestType> result = vector * scalar;
 
             CHECK(result.x == 52);
             CHECK(result.y == 24);
@@ -118,7 +115,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SECTION("scalar * vector")
         {
-            const sf::Vector3i result = scalar * vector;
+            const sf::Vector3<TestType> result = scalar * vector;
 
             CHECK(result.x == 52);
             CHECK(result.y == 24);
@@ -136,7 +133,7 @@ TEST_CASE("[System] sf::Vector3")
 
         SECTION("vector / scalar")
         {
-            const sf::Vector3i result = vector / scalar;
+            const sf::Vector3<TestType> result = vector / scalar;
 
             CHECK(result.x == 13);
             CHECK(result.y == 6);
@@ -155,9 +152,9 @@ TEST_CASE("[System] sf::Vector3")
 
     SECTION("Comparison operations (two equal and one different vector)")
     {
-        constexpr sf::Vector3i firstEqualVector(1, 5, 6);
-        constexpr sf::Vector3i secondEqualVector(1, 5, 6);
-        constexpr sf::Vector3i differentVector(6, 9, 7);
+        constexpr sf::Vector3<TestType> firstEqualVector(1, 5, 6);
+        constexpr sf::Vector3<TestType> secondEqualVector(1, 5, 6);
+        constexpr sf::Vector3<TestType> differentVector(6, 9, 7);
 
         SECTION("vector == vector")
         {
@@ -174,7 +171,7 @@ TEST_CASE("[System] sf::Vector3")
 
     SECTION("Structured bindings")
     {
-        sf::Vector3i vector(1, 2, 3); // NOLINT(misc-const-correctness)
+        sf::Vector3<TestType> vector(1, 2, 3); // NOLINT(misc-const-correctness)
 
         SECTION("destructure by value")
         {


### PR DESCRIPTION
## Description

Catch2 has a wonderful feature that lets you write tests that get ran for various template types. This is perfect for testing our class templates. This matters because it ensures that we don't overlook something which causes an issue with one particular specialization of these classes.