### PR TITLE
Remove reference to SFML 2

### DIFF
--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -334,7 +334,7 @@ Http::Response Http::sendRequest(const Http::Request& request, Time timeout)
     }
     if (!toSend.hasField("User-Agent"))
     {
-        toSend.setField("User-Agent", "libsfml-network/2.x");
+        toSend.setField("User-Agent", "libsfml-network/3.x");
     }
     if (!toSend.hasField("Host"))
     {


### PR DESCRIPTION
## Description

I somehow keep finding references to v2 in the codebase