### PR TITLE
Modernize memory management of FLAC pointers

### DIFF
--- a/src/SFML/Audio/SoundFileReaderFlac.hpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.hpp
@@ -30,6 +30,7 @@
 #include <SFML/Audio/SoundFileReader.hpp>
 
 #include <FLAC/stream_decoder.h>
+#include <memory>
 #include <vector>
 
 
@@ -51,12 +52,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(InputStream& stream);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    ~SoundFileReaderFlac() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a sound file for reading
@@ -109,16 +104,14 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
-    /// \brief Close the open FLAC file
-    ///
-    ////////////////////////////////////////////////////////////
-    void close();
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    FLAC__StreamDecoder* m_decoder{};  //!< FLAC decoder
-    ClientData           m_clientData; //!< Structure passed to the decoder callbacks
+    struct FlacStreamDecoderDeleter
+    {
+        void operator()(FLAC__StreamDecoder* decoder) const;
+    };
+    std::unique_ptr<FLAC__StreamDecoder, FlacStreamDecoderDeleter> m_decoder; //!< FLAC decoder
+    ClientData m_clientData; //!< Structure passed to the decoder callbacks
 };
 
 } // namespace sf::priv

--- a/src/SFML/Audio/SoundFileWriterFlac.hpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.hpp
@@ -31,6 +31,7 @@
 
 #include <FLAC/stream_encoder.h>
 #include <filesystem>
+#include <memory>
 #include <vector>
 
 
@@ -52,12 +53,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(const std::filesystem::path& filename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Destructor
-    ///
-    ////////////////////////////////////////////////////////////
-    ~SoundFileWriterFlac() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a sound file for writing
@@ -82,17 +77,15 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
-    /// \brief Close the file
-    ///
-    ////////////////////////////////////////////////////////////
-    void close();
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    FLAC__StreamEncoder*      m_encoder{};      //!< FLAC stream encoder
-    unsigned int              m_channelCount{}; //!< Number of channels
-    std::vector<std::int32_t> m_samples32;      //!< Conversion buffer
+    struct FlacStreamEncoderDeleter
+    {
+        void operator()(FLAC__StreamEncoder* encoder) const;
+    };
+    std::unique_ptr<FLAC__StreamEncoder, FlacStreamEncoderDeleter> m_encoder;        //!< FLAC stream encoder
+    unsigned int                                                   m_channelCount{}; //!< Number of channels
+    std::vector<std::int32_t>                                      m_samples32;      //!< Conversion buffer
 };
 
 } // namespace sf::priv


### PR DESCRIPTION
## Description

Using `std::unique_ptr` lets us simplify the implementation of the FLAC reader and writer