### PR TITLE
Use `struct` for data type with exclusively public contents

### DIFF
--- a/include/SFML/Graphics/Drawable.hpp
+++ b/include/SFML/Graphics/Drawable.hpp
@@ -33,7 +33,7 @@
 namespace sf
 {
 class RenderTarget;
-class RenderStates;
+struct RenderStates;
 
 ////////////////////////////////////////////////////////////
 /// \brief Abstract base class for objects that can be drawn

--- a/include/SFML/Graphics/RenderStates.hpp
+++ b/include/SFML/Graphics/RenderStates.hpp
@@ -42,9 +42,8 @@ class Texture;
 /// \brief Define the states used for drawing to a RenderTarget
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API RenderStates
+struct SFML_GRAPHICS_API RenderStates
 {
-public:
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///


### PR DESCRIPTION
## Description

See https://github.com/SFML/SFML/pull/2858, https://github.com/SFML/SFML/pull/2590, and https://github.com/SFML/SFML/commit/73a5a7382df0a82fb74bc8ffcca60eac8d3416a5.
