### PR TITLE
Cleanup `sf::FileInputStream` implementation

### DIFF
--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -80,13 +80,12 @@ bool FileInputStream::open(const std::filesystem::path& filename)
 ////////////////////////////////////////////////////////////
 std::int64_t FileInputStream::read(void* data, std::int64_t size)
 {
+    if (!m_file)
+        return -1;
 #ifdef SFML_SYSTEM_ANDROID
     return m_file->read(data, size);
 #else
-    if (m_file)
-        return static_cast<std::int64_t>(std::fread(data, 1, static_cast<std::size_t>(size), m_file.get()));
-    else
-        return -1;
+    return static_cast<std::int64_t>(std::fread(data, 1, static_cast<std::size_t>(size), m_file.get()));
 #endif
 }
 
@@ -94,20 +93,15 @@ std::int64_t FileInputStream::read(void* data, std::int64_t size)
 ////////////////////////////////////////////////////////////
 std::int64_t FileInputStream::seek(std::int64_t position)
 {
+    if (!m_file)
+        return -1;
 #ifdef SFML_SYSTEM_ANDROID
     return m_file->seek(position);
 #else
-    if (m_file)
-    {
-        if (std::fseek(m_file.get(), static_cast<long>(position), SEEK_SET))
-            return -1;
-
-        return tell();
-    }
-    else
-    {
+    if (std::fseek(m_file.get(), static_cast<long>(position), SEEK_SET))
         return -1;
-    }
+
+    return tell();
 #endif
 }
 
@@ -115,13 +109,12 @@ std::int64_t FileInputStream::seek(std::int64_t position)
 ////////////////////////////////////////////////////////////
 std::int64_t FileInputStream::tell()
 {
+    if (!m_file)
+        return -1;
 #ifdef SFML_SYSTEM_ANDROID
     return m_file->tell();
 #else
-    if (m_file)
-        return std::ftell(m_file.get());
-    else
-        return -1;
+    return std::ftell(m_file.get());
 #endif
 }
 
@@ -129,24 +122,19 @@ std::int64_t FileInputStream::tell()
 ////////////////////////////////////////////////////////////
 std::int64_t FileInputStream::getSize()
 {
+    if (!m_file)
+        return -1;
 #ifdef SFML_SYSTEM_ANDROID
     return m_file->getSize();
 #else
-    if (m_file)
-    {
-        const std::int64_t position = tell();
-        std::fseek(m_file.get(), 0, SEEK_END);
-        const std::int64_t size = tell();
+    const std::int64_t position = tell();
+    std::fseek(m_file.get(), 0, SEEK_END);
+    const std::int64_t size = tell();
 
-        if (seek(position) == -1)
-            return -1;
-
-        return size;
-    }
-    else
-    {
+    if (seek(position) == -1)
         return -1;
-    }
+
+    return size;
 #endif
 }
 


### PR DESCRIPTION
## Description

I was looking at this file and noticed a few things about it that can be improved.

~~First, we don't need to explicitly define all these special member functions. This class already properly cleans up after itself. We don't need a virtual destructor because it already inherits from a type with a virtual destructor and thus its own destructor is virtual.~~ (EDIT: This is necessary for the Android build which uses a pointer to an incomplete type)

Second, I realized that this class actually behaves differently on Android when you call member functions before opening a file so I fixed that as well.