### PR TITLE
Remove unused CMake variable

### DIFF
--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -84,7 +84,7 @@ source_group("render texture" FILES ${RENDER_TEXTURE_SRC})
 
 # define the sfml-graphics target
 sfml_add_library(Graphics
-                 SOURCES ${SRC} ${DRAWABLES_SRC} ${RENDER_TEXTURE_SRC} ${STB_SRC})
+                 SOURCES ${SRC} ${DRAWABLES_SRC} ${RENDER_TEXTURE_SRC})
 
 # setup dependencies
 target_link_libraries(sfml-graphics PUBLIC SFML::Window)


### PR DESCRIPTION
## Description

This was caught by enabling CMake's uninitialized variable warnings. CMake lets you expand variables that were never defined. They expand into nothing.