### PR TITLE
Remove unhelpful return values

### DIFF
--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -475,7 +475,7 @@ private:
     /// \param event Event to filter
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool filterEvent(const Event& event);
+    void filterEvent(const Event& event);
 
     ////////////////////////////////////////////////////////////
     /// \brief Perform some common internal initializations

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -93,11 +93,7 @@ bool SoundFileWriterWav::open(const std::filesystem::path& filename, unsigned in
     }
 
     // Write the header
-    if (!writeHeader(sampleRate, channelCount))
-    {
-        err() << "Failed to write header of WAV sound file\n" << formatDebugPathInfo(filename) << std::endl;
-        return false;
-    }
+    writeHeader(sampleRate, channelCount);
 
     return true;
 }
@@ -114,7 +110,7 @@ void SoundFileWriterWav::write(const std::int16_t* samples, std::uint64_t count)
 
 
 ////////////////////////////////////////////////////////////
-bool SoundFileWriterWav::writeHeader(unsigned int sampleRate, unsigned int channelCount)
+void SoundFileWriterWav::writeHeader(unsigned int sampleRate, unsigned int channelCount)
 {
     assert(m_file.good() && "Most recent I/O operation failed");
 
@@ -152,8 +148,6 @@ bool SoundFileWriterWav::writeHeader(unsigned int sampleRate, unsigned int chann
     m_file.write(dataChunkId, sizeof(dataChunkId));
     const std::uint32_t dataChunkSize = 0; // placeholder, will be written later
     encode(m_file, dataChunkSize);
-
-    return true;
 }
 
 

--- a/src/SFML/Audio/SoundFileWriterWav.hpp
+++ b/src/SFML/Audio/SoundFileWriterWav.hpp
@@ -86,10 +86,8 @@ private:
     /// \param sampleRate   Sample rate of the sound
     /// \param channelCount Number of channels of the sound
     ///
-    /// \return True on success, false on error
-    ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool writeHeader(unsigned int sampleRate, unsigned int channelCount);
+    void writeHeader(unsigned int sampleRate, unsigned int channelCount);
 
     ////////////////////////////////////////////////////////////
     /// \brief Close the file

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -161,7 +161,8 @@ bool WindowBase::pollEvent(Event& event)
 {
     if (m_impl && m_impl->popEvent(event, false))
     {
-        return filterEvent(event);
+        filterEvent(event);
+        return true;
     }
     else
     {
@@ -175,7 +176,8 @@ bool WindowBase::waitEvent(Event& event)
 {
     if (m_impl && m_impl->popEvent(event, true))
     {
-        return filterEvent(event);
+        filterEvent(event);
+        return true;
     }
     else
     {
@@ -380,7 +382,7 @@ void WindowBase::onResize()
 
 
 ////////////////////////////////////////////////////////////
-bool WindowBase::filterEvent(const Event& event)
+void WindowBase::filterEvent(const Event& event)
 {
     // Notify resize events to the derived class
     if (event.type == Event::Resized)
@@ -391,8 +393,6 @@ bool WindowBase::filterEvent(const Event& event)
         // Notify the derived class
         onResize();
     }
-
-    return true;
 }
 
 


### PR DESCRIPTION
## Description

These two private functions always return `true`. It's simpler to have no return value than to return the same thing every time.