### PR TITLE
CMake 3.28 no longer supports exec_program

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -59,7 +59,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
         set(OPENGL_ES 0)
 
         # detect OS X version. (use '/usr/bin/sw_vers -productVersion' to extract V from '10.V.x'.)
-        EXEC_PROGRAM(/usr/bin/sw_vers ARGS -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
+        execute_process(COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
         STRING(REGEX REPLACE "10\\.([0-9]+).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
 
         if(${MACOSX_VERSION} LESS 7)

--- a/cmake/toolchains/iOS.toolchain.cmake
+++ b/cmake/toolchains/iOS.toolchain.cmake
@@ -54,7 +54,7 @@ set (CMAKE_OSX_DEPLOYMENT_TARGET "" CACHE STRING "Force unset of the deployment 
 # Determine the cmake host system version so we know where to find the iOS SDKs
 find_program (CMAKE_UNAME uname /bin /usr/bin /usr/local/bin)
 if (CMAKE_UNAME)
-	exec_program(uname ARGS -r OUTPUT_VARIABLE CMAKE_HOST_SYSTEM_VERSION)
+	execute_process(COMMAND uname -r OUTPUT_VARIABLE CMAKE_HOST_SYSTEM_VERSION)
 	string (REGEX REPLACE "^([0-9]+)\\.([0-9]+).*$" "\\1" DARWIN_MAJOR_VERSION "${CMAKE_HOST_SYSTEM_VERSION}")
 endif (CMAKE_UNAME)
 
@@ -123,7 +123,7 @@ else ()
 endif ()
 
 # Setup iOS developer location unless specified manually with IOS_DEVELOPER_ROOT
-exec_program(/usr/bin/xcode-select ARGS -print-path OUTPUT_VARIABLE XCODE_DEVELOPER_DIR)
+execute_process(COMMAND /usr/bin/xcode-select -print-path OUTPUT_VARIABLE XCODE_DEVELOPER_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
 set (IOS_DEVELOPER_ROOT "${XCODE_DEVELOPER_DIR}/Platforms/${IOS_PLATFORM_LOCATION}/Developer" CACHE PATH "Location of iOS Platform")
 
 # Find and use the most recent iOS sdk unless specified manually with IOS_SDK_ROOT


### PR DESCRIPTION
The iOS toolchain is broken on the SFML 2.6.x branch when using CMake 3.28 (which is now used by Github Actions). The "MacOS XCode iOS" CI job is also failing due to this.

CMake 3.28 disabled the long deprecated `exec_program` command with [policy CMP0153](https://cmake.org/cmake/help/v3.28/policy/CMP0153.html). This PR replaces it with the newer `execute_process` function.

This issue does not affect the master branch, as the toolchain file no longer exists there (and the changed code in Config.cmake is also different).

CI is failing on the Android jobs in this PR, but that will be resolved once https://github.com/SFML/SFML/pull/2887 is merged. As long as the "MacOS XCode iOS" job is passing then this PR works.