### PR TITLE
Use scoped enumerations in Window module

### DIFF
--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -55,29 +55,29 @@ public:
     /// Refer to the following table to determine which cursor
     /// is available on which platform.
     ///
-    ///  Type                               | Linux | macOS | Windows  |
-    /// ------------------------------------|:-----:|:-----:|:--------:|
-    ///  sf::Cursor::Arrow                  |  yes  | yes   |   yes    |
-    ///  sf::Cursor::ArrowWait              |  no   | no    |   yes    |
-    ///  sf::Cursor::Wait                   |  yes  | no    |   yes    |
-    ///  sf::Cursor::Text                   |  yes  | yes   |   yes    |
-    ///  sf::Cursor::Hand                   |  yes  | yes   |   yes    |
-    ///  sf::Cursor::SizeHorizontal         |  yes  | yes   |   yes    |
-    ///  sf::Cursor::SizeVertical           |  yes  | yes   |   yes    |
-    ///  sf::Cursor::SizeTopLeftBottomRight |  no   | yes*  |   yes    |
-    ///  sf::Cursor::SizeBottomLeftTopRight |  no   | yes*  |   yes    |
-    ///  sf::Cursor::SizeLeft               |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeRight              |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeTop                |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeBottom             |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeTopLeft            |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeTopRight           |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeBottomLeft         |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeBottomRight        |  yes  | yes** |   yes**  |
-    ///  sf::Cursor::SizeAll                |  yes  | no    |   yes    |
-    ///  sf::Cursor::Cross                  |  yes  | yes   |   yes    |
-    ///  sf::Cursor::Help                   |  yes  | yes*  |   yes    |
-    ///  sf::Cursor::NotAllowed             |  yes  | yes   |   yes    |
+    ///  Type                                     | Linux | macOS | Windows  |
+    /// ------------------------------------------|:-----:|:-----:|:--------:|
+    ///  sf::Cursor::Type::Arrow                  |  yes  | yes   |   yes    |
+    ///  sf::Cursor::Type::ArrowWait              |  no   | no    |   yes    |
+    ///  sf::Cursor::Type::Wait                   |  yes  | no    |   yes    |
+    ///  sf::Cursor::Type::Text                   |  yes  | yes   |   yes    |
+    ///  sf::Cursor::Type::Hand                   |  yes  | yes   |   yes    |
+    ///  sf::Cursor::Type::SizeHorizontal         |  yes  | yes   |   yes    |
+    ///  sf::Cursor::Type::SizeVertical           |  yes  | yes   |   yes    |
+    ///  sf::Cursor::Type::SizeTopLeftBottomRight |  no   | yes*  |   yes    |
+    ///  sf::Cursor::Type::SizeBottomLeftTopRight |  no   | yes*  |   yes    |
+    ///  sf::Cursor::Type::SizeLeft               |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeRight              |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeTop                |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeBottom             |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeTopLeft            |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeTopRight           |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeBottomLeft         |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeBottomRight        |  yes  | yes** |   yes**  |
+    ///  sf::Cursor::Type::SizeAll                |  yes  | no    |   yes    |
+    ///  sf::Cursor::Type::Cross                  |  yes  | yes   |   yes    |
+    ///  sf::Cursor::Type::Help                   |  yes  | yes*  |   yes    |
+    ///  sf::Cursor::Type::NotAllowed             |  yes  | yes   |   yes    |
     ///
     ///  * These cursor types are undocumented so may not
     ///    be available on all versions, but have been tested on 10.13
@@ -85,7 +85,7 @@ public:
     ///  ** On Windows and macOS, double-headed arrows are used
     ///
     ////////////////////////////////////////////////////////////
-    enum Type
+    enum class Type
     {
         Arrow,                  //!< Arrow cursor (default)
         ArrowWait,              //!< Busy arrow cursor
@@ -250,7 +250,7 @@ private:
 /// // ... create window as usual ...
 ///
 /// sf::Cursor cursor;
-/// if (cursor.loadFromSystem(sf::Cursor::Hand))
+/// if (cursor.loadFromSystem(sf::Cursor::Type::Hand))
 ///     window.setMouseCursor(cursor);
 /// \endcode
 ///

--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -51,7 +51,7 @@ static constexpr unsigned int AxisCount{8};    //!< Maximum number of supported 
 /// \brief Axes supported by SFML joysticks
 ///
 ////////////////////////////////////////////////////////////
-enum Axis
+enum class Axis
 {
     X,    //!< The X axis
     Y,    //!< The Y axis
@@ -199,13 +199,13 @@ SFML_WINDOW_API void update();
 /// unsigned int buttons = sf::Joystick::getButtonCount(0);
 ///
 /// // Does joystick #0 define a X axis?
-/// bool hasX = sf::Joystick::hasAxis(0, sf::Joystick::X);
+/// bool hasX = sf::Joystick::hasAxis(0, sf::Joystick::Axis::X);
 ///
 /// // Is button #2 pressed on joystick #0?
 /// bool pressed = sf::Joystick::isButtonPressed(0, 2);
 ///
 /// // What's the current position of the Y axis on joystick #0?
-/// float position = sf::Joystick::getAxisPosition(0, sf::Joystick::Y);
+/// float position = sf::Joystick::getAxisPosition(0, sf::Joystick::Axis::Y);
 /// \endcode
 ///
 /// \see sf::Keyboard, sf::Mouse

--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -46,32 +46,33 @@ namespace Mouse
 /// \brief Mouse buttons
 ///
 ////////////////////////////////////////////////////////////
-enum Button
+enum class Button
 {
     Left,     //!< The left mouse button
     Right,    //!< The right mouse button
     Middle,   //!< The middle (wheel) mouse button
     XButton1, //!< The first extra mouse button
-    XButton2, //!< The second extra mouse button
-
-    ButtonCount //!< Keep last -- the total number of mouse buttons
+    XButton2  //!< The second extra mouse button
 };
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static constexpr unsigned int ButtonCount{5}; //!< The total number of mouse buttons
 
 ////////////////////////////////////////////////////////////
 /// \brief Mouse wheels
 ///
 ////////////////////////////////////////////////////////////
-enum Wheel
+enum class Wheel
 {
-    VerticalWheel,  //!< The vertical mouse wheel
-    HorizontalWheel //!< The horizontal mouse wheel
+    Vertical,  //!< The vertical mouse wheel
+    Horizontal //!< The horizontal mouse wheel
 };
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a mouse button is pressed
 ///
-/// \warning Checking the state of buttons Mouse::XButton1 and
-/// Mouse::XButton2 is not supported on Linux with X11.
+/// \warning Checking the state of buttons Mouse::Button::XButton1 and
+/// Mouse::Button::XButton2 is not supported on Linux with X11.
 ///
 /// \param button Button to check
 ///
@@ -157,7 +158,7 @@ SFML_WINDOW_API void setPosition(const Vector2i& position, const WindowBase& rel
 ///
 /// Usage example:
 /// \code
-/// if (sf::Mouse::isButtonPressed(sf::Mouse::Left))
+/// if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left))
 /// {
 ///     // left click...
 /// }

--- a/include/SFML/Window/Sensor.hpp
+++ b/include/SFML/Window/Sensor.hpp
@@ -41,17 +41,18 @@ namespace sf::Sensor
 /// \brief Sensor type
 ///
 ////////////////////////////////////////////////////////////
-enum Type
+enum class Type
 {
     Accelerometer,    //!< Measures the raw acceleration (m/s^2)
     Gyroscope,        //!< Measures the raw rotation rates (degrees/s)
     Magnetometer,     //!< Measures the ambient magnetic field (micro-teslas)
     Gravity,          //!< Measures the direction and intensity of gravity, independent of device acceleration (m/s^2)
     UserAcceleration, //!< Measures the direction and intensity of device acceleration, independent of the gravity (m/s^2)
-    Orientation,      //!< Measures the absolute 3D orientation (degrees)
-
-    Count //!< Keep last -- the total number of sensor types
+    Orientation       //!< Measures the absolute 3D orientation (degrees)
 };
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static constexpr unsigned int Count{6}; //!< The total number of sensor types
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a sensor is available on the underlying platform
@@ -123,16 +124,16 @@ SFML_WINDOW_API Vector3f getValue(Type sensor);
 ///
 /// Usage example:
 /// \code
-/// if (sf::Sensor::isAvailable(sf::Sensor::Gravity))
+/// if (sf::Sensor::isAvailable(sf::Sensor::Type::Gravity))
 /// {
 ///     // gravity sensor is available
 /// }
 ///
 /// // enable the gravity sensor
-/// sf::Sensor::setEnabled(sf::Sensor::Gravity, true);
+/// sf::Sensor::setEnabled(sf::Sensor::Type::Gravity, true);
 ///
 /// // get the current value of gravity
-/// sf::Vector3f gravity = sf::Sensor::getValue(sf::Sensor::Gravity);
+/// sf::Vector3f gravity = sf::Sensor::getValue(sf::Sensor::Type::Gravity);
 /// \endcode
 ///
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/Android/InputImpl.cpp
+++ b/src/SFML/Window/Android/InputImpl.cpp
@@ -171,7 +171,7 @@ bool isMouseButtonPressed(Mouse::Button button)
     ActivityStates& states = getActivity();
     std::lock_guard lock(states.mutex);
 
-    return states.isButtonPressed[button];
+    return states.isButtonPressed[static_cast<int>(button)];
 }
 
 

--- a/src/SFML/Window/Android/SensorImpl.cpp
+++ b/src/SFML/Window/Android/SensorImpl.cpp
@@ -31,6 +31,8 @@
 
 #include <android/looper.h>
 
+#include <optional>
+
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -147,7 +149,7 @@ const ASensor* SensorImpl::getDefaultSensor(Sensor::Type sensor)
                           ASENSOR_TYPE_LINEAR_ACCELERATION,
                           ASENSOR_TYPE_ORIENTATION};
 
-    int type = types[sensor];
+    int type = types[static_cast<int>(sensor)];
 
     // Retrieve the default sensor matching this type
     return ASensorManager_getDefaultSensor(sensorManager, type);
@@ -161,48 +163,48 @@ int SensorImpl::processSensorEvents(int /* fd */, int /* events */, void* /* sen
 
     while (ASensorEventQueue_getEvents(sensorEventQueue, &event, 1) > 0)
     {
-        unsigned int type = Sensor::Count;
-        Vector3f     data;
+        std::optional<Sensor::Type> type;
+        Vector3f                    data;
 
         switch (event.type)
         {
             case ASENSOR_TYPE_ACCELEROMETER:
-                type   = Sensor::Accelerometer;
+                type   = Sensor::Type::Accelerometer;
                 data.x = event.acceleration.x;
                 data.y = event.acceleration.y;
                 data.z = event.acceleration.z;
                 break;
 
             case ASENSOR_TYPE_GYROSCOPE:
-                type   = Sensor::Gyroscope;
+                type   = Sensor::Type::Gyroscope;
                 data.x = event.vector.x;
                 data.y = event.vector.y;
                 data.z = event.vector.z;
                 break;
 
             case ASENSOR_TYPE_MAGNETIC_FIELD:
-                type   = Sensor::Magnetometer;
+                type   = Sensor::Type::Magnetometer;
                 data.x = event.magnetic.x;
                 data.y = event.magnetic.y;
                 data.z = event.magnetic.z;
                 break;
 
             case ASENSOR_TYPE_GRAVITY:
-                type   = Sensor::Gravity;
+                type   = Sensor::Type::Gravity;
                 data.x = event.vector.x;
                 data.y = event.vector.y;
                 data.z = event.vector.z;
                 break;
 
             case ASENSOR_TYPE_LINEAR_ACCELERATION:
-                type   = Sensor::UserAcceleration;
+                type   = Sensor::Type::UserAcceleration;
                 data.x = event.acceleration.x;
                 data.y = event.acceleration.y;
                 data.z = event.acceleration.z;
                 break;
 
             case ASENSOR_TYPE_ORIENTATION:
-                type   = Sensor::Orientation;
+                type   = Sensor::Type::Orientation;
                 data.x = event.vector.x;
                 data.y = event.vector.y;
                 data.z = event.vector.z;
@@ -210,10 +212,10 @@ int SensorImpl::processSensorEvents(int /* fd */, int /* events */, void* /* sen
         }
 
         // An unknown sensor event has been detected, we don't know how to process it
-        if (type == Sensor::Count)
+        if (!type)
             continue;
 
-        sensorData[type] = data;
+        sensorData[static_cast<int>(*type)] = data;
     }
 
     return 1;

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -393,7 +393,7 @@ int WindowImplAndroid::processScrollEvent(AInputEvent* inputEvent, ActivityState
     // Create and send our mouse wheel event
     Event event;
     event.type                   = Event::MouseWheelScrolled;
-    event.mouseWheelScroll.wheel = Mouse::VerticalWheel;
+    event.mouseWheelScroll.wheel = Mouse::Wheel::Vertical;
     event.mouseWheelScroll.delta = static_cast<float>(delta);
     event.mouseWheelScroll.x     = static_cast<int>(AMotionEvent_getX(inputEvent, 0));
     event.mouseWheelScroll.y     = static_cast<int>(AMotionEvent_getY(inputEvent, 0));
@@ -539,7 +539,7 @@ int WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* inputEvent,
             event.mouseButton.x      = x;
             event.mouseButton.y      = y;
 
-            if (id >= 0 && id < Mouse::ButtonCount)
+            if (id >= 0 && id < static_cast<int>(Mouse::ButtonCount))
                 states.isButtonPressed[id] = true;
         }
         else if (static_cast<unsigned int>(device) & AINPUT_SOURCE_TOUCHSCREEN)
@@ -561,7 +561,7 @@ int WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* inputEvent,
             event.mouseButton.x      = x;
             event.mouseButton.y      = y;
 
-            if (id >= 0 && id < Mouse::ButtonCount)
+            if (id >= 0 && id < static_cast<int>(Mouse::ButtonCount))
                 states.isButtonPressed[id] = false;
         }
         else if (static_cast<std::uint32_t>(device) & AINPUT_SOURCE_TOUCHSCREEN)

--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -30,6 +30,7 @@
 
 #include <dirent.h>
 #include <fcntl.h>
+#include <optional>
 #include <string>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -135,31 +136,31 @@ void updatePluggedList()
     }
 }
 
-int usageToAxis(int usage)
+std::optional<sf::Joystick::Axis> usageToAxis(int usage)
 {
     switch (usage)
     {
         case HUG_X:
-            return sf::Joystick::X;
+            return sf::Joystick::Axis::X;
         case HUG_Y:
-            return sf::Joystick::Y;
+            return sf::Joystick::Axis::Y;
         case HUG_Z:
-            return sf::Joystick::Z;
+            return sf::Joystick::Axis::Z;
         case HUG_RZ:
-            return sf::Joystick::R;
+            return sf::Joystick::Axis::R;
         case HUG_RX:
-            return sf::Joystick::U;
+            return sf::Joystick::Axis::U;
         case HUG_RY:
-            return sf::Joystick::V;
+            return sf::Joystick::Axis::V;
         default:
-            return -1;
+            return std::nullopt;
     }
 }
 
 void hatValueToSfml(int value, sf::priv::JoystickState& state)
 {
-    state.axes[sf::Joystick::PovX] = static_cast<float>(hatValueMap[value].first);
-    state.axes[sf::Joystick::PovY] = static_cast<float>(hatValueMap[value].second);
+    state.axes[static_cast<int>(sf::Joystick::Axis::PovX)] = static_cast<float>(hatValueMap[value].first);
+    state.axes[static_cast<int>(sf::Joystick::Axis::PovY)] = static_cast<float>(hatValueMap[value].second);
 }
 } // namespace
 
@@ -268,16 +269,14 @@ JoystickCaps JoystickImpl::getCapabilities() const
             }
             else if (usage == HUP_GENERIC_DESKTOP)
             {
-                int axis = usageToAxis(usage);
-
                 if (usage == HUG_HAT_SWITCH)
                 {
-                    caps.axes[Joystick::PovX] = true;
-                    caps.axes[Joystick::PovY] = true;
+                    caps.axes[static_cast<int>(Joystick::Axis::PovX)] = true;
+                    caps.axes[static_cast<int>(Joystick::Axis::PovY)] = true;
                 }
-                else if (axis != -1)
+                else if (const std::optional<Joystick::Axis> axis = usageToAxis(usage))
                 {
-                    caps.axes[axis] = true;
+                    caps.axes[static_cast<int>(*axis)] = true;
                 }
             }
         }
@@ -323,19 +322,18 @@ JoystickState JoystickImpl::JoystickImpl::update()
                 else if (usage == HUP_GENERIC_DESKTOP)
                 {
                     int value = hid_get_data(m_buffer.data(), &item);
-                    int axis  = usageToAxis(usage);
 
                     if (usage == HUG_HAT_SWITCH)
                     {
                         hatValueToSfml(value, m_state);
                     }
-                    else if (axis != -1)
+                    else if (const std::optional<Joystick::Axis> axis = usageToAxis(usage))
                     {
                         int minimum = item.logical_minimum;
                         int maximum = item.logical_maximum;
 
-                        value              = (value - minimum) * 200 / (maximum - minimum) - 100;
-                        m_state.axes[axis] = static_cast<float>(value);
+                        value                                 = (value - minimum) * 200 / (maximum - minimum) - 100;
+                        m_state.axes[static_cast<int>(*axis)] = static_cast<float>(value);
                     }
                 }
             }

--- a/src/SFML/Window/Joystick.cpp
+++ b/src/SFML/Window/Joystick.cpp
@@ -50,7 +50,7 @@ unsigned int Joystick::getButtonCount(unsigned int joystick)
 ////////////////////////////////////////////////////////////
 bool Joystick::hasAxis(unsigned int joystick, Axis axis)
 {
-    return priv::JoystickManager::getInstance().getCapabilities(joystick).axes[axis];
+    return priv::JoystickManager::getInstance().getCapabilities(joystick).axes[static_cast<int>(axis)];
 }
 
 
@@ -65,7 +65,7 @@ bool Joystick::isButtonPressed(unsigned int joystick, unsigned int button)
 ////////////////////////////////////////////////////////////
 float Joystick::getAxisPosition(unsigned int joystick, Axis axis)
 {
-    return priv::JoystickManager::getInstance().getState(joystick).axes[axis];
+    return priv::JoystickManager::getInstance().getState(joystick).axes[static_cast<int>(axis)];
 }
 
 

--- a/src/SFML/Window/SensorManager.cpp
+++ b/src/SFML/Window/SensorManager.cpp
@@ -45,17 +45,17 @@ SensorManager& SensorManager::getInstance()
 ////////////////////////////////////////////////////////////
 bool SensorManager::isAvailable(Sensor::Type sensor)
 {
-    return m_sensors[sensor].available;
+    return m_sensors[static_cast<int>(sensor)].available;
 }
 
 
 ////////////////////////////////////////////////////////////
 void SensorManager::setEnabled(Sensor::Type sensor, bool enabled)
 {
-    if (m_sensors[sensor].available)
+    if (m_sensors[static_cast<int>(sensor)].available)
     {
-        m_sensors[sensor].enabled = enabled;
-        m_sensors[sensor].sensor.setEnabled(enabled);
+        m_sensors[static_cast<int>(sensor)].enabled = enabled;
+        m_sensors[static_cast<int>(sensor)].sensor.setEnabled(enabled);
     }
     else
     {
@@ -68,14 +68,14 @@ void SensorManager::setEnabled(Sensor::Type sensor, bool enabled)
 ////////////////////////////////////////////////////////////
 bool SensorManager::isEnabled(Sensor::Type sensor) const
 {
-    return m_sensors[sensor].enabled;
+    return m_sensors[static_cast<int>(sensor)].enabled;
 }
 
 
 ////////////////////////////////////////////////////////////
 Vector3f SensorManager::getValue(Sensor::Type sensor) const
 {
-    return m_sensors[sensor].value;
+    return m_sensors[static_cast<int>(sensor)].value;
 }
 
 
@@ -98,7 +98,7 @@ SensorManager::SensorManager()
     SensorImpl::initialize();
 
     // Per sensor initialization
-    for (int i = 0; i < Sensor::Count; ++i)
+    for (unsigned int i = 0; i < Sensor::Count; ++i)
     {
         // Check which sensors are available
         m_sensors[i].available = SensorImpl::isAvailable(static_cast<Sensor::Type>(i));

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -179,24 +179,24 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
     {
         default: return false;
 
-        case Cursor::Arrow:           shape = XC_arrow;               break;
-        case Cursor::Wait:            shape = XC_watch;               break;
-        case Cursor::Text:            shape = XC_xterm;               break;
-        case Cursor::Hand:            shape = XC_hand2;               break;
-        case Cursor::SizeHorizontal:  shape = XC_sb_h_double_arrow;   break;
-        case Cursor::SizeVertical:    shape = XC_sb_v_double_arrow;   break;
-        case Cursor::SizeLeft:        shape = XC_left_side;           break;
-        case Cursor::SizeRight:       shape = XC_right_side;          break;
-        case Cursor::SizeTop:         shape = XC_top_side;            break;
-        case Cursor::SizeBottom:      shape = XC_bottom_side;         break;
-        case Cursor::SizeTopLeft:     shape = XC_top_left_corner;     break;
-        case Cursor::SizeBottomRight: shape = XC_bottom_right_corner; break;
-        case Cursor::SizeBottomLeft:  shape = XC_bottom_left_corner;  break;
-        case Cursor::SizeTopRight:    shape = XC_top_right_corner;    break;
-        case Cursor::SizeAll:         shape = XC_fleur;               break;
-        case Cursor::Cross:           shape = XC_crosshair;           break;
-        case Cursor::Help:            shape = XC_question_arrow;      break;
-        case Cursor::NotAllowed:      shape = XC_X_cursor;            break;
+        case Cursor::Type::Arrow:           shape = XC_arrow;               break;
+        case Cursor::Type::Wait:            shape = XC_watch;               break;
+        case Cursor::Type::Text:            shape = XC_xterm;               break;
+        case Cursor::Type::Hand:            shape = XC_hand2;               break;
+        case Cursor::Type::SizeHorizontal:  shape = XC_sb_h_double_arrow;   break;
+        case Cursor::Type::SizeVertical:    shape = XC_sb_v_double_arrow;   break;
+        case Cursor::Type::SizeLeft:        shape = XC_left_side;           break;
+        case Cursor::Type::SizeRight:       shape = XC_right_side;          break;
+        case Cursor::Type::SizeTop:         shape = XC_top_side;            break;
+        case Cursor::Type::SizeBottom:      shape = XC_bottom_side;         break;
+        case Cursor::Type::SizeTopLeft:     shape = XC_top_left_corner;     break;
+        case Cursor::Type::SizeBottomRight: shape = XC_bottom_right_corner; break;
+        case Cursor::Type::SizeBottomLeft:  shape = XC_bottom_left_corner;  break;
+        case Cursor::Type::SizeTopRight:    shape = XC_top_right_corner;    break;
+        case Cursor::Type::SizeAll:         shape = XC_fleur;               break;
+        case Cursor::Type::Cross:           shape = XC_crosshair;           break;
+        case Cursor::Type::Help:            shape = XC_question_arrow;      break;
+        case Cursor::Type::NotAllowed:      shape = XC_X_cursor;            break;
     }
     // clang-format on
 

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -103,16 +103,16 @@ bool isMouseButtonPressed(Mouse::Button button)
 
     // Buttons 4 and 5 are the vertical wheel and 6 and 7 the horizontal wheel.
     // There is no mask for buttons 8 and 9, so checking the state of buttons
-    // Mouse::XButton1 and Mouse::XButton2 is not supported.
+    // Mouse::Button::XButton1 and Mouse::Button::XButton2 is not supported.
     // clang-format off
     switch (button)
     {
-        case Mouse::Left:     return buttons & Button1Mask;
-        case Mouse::Right:    return buttons & Button3Mask;
-        case Mouse::Middle:   return buttons & Button2Mask;
-        case Mouse::XButton1: return false; // not supported by X
-        case Mouse::XButton2: return false; // not supported by X
-        default:              return false;
+        case Mouse::Button::Left:     return buttons & Button1Mask;
+        case Mouse::Button::Right:    return buttons & Button3Mask;
+        case Mouse::Button::Middle:   return buttons & Button2Mask;
+        case Mouse::Button::XButton1: return false; // not supported by X
+        case Mouse::Button::XButton2: return false; // not supported by X
+        default:                      return false;
     }
     // clang-format on
 }

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -603,17 +603,17 @@ JoystickCaps JoystickImpl::getCapabilities() const
         switch (m_mapping[i])
         {
             // clang-format off
-            case ABS_X:        caps.axes[Joystick::X]    = true; break;
-            case ABS_Y:        caps.axes[Joystick::Y]    = true; break;
+            case ABS_X:        caps.axes[static_cast<int>(Joystick::Axis::X)]    = true; break;
+            case ABS_Y:        caps.axes[static_cast<int>(Joystick::Axis::Y)]    = true; break;
             case ABS_Z:
-            case ABS_THROTTLE: caps.axes[Joystick::Z]    = true; break;
+            case ABS_THROTTLE: caps.axes[static_cast<int>(Joystick::Axis::Z)]    = true; break;
             case ABS_RZ:
-            case ABS_RUDDER:   caps.axes[Joystick::R]    = true; break;
-            case ABS_RX:       caps.axes[Joystick::U]    = true; break;
-            case ABS_RY:       caps.axes[Joystick::V]    = true; break;
-            case ABS_HAT0X:    caps.axes[Joystick::PovX] = true; break;
-            case ABS_HAT0Y:    caps.axes[Joystick::PovY] = true; break;
-            default:                                             break;
+            case ABS_RUDDER:   caps.axes[static_cast<int>(Joystick::Axis::R)]    = true; break;
+            case ABS_RX:       caps.axes[static_cast<int>(Joystick::Axis::U)]    = true; break;
+            case ABS_RY:       caps.axes[static_cast<int>(Joystick::Axis::V)]    = true; break;
+            case ABS_HAT0X:    caps.axes[static_cast<int>(Joystick::Axis::PovX)] = true; break;
+            case ABS_HAT0Y:    caps.axes[static_cast<int>(Joystick::Axis::PovY)] = true; break;
+            default:                                                                     break;
                 // clang-format on
         }
     }
@@ -655,30 +655,30 @@ JoystickState JoystickImpl::JoystickImpl::update()
                     switch (m_mapping[joyState.number])
                     {
                         case ABS_X:
-                            m_state.axes[Joystick::X] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::X)] = value;
                             break;
                         case ABS_Y:
-                            m_state.axes[Joystick::Y] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::Y)] = value;
                             break;
                         case ABS_Z:
                         case ABS_THROTTLE:
-                            m_state.axes[Joystick::Z] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::Z)] = value;
                             break;
                         case ABS_RZ:
                         case ABS_RUDDER:
-                            m_state.axes[Joystick::R] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::R)] = value;
                             break;
                         case ABS_RX:
-                            m_state.axes[Joystick::U] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::U)] = value;
                             break;
                         case ABS_RY:
-                            m_state.axes[Joystick::V] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::V)] = value;
                             break;
                         case ABS_HAT0X:
-                            m_state.axes[Joystick::PovX] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::PovX)] = value;
                             break;
                         case ABS_HAT0Y:
-                            m_state.axes[Joystick::PovY] = value;
+                            m_state.axes[static_cast<int>(Joystick::Axis::PovY)] = value;
                             break;
                         default:
                             break;

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1937,11 +1937,11 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 // clang-format off
                 switch(button)
                 {
-                    case Button1: event.mouseButton.button = Mouse::Left;     break;
-                    case Button2: event.mouseButton.button = Mouse::Middle;   break;
-                    case Button3: event.mouseButton.button = Mouse::Right;    break;
-                    case 8:       event.mouseButton.button = Mouse::XButton1; break;
-                    case 9:       event.mouseButton.button = Mouse::XButton2; break;
+                    case Button1: event.mouseButton.button = Mouse::Button::Left;     break;
+                    case Button2: event.mouseButton.button = Mouse::Button::Middle;   break;
+                    case Button3: event.mouseButton.button = Mouse::Button::Right;    break;
+                    case 8:       event.mouseButton.button = Mouse::Button::XButton1; break;
+                    case 9:       event.mouseButton.button = Mouse::Button::XButton2; break;
                 }
                 // clang-format on
 
@@ -1966,19 +1966,19 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 switch (button)
                 {
                     case Button1:
-                        event.mouseButton.button = Mouse::Left;
+                        event.mouseButton.button = Mouse::Button::Left;
                         break;
                     case Button2:
-                        event.mouseButton.button = Mouse::Middle;
+                        event.mouseButton.button = Mouse::Button::Middle;
                         break;
                     case Button3:
-                        event.mouseButton.button = Mouse::Right;
+                        event.mouseButton.button = Mouse::Button::Right;
                         break;
                     case 8:
-                        event.mouseButton.button = Mouse::XButton1;
+                        event.mouseButton.button = Mouse::Button::XButton1;
                         break;
                     case 9:
-                        event.mouseButton.button = Mouse::XButton2;
+                        event.mouseButton.button = Mouse::Button::XButton2;
                         break;
                 }
                 pushEvent(event);
@@ -1988,7 +1988,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 Event event;
 
                 event.type                   = Event::MouseWheelScrolled;
-                event.mouseWheelScroll.wheel = Mouse::VerticalWheel;
+                event.mouseWheelScroll.wheel = Mouse::Wheel::Vertical;
                 event.mouseWheelScroll.delta = (button == Button4) ? 1 : -1;
                 event.mouseWheelScroll.x     = windowEvent.xbutton.x;
                 event.mouseWheelScroll.y     = windowEvent.xbutton.y;
@@ -1998,7 +1998,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
             {
                 Event event;
                 event.type                   = Event::MouseWheelScrolled;
-                event.mouseWheelScroll.wheel = Mouse::HorizontalWheel;
+                event.mouseWheelScroll.wheel = Mouse::Wheel::Horizontal;
                 event.mouseWheelScroll.delta = (button == 6) ? 1 : -1;
                 event.mouseWheelScroll.x     = windowEvent.xbutton.x;
                 event.mouseWheelScroll.y     = windowEvent.xbutton.y;

--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -135,27 +135,27 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
     // clang-format off
     switch (type)
     {
-        case Cursor::Arrow:                  shape = IDC_ARROW;       break;
-        case Cursor::ArrowWait:              shape = IDC_APPSTARTING; break;
-        case Cursor::Wait:                   shape = IDC_WAIT;        break;
-        case Cursor::Text:                   shape = IDC_IBEAM;       break;
-        case Cursor::Hand:                   shape = IDC_HAND;        break;
-        case Cursor::SizeHorizontal:         shape = IDC_SIZEWE;      break;
-        case Cursor::SizeVertical:           shape = IDC_SIZENS;      break;
-        case Cursor::SizeTopLeftBottomRight: shape = IDC_SIZENWSE;    break;
-        case Cursor::SizeBottomLeftTopRight: shape = IDC_SIZENESW;    break;
-        case Cursor::SizeLeft:               shape = IDC_SIZEWE;      break;
-        case Cursor::SizeRight:              shape = IDC_SIZEWE;      break;
-        case Cursor::SizeTop:                shape = IDC_SIZENS;      break;
-        case Cursor::SizeBottom:             shape = IDC_SIZENS;      break;
-        case Cursor::SizeTopLeft:            shape = IDC_SIZENWSE;    break;
-        case Cursor::SizeBottomRight:        shape = IDC_SIZENWSE;    break;
-        case Cursor::SizeBottomLeft:         shape = IDC_SIZENESW;    break;
-        case Cursor::SizeTopRight:           shape = IDC_SIZENESW;    break;
-        case Cursor::SizeAll:                shape = IDC_SIZEALL;     break;
-        case Cursor::Cross:                  shape = IDC_CROSS;       break;
-        case Cursor::Help:                   shape = IDC_HELP;        break;
-        case Cursor::NotAllowed:             shape = IDC_NO;          break;
+        case Cursor::Type::Arrow:                  shape = IDC_ARROW;       break;
+        case Cursor::Type::ArrowWait:              shape = IDC_APPSTARTING; break;
+        case Cursor::Type::Wait:                   shape = IDC_WAIT;        break;
+        case Cursor::Type::Text:                   shape = IDC_IBEAM;       break;
+        case Cursor::Type::Hand:                   shape = IDC_HAND;        break;
+        case Cursor::Type::SizeHorizontal:         shape = IDC_SIZEWE;      break;
+        case Cursor::Type::SizeVertical:           shape = IDC_SIZENS;      break;
+        case Cursor::Type::SizeTopLeftBottomRight: shape = IDC_SIZENWSE;    break;
+        case Cursor::Type::SizeBottomLeftTopRight: shape = IDC_SIZENESW;    break;
+        case Cursor::Type::SizeLeft:               shape = IDC_SIZEWE;      break;
+        case Cursor::Type::SizeRight:              shape = IDC_SIZEWE;      break;
+        case Cursor::Type::SizeTop:                shape = IDC_SIZENS;      break;
+        case Cursor::Type::SizeBottom:             shape = IDC_SIZENS;      break;
+        case Cursor::Type::SizeTopLeft:            shape = IDC_SIZENWSE;    break;
+        case Cursor::Type::SizeBottomRight:        shape = IDC_SIZENWSE;    break;
+        case Cursor::Type::SizeBottomLeft:         shape = IDC_SIZENESW;    break;
+        case Cursor::Type::SizeTopRight:           shape = IDC_SIZENESW;    break;
+        case Cursor::Type::SizeAll:                shape = IDC_SIZEALL;     break;
+        case Cursor::Type::Cross:                  shape = IDC_CROSS;       break;
+        case Cursor::Type::Help:                   shape = IDC_HELP;        break;
+        case Cursor::Type::NotAllowed:             shape = IDC_NO;          break;
     }
     // clang-format on
 

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -622,19 +622,19 @@ bool isMouseButtonPressed(Mouse::Button button)
     int virtualKey = 0;
     switch (button)
     {
-        case Mouse::Left:
+        case Mouse::Button::Left:
             virtualKey = GetSystemMetrics(SM_SWAPBUTTON) ? VK_RBUTTON : VK_LBUTTON;
             break;
-        case Mouse::Right:
+        case Mouse::Button::Right:
             virtualKey = GetSystemMetrics(SM_SWAPBUTTON) ? VK_LBUTTON : VK_RBUTTON;
             break;
-        case Mouse::Middle:
+        case Mouse::Button::Middle:
             virtualKey = VK_MBUTTON;
             break;
-        case Mouse::XButton1:
+        case Mouse::Button::XButton1:
             virtualKey = VK_XBUTTON1;
             break;
-        case Mouse::XButton2:
+        case Mouse::Button::XButton2:
             virtualKey = VK_XBUTTON2;
             break;
         default:

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -331,14 +331,14 @@ JoystickCaps JoystickImpl::getCapabilities() const
     if (caps.buttonCount > Joystick::ButtonCount)
         caps.buttonCount = Joystick::ButtonCount;
 
-    caps.axes[Joystick::X]    = true;
-    caps.axes[Joystick::Y]    = true;
-    caps.axes[Joystick::Z]    = (m_caps.wCaps & JOYCAPS_HASZ) != 0;
-    caps.axes[Joystick::R]    = (m_caps.wCaps & JOYCAPS_HASR) != 0;
-    caps.axes[Joystick::U]    = (m_caps.wCaps & JOYCAPS_HASU) != 0;
-    caps.axes[Joystick::V]    = (m_caps.wCaps & JOYCAPS_HASV) != 0;
-    caps.axes[Joystick::PovX] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
-    caps.axes[Joystick::PovY] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
+    caps.axes[static_cast<int>(Joystick::Axis::X)]    = true;
+    caps.axes[static_cast<int>(Joystick::Axis::Y)]    = true;
+    caps.axes[static_cast<int>(Joystick::Axis::Z)]    = (m_caps.wCaps & JOYCAPS_HASZ) != 0;
+    caps.axes[static_cast<int>(Joystick::Axis::R)]    = (m_caps.wCaps & JOYCAPS_HASR) != 0;
+    caps.axes[static_cast<int>(Joystick::Axis::U)]    = (m_caps.wCaps & JOYCAPS_HASU) != 0;
+    caps.axes[static_cast<int>(Joystick::Axis::V)]    = (m_caps.wCaps & JOYCAPS_HASV) != 0;
+    caps.axes[static_cast<int>(Joystick::Axis::PovX)] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
+    caps.axes[static_cast<int>(Joystick::Axis::PovY)] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
 
     return caps;
 }
@@ -379,30 +379,36 @@ JoystickState JoystickImpl::update()
         state.connected = true;
 
         // Axes
-        state.axes[Joystick::X] = (static_cast<float>(pos.dwXpos) - static_cast<float>(m_caps.wXmax + m_caps.wXmin) / 2.f) *
-                                  200.f / static_cast<float>(m_caps.wXmax - m_caps.wXmin);
-        state.axes[Joystick::Y] = (static_cast<float>(pos.dwYpos) - static_cast<float>(m_caps.wYmax + m_caps.wYmin) / 2.f) *
-                                  200.f / static_cast<float>(m_caps.wYmax - m_caps.wYmin);
-        state.axes[Joystick::Z] = (static_cast<float>(pos.dwZpos) - static_cast<float>(m_caps.wZmax + m_caps.wZmin) / 2.f) *
-                                  200.f / static_cast<float>(m_caps.wZmax - m_caps.wZmin);
-        state.axes[Joystick::R] = (static_cast<float>(pos.dwRpos) - static_cast<float>(m_caps.wRmax + m_caps.wRmin) / 2.f) *
-                                  200.f / static_cast<float>(m_caps.wRmax - m_caps.wRmin);
-        state.axes[Joystick::U] = (static_cast<float>(pos.dwUpos) - static_cast<float>(m_caps.wUmax + m_caps.wUmin) / 2.f) *
-                                  200.f / static_cast<float>(m_caps.wUmax - m_caps.wUmin);
-        state.axes[Joystick::V] = (static_cast<float>(pos.dwVpos) - static_cast<float>(m_caps.wVmax + m_caps.wVmin) / 2.f) *
-                                  200.f / static_cast<float>(m_caps.wVmax - m_caps.wVmin);
+        state.axes[static_cast<int>(Joystick::Axis::X)] = (static_cast<float>(pos.dwXpos) -
+                                                           static_cast<float>(m_caps.wXmax + m_caps.wXmin) / 2.f) *
+                                                          200.f / static_cast<float>(m_caps.wXmax - m_caps.wXmin);
+        state.axes[static_cast<int>(Joystick::Axis::Y)] = (static_cast<float>(pos.dwYpos) -
+                                                           static_cast<float>(m_caps.wYmax + m_caps.wYmin) / 2.f) *
+                                                          200.f / static_cast<float>(m_caps.wYmax - m_caps.wYmin);
+        state.axes[static_cast<int>(Joystick::Axis::Z)] = (static_cast<float>(pos.dwZpos) -
+                                                           static_cast<float>(m_caps.wZmax + m_caps.wZmin) / 2.f) *
+                                                          200.f / static_cast<float>(m_caps.wZmax - m_caps.wZmin);
+        state.axes[static_cast<int>(Joystick::Axis::R)] = (static_cast<float>(pos.dwRpos) -
+                                                           static_cast<float>(m_caps.wRmax + m_caps.wRmin) / 2.f) *
+                                                          200.f / static_cast<float>(m_caps.wRmax - m_caps.wRmin);
+        state.axes[static_cast<int>(Joystick::Axis::U)] = (static_cast<float>(pos.dwUpos) -
+                                                           static_cast<float>(m_caps.wUmax + m_caps.wUmin) / 2.f) *
+                                                          200.f / static_cast<float>(m_caps.wUmax - m_caps.wUmin);
+        state.axes[static_cast<int>(Joystick::Axis::V)] = (static_cast<float>(pos.dwVpos) -
+                                                           static_cast<float>(m_caps.wVmax + m_caps.wVmin) / 2.f) *
+                                                          200.f / static_cast<float>(m_caps.wVmax - m_caps.wVmin);
 
         // Special case for POV, it is given as an angle
         if (pos.dwPOV != 0xFFFF)
         {
-            const float angle          = static_cast<float>(pos.dwPOV) / 18000.f * 3.141592654f;
-            state.axes[Joystick::PovX] = std::sin(angle) * 100;
-            state.axes[Joystick::PovY] = std::cos(angle) * 100;
+            const float angle                                  = static_cast<float>(pos.dwPOV) / 18000.f * 3.141592654f;
+            state.axes[static_cast<int>(Joystick::Axis::PovX)] = std::sin(angle) * 100;
+            state.axes[static_cast<int>(Joystick::Axis::PovY)] = std::cos(angle) * 100;
         }
         else
         {
-            state.axes[Joystick::PovX] = 0;
-            state.axes[Joystick::PovY] = 0;
+            state.axes[static_cast<int>(Joystick::Axis::PovX)] = 0;
+            state.axes[static_cast<int>(Joystick::Axis::PovY)] = 0;
         }
 
         // Buttons
@@ -925,7 +931,7 @@ JoystickState JoystickImpl::updateDInputBuffered()
         {
             if (m_axes[j] == static_cast<int>(events[i].dwOfs))
             {
-                if ((j == Joystick::PovX) || (j == Joystick::PovY))
+                if ((j == static_cast<int>(Joystick::Axis::PovX)) || (j == static_cast<int>(Joystick::Axis::PovY)))
                 {
                     const unsigned short value = LOWORD(events[i].dwData);
 
@@ -933,13 +939,13 @@ JoystickState JoystickImpl::updateDInputBuffered()
                     {
                         const float angle = (static_cast<float>(value)) * 3.141592654f / DI_DEGREES / 180.f;
 
-                        m_state.axes[Joystick::PovX] = std::sin(angle) * 100.f;
-                        m_state.axes[Joystick::PovY] = std::cos(angle) * 100.f;
+                        m_state.axes[static_cast<int>(Joystick::Axis::PovX)] = std::sin(angle) * 100.f;
+                        m_state.axes[static_cast<int>(Joystick::Axis::PovY)] = std::cos(angle) * 100.f;
                     }
                     else
                     {
-                        m_state.axes[Joystick::PovX] = 0.f;
-                        m_state.axes[Joystick::PovY] = 0.f;
+                        m_state.axes[static_cast<int>(Joystick::Axis::PovX)] = 0.f;
+                        m_state.axes[static_cast<int>(Joystick::Axis::PovY)] = 0.f;
                     }
                 }
                 else
@@ -1014,7 +1020,7 @@ JoystickState JoystickImpl::updateDInputPolled()
         {
             if (m_axes[i] != -1)
             {
-                if ((i == Joystick::PovX) || (i == Joystick::PovY))
+                if ((i == static_cast<int>(Joystick::Axis::PovX)) || (i == static_cast<int>(Joystick::Axis::PovY)))
                 {
                     const unsigned short value = LOWORD(
                         *reinterpret_cast<const DWORD*>(reinterpret_cast<const char*>(&joystate) + m_axes[i]));
@@ -1023,13 +1029,13 @@ JoystickState JoystickImpl::updateDInputPolled()
                     {
                         const float angle = (static_cast<float>(value)) * 3.141592654f / DI_DEGREES / 180.f;
 
-                        state.axes[Joystick::PovX] = std::sin(angle) * 100.f;
-                        state.axes[Joystick::PovY] = std::cos(angle) * 100.f;
+                        state.axes[static_cast<int>(Joystick::Axis::PovX)] = std::sin(angle) * 100.f;
+                        state.axes[static_cast<int>(Joystick::Axis::PovY)] = std::cos(angle) * 100.f;
                     }
                     else
                     {
-                        state.axes[Joystick::PovX] = 0.f;
-                        state.axes[Joystick::PovY] = 0.f;
+                        state.axes[static_cast<int>(Joystick::Axis::PovX)] = 0.f;
+                        state.axes[static_cast<int>(Joystick::Axis::PovY)] = 0.f;
                     }
                 }
                 else
@@ -1097,23 +1103,23 @@ BOOL CALLBACK JoystickImpl::deviceObjectEnumerationCallback(const DIDEVICEOBJECT
     {
         // Axes
         if (deviceObjectInstance->guidType == guids::GUID_XAxis)
-            joystick.m_axes[Joystick::X] = DIJOFS_X;
+            joystick.m_axes[static_cast<int>(Joystick::Axis::X)] = DIJOFS_X;
         else if (deviceObjectInstance->guidType == guids::GUID_YAxis)
-            joystick.m_axes[Joystick::Y] = DIJOFS_Y;
+            joystick.m_axes[static_cast<int>(Joystick::Axis::Y)] = DIJOFS_Y;
         else if (deviceObjectInstance->guidType == guids::GUID_ZAxis)
-            joystick.m_axes[Joystick::Z] = DIJOFS_Z;
+            joystick.m_axes[static_cast<int>(Joystick::Axis::Z)] = DIJOFS_Z;
         else if (deviceObjectInstance->guidType == guids::GUID_RzAxis)
-            joystick.m_axes[Joystick::R] = DIJOFS_RZ;
+            joystick.m_axes[static_cast<int>(Joystick::Axis::R)] = DIJOFS_RZ;
         else if (deviceObjectInstance->guidType == guids::GUID_RxAxis)
-            joystick.m_axes[Joystick::U] = DIJOFS_RX;
+            joystick.m_axes[static_cast<int>(Joystick::Axis::U)] = DIJOFS_RX;
         else if (deviceObjectInstance->guidType == guids::GUID_RyAxis)
-            joystick.m_axes[Joystick::V] = DIJOFS_RY;
+            joystick.m_axes[static_cast<int>(Joystick::Axis::V)] = DIJOFS_RY;
         else if (deviceObjectInstance->guidType == guids::GUID_Slider)
         {
-            if (joystick.m_axes[Joystick::U] == -1)
-                joystick.m_axes[Joystick::U] = DIJOFS_SLIDER(0);
+            if (joystick.m_axes[static_cast<int>(Joystick::Axis::U)] == -1)
+                joystick.m_axes[static_cast<int>(Joystick::Axis::U)] = DIJOFS_SLIDER(0);
             else
-                joystick.m_axes[Joystick::V] = DIJOFS_SLIDER(1);
+                joystick.m_axes[static_cast<int>(Joystick::Axis::V)] = DIJOFS_SLIDER(1);
         }
         else
             return DIENUM_CONTINUE;
@@ -1139,10 +1145,10 @@ BOOL CALLBACK JoystickImpl::deviceObjectEnumerationCallback(const DIDEVICEOBJECT
         // POVs
         if (deviceObjectInstance->guidType == guids::GUID_POV)
         {
-            if (joystick.m_axes[Joystick::PovX] == -1)
+            if (joystick.m_axes[static_cast<int>(Joystick::Axis::PovX)] == -1)
             {
-                joystick.m_axes[Joystick::PovX] = DIJOFS_POV(0);
-                joystick.m_axes[Joystick::PovY] = DIJOFS_POV(0);
+                joystick.m_axes[static_cast<int>(Joystick::Axis::PovX)] = DIJOFS_POV(0);
+                joystick.m_axes[static_cast<int>(Joystick::Axis::PovY)] = DIJOFS_POV(0);
             }
         }
 

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -921,7 +921,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             Event event;
 
             event.type                   = Event::MouseWheelScrolled;
-            event.mouseWheelScroll.wheel = Mouse::VerticalWheel;
+            event.mouseWheelScroll.wheel = Mouse::Wheel::Vertical;
             event.mouseWheelScroll.delta = static_cast<float>(delta) / 120.f;
             event.mouseWheelScroll.x     = position.x;
             event.mouseWheelScroll.y     = position.y;
@@ -942,7 +942,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
 
             Event event;
             event.type                   = Event::MouseWheelScrolled;
-            event.mouseWheelScroll.wheel = Mouse::HorizontalWheel;
+            event.mouseWheelScroll.wheel = Mouse::Wheel::Horizontal;
             event.mouseWheelScroll.delta = -static_cast<float>(delta) / 120.f;
             event.mouseWheelScroll.x     = position.x;
             event.mouseWheelScroll.y     = position.y;
@@ -955,7 +955,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonPressed;
-            event.mouseButton.button = Mouse::Left;
+            event.mouseButton.button = Mouse::Button::Left;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -967,7 +967,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonReleased;
-            event.mouseButton.button = Mouse::Left;
+            event.mouseButton.button = Mouse::Button::Left;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -979,7 +979,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonPressed;
-            event.mouseButton.button = Mouse::Right;
+            event.mouseButton.button = Mouse::Button::Right;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -991,7 +991,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonReleased;
-            event.mouseButton.button = Mouse::Right;
+            event.mouseButton.button = Mouse::Button::Right;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -1003,7 +1003,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonPressed;
-            event.mouseButton.button = Mouse::Middle;
+            event.mouseButton.button = Mouse::Button::Middle;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -1015,7 +1015,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonReleased;
-            event.mouseButton.button = Mouse::Middle;
+            event.mouseButton.button = Mouse::Button::Middle;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -1027,7 +1027,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonPressed;
-            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::XButton1 : Mouse::XButton2;
+            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::Button::XButton1 : Mouse::Button::XButton2;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -1039,7 +1039,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonReleased;
-            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::XButton1 : Mouse::XButton2;
+            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::Button::XButton1 : Mouse::Button::XButton2;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -252,19 +252,18 @@ void WindowImpl::processJoystickEvents()
             {
                 if (caps.axes[j])
                 {
-                    const auto  axis    = static_cast<Joystick::Axis>(j);
-                    const float prevPos = m_previousAxes[i][axis];
-                    const float currPos = m_joystickStatesImpl->states[i].axes[axis];
+                    const float prevPos = m_previousAxes[i][j];
+                    const float currPos = m_joystickStatesImpl->states[i].axes[j];
                     if (std::abs(currPos - prevPos) >= m_joystickThreshold)
                     {
                         Event event;
                         event.type                    = Event::JoystickMoved;
                         event.joystickMove.joystickId = i;
-                        event.joystickMove.axis       = axis;
+                        event.joystickMove.axis       = static_cast<Joystick::Axis>(j);
                         event.joystickMove.position   = currPos;
                         pushEvent(event);
 
-                        m_previousAxes[i][axis] = currPos;
+                        m_previousAxes[i][j] = currPos;
                     }
                 }
             }

--- a/src/SFML/Window/iOS/SensorImpl.mm
+++ b/src/SFML/Window/iOS/SensorImpl.mm
@@ -63,18 +63,18 @@ bool SensorImpl::isAvailable(Sensor::Type sensor)
 {
     switch (sensor)
     {
-        case Sensor::Accelerometer:
+        case Sensor::Type::Accelerometer:
             return [SFAppDelegate getInstance].motionManager.accelerometerAvailable;
 
-        case Sensor::Gyroscope:
+        case Sensor::Type::Gyroscope:
             return [SFAppDelegate getInstance].motionManager.gyroAvailable;
 
-        case Sensor::Magnetometer:
+        case Sensor::Type::Magnetometer:
             return [SFAppDelegate getInstance].motionManager.magnetometerAvailable;
 
-        case Sensor::Gravity:
-        case Sensor::UserAcceleration:
-        case Sensor::Orientation:
+        case Sensor::Type::Gravity:
+        case Sensor::Type::UserAcceleration:
+        case Sensor::Type::Orientation:
             return [SFAppDelegate getInstance].motionManager.deviceMotionAvailable;
 
         default:
@@ -96,21 +96,21 @@ bool SensorImpl::open(Sensor::Type sensor)
     constexpr NSTimeInterval updateInterval = 1. / 60.;
     switch (sensor)
     {
-        case Sensor::Accelerometer:
+        case Sensor::Type::Accelerometer:
             [SFAppDelegate getInstance].motionManager.accelerometerUpdateInterval = updateInterval;
             break;
 
-        case Sensor::Gyroscope:
+        case Sensor::Type::Gyroscope:
             [SFAppDelegate getInstance].motionManager.gyroUpdateInterval = updateInterval;
             break;
 
-        case Sensor::Magnetometer:
+        case Sensor::Type::Magnetometer:
             [SFAppDelegate getInstance].motionManager.magnetometerUpdateInterval = updateInterval;
             break;
 
-        case Sensor::Gravity:
-        case Sensor::UserAcceleration:
-        case Sensor::Orientation:
+        case Sensor::Type::Gravity:
+        case Sensor::Type::UserAcceleration:
+        case Sensor::Type::Orientation:
             [SFAppDelegate getInstance].motionManager.deviceMotionUpdateInterval = updateInterval;
             break;
 
@@ -137,35 +137,35 @@ Vector3f SensorImpl::update()
 
     switch (m_sensor)
     {
-        case Sensor::Accelerometer:
+        case Sensor::Type::Accelerometer:
             // Acceleration is given in G, convert to m/s^2
             value.x = static_cast<float>(manager.accelerometerData.acceleration.x * 9.81);
             value.y = static_cast<float>(manager.accelerometerData.acceleration.y * 9.81);
             value.z = static_cast<float>(manager.accelerometerData.acceleration.z * 9.81);
             break;
 
-        case Sensor::Gyroscope:
+        case Sensor::Type::Gyroscope:
             // Rotation rates are given in rad/s, convert to deg/s
             value.x = toDegrees(static_cast<float>(manager.gyroData.rotationRate.x));
             value.y = toDegrees(static_cast<float>(manager.gyroData.rotationRate.y));
             value.z = toDegrees(static_cast<float>(manager.gyroData.rotationRate.z));
             break;
 
-        case Sensor::Magnetometer:
+        case Sensor::Type::Magnetometer:
             // Magnetic field is given in microteslas
             value.x = static_cast<float>(manager.magnetometerData.magneticField.x);
             value.y = static_cast<float>(manager.magnetometerData.magneticField.y);
             value.z = static_cast<float>(manager.magnetometerData.magneticField.z);
             break;
 
-        case Sensor::UserAcceleration:
+        case Sensor::Type::UserAcceleration:
             // User acceleration is given in G, convert to m/s^2
             value.x = static_cast<float>(manager.deviceMotion.userAcceleration.x * 9.81);
             value.y = static_cast<float>(manager.deviceMotion.userAcceleration.y * 9.81);
             value.z = static_cast<float>(manager.deviceMotion.userAcceleration.z * 9.81);
             break;
 
-        case Sensor::Orientation:
+        case Sensor::Type::Orientation:
             // Absolute rotation (Euler) angles are given in radians, convert to degrees
             value.x = toDegrees(static_cast<float>(manager.deviceMotion.attitude.yaw));
             value.y = toDegrees(static_cast<float>(manager.deviceMotion.attitude.pitch));
@@ -189,30 +189,30 @@ void SensorImpl::setEnabled(bool enabled)
 
     switch (m_sensor)
     {
-        case Sensor::Accelerometer:
+        case Sensor::Type::Accelerometer:
             if (enabled)
                 [[SFAppDelegate getInstance].motionManager startAccelerometerUpdates];
             else
                 [[SFAppDelegate getInstance].motionManager stopAccelerometerUpdates];
             break;
 
-        case Sensor::Gyroscope:
+        case Sensor::Type::Gyroscope:
             if (enabled)
                 [[SFAppDelegate getInstance].motionManager startGyroUpdates];
             else
                 [[SFAppDelegate getInstance].motionManager stopGyroUpdates];
             break;
 
-        case Sensor::Magnetometer:
+        case Sensor::Type::Magnetometer:
             if (enabled)
                 [[SFAppDelegate getInstance].motionManager startMagnetometerUpdates];
             else
                 [[SFAppDelegate getInstance].motionManager stopMagnetometerUpdates];
             break;
 
-        case Sensor::Gravity:
-        case Sensor::UserAcceleration:
-        case Sensor::Orientation:
+        case Sensor::Type::Gravity:
+        case Sensor::Type::UserAcceleration:
+        case Sensor::Type::Orientation:
             // these 3 sensors all share the same implementation, so we must disable
             // it only if the three sensors are disabled
             if (enabled)

--- a/src/SFML/Window/macOS/CursorImpl.mm
+++ b/src/SFML/Window/macOS/CursorImpl.mm
@@ -92,34 +92,34 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
     {
         default: return false;
 
-        case Cursor::Arrow:           newCursor = [NSCursor arrowCursor];               break;
-        case Cursor::Text:            newCursor = [NSCursor IBeamCursor];               break;
-        case Cursor::Hand:            newCursor = [NSCursor pointingHandCursor];        break;
-        case Cursor::SizeHorizontal:  newCursor = [NSCursor resizeLeftRightCursor];     break;
-        case Cursor::SizeVertical:    newCursor = [NSCursor resizeUpDownCursor];        break;
-        case Cursor::Cross:           newCursor = [NSCursor crosshairCursor];           break;
-        case Cursor::NotAllowed:      newCursor = [NSCursor operationNotAllowedCursor]; break;
-        case Cursor::SizeLeft:        newCursor = [NSCursor resizeLeftRightCursor];     break;
-        case Cursor::SizeRight:       newCursor = [NSCursor resizeLeftRightCursor];     break;
-        case Cursor::SizeTop:         newCursor = [NSCursor resizeUpDownCursor];        break;
-        case Cursor::SizeBottom:      newCursor = [NSCursor resizeUpDownCursor];        break;
+        case Cursor::Type::Arrow:           newCursor = [NSCursor arrowCursor];               break;
+        case Cursor::Type::Text:            newCursor = [NSCursor IBeamCursor];               break;
+        case Cursor::Type::Hand:            newCursor = [NSCursor pointingHandCursor];        break;
+        case Cursor::Type::SizeHorizontal:  newCursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::Type::SizeVertical:    newCursor = [NSCursor resizeUpDownCursor];        break;
+        case Cursor::Type::Cross:           newCursor = [NSCursor crosshairCursor];           break;
+        case Cursor::Type::NotAllowed:      newCursor = [NSCursor operationNotAllowedCursor]; break;
+        case Cursor::Type::SizeLeft:        newCursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::Type::SizeRight:       newCursor = [NSCursor resizeLeftRightCursor];     break;
+        case Cursor::Type::SizeTop:         newCursor = [NSCursor resizeUpDownCursor];        break;
+        case Cursor::Type::SizeBottom:      newCursor = [NSCursor resizeUpDownCursor];        break;
 
         // These cursor types are undocumented, may not be available on some platforms
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundeclared-selector"
-        case Cursor::SizeTopRight:
-        case Cursor::SizeBottomLeft:
-        case Cursor::SizeBottomLeftTopRight:
+        case Cursor::Type::SizeTopRight:
+        case Cursor::Type::SizeBottomLeft:
+        case Cursor::Type::SizeBottomLeftTopRight:
             newCursor = loadFromSelector(@selector(_windowResizeNorthEastSouthWestCursor));
             break;
 
-        case Cursor::SizeTopLeft:
-        case Cursor::SizeBottomRight:
-        case Cursor::SizeTopLeftBottomRight:
+        case Cursor::Type::SizeTopLeft:
+        case Cursor::Type::SizeBottomRight:
+        case Cursor::Type::SizeTopLeftBottomRight:
             newCursor = loadFromSelector(@selector(_windowResizeNorthWestSouthEastCursor));
             break;
 
-        case Cursor::Help:
+        case Cursor::Type::Help:
             newCursor = loadFromSelector(@selector(_helpCursor));
             break;
 #pragma GCC diagnostic pop

--- a/src/SFML/Window/macOS/InputImpl.mm
+++ b/src/SFML/Window/macOS/InputImpl.mm
@@ -167,7 +167,7 @@ bool isMouseButtonPressed(Mouse::Button button)
 {
     const AutoreleasePool pool;
     const NSUInteger      state = [NSEvent pressedMouseButtons];
-    const NSUInteger      flag  = 1 << button;
+    const NSUInteger      flag  = 1 << static_cast<int>(button);
     return (state & flag) != 0;
 }
 

--- a/src/SFML/Window/macOS/JoystickImpl.cpp
+++ b/src/SFML/Window/macOS/JoystickImpl.cpp
@@ -240,22 +240,22 @@ bool JoystickImpl::open(unsigned int index)
                 switch (IOHIDElementGetUsage(element))
                 {
                     case kHIDUsage_GD_X:
-                        m_axis[Joystick::X] = element;
+                        m_axis[Joystick::Axis::X] = element;
                         break;
                     case kHIDUsage_GD_Y:
-                        m_axis[Joystick::Y] = element;
+                        m_axis[Joystick::Axis::Y] = element;
                         break;
                     case kHIDUsage_GD_Z:
-                        m_axis[Joystick::Z] = element;
+                        m_axis[Joystick::Axis::Z] = element;
                         break;
                     case kHIDUsage_GD_Rx:
-                        m_axis[Joystick::U] = element;
+                        m_axis[Joystick::Axis::U] = element;
                         break;
                     case kHIDUsage_GD_Ry:
-                        m_axis[Joystick::V] = element;
+                        m_axis[Joystick::Axis::V] = element;
                         break;
                     case kHIDUsage_GD_Rz:
-                        m_axis[Joystick::R] = element;
+                        m_axis[Joystick::Axis::R] = element;
                         break;
 
                     case kHIDUsage_GD_Hatswitch:
@@ -379,10 +379,10 @@ JoystickCaps JoystickImpl::getCapabilities() const
 
     // Axis:
     for (const auto& [axis, iohidElementRef] : m_axis)
-        caps.axes[axis] = true;
+        caps.axes[static_cast<int>(axis)] = true;
 
     if (m_hat != nullptr)
-        caps.axes[Joystick::PovX] = caps.axes[Joystick::PovY] = true;
+        caps.axes[static_cast<int>(Joystick::Axis::PovX)] = caps.axes[static_cast<int>(Joystick::Axis::PovY)] = true;
 
     return caps;
 }
@@ -482,7 +482,7 @@ JoystickState JoystickImpl::update()
         const double physicalValue = IOHIDValueGetScaledValue(value, kIOHIDValueScaleTypePhysical);
         const auto   scaledValue   = static_cast<float>(
             (((physicalValue - physicalMin) * (scaledMax - scaledMin)) / (physicalMax - physicalMin)) + scaledMin);
-        state.axes[axis] = scaledValue;
+        state.axes[static_cast<int>(axis)] = scaledValue;
     }
 
     // Update POV/Hat state. Assuming model described in `open`, values are:
@@ -510,17 +510,17 @@ JoystickState JoystickImpl::update()
             case 1:
             case 2:
             case 3:
-                state.axes[Joystick::PovX] = +100;
+                state.axes[static_cast<int>(Joystick::Axis::PovX)] = +100;
                 break;
 
             case 5:
             case 6:
             case 7:
-                state.axes[Joystick::PovX] = -100;
+                state.axes[static_cast<int>(Joystick::Axis::PovX)] = -100;
                 break;
 
             default:
-                state.axes[Joystick::PovX] = 0;
+                state.axes[static_cast<int>(Joystick::Axis::PovX)] = 0;
                 break;
         }
 
@@ -530,17 +530,17 @@ JoystickState JoystickImpl::update()
             case 0:
             case 1:
             case 7:
-                state.axes[Joystick::PovY] = +100;
+                state.axes[static_cast<int>(Joystick::Axis::PovY)] = +100;
                 break;
 
             case 3:
             case 4:
             case 5:
-                state.axes[Joystick::PovY] = -100;
+                state.axes[static_cast<int>(Joystick::Axis::PovY)] = -100;
                 break;
 
             default:
-                state.axes[Joystick::PovY] = 0;
+                state.axes[static_cast<int>(Joystick::Axis::PovY)] = 0;
                 break;
         }
     }

--- a/src/SFML/Window/macOS/SFOpenGLView+mouse.mm
+++ b/src/SFML/Window/macOS/SFOpenGLView+mouse.mm
@@ -131,14 +131,14 @@
 ////////////////////////////////////////////////////////
 - (void)handleMouseDown:(NSEvent*)theEvent
 {
-    sf::Mouse::Button button = [SFOpenGLView mouseButtonFromEvent:theEvent];
+    const std::optional<sf::Mouse::Button> button = [SFOpenGLView mouseButtonFromEvent:theEvent];
 
     if (m_requester != nil)
     {
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
 
-        if (button != sf::Mouse::ButtonCount)
-            m_requester->mouseDownAt(button, static_cast<int>(loc.x), static_cast<int>(loc.y));
+        if (button)
+            m_requester->mouseDownAt(*button, static_cast<int>(loc.x), static_cast<int>(loc.y));
     }
 }
 
@@ -176,14 +176,14 @@
 ////////////////////////////////////////////////////////////
 - (void)handleMouseUp:(NSEvent*)theEvent
 {
-    sf::Mouse::Button button = [SFOpenGLView mouseButtonFromEvent:theEvent];
+    const std::optional<sf::Mouse::Button> button = [SFOpenGLView mouseButtonFromEvent:theEvent];
 
     if (m_requester != nil)
     {
         NSPoint loc = [self cursorPositionFromEvent:theEvent];
 
-        if (button != sf::Mouse::ButtonCount)
-            m_requester->mouseUpAt(button, static_cast<int>(loc.x), static_cast<int>(loc.y));
+        if (button)
+            m_requester->mouseUpAt(*button, static_cast<int>(loc.x), static_cast<int>(loc.y));
     }
 }
 
@@ -407,22 +407,22 @@
 
 
 ////////////////////////////////////////////////////////
-+ (sf::Mouse::Button)mouseButtonFromEvent:(NSEvent*)event
++ (std::optional<sf::Mouse::Button>)mouseButtonFromEvent:(NSEvent*)event
 {
     switch ([event buttonNumber])
     {
         case 0:
-            return sf::Mouse::Left;
+            return sf::Mouse::Button::Left;
         case 1:
-            return sf::Mouse::Right;
+            return sf::Mouse::Button::Right;
         case 2:
-            return sf::Mouse::Middle;
+            return sf::Mouse::Button::Middle;
         case 3:
-            return sf::Mouse::XButton1;
+            return sf::Mouse::Button::XButton1;
         case 4:
-            return sf::Mouse::XButton2;
+            return sf::Mouse::Button::XButton2;
         default:
-            return sf::Mouse::ButtonCount; // Never happens! (hopefully)
+            return std::nullopt; // Never happens! (hopefully)
     }
 }
 

--- a/src/SFML/Window/macOS/SFOpenGLView+mouse_priv.h
+++ b/src/SFML/Window/macOS/SFOpenGLView+mouse_priv.h
@@ -30,6 +30,7 @@
 #import <SFML/Window/macOS/SFOpenGLView.h>
 
 #import <AppKit/AppKit.h>
+#include <optional>
 
 
 ////////////////////////////////////////////////////////////
@@ -98,13 +99,13 @@
 - (CGDirectDisplayID)displayId;
 
 ////////////////////////////////////////////////////////////
-/// \brief Convert the NSEvent mouse button type to SFML type
+/// \brief Try to convert the NSEvent mouse button type to SFML type
 ///
 /// \param event a mouse button event
 ///
-/// \return Left, Right, ..., or ButtonCount if the button is unknown
+/// \return Left, Right, ..., or std::nullopt if the button is unknown
 ///
 ////////////////////////////////////////////////////////////
-+ (sf::Mouse::Button)mouseButtonFromEvent:(NSEvent*)event;
++ (std::optional<sf::Mouse::Button>)mouseButtonFromEvent:(NSEvent*)event;
 
 @end

--- a/src/SFML/Window/macOS/WindowImplCocoa.mm
+++ b/src/SFML/Window/macOS/WindowImplCocoa.mm
@@ -298,7 +298,7 @@ void WindowImplCocoa::mouseWheelScrolledAt(float deltaX, float deltaY, int x, in
     Event event;
 
     event.type                   = Event::MouseWheelScrolled;
-    event.mouseWheelScroll.wheel = Mouse::VerticalWheel;
+    event.mouseWheelScroll.wheel = Mouse::Wheel::Vertical;
     event.mouseWheelScroll.delta = deltaY;
     event.mouseWheelScroll.x     = x;
     event.mouseWheelScroll.y     = y;
@@ -306,7 +306,7 @@ void WindowImplCocoa::mouseWheelScrolledAt(float deltaX, float deltaY, int x, in
     pushEvent(event);
 
     event.type                   = Event::MouseWheelScrolled;
-    event.mouseWheelScroll.wheel = Mouse::HorizontalWheel;
+    event.mouseWheelScroll.wheel = Mouse::Wheel::Horizontal;
     event.mouseWheelScroll.delta = deltaX;
     event.mouseWheelScroll.x     = x;
     event.mouseWheelScroll.y     = y;

--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -51,19 +51,19 @@ TEST_CASE("[Window] sf::Cursor", runDisplayTests())
     SECTION("loadFromSystem()")
     {
         sf::Cursor cursor;
-        CHECK(cursor.loadFromSystem(sf::Cursor::Hand));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeHorizontal));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeVertical));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeLeft));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeRight));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeTop));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeBottom));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeTopLeft));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeTopRight));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeBottomLeft));
-        CHECK(cursor.loadFromSystem(sf::Cursor::SizeBottomRight));
-        CHECK(cursor.loadFromSystem(sf::Cursor::Cross));
-        CHECK(cursor.loadFromSystem(sf::Cursor::Help));
-        CHECK(cursor.loadFromSystem(sf::Cursor::NotAllowed));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::Hand));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeHorizontal));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeVertical));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeLeft));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeRight));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeTop));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeBottom));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeTopLeft));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeTopRight));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeBottomLeft));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::SizeBottomRight));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::Cross));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::Help));
+        CHECK(cursor.loadFromSystem(sf::Cursor::Type::NotAllowed));
     }
 }

--- a/test/Window/Joystick.test.cpp
+++ b/test/Window/Joystick.test.cpp
@@ -38,14 +38,14 @@ TEST_CASE("[Window] sf::Joystick")
 
     SECTION("hasAxis()")
     {
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::X));
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Y));
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Z));
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::R));
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::U));
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::V));
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::PovX));
-        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::PovY));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::X));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::Y));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::Z));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::R));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::U));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::V));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::PovX));
+        CHECK(!sf::Joystick::hasAxis(joystick, sf::Joystick::Axis::PovY));
     }
 
     SECTION("isButtonPressed()")
@@ -56,14 +56,14 @@ TEST_CASE("[Window] sf::Joystick")
 
     SECTION("getAxisPosition")
     {
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::X) == 0);
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Y) == 0);
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Z) == 0);
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::R) == 0);
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::U) == 0);
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::V) == 0);
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::PovX) == 0);
-        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::PovY) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::X) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::Y) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::Z) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::R) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::U) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::V) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::PovX) == 0);
+        CHECK(sf::Joystick::getAxisPosition(joystick, sf::Joystick::Axis::PovY) == 0);
     }
 
     SECTION("getIdentification()")


### PR DESCRIPTION
Part of C++17 modernization for SFML 3, related to [SD: CPP 17 Support](https://github.com/SFML/SFML/wiki/SD%3A-CPP-17-Support#scoped-enumerations) and #2131.
Solution design suggests `enum struct` instead of `enum class` but this is not what we have been doing until now so I used `enum class` for consistency.

I did not convert all enums:
- `sf::Style` and `sf::ContextSettings::Attribute` because they represent flags.
- `sf::Event::EventType` because it is done in #2766.
- `sf::Keyboard::Key` because this PR is already big enough. 

