### PR TITLE
Remove redundant link libraries

### DIFF
--- a/examples/cocoa/CMakeLists.txt
+++ b/examples/cocoa/CMakeLists.txt
@@ -53,8 +53,8 @@ set_source_files_properties(${RESOURCES} PROPERTIES
 sfml_add_example(cocoa
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
-                 DEPENDS SFML::System SFML::Window SFML::Graphics)
+                 DEPENDS SFML::Graphics)
 set_target_properties(cocoa PROPERTIES
                       MACOSX_BUNDLE TRUE
                       MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/resources/Cocoa-Info.plist)
-target_link_libraries(cocoa PRIVATE "-framework Cocoa" "-framework Foundation" SFML::Graphics)
+target_link_libraries(cocoa PRIVATE "-framework Cocoa" "-framework Foundation")


### PR DESCRIPTION
## Description

This is the warning I got when building this locally
```
ld: warning: ignoring duplicate libraries: 'lib/libsfml-graphics-s-d.a', 'lib/libsfml-system-s-d.a', 'lib/libsfml-window-s-d.a'
```

This is something Clang (or I suppose lld?) started warning on sometime recently. Because I hadn't built this example locally (since I don't use Xcode) I hadn't yet seen it.