### PR TITLE
Default all `sf::Font` special member functions

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -67,42 +67,6 @@ public:
     };
 
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// This constructor defines an empty font
-    ///
-    ////////////////////////////////////////////////////////////
-    Font();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Copy constructor
-    ///
-    /// \param copy Instance to copy
-    ///
-    ////////////////////////////////////////////////////////////
-    Font(const Font& copy);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Move constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    Font(Font&&) noexcept;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Move assignment
-    ///
-    ////////////////////////////////////////////////////////////
-    Font& operator=(Font&&) noexcept;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Destructor
-    ///
-    /// Cleans up all the internal resources used by the font
-    ///
-    ////////////////////////////////////////////////////////////
-    ~Font();
-
-    ////////////////////////////////////////////////////////////
     /// \brief Load the font from a file
     ///
     /// The supported font formats are: TrueType, Type 1, CFF,
@@ -317,16 +281,6 @@ public:
     ////////////////////////////////////////////////////////////
     bool isSmooth() const;
 
-    ////////////////////////////////////////////////////////////
-    /// \brief Overload of assignment operator
-    ///
-    /// \param right Instance to assign
-    ///
-    /// \return Reference to self
-    ///
-    ////////////////////////////////////////////////////////////
-    Font& operator=(const Font& right);
-
 private:
     ////////////////////////////////////////////////////////////
     /// \brief Structure defining a row of glyphs
@@ -427,7 +381,7 @@ private:
     mutable PageTable            m_pages;          //!< Table containing the glyphs pages by character size
     mutable std::vector<std::uint8_t> m_pixelBuffer; //!< Pixel buffer holding a glyph's pixels before being written to the texture
 #ifdef SFML_SYSTEM_ANDROID
-    std::unique_ptr<priv::ResourceStream> m_stream; //!< Asset file streamer (if loaded from file)
+    std::shared_ptr<priv::ResourceStream> m_stream; //!< Asset file streamer (if loaded from file)
 #endif
 };
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -124,34 +124,6 @@ struct Font::FontHandles
 
 
 ////////////////////////////////////////////////////////////
-Font::Font() = default;
-
-
-////////////////////////////////////////////////////////////
-// NOLINTNEXTLINE(modernize-use-equals-default)
-Font::Font(const Font& copy) :
-m_fontHandles(copy.m_fontHandles),
-m_isSmooth(copy.m_isSmooth),
-m_info(copy.m_info),
-m_pages(copy.m_pages),
-m_pixelBuffer(copy.m_pixelBuffer)
-{
-}
-
-
-////////////////////////////////////////////////////////////
-Font::~Font() = default;
-
-
-////////////////////////////////////////////////////////////
-Font::Font(Font&&) noexcept = default;
-
-
-////////////////////////////////////////////////////////////
-Font& Font::operator=(Font&&) noexcept = default;
-
-
-////////////////////////////////////////////////////////////
 bool Font::loadFromFile(const std::filesystem::path& filename)
 {
 #ifndef SFML_SYSTEM_ANDROID
@@ -204,7 +176,7 @@ bool Font::loadFromFile(const std::filesystem::path& filename)
 
 #else
 
-    m_stream = std::make_unique<priv::ResourceStream>(filename);
+    m_stream = std::make_shared<priv::ResourceStream>(filename);
     return loadFromStream(*m_stream);
 
 #endif
@@ -499,25 +471,6 @@ void Font::setSmooth(bool smooth)
 bool Font::isSmooth() const
 {
     return m_isSmooth;
-}
-
-
-////////////////////////////////////////////////////////////
-Font& Font::operator=(const Font& right)
-{
-    Font temp(right);
-
-    std::swap(m_fontHandles, temp.m_fontHandles);
-    std::swap(m_isSmooth, temp.m_isSmooth);
-    std::swap(m_info, temp.m_info);
-    std::swap(m_pages, temp.m_pages);
-    std::swap(m_pixelBuffer, temp.m_pixelBuffer);
-
-#ifdef SFML_SYSTEM_ANDROID
-    std::swap(m_stream, temp.m_stream);
-#endif
-
-    return *this;
 }
 
 

--- a/test/Graphics/Font.test.cpp
+++ b/test/Graphics/Font.test.cpp
@@ -15,8 +15,8 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
     {
         STATIC_CHECK(std::is_copy_constructible_v<sf::Font>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Font>);
-        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Font>);
-        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Font>);
+        STATIC_CHECK(std::is_move_constructible_v<sf::Font>);
+        STATIC_CHECK(std::is_move_assignable_v<sf::Font>);
     }
 
     SECTION("Construction")


### PR DESCRIPTION
## Description

Closes #2791

There were apparently historical reasons why `sf::Font` had custom copy operations but we don't need that anymore. Once we switch to using a `shared_ptr` to own the Android `ResourceStream` then we can allow to compiler to generate all special member functions.