### PR TITLE
Use `std::array` to reduce code duplication

### DIFF
--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -37,6 +37,8 @@
 #include <SFML/Graphics/Vertex.hpp>
 #include <SFML/Graphics/View.hpp>
 
+#include <array>
+
 #include <cstddef>
 
 
@@ -506,17 +508,15 @@ private:
     ////////////////////////////////////////////////////////////
     struct StatesCache
     {
-        static constexpr std::size_t VertexCacheSize{4}; // NOLINT(readability-identifier-naming)
-
-        bool          enable;                       //!< Is the cache enabled?
-        bool          glStatesSet{};                //!< Are our internal GL states set yet?
-        bool          viewChanged;                  //!< Has the current view changed since last draw?
-        bool          scissorEnabled;               //!< Is scissor testing enabled?
-        BlendMode     lastBlendMode;                //!< Cached blending mode
-        std::uint64_t lastTextureId;                //!< Cached texture
-        bool          texCoordsArrayEnabled;        //!< Is GL_TEXTURE_COORD_ARRAY client state enabled?
-        bool          useVertexCache;               //!< Did we previously use the vertex cache?
-        Vertex        vertexCache[VertexCacheSize]; //!< Pre-transformed vertices cache
+        bool                  enable;                //!< Is the cache enabled?
+        bool                  glStatesSet{};         //!< Are our internal GL states set yet?
+        bool                  viewChanged;           //!< Has the current view changed since last draw?
+        bool                  scissorEnabled;        //!< Is scissor testing enabled?
+        BlendMode             lastBlendMode;         //!< Cached blending mode
+        std::uint64_t         lastTextureId;         //!< Cached texture
+        bool                  texCoordsArrayEnabled; //!< Is GL_TEXTURE_COORD_ARRAY client state enabled?
+        bool                  useVertexCache;        //!< Did we previously use the vertex cache?
+        std::array<Vertex, 4> vertexCache;           //!< Pre-transformed vertices cache
     };
 
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -222,9 +222,9 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Vertex         m_vertices[4]; //!< Vertices defining the sprite's geometry
-    const Texture* m_texture{};   //!< Texture of the sprite
-    IntRect        m_textureRect; //!< Rectangle defining the area of the source texture to display
+    std::array<Vertex, 4> m_vertices;    //!< Vertices defining the sprite's geometry
+    const Texture*        m_texture{};   //!< Texture of the sprite
+    IntRect               m_textureRect; //!< Rectangle defining the area of the source texture to display
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -33,6 +33,8 @@
 
 #include <SFML/System/Vector2.hpp>
 
+#include <array>
+
 
 namespace sf
 {

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -93,7 +93,7 @@ constexpr Vector2f Transform::transformPoint(const Vector2f& point) const
 constexpr FloatRect Transform::transformRect(const FloatRect& rectangle) const
 {
     // Transform the 4 corners of the rectangle
-    const Vector2f points[] = {transformPoint({rectangle.left, rectangle.top}),
+    const std::array points = {transformPoint({rectangle.left, rectangle.top}),
                                transformPoint({rectangle.left, rectangle.top + rectangle.height}),
                                transformPoint({rectangle.left + rectangle.width, rectangle.top}),
                                transformPoint({rectangle.left + rectangle.width, rectangle.top + rectangle.height})};
@@ -104,7 +104,7 @@ constexpr FloatRect Transform::transformRect(const FloatRect& rectangle) const
     float right  = points[0].x;
     float bottom = points[0].y;
 
-    for (int i = 1; i < 4; ++i)
+    for (std::size_t i = 1; i < points.size(); ++i)
     {
         // clang-format off
         if      (points[i].x < left)   left   = points[i].x;

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -272,7 +272,7 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount, Primiti
     if (RenderTargetImpl::isActive(m_id) || setActive(true))
     {
         // Check if the vertex count is low enough so that we can pre-transform them
-        const bool useVertexCache = (vertexCount <= StatesCache::VertexCacheSize);
+        const bool useVertexCache = (vertexCount <= m_cache.vertexCache.size());
 
         if (useVertexCache)
         {
@@ -306,7 +306,7 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount, Primiti
 
             // If we pre-transform the vertices, we must use our internal vertex cache
             if (useVertexCache)
-                data = reinterpret_cast<const std::byte*>(m_cache.vertexCache);
+                data = reinterpret_cast<const std::byte*>(m_cache.vertexCache.data());
 
             glCheck(glVertexPointer(2, GL_FLOAT, sizeof(Vertex), data + 0));
             glCheck(glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Vertex), data + 8));
@@ -316,7 +316,7 @@ void RenderTarget::draw(const Vertex* vertices, std::size_t vertexCount, Primiti
         else if (enableTexCoordsArray && !m_cache.texCoordsArrayEnabled)
         {
             // If we enter this block, we are already using our internal vertex cache
-            const auto* data = reinterpret_cast<const std::byte*>(m_cache.vertexCache);
+            const auto* data = reinterpret_cast<const std::byte*>(m_cache.vertexCache.data());
 
             glCheck(glTexCoordPointer(2, GL_FLOAT, sizeof(Vertex), data + 12));
         }

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -82,10 +82,8 @@ void Sprite::setTextureRect(const IntRect& rectangle)
 void Sprite::setColor(const Color& color)
 {
     // Update the vertices' color
-    m_vertices[0].color = color;
-    m_vertices[1].color = color;
-    m_vertices[2].color = color;
-    m_vertices[3].color = color;
+    for (auto& vertex : m_vertices)
+        vertex.color = color;
 }
 
 
@@ -134,7 +132,7 @@ void Sprite::draw(RenderTarget& target, const RenderStates& states) const
 
     statesCopy.transform *= getTransform();
     statesCopy.texture = m_texture;
-    target.draw(m_vertices, 4, PrimitiveType::TriangleStrip, statesCopy);
+    target.draw(m_vertices.data(), m_vertices.size(), PrimitiveType::TriangleStrip, statesCopy);
 }
 
 


### PR DESCRIPTION
## Description

`std::array` lets us have a single source of truth for array size rather than needing separate constants or magic numbers that have to stay in sync with the underlying array.

There is a clang-tidy check for prohibiting C-style arrays but we use a _lot_ of C_style arrays and in many cases C-style array aren't that bad of a choice so for now I'm not enabling that check. 