### PR TITLE
Simplify `sf::Packet::clear()`

### DIFF
--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -59,9 +59,7 @@ std::size_t Packet::getReadPosition() const
 ////////////////////////////////////////////////////////////
 void Packet::clear()
 {
-    m_data.clear();
-    m_readPos = 0;
-    m_isValid = true;
+    *this = {};
 }
 
 


### PR DESCRIPTION
## Description

Just like `sf::View::reset` perhaps this function should just be removed. If someone wants to clear a packet they can use the assignment operator plus the default constructor to do the same thing. We should not provide APIs that the language already naturally provides. Regardless we can at least simplify our existing implementation.

```cpp
sf::Packet packet;
... // Do stuff with the packet
packet = {}; // This clears it
```