### PR TITLE
Use EnumArray for Key or Scancode-indexed arrays

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -153,8 +153,15 @@ enum Key
     F15,          //!< The F15 key
     Pause,        //!< The Pause key
 
-    KeyCount, //!< Keep last -- the total number of keyboard keys
+    Last = Pause, //!< Keep equal to last enumerator -- used to define KeyCount
 };
+
+////////////////////////////////////////////////////////////
+/// \brief The total number of keyboard keys, ignoring Key::Unknown
+///
+////////////////////////////////////////////////////////////
+// NOLINTNEXTLINE(readability-identifier-naming)
+static constexpr unsigned int KeyCount{static_cast<unsigned int>(Key::Last) + 1};
 
 ////////////////////////////////////////////////////////////
 /// \brief Scancodes
@@ -320,10 +327,17 @@ enum class Scan
     LaunchMail,         //!< Keyboard Launch Mail key
     LaunchMediaSelect,  //!< Keyboard Launch Media Select key
 
-    ScancodeCount //!< Keep last -- the total number of scancodes
+    Last = LaunchMediaSelect, //!< Keep equal to last enumerator -- used to define ScancodeCount
 };
 
 using Scancode = Scan;
+
+////////////////////////////////////////////////////////////
+/// \brief The total number of scancodes, ignoring Scan::Unknown
+///
+////////////////////////////////////////////////////////////
+// NOLINTNEXTLINE(readability-identifier-naming)
+static constexpr unsigned int ScancodeCount{static_cast<unsigned int>(Scan::Last) + 1};
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a key is pressed

--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -63,7 +63,7 @@ sf::Vector2i         mousePos;   // current mouse position
 
 std::vector<int> fileDescriptors; // list of open file descriptors for /dev/input
 sf::priv::EnumArray<sf::Mouse::Button, bool, sf::Mouse::ButtonCount> mouseMap{}; // track whether mouse buttons are down
-std::vector<bool> keyMap(sf::Keyboard::KeyCount, false);                         // track whether keys are down
+sf::priv::EnumArray<sf::Keyboard::Key, bool, sf::Keyboard::KeyCount> keyMap{};   // track whether keys are down
 
 int                    touchFd = -1;    // file descriptor we have seen MT events on; assumes only 1
 std::vector<TouchSlot> touchSlots;      // track the state of each touch "slot"
@@ -427,7 +427,7 @@ bool eventProcess(sf::Event& event)
                         event.key.shift    = shiftDown();
                         event.key.system   = systemDown();
 
-                        keyMap[static_cast<std::size_t>(kb)] = inputEvent.value;
+                        keyMap[kb] = inputEvent.value;
 
                         if (special && inputEvent.value)
                             doDeferredText = special;
@@ -578,7 +578,7 @@ bool isKeyPressed(Keyboard::Key key)
         return false;
 
     update();
-    return keyMap[static_cast<std::size_t>(key)];
+    return keyMap[key];
 }
 
 

--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -48,8 +48,8 @@ namespace
 
 const KeyCode          nullKeyCode = 0;
 const int              maxKeyCode  = 256;
-KeyCode                scancodeToKeycode[static_cast<std::size_t>(sf::Keyboard::Scan::ScancodeCount)]; ///< Mapping of SFML scancode to X11 KeyCode
-sf::Keyboard::Scancode keycodeToScancode[maxKeyCode]; ///< Mapping of X11 KeyCode to SFML scancode
+KeyCode                scancodeToKeycode[sf::Keyboard::ScancodeCount]; ///< Mapping of SFML scancode to X11 KeyCode
+sf::Keyboard::Scancode keycodeToScancode[maxKeyCode];                  ///< Mapping of X11 KeyCode to SFML scancode
 
 ////////////////////////////////////////////////////////////
 bool isValidKeycode(KeyCode keycode)

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -28,13 +28,14 @@
 #include <SFML/Window/InputImpl.hpp>
 #include <SFML/Window/Window.hpp>
 
+#include <SFML/System/EnumArray.hpp>
 #include <SFML/System/String.hpp>
 #include <SFML/System/Win32/WindowsHeader.hpp>
 
 namespace
 {
-sf::Keyboard::Scancode keyToScancodeMapping[sf::Keyboard::KeyCount];      ///< Mapping from Key to Scancode
-sf::Keyboard::Key      scancodeToKeyMapping[sf::Keyboard::ScancodeCount]; ///< Mapping from Scancode to Key
+sf::priv::EnumArray<sf::Keyboard::Key, sf::Keyboard::Scancode, sf::Keyboard::KeyCount> keyToScancodeMapping; ///< Mapping from Key to Scancode
+sf::priv::EnumArray<sf::Keyboard::Scancode, sf::Keyboard::Key, sf::Keyboard::ScancodeCount> scancodeToKeyMapping; ///< Mapping from Scancode to Key
 
 sf::Keyboard::Key virtualKeyToSfKey(UINT virtualKey)
 {
@@ -520,11 +521,8 @@ void ensureMappings()
         return;
 
     // Phase 1: Initialize mappings with default values
-    for (auto& scancode : keyToScancodeMapping)
-        scancode = sf::Keyboard::Scan::Unknown;
-
-    for (auto& key : scancodeToKeyMapping)
-        key = sf::Keyboard::Unknown;
+    keyToScancodeMapping.fill(sf::Keyboard::Scan::Unknown);
+    scancodeToKeyMapping.fill(sf::Keyboard::Key::Unknown);
 
     // Phase 2: Translate scancode to virtual code to key names
     for (unsigned int i = 0; i < sf::Keyboard::ScancodeCount; ++i)
@@ -534,7 +532,7 @@ void ensureMappings()
         const sf::Keyboard::Key key        = virtualKeyToSfKey(virtualKey);
         if (key != sf::Keyboard::Unknown && keyToScancodeMapping[key] == sf::Keyboard::Scan::Unknown)
             keyToScancodeMapping[key] = scan;
-        scancodeToKeyMapping[static_cast<std::size_t>(scan)] = key;
+        scancodeToKeyMapping[scan] = key;
     }
 
     isMappingInitialized = true;
@@ -578,7 +576,7 @@ Keyboard::Key localize(Keyboard::Scancode code)
 
     ensureMappings();
 
-    return scancodeToKeyMapping[static_cast<std::size_t>(code)];
+    return scancodeToKeyMapping[code];
 }
 
 

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -33,8 +33,8 @@
 
 namespace
 {
-sf::Keyboard::Scancode keyToScancodeMapping[sf::Keyboard::KeyCount]; ///< Mapping from Key to Scancode
-sf::Keyboard::Key scancodeToKeyMapping[static_cast<std::size_t>(sf::Keyboard::Scan::ScancodeCount)]; ///< Mapping from Scancode to Key
+sf::Keyboard::Scancode keyToScancodeMapping[sf::Keyboard::KeyCount];      ///< Mapping from Key to Scancode
+sf::Keyboard::Key      scancodeToKeyMapping[sf::Keyboard::ScancodeCount]; ///< Mapping from Scancode to Key
 
 sf::Keyboard::Key virtualKeyToSfKey(UINT virtualKey)
 {
@@ -527,7 +527,7 @@ void ensureMappings()
         key = sf::Keyboard::Unknown;
 
     // Phase 2: Translate scancode to virtual code to key names
-    for (int i = 0; i < static_cast<int>(sf::Keyboard::Scan::ScancodeCount); ++i)
+    for (unsigned int i = 0; i < sf::Keyboard::ScancodeCount; ++i)
     {
         const auto              scan       = static_cast<sf::Keyboard::Scancode>(i);
         const UINT              virtualKey = sfScanToVirtualKey(scan);
@@ -542,12 +542,12 @@ void ensureMappings()
 
 bool isValidScancode(sf::Keyboard::Scancode code)
 {
-    return code > sf::Keyboard::Scan::Unknown && code < sf::Keyboard::Scan::ScancodeCount;
+    return code > sf::Keyboard::Scan::Unknown && static_cast<unsigned int>(code) < sf::Keyboard::ScancodeCount;
 }
 
 bool isValidKey(sf::Keyboard::Key key)
 {
-    return key > sf::Keyboard::Unknown && key < sf::Keyboard::KeyCount;
+    return key > sf::Keyboard::Unknown && static_cast<unsigned int>(key) < sf::Keyboard::KeyCount;
 }
 
 } // namespace

--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -286,10 +286,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    IOHIDManagerRef    m_manager{};                                       ///< Underlying HID Manager
-    IOHIDElements      m_keys[Keyboard::ScancodeCount];                   ///< All the keys on any connected keyboard
-    Keyboard::Scancode m_keyToScancodeMapping[Keyboard::KeyCount]{};      ///< Mapping from Key to Scancode
-    Keyboard::Key      m_scancodeToKeyMapping[Keyboard::ScancodeCount]{}; ///< Mapping from Scancode to Key
+    IOHIDManagerRef                                                       m_manager{}; ///< Underlying HID Manager
+    EnumArray<Keyboard::Scancode, IOHIDElements, Keyboard::ScancodeCount> m_keys; ///< All the keys on any connected keyboard
+    EnumArray<Keyboard::Key, Keyboard::Scancode, Keyboard::KeyCount> m_keyToScancodeMapping{}; ///< Mapping from Key to Scancode
+    EnumArray<Keyboard::Scancode, Keyboard::Key, Keyboard::ScancodeCount> m_scancodeToKeyMapping{}; ///< Mapping from Scancode to Key
 
     ////////////////////////////////////////////////////////////
     /// m_keys' index corresponds to sf::Keyboard::Scancode enum.

--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -286,10 +286,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    IOHIDManagerRef m_manager{};                                                   ///< Underlying HID Manager
-    IOHIDElements m_keys[static_cast<std::size_t>(Keyboard::Scan::ScancodeCount)]; ///< All the keys on any connected keyboard
-    Keyboard::Scancode m_keyToScancodeMapping[Keyboard::KeyCount]{};               ///< Mapping from Key to Scancode
-    Keyboard::Key m_scancodeToKeyMapping[static_cast<std::size_t>(Keyboard::Scan::ScancodeCount)]{}; ///< Mapping from Scancode to Key
+    IOHIDManagerRef    m_manager{};                                       ///< Underlying HID Manager
+    IOHIDElements      m_keys[Keyboard::ScancodeCount];                   ///< All the keys on any connected keyboard
+    Keyboard::Scancode m_keyToScancodeMapping[Keyboard::KeyCount]{};      ///< Mapping from Key to Scancode
+    Keyboard::Key      m_scancodeToKeyMapping[Keyboard::ScancodeCount]{}; ///< Mapping from Scancode to Key
 
     ////////////////////////////////////////////////////////////
     /// m_keys' index corresponds to sf::Keyboard::Scancode enum.

--- a/src/SFML/Window/macOS/HIDInputManager.mm
+++ b/src/SFML/Window/macOS/HIDInputManager.mm
@@ -562,7 +562,7 @@ bool HIDInputManager::isKeyPressed(Keyboard::Key key)
 ////////////////////////////////////////////////////////////
 bool HIDInputManager::isKeyPressed(Keyboard::Scancode code)
 {
-    return (code != Keyboard::Scan::Unknown) && isPressed(m_keys[static_cast<std::size_t>(code)]);
+    return (code != Keyboard::Scan::Unknown) && isPressed(m_keys[code]);
 }
 
 
@@ -572,7 +572,7 @@ Keyboard::Key HIDInputManager::localize(Keyboard::Scancode code)
     if (code == Keyboard::Scan::Unknown)
         return Keyboard::Unknown;
 
-    return m_scancodeToKeyMapping[static_cast<std::size_t>(code)];
+    return m_scancodeToKeyMapping[code];
 }
 
 
@@ -795,7 +795,7 @@ void HIDInputManager::loadKey(IOHIDElementRef key)
     if (code != Keyboard::Scan::Unknown)
     {
         CFRetain(key);
-        m_keys[static_cast<std::size_t>(code)].push_back(key);
+        m_keys[code].push_back(key);
     }
 }
 
@@ -804,10 +804,8 @@ void HIDInputManager::loadKey(IOHIDElementRef key)
 void HIDInputManager::buildMappings()
 {
     // Reset the mappings
-    for (auto& scancode : m_keyToScancodeMapping)
-        scancode = Keyboard::Scan::Unknown;
-    for (auto& key : m_scancodeToKeyMapping)
-        key = Keyboard::Unknown;
+    m_keyToScancodeMapping.fill(Keyboard::Scan::Unknown);
+    m_scancodeToKeyMapping.fill(Keyboard::Key::Unknown);
 
     // Get the current keyboard layout
     TISInputSourceRef tis  = TISCopyCurrentKeyboardLayoutInputSource();
@@ -899,7 +897,7 @@ void HIDInputManager::buildMappings()
         // Register the bi-mapping
         if (m_keyToScancodeMapping[code] == Keyboard::Scan::Unknown)
             m_keyToScancodeMapping[code] = scan;
-        m_scancodeToKeyMapping[static_cast<std::size_t>(scan)] = code;
+        m_scancodeToKeyMapping[scan] = code;
     }
 
     CFRelease(tis);

--- a/src/SFML/Window/macOS/HIDInputManager.mm
+++ b/src/SFML/Window/macOS/HIDInputManager.mm
@@ -824,7 +824,7 @@ void HIDInputManager::buildMappings()
 
     // For each scancode having a IOHIDElement, we translate the corresponding
     // virtual code to a localized Key.
-    for (int i = 0; i < static_cast<int>(Keyboard::Scan::ScancodeCount); ++i)
+    for (unsigned int i = 0; i < Keyboard::ScancodeCount; ++i)
     {
         const auto         scan        = static_cast<Keyboard::Scancode>(i);
         const std::uint8_t virtualCode = scanToVirtualCode(scan);


### PR DESCRIPTION
Follow-up of #2839, using `sf::priv::EnumArray` in internal SFML code to implement arrays indexed by `sf::Keyboard::Key` or `sf::Keyboard::Scancode` enumerations.

---

Regarding public API, it was the opportunity to move `sf::Keyboard::Key::KeyCount` and `sf::Keyboard::Scan::ScancodeCount` out of their enumerations.
So they become respectively:
- `sf::Keyboard::KeyCount`
- `sf::Keyboard::ScancodeCount`

This is consistent with other enumerations:
- `sf::Joystick::Axis` -> `sf::Joystick::AxisCount`
- `sf::Mouse::Button` -> `sf::Mouse::ButtonCount`

See commit message for more arguments in favor of this change.