### PR TITLE
Remove unnecessary `reinterpret_cast`s

### DIFF
--- a/examples/X11/X11.cpp
+++ b/examples/X11/X11.cpp
@@ -235,9 +235,9 @@ int main()
     }
 
 #ifdef SFML_OPENGL_ES
-    gladLoadGLES1(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+    gladLoadGLES1(sf::Context::getFunction);
 #else
-    gladLoadGL(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+    gladLoadGL(sf::Context::getFunction);
 #endif
 
     // Initialize our views

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -94,9 +94,9 @@ int main()
 
         // Load OpenGL or OpenGL ES entry points using glad
 #ifdef SFML_OPENGL_ES
-        gladLoadGLES1(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+        gladLoadGLES1(sf::Context::getFunction);
 #else
-        gladLoadGL(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+        gladLoadGL(sf::Context::getFunction);
 #endif
 
         // Enable Z-buffer read and write

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -41,9 +41,9 @@ int main()
 
     // Load OpenGL or OpenGL ES entry points using glad
 #ifdef SFML_OPENGL_ES
-    gladLoadGLES1(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+    gladLoadGLES1(sf::Context::getFunction);
 #else
-    gladLoadGL(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+    gladLoadGL(sf::Context::getFunction);
 #endif
 
     // Set the color and depth clear values

--- a/src/SFML/Graphics/GLExtensions.cpp
+++ b/src/SFML/Graphics/GLExtensions.cpp
@@ -61,9 +61,9 @@ void ensureExtensionsInit()
         initialized = true;
 
 #ifdef SFML_OPENGL_ES
-        gladLoadGLES1(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+        gladLoadGLES1(sf::Context::getFunction);
 #else
-        gladLoadGL(reinterpret_cast<GLADloadfunc>(sf::Context::getFunction));
+        gladLoadGL(sf::Context::getFunction);
 #endif
 
         // Retrieve the context version number


### PR DESCRIPTION
## Description

The function pointer already matches the type required so we can omit this cast