### PR TITLE
Print out new video mode when current mode is rejected

### DIFF
--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -94,6 +94,8 @@ void Window::create(VideoMode mode, const String& title, std::uint32_t style, co
                 err() << "The requested video mode is not available, switching to a valid mode" << std::endl;
                 assert(!VideoMode::getFullscreenModes().empty() && "No video modes available");
                 mode = VideoMode::getFullscreenModes()[0];
+                err() << "  VideoMode: { size: { " << mode.size.x << ", " << mode.size.y
+                      << " }, bitsPerPixel: " << mode.bitsPerPixel << " }" << std::endl;
             }
 
             // Update the fullscreen window

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -96,7 +96,10 @@ void WindowBase::create(VideoMode mode, const String& title, std::uint32_t style
             if (!mode.isValid())
             {
                 err() << "The requested video mode is not available, switching to a valid mode" << std::endl;
+                assert(!VideoMode::getFullscreenModes().empty() && "No video modes available");
                 mode = VideoMode::getFullscreenModes()[0];
+                err() << "  VideoMode: { size: { " << mode.size.x << ", " << mode.size.y
+                      << " }, bitsPerPixel: " << mode.bitsPerPixel << " }" << std::endl;
             }
 
             // Update the fullscreen window


### PR DESCRIPTION
## Description

While testing some potential fixes for #2300 I was getting an error in the console about the current video mode being rejected. I thought it would be helpful to print out the new video mode so you know what SFML automatically picked on your behalf.

While I was at it I added an assert that was present in Window but not WindowBase. `Window::create` and `WindowBase::create` share so much code that we ought to find a way to extract all the commonalities into one function.

Here's what the output looks like:
```
$ ./../../build/bin/tennis-d 
The requested video mode is not available, switching to a valid mode
  VideoMode: { size: { 3456, 2234 }, bitsPerPixel: 32 }
```