### PR TITLE
Fix Cocoa example clang-tidy errors

### DIFF
--- a/examples/cocoa/CocoaAppDelegate.h
+++ b/examples/cocoa/CocoaAppDelegate.h
@@ -37,6 +37,7 @@
 
 struct SFMLmainWindow;
 
+// NOLINTBEGIN(readability-identifier-naming)
 @interface CocoaAppDelegate : NSObject<NSApplicationDelegate>
 {
 @private
@@ -48,6 +49,7 @@ struct SFMLmainWindow;
     BOOL            m_visible;
     BOOL            m_initialized;
 }
+// NOLINTEND(readability-identifier-naming)
 
 @property (retain) IBOutlet NSWindow* window;
 

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -41,7 +41,7 @@ struct SFMLmainWindow
 {
     SFMLmainWindow(sf::WindowHandle win) : renderWindow(win)
     {
-        std::filesystem::path resPath = [[[NSBundle mainBundle] resourcePath] tostdstring];
+        const std::filesystem::path resPath = [[[NSBundle mainBundle] resourcePath] tostdstring];
         if (!logo.loadFromFile(resPath / "logo.png"))
             NSLog(@"Couldn't load the logo image");
 
@@ -144,7 +144,7 @@ struct SFMLmainWindow
     self.textField = nil;
 
     delete static_cast<SFMLmainWindow*>(self.mainWindow);
-    self.mainWindow  = 0;
+    self.mainWindow  = nil;
     self.renderTimer = nil;
 
     [super dealloc];

--- a/examples/cocoa/NSString+stdstring.mm
+++ b/examples/cocoa/NSString+stdstring.mm
@@ -43,7 +43,7 @@
 + (id)stringWithstdwstring:(const std::wstring&)string
 {
     const void* data = static_cast<const void*>(string.data());
-    unsigned    size = static_cast<unsigned>(string.size() * sizeof(wchar_t));
+    auto        size = static_cast<unsigned>(string.size() * sizeof(wchar_t));
 
     NSString* str = [[[NSString alloc] initWithBytes:data length:size
                                             encoding:NSUTF32LittleEndianStringEncoding] autorelease];


### PR DESCRIPTION
## Description

This example is only built when using Xcode and because our macOS clang-tidy job does not use Xcode this file was not getting analyzed. I analyzed it locally to fix a few minor errors.

I think we can remove that Xcode-only limitation from this example. I tried building it with Ninja locally and it worked fine. If we do that then our macOS clang-tidy job will start analyzing it.