### PR TITLE
Add readability-containers-contains clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,4 @@
 Checks: >
-  -*,
   bugprone-*,
   clang-analyzer-*,
   cppcoreguidelines-*,
@@ -60,7 +59,6 @@ Checks: >
   -performance-inefficient-string-concatenation,
   -performance-no-int-to-ptr,
   -readability-braces-around-statements,
-  -readability-container-contains,
   -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,


### PR DESCRIPTION
This check only matters if you're building in C++20 mode which we're not so there's no reason to disable this. Once we enable C++20 then we will want this check.