### PR TITLE
Remove unnecessary default destructor

### DIFF
--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -97,14 +97,6 @@ public:
     explicit RenderWindow(WindowHandle handle, const ContextSettings& settings = ContextSettings());
 
     ////////////////////////////////////////////////////////////
-    /// \brief Destructor
-    ///
-    /// Closes the window and frees all the resources attached to it.
-    ///
-    ////////////////////////////////////////////////////////////
-    ~RenderWindow() override;
-
-    ////////////////////////////////////////////////////////////
     /// \brief Get the size of the rendering region of the window
     ///
     /// The size doesn't include the titlebar and borders

--- a/src/SFML/Graphics/RenderWindow.cpp
+++ b/src/SFML/Graphics/RenderWindow.cpp
@@ -53,10 +53,6 @@ RenderWindow::RenderWindow(WindowHandle handle, const ContextSettings& settings)
 
 
 ////////////////////////////////////////////////////////////
-RenderWindow::~RenderWindow() = default;
-
-
-////////////////////////////////////////////////////////////
 Vector2u RenderWindow::getSize() const
 {
     return Window::getSize();

--- a/test/Graphics/RenderWindow.test.cpp
+++ b/test/Graphics/RenderWindow.test.cpp
@@ -17,6 +17,7 @@ TEST_CASE("[Graphics] sf::RenderWindow", runDisplayTests())
 {
     SECTION("Type traits")
     {
+        STATIC_CHECK(std::has_virtual_destructor_v<sf::RenderWindow>);
         STATIC_CHECK(!std::is_copy_constructible_v<sf::RenderWindow>);
         STATIC_CHECK(!std::is_copy_assignable_v<sf::RenderWindow>);
         STATIC_CHECK(!std::is_nothrow_move_constructible_v<sf::RenderWindow>);


### PR DESCRIPTION
## Description

`sf::RenderWindow` still inherits a virtual destructor from a base class so there's no need to explicitly declare a virtual destructor. I added a test to ensure this property was not broken. Always a pleasure to delete some code.