### PR TITLE
Clarify instructions for how to use `SFML_ROOT`

### DIFF
--- a/cmake/SFMLConfig.cmake.in
+++ b/cmake/SFMLConfig.cmake.in
@@ -41,9 +41,8 @@
 # Additionally, keep in mind that SFML frameworks are only available as release libraries unlike dylibs which
 # are available for both release and debug modes.
 #
-# If SFML is not installed in a standard path, you can use the SFML_ROOT CMake variable
-# to tell CMake where SFML's config file is located (PREFIX/lib/cmake/SFML for a library-based installation,
-# and PREFIX/SFML.framework/Resources/CMake on macOS for a framework-based installation).
+# If SFML is not installed in a standard path, you can use the SFML_ROOT CMake variable to tell CMake in what directory
+# SFML was installed.
 #
 # Output
 # ------


### PR DESCRIPTION
## Description

Apologies for accidentally pushing https://github.com/SFML/SFML/commit/30a986e63261eea3ae90e5d16b5b894f2f712403 straight to `master`. Luckily that commit is mostly good but it needs some refinement.

`SFML_ROOT` can simply point to the directory in which SFML was installed. This is verified by our install interface tests which do exactly that, even when SFML is built as a framework. CMake can figure out where to find the config module if you give it this much information.
