### PR TITLE
Add `sf::State` for specifying fullscreen or floating windows

### DIFF
--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -47,7 +47,11 @@ int main()
         contextSettings.sRgbCapable = sRgb;
 
         // Create the main window
-        sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML graphics with OpenGL", sf::Style::Default, contextSettings);
+        sf::RenderWindow window(sf::VideoMode({800, 600}),
+                                "SFML graphics with OpenGL",
+                                sf::Style::Default,
+                                sf::State::Windowed,
+                                contextSettings);
         window.setVerticalSyncEnabled(true);
         window.setMinimumSize(sf::Vector2u(400, 300));
         window.setMaximumSize(sf::Vector2u(1200, 900));

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -30,7 +30,7 @@ int main()
     contextSettings.depthBits = 24;
 
     // Create the main window
-    sf::Window window(sf::VideoMode({640, 480}), "SFML window with OpenGL", sf::Style::Default, contextSettings);
+    sf::Window window(sf::VideoMode({640, 480}), "SFML window with OpenGL", sf::Style::Default, sf::State::Windowed, contextSettings);
 
     // Make it the active window for OpenGL calls
     if (!window.setActive())

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -62,7 +62,7 @@ public:
     /// customize the look and behavior of the window (borders,
     /// title bar, resizable, closable, ...).
     ///
-    /// The fourth parameter is an optional structure specifying
+    /// The last parameter is an optional structure specifying
     /// advanced OpenGL context settings such as antialiasing,
     /// depth-buffer bits, etc. You shouldn't care about these
     /// parameters for a regular usage of the graphics module.
@@ -70,13 +70,34 @@ public:
     /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param title    Title of the window
     /// \param style    %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param state    %Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
     RenderWindow(VideoMode              mode,
                  const String&          title,
                  std::uint32_t          style    = Style::Default,
+                 State                  state    = State::Windowed,
                  const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a new window
+    ///
+    /// This constructor creates the window with the size and pixel
+    /// depth defined in \a mode. If \a state is State::Fullscreen,
+    /// then \a mode must be a valid video mode.
+    ///
+    /// The last parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc.
+    ///
+    /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title    Title of the window
+    /// \param state    %Window state
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderWindow(VideoMode mode, const String& title, State state, const ContextSettings& settings = ContextSettings());
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the window from an existing control

--- a/include/SFML/Window.hpp
+++ b/include/SFML/Window.hpp
@@ -40,8 +40,8 @@
 #include <SFML/Window/Touch.hpp>
 #include <SFML/Window/VideoMode.hpp>
 #include <SFML/Window/Window.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 #include <SFML/Window/WindowHandle.hpp>
-#include <SFML/Window/WindowStyle.hpp>
 
 #include <SFML/System.hpp>
 

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -68,23 +68,45 @@ public:
     /// This constructor creates the window with the size and pixel
     /// depth defined in \a mode. An optional style can be passed to
     /// customize the look and behavior of the window (borders,
-    /// title bar, resizable, closable, ...). If \a style contains
-    /// Style::Fullscreen, then \a mode must be a valid video mode.
+    /// title bar, resizable, closable, ...). An optional state can
+    /// be provided. If \a state is State::Fullscreen, then \a mode
+    /// must be a valid video mode.
     ///
-    /// The fourth parameter is an optional structure specifying
+    /// The last parameter is an optional structure specifying
     /// advanced OpenGL context settings such as antialiasing,
     /// depth-buffer bits, etc.
     ///
     /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param title    Title of the window
     /// \param style    %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param state    %Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
     Window(VideoMode              mode,
            const String&          title,
            std::uint32_t          style    = Style::Default,
+           State                  state    = State::Windowed,
            const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a new window
+    ///
+    /// This constructor creates the window with the size and pixel
+    /// depth defined in \a mode. If \a state is State::Fullscreen,
+    /// then \a mode must be a valid video mode.
+    ///
+    /// The last parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc.
+    ///
+    /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title    Title of the window
+    /// \param state    %Window state
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    Window(VideoMode mode, const String& title, State state, const ContextSettings& settings = ContextSettings());
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the window from an existing control
@@ -114,34 +136,36 @@ public:
     /// \brief Create (or recreate) the window
     ///
     /// If the window was already created, it closes it first.
-    /// If \a style contains Style::Fullscreen, then \a mode
-    /// must be a valid video mode.
+    /// If \a state is State::Fullscreen, then \a mode must be
+    /// a valid video mode.
     ///
     /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param title    Title of the window
     /// \param style    %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param state    %Window state
     ///
     ////////////////////////////////////////////////////////////
-    void create(VideoMode mode, const String& title, std::uint32_t style = Style::Default) override;
+    void create(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create (or recreate) the window
     ///
     /// If the window was already created, it closes it first.
-    /// If \a style contains Style::Fullscreen, then \a mode
-    /// must be a valid video mode.
+    /// If \a state is State::Fullscreen, then \a mode must be
+    /// a valid video mode.
     ///
-    /// The fourth parameter is an optional structure specifying
+    /// The last parameter is an optional structure specifying
     /// advanced OpenGL context settings such as antialiasing,
     /// depth-buffer bits, etc.
     ///
     /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param title    Title of the window
     /// \param style    %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param state    %Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    virtual void create(VideoMode mode, const String& title, std::uint32_t style, const ContextSettings& settings);
+    virtual void create(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create (or recreate) the window from an existing control

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -30,8 +30,8 @@
 #include <SFML/Window/Export.hpp>
 
 #include <SFML/Window/Vulkan.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 #include <SFML/Window/WindowHandle.hpp>
-#include <SFML/Window/WindowStyle.hpp>
 
 #include <SFML/System/Vector2.hpp>
 
@@ -74,15 +74,30 @@ public:
     /// This constructor creates the window with the size and pixel
     /// depth defined in \a mode. An optional style can be passed to
     /// customize the look and behavior of the window (borders,
-    /// title bar, resizable, closable, ...). If \a style contains
-    /// Style::Fullscreen, then \a mode must be a valid video mode.
+    /// title bar, resizable, closable, ...). An optional state can
+    /// be provided. If \a state is State::Fullscreen, then \a mode
+    /// must be a valid video mode.
     ///
     /// \param mode  Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param title Title of the window
     /// \param style %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param state %Window state
     ///
     ////////////////////////////////////////////////////////////
-    WindowBase(VideoMode mode, const String& title, std::uint32_t style = Style::Default);
+    WindowBase(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a new window
+    ///
+    /// This constructor creates the window with the size and pixel
+    /// depth defined in \a mode.
+    ///
+    /// \param mode  Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title Title of the window
+    /// \param state %Window state
+    ///
+    ////////////////////////////////////////////////////////////
+    WindowBase(VideoMode mode, const String& title, State state);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the window from an existing control
@@ -116,15 +131,16 @@ public:
     /// \brief Create (or recreate) the window
     ///
     /// If the window was already created, it closes it first.
-    /// If \a style contains Style::Fullscreen, then \a mode
-    /// must be a valid video mode.
+    /// If \a state is State::Fullscreen, then \a mode must be
+    /// a valid video mode.
     ///
     /// \param mode  Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param title Title of the window
     /// \param style %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param state %Window state
     ///
     ////////////////////////////////////////////////////////////
-    virtual void create(VideoMode mode, const String& title, std::uint32_t style = Style::Default);
+    virtual void create(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create (or recreate) the window from an existing control
@@ -471,9 +487,10 @@ private:
     ///
     /// \param mode  Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param style %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param state %Window state
     ///
     ////////////////////////////////////////////////////////////
-    void create(VideoMode mode, std::uint32_t& style);
+    void create(VideoMode mode, std::uint32_t& style, State& state);
 
     ////////////////////////////////////////////////////////////
     /// \brief Processes an event before it is sent to the user

--- a/include/SFML/Window/WindowEnums.hpp
+++ b/include/SFML/Window/WindowEnums.hpp
@@ -25,7 +25,9 @@
 #pragma once
 
 
-namespace sf::Style
+namespace sf
+{
+namespace Style
 {
 ////////////////////////////////////////////////////////////
 /// \ingroup window
@@ -34,12 +36,25 @@ namespace sf::Style
 ////////////////////////////////////////////////////////////
 enum
 {
-    None       = 0,      //!< No border / title bar (this flag and all others are mutually exclusive)
-    Titlebar   = 1 << 0, //!< Title bar + fixed border
-    Resize     = 1 << 1, //!< Title bar + resizable border + maximize button
-    Close      = 1 << 2, //!< Title bar + close button
-    Fullscreen = 1 << 3, //!< Fullscreen mode (this flag and all others are mutually exclusive)
+    None     = 0,      //!< No border / title bar (this flag and all others are mutually exclusive)
+    Titlebar = 1 << 0, //!< Title bar + fixed border
+    Resize   = 1 << 1, //!< Title bar + resizable border + maximize button
+    Close    = 1 << 2, //!< Title bar + close button
 
     Default = Titlebar | Resize | Close //!< Default window style
 };
-} // namespace sf::Style
+
+} // namespace Style
+
+////////////////////////////////////////////////////////////
+/// \ingroup window
+/// \brief Enumeration of the window states
+///
+////////////////////////////////////////////////////////////
+enum class State
+{
+    Windowed,  //!< Floating window
+    Fullscreen //!< Fullscreen window
+};
+
+} // namespace sf

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -37,10 +37,18 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-RenderWindow::RenderWindow(VideoMode mode, const String& title, std::uint32_t style, const ContextSettings& settings)
+RenderWindow::RenderWindow(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings)
 {
     // Don't call the base class constructor because it contains virtual function calls
-    Window::create(mode, title, style, settings);
+    Window::create(mode, title, style, state, settings);
+}
+
+
+////////////////////////////////////////////////////////////
+RenderWindow::RenderWindow(VideoMode mode, const String& title, State state, const ContextSettings& settings)
+{
+    // Don't call the base class constructor because it contains virtual function calls
+    Window::create(mode, title, sf::Style::Default, state, settings);
 }
 
 

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -28,7 +28,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Android/WindowImplAndroid.hpp>
 #include <SFML/Window/Event.hpp>
-#include <SFML/Window/WindowStyle.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 
 #include <SFML/System/Err.hpp>
 
@@ -59,14 +59,15 @@ WindowImplAndroid::WindowImplAndroid(WindowHandle /* handle */)
 ////////////////////////////////////////////////////////////
 WindowImplAndroid::WindowImplAndroid(VideoMode mode,
                                      const String& /* title */,
-                                     unsigned long style,
+                                     std::uint32_t /* style */,
+                                     State state,
                                      const ContextSettings& /* settings */) :
 m_size(mode.size)
 {
     ActivityStates&       states = getActivity();
     const std::lock_guard lock(states.mutex);
 
-    if (style & Style::Fullscreen)
+    if (state == State::Fullscreen)
         states.fullscreen = true;
 
     WindowImplAndroid::singleInstance = this;

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -58,11 +58,12 @@ public:
     ///
     /// \param mode     Video mode to use
     /// \param title    Title of the window
-    /// \param style    Window style (resizable, fixed, or fullscreen)
+    /// \param style    Window style
+    /// \param state    Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    WindowImplAndroid(VideoMode mode, const String& title, unsigned long style, const ContextSettings& settings);
+    WindowImplAndroid(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -44,10 +44,10 @@ set(SRC
     ${INCROOT}/Window.hpp
     ${SRCROOT}/WindowBase.cpp
     ${INCROOT}/WindowBase.hpp
+    ${INCROOT}/WindowEnums.hpp
     ${INCROOT}/WindowHandle.hpp
     ${SRCROOT}/WindowImpl.cpp
     ${SRCROOT}/WindowImpl.hpp
-    ${INCROOT}/WindowStyle.hpp
 )
 source_group("" FILES ${SRC})
 

--- a/src/SFML/Window/DRM/CursorImpl.hpp
+++ b/src/SFML/Window/DRM/CursorImpl.hpp
@@ -28,7 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Cursor.hpp>
-#include <SFML/Window/WindowStyle.hpp> // Prevent conflict with macro None from Xlib
+#include <SFML/Window/WindowEnums.hpp> // Prevent conflict with macro None from Xlib
 
 #include <SFML/System/Vector2.hpp>
 

--- a/src/SFML/Window/DRM/WindowImplDRM.cpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.cpp
@@ -29,7 +29,7 @@
 #include <SFML/Window/DRM/WindowImplDRM.hpp>
 #include <SFML/Window/Event.hpp>
 #include <SFML/Window/InputImpl.hpp>
-#include <SFML/Window/WindowStyle.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 
 #include <SFML/System/Err.hpp>
 
@@ -70,7 +70,11 @@ WindowImplDRM::WindowImplDRM(WindowHandle /*handle*/)
 
 
 ////////////////////////////////////////////////////////////
-WindowImplDRM::WindowImplDRM(VideoMode mode, const String& /*title*/, unsigned long /*style*/, const ContextSettings& /*settings*/) :
+WindowImplDRM::WindowImplDRM(VideoMode mode,
+                             const String& /*title*/,
+                             std::uint32_t /*style*/,
+                             State /*state*/,
+                             const ContextSettings& /*settings*/) :
 m_size(mode.size)
 {
     InputImpl::setTerminalConfig();

--- a/src/SFML/Window/DRM/WindowImplDRM.hpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.hpp
@@ -52,11 +52,12 @@ public:
     ///
     /// \param mode     Video mode to use
     /// \param title    Title of the window
-    /// \param style    Window style (resizable, fixed, or fullscreen)
+    /// \param style    Window style
+    /// \param state    Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    WindowImplDRM(VideoMode mode, const String& title, unsigned long style, const ContextSettings& settings);
+    WindowImplDRM(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/EglContext.hpp
+++ b/src/SFML/Window/EglContext.hpp
@@ -31,7 +31,7 @@
 #include <SFML/Window/EGLCheck.hpp>
 #include <SFML/Window/GlContext.hpp>
 #include <SFML/Window/VideoMode.hpp>
-#include <SFML/Window/WindowStyle.hpp> // Prevent conflict with macro None from Xlib
+#include <SFML/Window/WindowEnums.hpp> // Prevent conflict with macro None from Xlib
 
 #include <glad/egl.h>
 #if defined(SFML_SYSTEM_LINUX) && !defined(SFML_USE_DRM)

--- a/src/SFML/Window/Unix/ClipboardImpl.hpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.hpp
@@ -27,7 +27,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Window/WindowStyle.hpp> // Prevent conflict with macro None from Xlib
+#include <SFML/Window/WindowEnums.hpp> // Prevent conflict with macro None from Xlib
 
 #include <SFML/System/String.hpp>
 

--- a/src/SFML/Window/Unix/CursorImpl.hpp
+++ b/src/SFML/Window/Unix/CursorImpl.hpp
@@ -28,7 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Cursor.hpp>
-#include <SFML/Window/WindowStyle.hpp> // Prevent conflict with macro None from Xlib
+#include <SFML/Window/WindowEnums.hpp> // Prevent conflict with macro None from Xlib
 
 #include <SFML/System/Vector2.hpp>
 

--- a/src/SFML/Window/Unix/Display.hpp
+++ b/src/SFML/Window/Unix/Display.hpp
@@ -27,7 +27,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Window/WindowStyle.hpp> // Prevent conflict with macro None from Xlib
+#include <SFML/Window/WindowEnums.hpp> // Prevent conflict with macro None from Xlib
 
 #include <X11/Xlib.h>
 

--- a/src/SFML/Window/Unix/GlxContext.hpp
+++ b/src/SFML/Window/Unix/GlxContext.hpp
@@ -28,7 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/GlContext.hpp>
-#include <SFML/Window/WindowStyle.hpp> // Prevent conflict with macro None from Xlib
+#include <SFML/Window/WindowEnums.hpp> // Prevent conflict with macro None from Xlib
 
 #include <X11/Xlib.h>
 #include <glad/glx.h>

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -465,8 +465,8 @@ WindowImplX11::WindowImplX11(WindowHandle handle) : m_isExternal(true)
 
 
 ////////////////////////////////////////////////////////////
-WindowImplX11::WindowImplX11(VideoMode mode, const String& title, unsigned long style, const ContextSettings& settings) :
-m_fullscreen((style & Style::Fullscreen) != 0),
+WindowImplX11::WindowImplX11(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings) :
+m_fullscreen(state == State::Fullscreen),
 m_cursorGrabbed(m_fullscreen)
 {
     using namespace WindowImplX11Impl;

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -28,8 +28,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Event.hpp>
+#include <SFML/Window/WindowEnums.hpp> // Prevent conflict with macro None from Xlib
 #include <SFML/Window/WindowImpl.hpp>
-#include <SFML/Window/WindowStyle.hpp> // Prevent conflict with macro None from Xlib
 
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
@@ -59,11 +59,12 @@ public:
     ///
     /// \param mode  Video mode to use
     /// \param title Title of the window
-    /// \param style Window style (resizable, fixed, or fullscreen)
+    /// \param style Window style
+    /// \param state Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    WindowImplX11(VideoMode mode, const String& title, unsigned long style, const ContextSettings& settings);
+    WindowImplX11(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -27,7 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/JoystickImpl.hpp>
 #include <SFML/Window/Win32/WindowImplWin32.hpp>
-#include <SFML/Window/WindowStyle.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 
 #include <SFML/System/Err.hpp>
 #include <SFML/System/String.hpp>
@@ -150,9 +150,13 @@ WindowImplWin32::WindowImplWin32(WindowHandle handle) : m_handle(handle)
 
 
 ////////////////////////////////////////////////////////////
-WindowImplWin32::WindowImplWin32(VideoMode mode, const String& title, std::uint32_t style, const ContextSettings& /*settings*/) :
+WindowImplWin32::WindowImplWin32(VideoMode     mode,
+                                 const String& title,
+                                 std::uint32_t style,
+                                 State         state,
+                                 const ContextSettings& /*settings*/) :
 m_lastSize(mode.size),
-m_fullscreen((style & Style::Fullscreen) != 0),
+m_fullscreen(state == State::Fullscreen),
 m_cursorGrabbed(m_fullscreen)
 {
     // Set that this process is DPI aware and can handle DPI scaling

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -60,10 +60,11 @@ public:
     /// \param mode  Video mode to use
     /// \param title Title of the window
     /// \param style Window style
+    /// \param state Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    WindowImplWin32(VideoMode mode, const String& title, std::uint32_t style, const ContextSettings& settings);
+    WindowImplWin32(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -44,9 +44,16 @@ Window::Window() = default;
 
 
 ////////////////////////////////////////////////////////////
-Window::Window(VideoMode mode, const String& title, std::uint32_t style, const ContextSettings& settings)
+Window::Window(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings)
 {
-    Window::create(mode, title, style, settings);
+    Window::create(mode, title, style, state, settings);
+}
+
+
+////////////////////////////////////////////////////////////
+Window::Window(VideoMode mode, const String& title, State state, const ContextSettings& settings)
+{
+    Window::create(mode, title, sf::Style::Default, state, settings);
 }
 
 
@@ -65,20 +72,20 @@ Window::~Window()
 
 
 ////////////////////////////////////////////////////////////
-void Window::create(VideoMode mode, const String& title, std::uint32_t style)
+void Window::create(VideoMode mode, const String& title, std::uint32_t style, State state)
 {
-    Window::create(mode, title, style, ContextSettings());
+    Window::create(mode, title, style, state, ContextSettings());
 }
 
 
 ////////////////////////////////////////////////////////////
-void Window::create(VideoMode mode, const String& title, std::uint32_t style, const ContextSettings& settings)
+void Window::create(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings)
 {
     // Delegate to base class for creation logic
-    WindowBase::create(mode, style);
+    WindowBase::create(mode, style, state);
 
     // Recreate the window implementation
-    m_impl = priv::WindowImpl::create(mode, title, style, settings);
+    m_impl = priv::WindowImpl::create(mode, title, style, state, settings);
 
     // Recreate the context
     m_context = priv::GlContext::create(settings, *m_impl, mode.bitsPerPixel);

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -55,9 +55,16 @@ WindowBase::WindowBase() = default;
 
 
 ////////////////////////////////////////////////////////////
-WindowBase::WindowBase(VideoMode mode, const String& title, std::uint32_t style)
+WindowBase::WindowBase(VideoMode mode, const String& title, std::uint32_t style, State state)
 {
-    WindowBase::create(mode, title, style);
+    WindowBase::create(mode, title, style, state);
+}
+
+
+////////////////////////////////////////////////////////////
+WindowBase::WindowBase(VideoMode mode, const String& title, State state)
+{
+    WindowBase::create(mode, title, sf::Style::Default, state);
 }
 
 
@@ -76,12 +83,12 @@ WindowBase::~WindowBase()
 
 
 ////////////////////////////////////////////////////////////
-void WindowBase::create(VideoMode mode, const String& title, std::uint32_t style)
+void WindowBase::create(VideoMode mode, const String& title, std::uint32_t style, State state)
 {
-    WindowBase::create(mode, style);
+    WindowBase::create(mode, style, state);
 
     // Recreate the window implementation
-    m_impl = priv::WindowImpl::create(mode, title, style, ContextSettings(0, 0, 0, 0, 0, 0xFFFFFFFF, false));
+    m_impl = priv::WindowImpl::create(mode, title, style, state, ContextSettings(0, 0, 0, 0, 0, 0xFFFFFFFF, false));
 
     // Perform common initializations
     initialize();
@@ -347,19 +354,19 @@ void WindowBase::onResize()
 
 
 ////////////////////////////////////////////////////////////
-void WindowBase::create(VideoMode mode, std::uint32_t& style)
+void WindowBase::create(VideoMode mode, std::uint32_t& style, State& state)
 {
     // Destroy the previous window implementation
     close();
 
     // Fullscreen style requires some tests
-    if (style & Style::Fullscreen)
+    if (state == State::Fullscreen)
     {
         // Make sure there's not already a fullscreen window (only one is allowed)
         if (getFullscreenWindow())
         {
             err() << "Creating two fullscreen windows is not allowed, switching to windowed mode" << std::endl;
-            style &= ~static_cast<std::uint32_t>(Style::Fullscreen);
+            state = State::Windowed;
         }
         else
         {
@@ -380,7 +387,7 @@ void WindowBase::create(VideoMode mode, std::uint32_t& style)
 
 // Check validity of style according to the underlying platform
 #if defined(SFML_SYSTEM_IOS) || defined(SFML_SYSTEM_ANDROID)
-    if (style & Style::Fullscreen)
+    if (state == State::Fullscreen)
         style &= ~static_cast<std::uint32_t>(Style::Titlebar);
     else
         style |= Style::Titlebar;

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -100,9 +100,14 @@ struct WindowImpl::JoystickStatesImpl
 };
 
 ////////////////////////////////////////////////////////////
-std::unique_ptr<WindowImpl> WindowImpl::create(VideoMode mode, const String& title, std::uint32_t style, const ContextSettings& settings)
+std::unique_ptr<WindowImpl> WindowImpl::create(
+    VideoMode              mode,
+    const String&          title,
+    std::uint32_t          style,
+    State                  state,
+    const ContextSettings& settings)
 {
-    return std::make_unique<WindowImplType>(mode, title, style, settings);
+    return std::make_unique<WindowImplType>(mode, title, style, state, settings);
 }
 
 

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -37,6 +37,7 @@
 #include <SFML/Window/SensorImpl.hpp>
 #include <SFML/Window/VideoMode.hpp>
 #include <SFML/Window/Vulkan.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 #include <SFML/Window/WindowHandle.hpp>
 
 #include <SFML/System/EnumArray.hpp>
@@ -66,6 +67,7 @@ public:
     /// \param mode  Video mode to use
     /// \param title Title of the window
     /// \param style Window style
+    /// \param state Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     /// \return Pointer to the created window
@@ -74,6 +76,7 @@ public:
     static std::unique_ptr<WindowImpl> create(VideoMode              mode,
                                               const String&          title,
                                               std::uint32_t          style,
+                                              State                  state,
                                               const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -59,11 +59,12 @@ public:
     ///
     /// \param mode     Video mode to use
     /// \param title    Title of the window
-    /// \param style    Window style (resizable, fixed, or fullscreen)
+    /// \param style    Window style
+    /// \param state    Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    WindowImplUIKit(VideoMode mode, const String& title, unsigned long style, const ContextSettings& settings);
+    WindowImplUIKit(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the OS-specific handle of the window

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Window/WindowStyle.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 #include <SFML/Window/iOS/SFAppDelegate.hpp>
 #include <SFML/Window/iOS/SFView.hpp>
 #include <SFML/Window/iOS/SFViewController.hpp>
@@ -47,12 +47,16 @@ WindowImplUIKit::WindowImplUIKit(WindowHandle /* handle */)
 
 
 ////////////////////////////////////////////////////////////
-WindowImplUIKit::WindowImplUIKit(VideoMode mode, const String& /* title */, unsigned long style, const ContextSettings& /* settings */)
+WindowImplUIKit::WindowImplUIKit(VideoMode mode,
+                                 const String& /* title */,
+                                 std::uint32_t style,
+                                 State         state,
+                                 const ContextSettings& /* settings */)
 {
     m_backingScale = static_cast<float>([SFAppDelegate getInstance].backingScaleFactor);
 
     // Apply the fullscreen flag
-    [UIApplication sharedApplication].statusBarHidden = !(style & Style::Titlebar) || (style & Style::Fullscreen);
+    [UIApplication sharedApplication].statusBarHidden = !(style & Style::Titlebar) || (state == State::Fullscreen);
 
     // Set the orientation according to the requested size
     if (mode.size.x > mode.size.y)

--- a/src/SFML/Window/macOS/SFWindowController.h
+++ b/src/SFML/Window/macOS/SFWindowController.h
@@ -27,6 +27,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/VideoMode.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 #import <SFML/Window/macOS/WindowImplDelegateProtocol.h>
 
 ////////////////////////////////////////////////////////////
@@ -80,10 +81,11 @@ class WindowImplCocoa;
 ///
 /// \param mode Video mode
 /// \param style Window's style, as described by sf::Style
+/// \param state Window's state
 ///
 /// \return an initialized controller
 ///
 ////////////////////////////////////////////////////////////
-- (id)initWithMode:(const sf::VideoMode&)mode andStyle:(unsigned long)style;
+- (id)initWithMode:(const sf::VideoMode&)mode andStyle:(std::uint32_t)style andState:(sf::State)state;
 
 @end

--- a/src/SFML/Window/macOS/SFWindowController.mm
+++ b/src/SFML/Window/macOS/SFWindowController.mm
@@ -27,8 +27,8 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/VideoMode.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 #include <SFML/Window/WindowHandle.hpp>
-#include <SFML/Window/WindowStyle.hpp>
 #import <SFML/Window/macOS/NSImage+raw.h>
 #import <SFML/Window/macOS/SFApplication.h>
 #import <SFML/Window/macOS/SFOpenGLView.h>
@@ -135,7 +135,7 @@
 
 
 ////////////////////////////////////////////////////////
-- (id)initWithMode:(const sf::VideoMode&)mode andStyle:(unsigned long)style
+- (id)initWithMode:(const sf::VideoMode&)mode andStyle:(std::uint32_t)style andState:(sf::State)state
 {
     // If we are not on the main thread we stop here and advice the user.
     if ([NSThread currentThread] != [NSThread mainThread])
@@ -154,7 +154,7 @@
         m_window        = nil;
         m_oglView       = nil;
         m_requester     = nil;
-        m_fullscreen    = ((style & sf::Style::Fullscreen) != 0) ? YES : NO;
+        m_fullscreen    = (state == sf::State::Fullscreen) ? YES : NO;
         m_restoreResize = NO;
         m_highDpi       = NO;
 
@@ -236,9 +236,9 @@
 
 
 ////////////////////////////////////////////////////////
-- (void)setupWindowWithMode:(const sf::VideoMode&)mode andStyle:(unsigned long)style
+- (void)setupWindowWithMode:(const sf::VideoMode&)mode andStyle:(std::uint32_t)style
 {
-    // We know that style & sf::Style::Fullscreen is false.
+    // We know that sf::State is not Fullscreen
 
     // Create our window size.
     NSRect rect = NSMakeRect(0, 0, mode.size.x, mode.size.y);

--- a/src/SFML/Window/macOS/WindowImplCocoa.hpp
+++ b/src/SFML/Window/macOS/WindowImplCocoa.hpp
@@ -29,6 +29,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Event.hpp>
+#include <SFML/Window/WindowEnums.hpp>
 #include <SFML/Window/WindowImpl.hpp>
 
 #pragma GCC diagnostic push
@@ -80,11 +81,12 @@ public:
     ///
     /// \param mode  Video mode to use
     /// \param title Title of the window
-    /// \param style Window style (resizeable, fixed, or fullscreen)
+    /// \param style Window style
+    /// \param state Window state
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    WindowImplCocoa(VideoMode mode, const String& title, unsigned long style, const ContextSettings& settings);
+    WindowImplCocoa(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/macOS/WindowImplCocoa.mm
+++ b/src/SFML/Window/macOS/WindowImplCocoa.mm
@@ -132,13 +132,13 @@ WindowImplCocoa::WindowImplCocoa(WindowHandle handle)
 
 
 ////////////////////////////////////////////////////////////
-WindowImplCocoa::WindowImplCocoa(VideoMode mode, const String& title, unsigned long style, const ContextSettings& /*settings*/)
+WindowImplCocoa::WindowImplCocoa(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& /*settings*/)
 {
     const AutoreleasePool pool;
     // Transform the app process.
     setUpProcess();
 
-    m_delegate = [[SFWindowController alloc] initWithMode:mode andStyle:style];
+    m_delegate = [[SFWindowController alloc] initWithMode:mode andStyle:style andState:state];
     [m_delegate changeTitle:sfStringToNSString(title)];
     [m_delegate setRequesterTo:this];
 

--- a/test/Graphics/RenderWindow.test.cpp
+++ b/test/Graphics/RenderWindow.test.cpp
@@ -26,11 +26,43 @@ TEST_CASE("[Graphics] sf::RenderWindow", runDisplayTests())
 
     SECTION("Construction")
     {
-        const sf::RenderWindow window(sf::VideoMode(sf::Vector2u(256, 256), 24),
-                                      "Window Title",
-                                      sf::Style::Default,
-                                      sf::ContextSettings());
-        CHECK(window.getSize() == sf::Vector2u(256, 256));
+        SECTION("Style, state, and settings")
+        {
+            const sf::RenderWindow window(sf::VideoMode(sf::Vector2u(256, 256), 24),
+                                          "Window Title",
+                                          sf::Style::Default,
+                                          sf::State::Windowed,
+                                          sf::ContextSettings());
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(256, 256));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
+            CHECK(!window.isSrgb());
+            CHECK(window.getView().getCenter() == sf::Vector2f(128, 128));
+            CHECK(window.getView().getSize() == sf::Vector2f(256, 256));
+            CHECK(window.getView().getRotation() == sf::Angle::Zero);
+            CHECK(window.getView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
+            CHECK(window.getView().getTransform() == sf::Transform(0.0078125f, 0, -1, 0, -0.0078125f, 1, 0, 0, 1));
+        }
+
+        SECTION("State and settings")
+        {
+            const sf::RenderWindow window(sf::VideoMode(sf::Vector2u(240, 300), 24),
+                                          "Window Title",
+                                          sf::State::Windowed,
+                                          sf::ContextSettings());
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(240, 300));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
+            CHECK(!window.isSrgb());
+            CHECK(window.getView().getCenter() == sf::Vector2f(120, 150));
+            CHECK(window.getView().getSize() == sf::Vector2f(240, 300));
+            CHECK(window.getView().getRotation() == sf::Angle::Zero);
+            CHECK(window.getView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
+            CHECK(window.getView().getTransform() ==
+                  Approx(sf::Transform(0.00833333f, 0, -1, 0, -0.00666667f, 1, 0, 0, 1)));
+        }
     }
 
     SECTION("Clear")
@@ -38,6 +70,7 @@ TEST_CASE("[Graphics] sf::RenderWindow", runDisplayTests())
         sf::RenderWindow window(sf::VideoMode(sf::Vector2u(256, 256), 24),
                                 "Window Title",
                                 sf::Style::Default,
+                                sf::State::Windowed,
                                 sf::ContextSettings());
         REQUIRE(window.getSize() == sf::Vector2u(256, 256));
 

--- a/test/Window/Window.test.cpp
+++ b/test/Window/Window.test.cpp
@@ -57,9 +57,45 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
         }
 
-        SECTION("Mode, title, style, and context settings constructor")
+        SECTION("Mode, title, style, and state constructor")
         {
-            const sf::Window window(sf::VideoMode({360, 240}), "Window Tests", sf::Style::Resize, sf::ContextSettings(1, 1, 1));
+            const sf::Window window(sf::VideoMode({360, 240}), "Window Tests", sf::Style::Resize, sf::State::Windowed);
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(360, 240));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
+        }
+
+        SECTION("Mode, title, style, state, and context settings constructor")
+        {
+            const sf::Window window(sf::VideoMode({360, 240}),
+                                    "Window Tests",
+                                    sf::Style::Resize,
+                                    sf::State::Windowed,
+                                    sf::ContextSettings(1, 1, 1));
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(360, 240));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().depthBits >= 1);
+            CHECK(window.getSettings().stencilBits >= 1);
+            CHECK(window.getSettings().antialiasingLevel >= 1);
+        }
+
+        SECTION("Mode, title, and state")
+        {
+            const sf::Window window(sf::VideoMode({360, 240}), "Window Tests", sf::State::Windowed);
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(360, 240));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
+        }
+
+        SECTION("Mode, title, state, and context settings constructor")
+        {
+            const sf::Window window(sf::VideoMode({360, 240}),
+                                    "Window Tests",
+                                    sf::State::Windowed,
+                                    sf::ContextSettings(1, 1, 1));
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(360, 240));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
@@ -93,7 +129,11 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
 
         SECTION("Mode, title, style, and context settings")
         {
-            window.create(sf::VideoMode({240, 360}), "Window Tests", sf::Style::Resize, sf::ContextSettings(1, 1, 1));
+            window.create(sf::VideoMode({240, 360}),
+                          "Window Tests",
+                          sf::Style::Resize,
+                          sf::State::Windowed,
+                          sf::ContextSettings(1, 1, 1));
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(240, 360));
             CHECK(window.getNativeHandle() != sf::WindowHandle());

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -48,6 +48,22 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
             CHECK(windowBase.getSize() == sf::Vector2u(360, 240));
             CHECK(windowBase.getNativeHandle() != sf::WindowHandle());
         }
+
+        SECTION("Mode, title, style, and state constructor")
+        {
+            const sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests", sf::Style::Resize, sf::State::Windowed);
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(360, 240));
+            CHECK(windowBase.getNativeHandle() != sf::WindowHandle());
+        }
+
+        SECTION("Mode, title, and state constructor")
+        {
+            const sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests", sf::State::Windowed);
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(360, 240));
+            CHECK(windowBase.getNativeHandle() != sf::WindowHandle());
+        }
     }
 
     SECTION("create()")
@@ -65,6 +81,14 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
         SECTION("Mode, title, and style")
         {
             windowBase.create(sf::VideoMode({240, 360}), "WindowBase Tests", sf::Style::Resize);
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(240, 360));
+            CHECK(windowBase.getNativeHandle() != sf::WindowHandle());
+        }
+
+        SECTION("Mode, title, style, and state")
+        {
+            windowBase.create(sf::VideoMode({240, 360}), "WindowBase Tests", sf::Style::Resize, sf::State::Windowed);
             CHECK(windowBase.isOpen());
             CHECK(windowBase.getSize() == sf::Vector2u(240, 360));
             CHECK(windowBase.getNativeHandle() != sf::WindowHandle());


### PR DESCRIPTION
## Description

This is the first step towards implementing https://github.com/SFML/SFML/wiki/SD%3A-States-and-Styles

It converts `Fullscreen` from a `Style` to a `State`. While I was touching this code I fixed an inconsistency where `sf::Style`s were sometimes passed as a `std::uint32_t` and sometimes an `unsigned long`.  