### PR TITLE
Add missing `std::` namespace

### DIFF
--- a/src/SFML/System/Err.cpp
+++ b/src/SFML/System/Err.cpp
@@ -85,7 +85,7 @@ private:
         {
             // Print the contents of the write buffer into the standard error output
             const auto size = static_cast<std::size_t>(pptr() - pbase());
-            fwrite(pbase(), 1, size, stderr);
+            std::fwrite(pbase(), 1, size, stderr);
 
             // Reset the pointer position to the beginning of the write buffer
             setp(pbase(), epptr());


### PR DESCRIPTION
## Description

I wish there was a systematic way to find uses of C standard library functions that have C++ standard library equivalents. The only way I find this is by staring at enough code for a long time.

Eventually once we can use `import std;` then any remaining uses of C standard library functions will be detected since `import std;` does not include the C standard library.