### PR TITLE
Remove unnecessary `return` statements

### DIFF
--- a/src/SFML/Window/Clipboard.cpp
+++ b/src/SFML/Window/Clipboard.cpp
@@ -43,7 +43,7 @@ String Clipboard::getString()
 ////////////////////////////////////////////////////////////
 void Clipboard::setString(const String& text)
 {
-    return priv::ClipboardImpl::setString(text);
+    priv::ClipboardImpl::setString(text);
 }
 
 } // namespace sf

--- a/src/SFML/Window/Joystick.cpp
+++ b/src/SFML/Window/Joystick.cpp
@@ -79,7 +79,7 @@ Joystick::Identification Joystick::getIdentification(unsigned int joystick)
 ////////////////////////////////////////////////////////////
 void Joystick::update()
 {
-    return priv::JoystickManager::getInstance().update();
+    priv::JoystickManager::getInstance().update();
 }
 
 } // namespace sf

--- a/src/SFML/Window/Sensor.cpp
+++ b/src/SFML/Window/Sensor.cpp
@@ -41,7 +41,7 @@ bool Sensor::isAvailable(Type sensor)
 ////////////////////////////////////////////////////////////
 void Sensor::setEnabled(Type sensor, bool enabled)
 {
-    return priv::SensorManager::getInstance().setEnabled(sensor, enabled);
+    priv::SensorManager::getInstance().setEnabled(sensor, enabled);
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/macOS/SFViewController.mm
+++ b/src/SFML/Window/macOS/SFViewController.mm
@@ -134,7 +134,7 @@
 ////////////////////////////////////////////////////////
 - (void)setCursor:(NSCursor*)cursor
 {
-    return [m_oglView setCursor:cursor];
+    [m_oglView setCursor:cursor];
 }
 
 

--- a/src/SFML/Window/macOS/SFWindowController.mm
+++ b/src/SFML/Window/macOS/SFWindowController.mm
@@ -375,7 +375,7 @@
 ////////////////////////////////////////////////////////
 - (void)setCursor:(NSCursor*)cursor
 {
-    return [m_oglView setCursor:cursor];
+    [m_oglView setCursor:cursor];
 }
 
 


### PR DESCRIPTION
## Description
A new check in clang-tidy-18 catches this. I built it from source and ran it locally to find this.
