### PR TITLE
Fix file extension typo in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,6 @@ extlibs/**/* -text -eol linguist-vendored
 *.wav -text -eol
 *.ogg -text -eol
 *.flac -text -eol
-*.tff -text -eol
+*.ttf -text -eol
 *.icns -text -eol
 *.rtf -text -eol


### PR DESCRIPTION
## Description

".tff" which never appears in the repo is surely a typo for ".ttf" which is used multiple times in the repo.