### PR TITLE
Fixed crash on Android when using copied font while original font is destroyed

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -427,7 +427,7 @@ private:
     mutable PageTable            m_pages;          //!< Table containing the glyphs pages by character size
     mutable std::vector<std::uint8_t> m_pixelBuffer; //!< Pixel buffer holding a glyph's pixels before being written to the texture
 #ifdef SFML_SYSTEM_ANDROID
-    std::unique_ptr<priv::ResourceStream> m_stream; //!< Asset file streamer (if loaded from file)
+    std::shared_ptr<priv::ResourceStream> m_stream; //!< Asset file streamer (if loaded from file)
 #endif
 };
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -136,6 +136,9 @@ m_info(copy.m_info),
 m_pages(copy.m_pages),
 m_pixelBuffer(copy.m_pixelBuffer)
 {
+#ifdef SFML_SYSTEM_ANDROID
+    m_stream = copy.m_stream;
+#endif
 }
 
 
@@ -204,7 +207,7 @@ bool Font::loadFromFile(const std::filesystem::path& filename)
 
 #else
 
-    m_stream = std::make_unique<priv::ResourceStream>(filename);
+    m_stream = std::make_shared<priv::ResourceStream>(filename);
     return loadFromStream(*m_stream);
 
 #endif


### PR DESCRIPTION
## Description

On android, the Font class opens a stream to the .ttf file in loadFromFile. When copying the font, this stream isn't copied.

The copied font can be used as long as the original font (which contains the stream) still exists. Destroying the original font will destroy the stream and cause a crash when attempting to use the copied font.

This fixes https://github.com/SFML/SFML/issues/1528

Remarks about the code:
- I added code to the body of the copy constructor instead of using the initializer list because otherwise a comma would need to exist on the line above depending on whether or not you are building for android.
- As far as I can tell the copy constructor and copy assignment operator are no longer special and we could just define them as "= default". Since all constructor, assignment operators and destructor would become defaulted, they can probably all be removed completely.

## Tasks

-   [x] Tested on Android

## How to test this PR?

Build the android example with the following code in main.cpp, if you see the "Tap anywhere to move the logo" text at the top then the code is working. Without this PR the example will crash or it may run but without the text being rendered.
```c++
#include <SFML/Graphics.hpp>

using std::string;
using sf::Font;

void LoadFontInto(Font& font){
    sf::Font local;
    local.loadFromFile("tuffy.ttf");
    font = Font{local};
}

int main(int argc, char *argv[])
{
    sf::VideoMode screen(sf::VideoMode::getDesktopMode());

    sf::RenderWindow window(screen, "");
    window.setFramerateLimit(30);

    sf::View view = window.getDefaultView();

    sf::Color background = sf::Color::White;

    Font font;
    LoadFontInto(font);

    sf::Text text(font, "Tap anywhere to move the logo.", 64);
    text.setFillColor(sf::Color::Black);
    text.setPosition({10, 10});

    bool active = true;

    while (window.isOpen())
    {
        sf::Event event;

        while (active ? window.pollEvent(event) : window.waitEvent(event))
        {
            switch (event.type)
            {
                case sf::Event::Closed:
                    window.close();
                    break;
                case sf::Event::KeyPressed:
                    if (event.key.code == sf::Keyboard::Escape)
                        window.close();
                    break;
                case sf::Event::Resized:
                    view.setSize({static_cast<float>(event.size.width), static_cast<float>(event.size.height)});
                    view.setCenter({event.size.width/2.f, event.size.height/2.f});
                    window.setView(view);
                    break;
                case sf::Event::LostFocus:
                    background = sf::Color::Black;
                    break;
                case sf::Event::GainedFocus:
                    background = sf::Color::White;
                    break;
                case sf::Event::MouseLeft:
                    active = false;
                    break;
                case sf::Event::MouseEntered:
                    active = true;
                    break;
                default:
                    break;
            }
        }

        if (active)
        {
            window.clear(background);
            window.draw(text);
            window.display();
        }
        else {
            sf::sleep(sf::milliseconds(100));
        }
    }
}
```
