### PR TITLE
Rename XButton1 and XButton2 into Extra1 and Extra2

### DIFF
--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -48,11 +48,11 @@ namespace Mouse
 ////////////////////////////////////////////////////////////
 enum class Button
 {
-    Left,     //!< The left mouse button
-    Right,    //!< The right mouse button
-    Middle,   //!< The middle (wheel) mouse button
-    XButton1, //!< The first extra mouse button
-    XButton2  //!< The second extra mouse button
+    Left,   //!< The left mouse button
+    Right,  //!< The right mouse button
+    Middle, //!< The middle (wheel) mouse button
+    Extra1, //!< The first extra mouse button
+    Extra2  //!< The second extra mouse button
 };
 
 // NOLINTNEXTLINE(readability-identifier-naming)
@@ -71,8 +71,8 @@ enum class Wheel
 ////////////////////////////////////////////////////////////
 /// \brief Check if a mouse button is pressed
 ///
-/// \warning Checking the state of buttons Mouse::Button::XButton1 and
-/// Mouse::Button::XButton2 is not supported on Linux with X11.
+/// \warning Checking the state of buttons Mouse::Button::Extra1 and
+/// Mouse::Button::Extra2 is not supported on Linux with X11.
 ///
 /// \param button Button to check
 ///

--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -177,9 +177,9 @@ std::optional<sf::Mouse::Button> toMouseButton(int code)
         case BTN_MIDDLE:
             return sf::Mouse::Button::Middle;
         case BTN_SIDE:
-            return sf::Mouse::Button::XButton1;
+            return sf::Mouse::Button::Extra1;
         case BTN_EXTRA:
-            return sf::Mouse::Button::XButton2;
+            return sf::Mouse::Button::Extra2;
 
         default:
             return std::nullopt;

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -103,16 +103,16 @@ bool isMouseButtonPressed(Mouse::Button button)
 
     // Buttons 4 and 5 are the vertical wheel and 6 and 7 the horizontal wheel.
     // There is no mask for buttons 8 and 9, so checking the state of buttons
-    // Mouse::Button::XButton1 and Mouse::Button::XButton2 is not supported.
+    // Mouse::Button::Extra1 and Mouse::Button::Extra2 is not supported.
     // clang-format off
     switch (button)
     {
-        case Mouse::Button::Left:     return buttons & Button1Mask;
-        case Mouse::Button::Right:    return buttons & Button3Mask;
-        case Mouse::Button::Middle:   return buttons & Button2Mask;
-        case Mouse::Button::XButton1: return false; // not supported by X
-        case Mouse::Button::XButton2: return false; // not supported by X
-        default:                      return false;
+        case Mouse::Button::Left:   return buttons & Button1Mask;
+        case Mouse::Button::Right:  return buttons & Button3Mask;
+        case Mouse::Button::Middle: return buttons & Button2Mask;
+        case Mouse::Button::Extra1: return false; // not supported by X
+        case Mouse::Button::Extra2: return false; // not supported by X
+        default:                    return false;
     }
     // clang-format on
 }

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1937,11 +1937,11 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 // clang-format off
                 switch(button)
                 {
-                    case Button1: event.mouseButton.button = Mouse::Button::Left;     break;
-                    case Button2: event.mouseButton.button = Mouse::Button::Middle;   break;
-                    case Button3: event.mouseButton.button = Mouse::Button::Right;    break;
-                    case 8:       event.mouseButton.button = Mouse::Button::XButton1; break;
-                    case 9:       event.mouseButton.button = Mouse::Button::XButton2; break;
+                    case Button1: event.mouseButton.button = Mouse::Button::Left;   break;
+                    case Button2: event.mouseButton.button = Mouse::Button::Middle; break;
+                    case Button3: event.mouseButton.button = Mouse::Button::Right;  break;
+                    case 8:       event.mouseButton.button = Mouse::Button::Extra1; break;
+                    case 9:       event.mouseButton.button = Mouse::Button::Extra2; break;
                 }
                 // clang-format on
 
@@ -1975,10 +1975,10 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                         event.mouseButton.button = Mouse::Button::Right;
                         break;
                     case 8:
-                        event.mouseButton.button = Mouse::Button::XButton1;
+                        event.mouseButton.button = Mouse::Button::Extra1;
                         break;
                     case 9:
-                        event.mouseButton.button = Mouse::Button::XButton2;
+                        event.mouseButton.button = Mouse::Button::Extra2;
                         break;
                 }
                 pushEvent(event);

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -631,10 +631,10 @@ bool isMouseButtonPressed(Mouse::Button button)
         case Mouse::Button::Middle:
             virtualKey = VK_MBUTTON;
             break;
-        case Mouse::Button::XButton1:
+        case Mouse::Button::Extra1:
             virtualKey = VK_XBUTTON1;
             break;
-        case Mouse::Button::XButton2:
+        case Mouse::Button::Extra2:
             virtualKey = VK_XBUTTON2;
             break;
         default:

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -1027,7 +1027,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonPressed;
-            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::Button::XButton1 : Mouse::Button::XButton2;
+            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::Button::Extra1 : Mouse::Button::Extra2;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);
@@ -1039,7 +1039,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             Event event;
             event.type               = Event::MouseButtonReleased;
-            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::Button::XButton1 : Mouse::Button::XButton2;
+            event.mouseButton.button = HIWORD(wParam) == XBUTTON1 ? Mouse::Button::Extra1 : Mouse::Button::Extra2;
             event.mouseButton.x      = static_cast<std::int16_t>(LOWORD(lParam));
             event.mouseButton.y      = static_cast<std::int16_t>(HIWORD(lParam));
             pushEvent(event);

--- a/src/SFML/Window/macOS/SFOpenGLView+mouse.mm
+++ b/src/SFML/Window/macOS/SFOpenGLView+mouse.mm
@@ -418,9 +418,9 @@
         case 2:
             return sf::Mouse::Button::Middle;
         case 3:
-            return sf::Mouse::Button::XButton1;
+            return sf::Mouse::Button::Extra1;
         case 4:
-            return sf::Mouse::Button::XButton2;
+            return sf::Mouse::Button::Extra2;
         default:
             return std::nullopt; // Never happens! (hopefully)
     }


### PR DESCRIPTION
This is to avoid repeating Button when using those values now that the sf::Mouse::Button enumeration is a scoped enumeration.

Follow-up of review comment https://github.com/SFML/SFML/pull/2822#discussion_r1428646949
