### PR TITLE
Use `sf::Rect<T>::getCenter()` in more places

### DIFF
--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -47,9 +47,7 @@ struct SFMLmainWindow
 
         logo.setSmooth(true);
 
-        sf::FloatRect rect = sprite.getLocalBounds();
-        sf::Vector2f  size(rect.width, rect.height);
-        sprite.setOrigin(size / 2.f);
+        sprite.setOrigin(sprite.getLocalBounds().getCenter());
         sprite.scale({0.3f, 0.3f});
 
         unsigned int ww = renderWindow.getSize().x;

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -398,8 +398,7 @@ void Text::ensureGeometryUpdate() const
     // Compute the location of the strike through dynamically
     // We use the center point of the lowercase 'x' glyph as the reference
     // We reuse the underline thickness as the thickness of the strike through as well
-    const FloatRect xBounds             = m_font->getGlyph(U'x', m_characterSize, isBold).bounds;
-    const float     strikeThroughOffset = xBounds.top + xBounds.height / 2.f;
+    const float strikeThroughOffset = m_font->getGlyph(U'x', m_characterSize, isBold).bounds.getCenter().y;
 
     // Precompute the variables needed by the algorithm
     float       whitespaceWidth = m_font->getGlyph(U' ', m_characterSize, isBold).advance;


### PR DESCRIPTION
## Description

I missed a few more places to use the new `sf::Rect::getCenter` API.