### PR TITLE
Fix typo in `sf::Vector3<T>` type trait tests

### DIFF
--- a/test/System/Vector3.test.cpp
+++ b/test/System/Vector3.test.cpp
@@ -9,7 +9,7 @@ TEMPLATE_TEST_CASE("[System] sf::Vector3", "", int, float)
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Vector3i>);
+        STATIC_CHECK(std::is_copy_constructible_v<sf::Vector3<TestType>>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Vector3<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector3<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector3<TestType>>);


### PR DESCRIPTION
## Description

Minor oversight from https://github.com/SFML/SFML/pull/2784