### PR TITLE
Delete unnecessary destructor

### DIFF
--- a/examples/shader/Effect.hpp
+++ b/examples/shader/Effect.hpp
@@ -17,8 +17,6 @@
 class Effect : public sf::Drawable
 {
 public:
-    ~Effect() override = default;
-
     static void setFont(const sf::Font& font)
     {
         s_font = &font;


### PR DESCRIPTION
## Description

Any type that inherits from a type with a virtual destructor itself has a virtual destructor by default. There's no need to include `~T() override = default` inside a class's declaration.