### PR TITLE
Issue CMake Warning when using UCRT MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,8 @@ if(SFML_USE_SYSTEM_DEPS)
     endforeach()
 
     list(REMOVE_DUPLICATES CMAKE_IGNORE_PATH)
+elseif(SFML_COMPILER_GCC AND GCC_COMPILER_VERSION MATCHES "ucrt")
+    message(FATAL_ERROR "The pre-compiled SFML dependencies for MinGW are not compatible with the UCRT. Either switch to the MSVCRT or build the dependencies yourself.")
 endif()
 
 # Visual C++: remove warnings regarding SL security and algorithms on pointers

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -8,6 +8,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     # detect the architecture (note: this test won't work for cross-compilation)
     include(CheckTypeSize)
     check_type_size(void* SIZEOF_VOID_PTR)
+
     if(${SIZEOF_VOID_PTR} STREQUAL "4")
         set(ARCH_32BITS 1)
     elseif(${SIZEOF_VOID_PTR} STREQUAL "8")
@@ -18,25 +19,31 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     endif()
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(SFML_OS_UNIX 1)
+
     if(ANDROID)
         set(SFML_OS_ANDROID 1)
+
         # use the OpenGL ES implementation on Android
         set(OPENGL_ES 1)
     else()
         set(SFML_OS_LINUX 1)
+
         # don't use the OpenGL ES implementation on Linux
         set(OPENGL_ES 0)
     endif()
 elseif(CMAKE_SYSTEM_NAME MATCHES "^k?FreeBSD$")
     set(SFML_OS_FREEBSD 1)
+
     # don't use the OpenGL ES implementation on FreeBSD
     set(OPENGL_ES 0)
 elseif(CMAKE_SYSTEM_NAME MATCHES "^OpenBSD$")
     set(SFML_OS_OPENBSD 1)
+
     # don't use the OpenGL ES implementation on OpenBSD
     set(OPENGL_ES 0)
 elseif(CMAKE_SYSTEM_NAME MATCHES "^NetBSD$")
     set(SFML_OS_NETBSD 1)
+
     # don't use the OpenGL ES implementation on NetBSD
     set(OPENGL_ES 0)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
@@ -54,6 +61,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
         # detect OS X version. (use '/usr/bin/sw_vers -productVersion' to extract V from '10.V.x'.)
         EXEC_PROGRAM(/usr/bin/sw_vers ARGS -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
         STRING(REGEX REPLACE "10\\.([0-9]+).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
+
         if(${MACOSX_VERSION} LESS 7)
             message(FATAL_ERROR "Unsupported version of OS X: ${MACOSX_VERSION_RAW}")
             return()
@@ -64,6 +72,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
 
     # use the OpenGL ES implementation on Android
     set(OPENGL_ES 1)
+
 # comparing CMAKE_SYSTEM_NAME with "CYGWIN" generates a false warning depending on the CMake version
 # let's avoid it so the actual error is more visible
 elseif(${CYGWIN})
@@ -99,11 +108,11 @@ if(MSVC)
     elseif(MSVC_VERSION LESS_EQUAL 1939)
         set(SFML_MSVC_VERSION 17)
     endif()
-	
-	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-		set(SFML_COMPILER_CLANG_CL 1)
-	endif()
-	
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(SFML_COMPILER_CLANG_CL 1)
+    endif()
+
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(SFML_COMPILER_CLANG 1)
 


### PR DESCRIPTION
## Description

[WinLibs](https://winlibs.com/) has popularized or even introduced MinGW versions using the UCRT instead of the previously MSVCRT. Unfortunately, as our MinGW dependencies are built for MSVCRT, the linking will fail.  
Maybe eventually we'll provide compatible binaries or always build from source, but until then, we'll output a warning.  

We only issue an error if the user tries to use the built-in libraries. If they provide their own, we don't issue anything.

## Tasks

-   [x] Tested on Windows

## How to test this PR?

Build SFML with MinGW using the UCRT.

Expected output:
```
CMake Error at CMakeLists.txt:199 (message):
  The pre-compiled SFML dependencies for MinGW are not compatible with the
  UCRT.  Either switch to the MSVCRT or build the dependencies yourself.


-- Configuring incomplete, errors occurred!
```