### PR TITLE
Remove unnecessary preprocessor conditionals

### DIFF
--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -36,8 +36,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 
-#ifdef SFML_SYSTEM_ANDROID
-
 #include <SFML/System/Android/Activity.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Sleep.hpp>
@@ -568,5 +566,3 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
     // Share this state with the callback functions
     activity->instance = states;
 }
-
-#endif // SFML_SYSTEM_ANDROID

--- a/src/SFML/Main/MainWin32.cpp
+++ b/src/SFML/Main/MainWin32.cpp
@@ -37,8 +37,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 
-#ifdef SFML_SYSTEM_WINDOWS
-
 #include <SFML/System/Win32/WindowsHeader.hpp>
 
 #include <cstdlib> // for `__argc` and `__argv`
@@ -53,5 +51,3 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
     return main(__argc, __argv);
 #pragma GCC diagnostic pop
 }
-
-#endif // SFML_SYSTEM_WINDOWS

--- a/src/SFML/Main/MainiOS.mm
+++ b/src/SFML/Main/MainiOS.mm
@@ -43,8 +43,6 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 
-#ifdef SFML_SYSTEM_IOS
-
 #include <UIKit/UIKit.h>
 
 
@@ -59,5 +57,3 @@ int main(int argc, char** argv)
 
     return UIApplicationMain(argc, argv, nil, @"SFAppDelegate");
 }
-
-#endif // SFML_SYSTEM_IOS


### PR DESCRIPTION
## Description
The build system handles whether or not these files are compiled. We don't need the preprocessor to do that.

https://github.com/SFML/SFML/blob/1e4cdf89b67b36eeca3b7c4c6b45323a6e6d9bdc/src/SFML/Main/CMakeLists.txt#L5-L12

Here's the CMake code which selects the correct .cpp file to compile.