### PR TITLE
Fix crash when glBlendEquation is missing

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -638,7 +638,7 @@ void RenderTarget::applyBlendMode(const BlendMode& mode)
                 equationToGlConstant(mode.colorEquation),
                 equationToGlConstant(mode.alphaEquation)));
         }
-        else
+        else if (GLEXT_glBlendEquation)
         {
             glCheck(GLEXT_glBlendEquation(equationToGlConstant(mode.colorEquation)));
         }


### PR DESCRIPTION
## Description

Fix to this issue: https://github.com/SFML/SFML/issues/2462

![image](https://github.com/SFML/SFML/assets/54750550/9b48ff75-6da5-4b19-b03c-aa8a6c5b7ae8)


Basically, I noticed that the Galaxy S22 Exynos crashes when running any SFML apps, and it seems like it does not have the glBlendEquation extension, SFML does not check whether it has it or not, it just tries to use it, resulting in a crash. Adding an else if statement fixes this.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [x] Tested on Android
