### PR TITLE
Fix shader loading check for empty streams

### DIFF
--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -100,7 +100,7 @@ bool getFileContents(const std::filesystem::path& filename, std::vector<char>& b
 // Read the contents of a stream into an array of char
 bool getStreamContents(sf::InputStream& stream, std::vector<char>& buffer)
 {
-    bool               success = true;
+    bool               success = false;
     const std::int64_t size    = stream.getSize();
     if (size > 0)
     {


### PR DESCRIPTION
## Description

While running the test suite locally, I noticed that the shader tests were failing on my Windows 11 PC with a Nvidia graphics card for MinGW as well as MSVC.

Turns out the stream check didn't return `false` if an empty stream was provided.

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run the Shader.test.cpp tests