### PR TITLE
Remove unnecessary `sf::` namespaces

### DIFF
--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -696,7 +696,7 @@ Vector2i getTouchPosition(unsigned int finger, const WindowBase& /*relativeTo*/)
 
 
 ////////////////////////////////////////////////////////////
-bool checkEvent(sf::Event& event)
+bool checkEvent(Event& event)
 {
     const std::lock_guard lock(inputMutex);
     if (!eventQueue.empty())

--- a/src/SFML/Window/DRM/VideoModeImpl.cpp
+++ b/src/SFML/Window/DRM/VideoModeImpl.cpp
@@ -38,7 +38,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 {
     std::vector<VideoMode> modes;
 
-    const Drm&          drm  = sf::priv::DRMContext::getDRM();
+    const Drm&          drm  = DRMContext::getDRM();
     drmModeConnectorPtr conn = drm.savedConnector;
 
     if (conn)
@@ -56,7 +56,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 ////////////////////////////////////////////////////////////
 VideoMode VideoModeImpl::getDesktopMode()
 {
-    const Drm&         drm = sf::priv::DRMContext::getDRM();
+    const Drm&         drm = DRMContext::getDRM();
     drmModeModeInfoPtr ptr = drm.mode;
     if (ptr)
         return VideoMode({ptr->hdisplay, ptr->vdisplay});

--- a/src/SFML/Window/DRM/WindowImplDRM.cpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.cpp
@@ -46,7 +46,7 @@ namespace InputImpl
 /// \return False if event queue is empty
 ///
 ////////////////////////////////////////////////////////////
-bool checkEvent(sf::Event& event);
+bool checkEvent(Event& event);
 
 ////////////////////////////////////////////////////////////
 /// \brief Backup terminal configuration and disable console feedback
@@ -65,7 +65,7 @@ void restoreTerminalConfig();
 ////////////////////////////////////////////////////////////
 WindowImplDRM::WindowImplDRM(WindowHandle /*handle*/)
 {
-    sf::priv::InputImpl::setTerminalConfig();
+    InputImpl::setTerminalConfig();
 }
 
 
@@ -73,21 +73,21 @@ WindowImplDRM::WindowImplDRM(WindowHandle /*handle*/)
 WindowImplDRM::WindowImplDRM(VideoMode mode, const String& /*title*/, unsigned long /*style*/, const ContextSettings& /*settings*/) :
 m_size(mode.size)
 {
-    sf::priv::InputImpl::setTerminalConfig();
+    InputImpl::setTerminalConfig();
 }
 
 
 ////////////////////////////////////////////////////////////
 WindowImplDRM::~WindowImplDRM()
 {
-    sf::priv::InputImpl::restoreTerminalConfig();
+    InputImpl::restoreTerminalConfig();
 }
 
 
 ////////////////////////////////////////////////////////////
 WindowHandle WindowImplDRM::getNativeHandle() const
 {
-    const Drm& drm = sf::priv::DRMContext::getDRM();
+    const Drm& drm = DRMContext::getDRM();
     return static_cast<WindowHandle>(drm.fileDescriptor);
 }
 
@@ -186,8 +186,8 @@ bool WindowImplDRM::hasFocus() const
 
 void WindowImplDRM::processEvents()
 {
-    sf::Event event;
-    while (sf::priv::InputImpl::checkEvent(event))
+    Event event;
+    while (InputImpl::checkEvent(event))
         pushEvent(event);
 }
 


### PR DESCRIPTION
## Description

The DRM code was using `sf::` in places where it was not necessary. The convention of the library is to omit `sf::` in as many places as possible.