### PR TITLE
Fix typos

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -58,7 +58,7 @@ public:
     ///
     /// \param mode     Video mode to use
     /// \param title    Title of the window
-    /// \param style    Window style (resizable, fixed, or fullscren)
+    /// \param style    Window style (resizable, fixed, or fullscreen)
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/DRM/WindowImplDRM.hpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.hpp
@@ -52,7 +52,7 @@ public:
     ///
     /// \param mode     Video mode to use
     /// \param title    Title of the window
-    /// \param style    Window style (resizable, fixed, or fullscren)
+    /// \param style    Window style (resizable, fixed, or fullscreen)
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -59,7 +59,7 @@ public:
     ///
     /// \param mode  Video mode to use
     /// \param title Title of the window
-    /// \param style Window style (resizable, fixed, or fullscren)
+    /// \param style Window style (resizable, fixed, or fullscreen)
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -59,7 +59,7 @@ public:
     ///
     /// \param mode     Video mode to use
     /// \param title    Title of the window
-    /// \param style    Window style (resizable, fixed, or fullscren)
+    /// \param style    Window style (resizable, fixed, or fullscreen)
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/macOS/WindowImplCocoa.hpp
+++ b/src/SFML/Window/macOS/WindowImplCocoa.hpp
@@ -80,7 +80,7 @@ public:
     ///
     /// \param mode  Video mode to use
     /// \param title Title of the window
-    /// \param style Window style (resizeable, fixed, or fullscren)
+    /// \param style Window style (resizeable, fixed, or fullscreen)
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

The Python codespell spellchecker somehow didn't catch this last time I ran that