### PR TITLE
Enable clang-tidy Objective-C checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@ Checks: >
   cppcoreguidelines-*,
   misc-*,
   modernize-*,
+  objc-*,
   performance-*,
   portability-*,
   readability-*,


### PR DESCRIPTION
## Description

I just discovered that there are clang-tidy Objective-C checks so it seemed wise to enable them.