### PR TITLE
Update location of sdkmanager in Android CI jobs in 2.6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install Android Components
       if: matrix.platform.name == 'Android'
       run: |
-        echo "y" | /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "cmake;3.10.2.4988404" --sdk_root=ANDROID_SDK_ROOT
+        echo "y" | ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.10.2.4988404" --sdk_root=ANDROID_SDK_ROOT
         sudo ln -sf /usr/local/lib/android/sdk/cmake/3.10.2.4988404/bin/cmake /usr/bin/cmake
         wget -nv https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip -P $GITHUB_WORKSPACE
         unzip -qq -d $GITHUB_WORKSPACE android-ndk-r18b-linux-x86_64.zip


### PR DESCRIPTION
The location of the sdkmanager tool was changed in the Github Actions runners, which caused the CI to fail. This PR updates the path to the sdkmanager program.

This is a backport to the 2.6.x branch, this was already fixed on the master branch in https://github.com/SFML/SFML/pull/2879

CI is currently failing on the MacOS XCode iOS job, but that is an unrelated issue (which will be fixed once https://github.com/SFML/SFML/pull/2888 is merged). As long as the 4 Android jobs are passing then this PR works.