### PR TITLE
Use `struct` for type with exclusively public contents

### DIFF
--- a/include/SFML/System/SuspendAwareClock.hpp
+++ b/include/SFML/System/SuspendAwareClock.hpp
@@ -51,9 +51,8 @@ namespace sf
 /// Make sure this implementation is required for your use case.
 ///
 ////////////////////////////////////////////////////////////
-class SFML_SYSTEM_API SuspendAwareClock
+struct SFML_SYSTEM_API SuspendAwareClock
 {
-public:
     ////////////////////////////////////////////////////////////
     /// \brief Type traits and static members
     ///


### PR DESCRIPTION
## Description

Continuation of existing precedent. See https://github.com/SFML/SFML/pull/2590 and https://github.com/SFML/SFML/pull/2665/commits/73a5a7382df0a82fb74bc8ffcca60eac8d3416a5 for prior examples.