### PR TITLE
Use scoped enumerations in Graphics module

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -99,7 +99,7 @@ int main()
     sf::Text               statusText(font);
     sf::Shader             terrainShader;
     const sf::RenderStates terrainStates(&terrainShader);
-    sf::VertexBuffer       terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Static);
+    sf::VertexBuffer       terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Usage::Static);
 
     // Set up our text drawables
     statusText.setCharacterSize(28);

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -33,7 +33,7 @@ public:
         m_sprite.emplace(m_texture);
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/pixelate.frag", sf::Shader::Fragment))
+        if (!m_shader.loadFromFile("resources/pixelate.frag", sf::Shader::Type::Fragment))
             return false;
         m_shader.setUniform("texture", sf::Shader::CurrentTexture);
 
@@ -209,7 +209,7 @@ public:
         }
 
         // Load the shader
-        if (!m_shader.loadFromFile("resources/edge.frag", sf::Shader::Fragment))
+        if (!m_shader.loadFromFile("resources/edge.frag", sf::Shader::Type::Fragment))
             return false;
         m_shader.setUniform("texture", sf::Shader::CurrentTexture);
 

--- a/include/SFML/Graphics/BlendMode.hpp
+++ b/include/SFML/Graphics/BlendMode.hpp
@@ -45,7 +45,7 @@ struct SFML_GRAPHICS_API BlendMode
     /// The factors are mapped directly to their OpenGL equivalents,
     /// specified by glBlendFunc() or glBlendFuncSeparate().
     ////////////////////////////////////////////////////////
-    enum Factor
+    enum class Factor
     {
         Zero,             //!< (0, 0, 0, 0)
         One,              //!< (1, 1, 1, 1)
@@ -65,7 +65,7 @@ struct SFML_GRAPHICS_API BlendMode
     /// The equations are mapped directly to their OpenGL equivalents,
     /// specified by glBlendEquation() or glBlendEquationSeparate().
     ////////////////////////////////////////////////////////
-    enum Equation
+    enum class Equation
     {
         Add,             //!< Pixel = Src * SrcFactor + Dst * DstFactor
         Subtract,        //!< Pixel = Src * SrcFactor - Dst * DstFactor
@@ -93,7 +93,7 @@ struct SFML_GRAPHICS_API BlendMode
     /// \param blendEquation     Specifies how to combine the source and destination colors and alpha.
     ///
     ////////////////////////////////////////////////////////////
-    BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation = Add);
+    BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation = Equation::Add);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the blend mode given the factors and equation.
@@ -116,12 +116,12 @@ struct SFML_GRAPHICS_API BlendMode
     ////////////////////////////////////////////////////////////
     // Member Data
     ////////////////////////////////////////////////////////////
-    Factor   colorSrcFactor{BlendMode::SrcAlpha};         //!< Source blending factor for the color channels
-    Factor   colorDstFactor{BlendMode::OneMinusSrcAlpha}; //!< Destination blending factor for the color channels
-    Equation colorEquation{BlendMode::Add};               //!< Blending equation for the color channels
-    Factor   alphaSrcFactor{BlendMode::One};              //!< Source blending factor for the alpha channel
-    Factor   alphaDstFactor{BlendMode::OneMinusSrcAlpha}; //!< Destination blending factor for the alpha channel
-    Equation alphaEquation{BlendMode::Add};               //!< Blending equation for the alpha channel
+    Factor colorSrcFactor{BlendMode::Factor::SrcAlpha};         //!< Source blending factor for the color channels
+    Factor colorDstFactor{BlendMode::Factor::OneMinusSrcAlpha}; //!< Destination blending factor for the color channels
+    Equation colorEquation{BlendMode::Equation::Add};           //!< Blending equation for the color channels
+    Factor   alphaSrcFactor{BlendMode::Factor::One};            //!< Source blending factor for the alpha channel
+    Factor   alphaDstFactor{BlendMode::Factor::OneMinusSrcAlpha}; //!< Destination blending factor for the alpha channel
+    Equation alphaEquation{BlendMode::Equation::Add};             //!< Blending equation for the alpha channel
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -59,7 +59,7 @@ public:
     /// \brief Types of shaders
     ///
     ////////////////////////////////////////////////////////////
-    enum Type
+    enum class Type
     {
         Vertex,   //!< %Vertex shader
         Geometry, //!< Geometry shader

--- a/include/SFML/Graphics/Vertex.hpp
+++ b/include/SFML/Graphics/Vertex.hpp
@@ -135,7 +135,7 @@ public:
 /// };
 ///
 /// // draw it
-/// window.draw(vertices, 6, sf::Triangles);
+/// window.draw(vertices, 6, sf::PrimitiveType::Triangles);
 /// \endcode
 ///
 /// Note: although texture coordinates are supposed to be an integer

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -144,7 +144,7 @@ public:
     /// \li As points
     /// \li As lines
     /// \li As triangles
-    /// The default primitive type is sf::Points.
+    /// The default primitive type is sf::PrimitiveType::Points.
     ///
     /// \param type Type of primitive
     ///
@@ -202,7 +202,7 @@ private:
 ///
 /// Example:
 /// \code
-/// sf::VertexArray lines(sf::LineStrip, 4);
+/// sf::VertexArray lines(sf::PrimitiveType::LineStrip, 4);
 /// lines[0].position = sf::Vector2f(10, 0);
 /// lines[1].position = sf::Vector2f(20, 0);
 /// lines[2].position = sf::Vector2f(30, 5);

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -245,7 +245,7 @@ public:
     /// This function defines how the vertices must be interpreted
     /// when it's time to draw them.
     ///
-    /// The default primitive type is sf::Points.
+    /// The default primitive type is sf::PrimitiveType::Points.
     ///
     /// \param type Type of primitive
     ///
@@ -401,7 +401,7 @@ SFML_GRAPHICS_API void swap(VertexBuffer& left, VertexBuffer& right) noexcept;
 /// \code
 /// sf::Vertex vertices[15];
 /// ...
-/// sf::VertexBuffer triangles(sf::Triangles);
+/// sf::VertexBuffer triangles(sf::PrimitiveType::Triangles);
 /// triangles.create(15);
 /// triangles.update(vertices);
 /// ...

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -59,7 +59,7 @@ public:
     /// good compromise.
     ///
     ////////////////////////////////////////////////////////////
-    enum Usage
+    enum class Usage
     {
         Stream,  //!< Constantly changing data
         Dynamic, //!< Occasionally changing data
@@ -270,7 +270,7 @@ public:
     /// to be updated with new data for the usage specifier to
     /// take effect.
     ///
-    /// The default primitive type is sf::VertexBuffer::Stream.
+    /// The default usage type is sf::VertexBuffer::Usage::Stream.
     ///
     /// \param usage Usage specifier
     ///
@@ -336,7 +336,7 @@ private:
     unsigned int  m_buffer{};                             //!< Internal buffer identifier
     std::size_t   m_size{};                               //!< Size in Vertices of the currently allocated buffer
     PrimitiveType m_primitiveType{PrimitiveType::Points}; //!< Type of primitives to draw
-    Usage         m_usage{Stream};                        //!< How this vertex buffer is to be used
+    Usage         m_usage{Usage::Stream};                 //!< How this vertex buffer is to be used
 };
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/BlendMode.cpp
+++ b/src/SFML/Graphics/BlendMode.cpp
@@ -33,17 +33,22 @@ namespace sf
 ////////////////////////////////////////////////////////////
 // Commonly used blending modes
 ////////////////////////////////////////////////////////////
-const BlendMode BlendAlpha(BlendMode::SrcAlpha,
-                           BlendMode::OneMinusSrcAlpha,
-                           BlendMode::Add,
-                           BlendMode::One,
-                           BlendMode::OneMinusSrcAlpha,
-                           BlendMode::Add);
-const BlendMode BlendAdd(BlendMode::SrcAlpha, BlendMode::One, BlendMode::Add, BlendMode::One, BlendMode::One, BlendMode::Add);
-const BlendMode BlendMultiply(BlendMode::DstColor, BlendMode::Zero, BlendMode::Add);
-const BlendMode BlendMin(BlendMode::One, BlendMode::One, BlendMode::Min);
-const BlendMode BlendMax(BlendMode::One, BlendMode::One, BlendMode::Max);
-const BlendMode BlendNone(BlendMode::One, BlendMode::Zero, BlendMode::Add);
+const BlendMode BlendAlpha(BlendMode::Factor::SrcAlpha,
+                           BlendMode::Factor::OneMinusSrcAlpha,
+                           BlendMode::Equation::Add,
+                           BlendMode::Factor::One,
+                           BlendMode::Factor::OneMinusSrcAlpha,
+                           BlendMode::Equation::Add);
+const BlendMode BlendAdd(BlendMode::Factor::SrcAlpha,
+                         BlendMode::Factor::One,
+                         BlendMode::Equation::Add,
+                         BlendMode::Factor::One,
+                         BlendMode::Factor::One,
+                         BlendMode::Equation::Add);
+const BlendMode BlendMultiply(BlendMode::Factor::DstColor, BlendMode::Factor::Zero, BlendMode::Equation::Add);
+const BlendMode BlendMin(BlendMode::Factor::One, BlendMode::Factor::One, BlendMode::Equation::Min);
+const BlendMode BlendMax(BlendMode::Factor::One, BlendMode::Factor::One, BlendMode::Equation::Max);
+const BlendMode BlendNone(BlendMode::Factor::One, BlendMode::Factor::Zero, BlendMode::Equation::Add);
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/RenderStates.cpp
+++ b/src/SFML/Graphics/RenderStates.cpp
@@ -36,12 +36,12 @@ namespace sf
 // We cannot use the default constructor here, because it accesses BlendAlpha, which is also global (and dynamically
 // initialized). Initialization order of global objects in different translation units is not defined.
 const RenderStates RenderStates::Default(BlendMode(
-    BlendMode::SrcAlpha,
-    BlendMode::OneMinusSrcAlpha,
-    BlendMode::Add,
-    BlendMode::One,
-    BlendMode::OneMinusSrcAlpha,
-    BlendMode::Add));
+    BlendMode::Factor::SrcAlpha,
+    BlendMode::Factor::OneMinusSrcAlpha,
+    BlendMode::Equation::Add,
+    BlendMode::Factor::One,
+    BlendMode::Factor::OneMinusSrcAlpha,
+    BlendMode::Equation::Add));
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -91,45 +91,45 @@ std::uint32_t factorToGlConstant(sf::BlendMode::Factor blendFactor)
     // clang-format off
     switch (blendFactor)
     {
-        case sf::BlendMode::Zero:             return GL_ZERO;
-        case sf::BlendMode::One:              return GL_ONE;
-        case sf::BlendMode::SrcColor:         return GL_SRC_COLOR;
-        case sf::BlendMode::OneMinusSrcColor: return GL_ONE_MINUS_SRC_COLOR;
-        case sf::BlendMode::DstColor:         return GL_DST_COLOR;
-        case sf::BlendMode::OneMinusDstColor: return GL_ONE_MINUS_DST_COLOR;
-        case sf::BlendMode::SrcAlpha:         return GL_SRC_ALPHA;
-        case sf::BlendMode::OneMinusSrcAlpha: return GL_ONE_MINUS_SRC_ALPHA;
-        case sf::BlendMode::DstAlpha:         return GL_DST_ALPHA;
-        case sf::BlendMode::OneMinusDstAlpha: return GL_ONE_MINUS_DST_ALPHA;
+        case sf::BlendMode::Factor::Zero:             return GL_ZERO;
+        case sf::BlendMode::Factor::One:              return GL_ONE;
+        case sf::BlendMode::Factor::SrcColor:         return GL_SRC_COLOR;
+        case sf::BlendMode::Factor::OneMinusSrcColor: return GL_ONE_MINUS_SRC_COLOR;
+        case sf::BlendMode::Factor::DstColor:         return GL_DST_COLOR;
+        case sf::BlendMode::Factor::OneMinusDstColor: return GL_ONE_MINUS_DST_COLOR;
+        case sf::BlendMode::Factor::SrcAlpha:         return GL_SRC_ALPHA;
+        case sf::BlendMode::Factor::OneMinusSrcAlpha: return GL_ONE_MINUS_SRC_ALPHA;
+        case sf::BlendMode::Factor::DstAlpha:         return GL_DST_ALPHA;
+        case sf::BlendMode::Factor::OneMinusDstAlpha: return GL_ONE_MINUS_DST_ALPHA;
     }
     // clang-format on
 
-    sf::err() << "Invalid value for sf::BlendMode::Factor! Fallback to sf::BlendMode::Zero." << std::endl;
+    sf::err() << "Invalid value for sf::BlendMode::Factor! Fallback to sf::BlendMode::Factor::Zero." << std::endl;
     assert(false);
     return GL_ZERO;
 }
 
 
-// Convert an sf::BlendMode::BlendEquation constant to the corresponding OpenGL constant.
+// Convert an sf::BlendMode::Equation constant to the corresponding OpenGL constant.
 std::uint32_t equationToGlConstant(sf::BlendMode::Equation blendEquation)
 {
     switch (blendEquation)
     {
-        case sf::BlendMode::Add:
+        case sf::BlendMode::Equation::Add:
             return GLEXT_GL_FUNC_ADD;
-        case sf::BlendMode::Subtract:
+        case sf::BlendMode::Equation::Subtract:
             if (GLEXT_blend_subtract)
                 return GLEXT_GL_FUNC_SUBTRACT;
             break;
-        case sf::BlendMode::ReverseSubtract:
+        case sf::BlendMode::Equation::ReverseSubtract:
             if (GLEXT_blend_subtract)
                 return GLEXT_GL_FUNC_REVERSE_SUBTRACT;
             break;
-        case sf::BlendMode::Min:
+        case sf::BlendMode::Equation::Min:
             if (GLEXT_blend_minmax)
                 return GLEXT_GL_MIN;
             break;
-        case sf::BlendMode::Max:
+        case sf::BlendMode::Equation::Max:
             if (GLEXT_blend_minmax)
                 return GLEXT_GL_MAX;
             break;
@@ -139,7 +139,7 @@ std::uint32_t equationToGlConstant(sf::BlendMode::Equation blendEquation)
     if (!warned)
     {
         sf::err() << "OpenGL extension EXT_blend_minmax or EXT_blend_subtract unavailable" << '\n'
-                  << "Some blending equations will fallback to sf::BlendMode::Add" << '\n'
+                  << "Some blending equations will fallback to sf::BlendMode::Equation::Add" << '\n'
                   << "Ensure that hardware acceleration is enabled if available" << std::endl;
 
         warned = true;
@@ -641,7 +641,7 @@ void RenderTarget::applyBlendMode(const BlendMode& mode)
             glCheck(GLEXT_glBlendEquation(equationToGlConstant(mode.colorEquation)));
         }
     }
-    else if ((mode.colorEquation != BlendMode::Add) || (mode.alphaEquation != BlendMode::Add))
+    else if ((mode.colorEquation != BlendMode::Equation::Add) || (mode.alphaEquation != BlendMode::Equation::Add))
     {
         static bool warned = false;
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -281,9 +281,9 @@ bool Shader::loadFromFile(const std::filesystem::path& filename, Type type)
     }
 
     // Compile the shader program
-    if (type == Vertex)
+    if (type == Type::Vertex)
         return compile(shader.data(), nullptr, nullptr);
-    else if (type == Geometry)
+    else if (type == Type::Geometry)
         return compile(nullptr, shader.data(), nullptr);
     else
         return compile(nullptr, nullptr, shader.data());
@@ -353,9 +353,9 @@ bool Shader::loadFromFile(const std::filesystem::path& vertexShaderFilename,
 bool Shader::loadFromMemory(const std::string& shader, Type type)
 {
     // Compile the shader program
-    if (type == Vertex)
+    if (type == Type::Vertex)
         return compile(shader.c_str(), nullptr, nullptr);
-    else if (type == Geometry)
+    else if (type == Type::Geometry)
         return compile(nullptr, shader.c_str(), nullptr);
     else
         return compile(nullptr, nullptr, shader.c_str());
@@ -390,9 +390,9 @@ bool Shader::loadFromStream(InputStream& stream, Type type)
     }
 
     // Compile the shader program
-    if (type == Vertex)
+    if (type == Type::Vertex)
         return compile(shader.data(), nullptr, nullptr);
-    else if (type == Geometry)
+    else if (type == Type::Geometry)
         return compile(nullptr, shader.data(), nullptr);
     else
         return compile(nullptr, nullptr, shader.data());

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -47,9 +47,9 @@ GLenum usageToGlEnum(sf::VertexBuffer::Usage usage)
 {
     switch (usage)
     {
-        case sf::VertexBuffer::Static:
+        case sf::VertexBuffer::Usage::Static:
             return GLEXT_GL_STATIC_DRAW;
-        case sf::VertexBuffer::Dynamic:
+        case sf::VertexBuffer::Usage::Dynamic:
             return GLEXT_GL_DYNAMIC_DRAW;
         default:
             return GLEXT_GL_STREAM_DRAW;

--- a/test/Graphics/BlendMode.test.cpp
+++ b/test/Graphics/BlendMode.test.cpp
@@ -20,50 +20,52 @@ TEST_CASE("[Graphics] sf::BlendMode")
         SECTION("Default constructor")
         {
             const sf::BlendMode blendMode;
-            CHECK(blendMode.colorSrcFactor == sf::BlendMode::SrcAlpha);
-            CHECK(blendMode.colorDstFactor == sf::BlendMode::OneMinusSrcAlpha);
-            CHECK(blendMode.colorEquation == sf::BlendMode::Add);
-            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::One);
-            CHECK(blendMode.alphaDstFactor == sf::BlendMode::OneMinusSrcAlpha);
-            CHECK(blendMode.alphaEquation == sf::BlendMode::Add);
+            CHECK(blendMode.colorSrcFactor == sf::BlendMode::Factor::SrcAlpha);
+            CHECK(blendMode.colorDstFactor == sf::BlendMode::Factor::OneMinusSrcAlpha);
+            CHECK(blendMode.colorEquation == sf::BlendMode::Equation::Add);
+            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::Factor::One);
+            CHECK(blendMode.alphaDstFactor == sf::BlendMode::Factor::OneMinusSrcAlpha);
+            CHECK(blendMode.alphaEquation == sf::BlendMode::Equation::Add);
         }
 
         SECTION("Combined color and alpha constructor using default parameter")
         {
-            const sf::BlendMode blendMode(sf::BlendMode::Zero, sf::BlendMode::SrcColor);
-            CHECK(blendMode.colorSrcFactor == sf::BlendMode::Zero);
-            CHECK(blendMode.colorDstFactor == sf::BlendMode::SrcColor);
-            CHECK(blendMode.colorEquation == sf::BlendMode::Add);
-            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::Zero);
-            CHECK(blendMode.alphaDstFactor == sf::BlendMode::SrcColor);
-            CHECK(blendMode.alphaEquation == sf::BlendMode::Add);
+            const sf::BlendMode blendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::SrcColor);
+            CHECK(blendMode.colorSrcFactor == sf::BlendMode::Factor::Zero);
+            CHECK(blendMode.colorDstFactor == sf::BlendMode::Factor::SrcColor);
+            CHECK(blendMode.colorEquation == sf::BlendMode::Equation::Add);
+            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::Factor::Zero);
+            CHECK(blendMode.alphaDstFactor == sf::BlendMode::Factor::SrcColor);
+            CHECK(blendMode.alphaEquation == sf::BlendMode::Equation::Add);
         }
 
         SECTION("Combined color and alpha constructor")
         {
-            const sf::BlendMode blendMode(sf::BlendMode::Zero, sf::BlendMode::SrcColor, sf::BlendMode::ReverseSubtract);
-            CHECK(blendMode.colorSrcFactor == sf::BlendMode::Zero);
-            CHECK(blendMode.colorDstFactor == sf::BlendMode::SrcColor);
-            CHECK(blendMode.colorEquation == sf::BlendMode::ReverseSubtract);
-            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::Zero);
-            CHECK(blendMode.alphaDstFactor == sf::BlendMode::SrcColor);
-            CHECK(blendMode.alphaEquation == sf::BlendMode::ReverseSubtract);
+            const sf::BlendMode blendMode(sf::BlendMode::Factor::Zero,
+                                          sf::BlendMode::Factor::SrcColor,
+                                          sf::BlendMode::Equation::ReverseSubtract);
+            CHECK(blendMode.colorSrcFactor == sf::BlendMode::Factor::Zero);
+            CHECK(blendMode.colorDstFactor == sf::BlendMode::Factor::SrcColor);
+            CHECK(blendMode.colorEquation == sf::BlendMode::Equation::ReverseSubtract);
+            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::Factor::Zero);
+            CHECK(blendMode.alphaDstFactor == sf::BlendMode::Factor::SrcColor);
+            CHECK(blendMode.alphaEquation == sf::BlendMode::Equation::ReverseSubtract);
         }
 
         SECTION("Separate color and alpha constructor")
         {
-            const sf::BlendMode blendMode(sf::BlendMode::Zero,
-                                          sf::BlendMode::SrcColor,
-                                          sf::BlendMode::ReverseSubtract,
-                                          sf::BlendMode::OneMinusDstAlpha,
-                                          sf::BlendMode::DstAlpha,
-                                          sf::BlendMode::Max);
-            CHECK(blendMode.colorSrcFactor == sf::BlendMode::Zero);
-            CHECK(blendMode.colorDstFactor == sf::BlendMode::SrcColor);
-            CHECK(blendMode.colorEquation == sf::BlendMode::ReverseSubtract);
-            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::OneMinusDstAlpha);
-            CHECK(blendMode.alphaDstFactor == sf::BlendMode::DstAlpha);
-            CHECK(blendMode.alphaEquation == sf::BlendMode::Max);
+            const sf::BlendMode blendMode(sf::BlendMode::Factor::Zero,
+                                          sf::BlendMode::Factor::SrcColor,
+                                          sf::BlendMode::Equation::ReverseSubtract,
+                                          sf::BlendMode::Factor::OneMinusDstAlpha,
+                                          sf::BlendMode::Factor::DstAlpha,
+                                          sf::BlendMode::Equation::Max);
+            CHECK(blendMode.colorSrcFactor == sf::BlendMode::Factor::Zero);
+            CHECK(blendMode.colorDstFactor == sf::BlendMode::Factor::SrcColor);
+            CHECK(blendMode.colorEquation == sf::BlendMode::Equation::ReverseSubtract);
+            CHECK(blendMode.alphaSrcFactor == sf::BlendMode::Factor::OneMinusDstAlpha);
+            CHECK(blendMode.alphaDstFactor == sf::BlendMode::Factor::DstAlpha);
+            CHECK(blendMode.alphaEquation == sf::BlendMode::Equation::Max);
         }
     }
 
@@ -72,118 +74,118 @@ TEST_CASE("[Graphics] sf::BlendMode")
         SECTION("operator==")
         {
             CHECK(sf::BlendMode() == sf::BlendMode());
-            CHECK(sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One) ==
-                  sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One));
-            CHECK(sf::BlendMode(sf::BlendMode::Zero,
-                                sf::BlendMode::SrcColor,
-                                sf::BlendMode::ReverseSubtract,
-                                sf::BlendMode::OneMinusDstAlpha,
-                                sf::BlendMode::DstAlpha,
-                                sf::BlendMode::Max) ==
-                  sf::BlendMode(sf::BlendMode::Zero,
-                                sf::BlendMode::SrcColor,
-                                sf::BlendMode::ReverseSubtract,
-                                sf::BlendMode::OneMinusDstAlpha,
-                                sf::BlendMode::DstAlpha,
-                                sf::BlendMode::Max));
+            CHECK(sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One) ==
+                  sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One));
+            CHECK(sf::BlendMode(sf::BlendMode::Factor::Zero,
+                                sf::BlendMode::Factor::SrcColor,
+                                sf::BlendMode::Equation::ReverseSubtract,
+                                sf::BlendMode::Factor::OneMinusDstAlpha,
+                                sf::BlendMode::Factor::DstAlpha,
+                                sf::BlendMode::Equation::Max) ==
+                  sf::BlendMode(sf::BlendMode::Factor::Zero,
+                                sf::BlendMode::Factor::SrcColor,
+                                sf::BlendMode::Equation::ReverseSubtract,
+                                sf::BlendMode::Factor::OneMinusDstAlpha,
+                                sf::BlendMode::Factor::DstAlpha,
+                                sf::BlendMode::Equation::Max));
 
-            CHECK_FALSE(sf::BlendMode() == sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One));
-            CHECK_FALSE(sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One) ==
-                        sf::BlendMode(sf::BlendMode::One, sf::BlendMode::Zero));
+            CHECK_FALSE(sf::BlendMode() == sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One));
+            CHECK_FALSE(sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One) ==
+                        sf::BlendMode(sf::BlendMode::Factor::One, sf::BlendMode::Factor::Zero));
             CHECK_FALSE(
-                sf::BlendMode(sf::BlendMode::Zero,
-                              sf::BlendMode::SrcColor,
-                              sf::BlendMode::ReverseSubtract,
-                              sf::BlendMode::OneMinusDstAlpha,
-                              sf::BlendMode::DstAlpha,
-                              sf::BlendMode::Max) ==
-                sf::BlendMode(sf::BlendMode::One,
-                              sf::BlendMode::SrcColor,
-                              sf::BlendMode::ReverseSubtract,
-                              sf::BlendMode::OneMinusDstAlpha,
-                              sf::BlendMode::DstAlpha,
-                              sf::BlendMode::Max));
+                sf::BlendMode(sf::BlendMode::Factor::Zero,
+                              sf::BlendMode::Factor::SrcColor,
+                              sf::BlendMode::Equation::ReverseSubtract,
+                              sf::BlendMode::Factor::OneMinusDstAlpha,
+                              sf::BlendMode::Factor::DstAlpha,
+                              sf::BlendMode::Equation::Max) ==
+                sf::BlendMode(sf::BlendMode::Factor::One,
+                              sf::BlendMode::Factor::SrcColor,
+                              sf::BlendMode::Equation::ReverseSubtract,
+                              sf::BlendMode::Factor::OneMinusDstAlpha,
+                              sf::BlendMode::Factor::DstAlpha,
+                              sf::BlendMode::Equation::Max));
         }
 
         SECTION("operator!=")
         {
             CHECK_FALSE(sf::BlendMode() != sf::BlendMode());
-            CHECK_FALSE(sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One) !=
-                        sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One));
+            CHECK_FALSE(sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One) !=
+                        sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One));
             CHECK_FALSE(
-                sf::BlendMode(sf::BlendMode::Zero,
-                              sf::BlendMode::SrcColor,
-                              sf::BlendMode::ReverseSubtract,
-                              sf::BlendMode::OneMinusDstAlpha,
-                              sf::BlendMode::DstAlpha,
-                              sf::BlendMode::Max) !=
-                sf::BlendMode(sf::BlendMode::Zero,
-                              sf::BlendMode::SrcColor,
-                              sf::BlendMode::ReverseSubtract,
-                              sf::BlendMode::OneMinusDstAlpha,
-                              sf::BlendMode::DstAlpha,
-                              sf::BlendMode::Max));
+                sf::BlendMode(sf::BlendMode::Factor::Zero,
+                              sf::BlendMode::Factor::SrcColor,
+                              sf::BlendMode::Equation::ReverseSubtract,
+                              sf::BlendMode::Factor::OneMinusDstAlpha,
+                              sf::BlendMode::Factor::DstAlpha,
+                              sf::BlendMode::Equation::Max) !=
+                sf::BlendMode(sf::BlendMode::Factor::Zero,
+                              sf::BlendMode::Factor::SrcColor,
+                              sf::BlendMode::Equation::ReverseSubtract,
+                              sf::BlendMode::Factor::OneMinusDstAlpha,
+                              sf::BlendMode::Factor::DstAlpha,
+                              sf::BlendMode::Equation::Max));
 
-            CHECK(sf::BlendMode() != sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One));
-            CHECK(sf::BlendMode(sf::BlendMode::Zero, sf::BlendMode::One) !=
-                  sf::BlendMode(sf::BlendMode::One, sf::BlendMode::Zero));
-            CHECK(sf::BlendMode(sf::BlendMode::Zero,
-                                sf::BlendMode::SrcColor,
-                                sf::BlendMode::ReverseSubtract,
-                                sf::BlendMode::OneMinusDstAlpha,
-                                sf::BlendMode::DstAlpha,
-                                sf::BlendMode::Max) !=
-                  sf::BlendMode(sf::BlendMode::One,
-                                sf::BlendMode::SrcColor,
-                                sf::BlendMode::ReverseSubtract,
-                                sf::BlendMode::OneMinusDstAlpha,
-                                sf::BlendMode::DstAlpha,
-                                sf::BlendMode::Max));
+            CHECK(sf::BlendMode() != sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One));
+            CHECK(sf::BlendMode(sf::BlendMode::Factor::Zero, sf::BlendMode::Factor::One) !=
+                  sf::BlendMode(sf::BlendMode::Factor::One, sf::BlendMode::Factor::Zero));
+            CHECK(sf::BlendMode(sf::BlendMode::Factor::Zero,
+                                sf::BlendMode::Factor::SrcColor,
+                                sf::BlendMode::Equation::ReverseSubtract,
+                                sf::BlendMode::Factor::OneMinusDstAlpha,
+                                sf::BlendMode::Factor::DstAlpha,
+                                sf::BlendMode::Equation::Max) !=
+                  sf::BlendMode(sf::BlendMode::Factor::One,
+                                sf::BlendMode::Factor::SrcColor,
+                                sf::BlendMode::Equation::ReverseSubtract,
+                                sf::BlendMode::Factor::OneMinusDstAlpha,
+                                sf::BlendMode::Factor::DstAlpha,
+                                sf::BlendMode::Equation::Max));
         }
     }
 
     SECTION("Static constants")
     {
-        CHECK(sf::BlendAlpha.colorSrcFactor == sf::BlendMode::SrcAlpha);
-        CHECK(sf::BlendAlpha.colorDstFactor == sf::BlendMode::OneMinusSrcAlpha);
-        CHECK(sf::BlendAlpha.colorEquation == sf::BlendMode::Add);
-        CHECK(sf::BlendAlpha.alphaSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendAlpha.alphaDstFactor == sf::BlendMode::OneMinusSrcAlpha);
-        CHECK(sf::BlendAlpha.alphaEquation == sf::BlendMode::Add);
+        CHECK(sf::BlendAlpha.colorSrcFactor == sf::BlendMode::Factor::SrcAlpha);
+        CHECK(sf::BlendAlpha.colorDstFactor == sf::BlendMode::Factor::OneMinusSrcAlpha);
+        CHECK(sf::BlendAlpha.colorEquation == sf::BlendMode::Equation::Add);
+        CHECK(sf::BlendAlpha.alphaSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendAlpha.alphaDstFactor == sf::BlendMode::Factor::OneMinusSrcAlpha);
+        CHECK(sf::BlendAlpha.alphaEquation == sf::BlendMode::Equation::Add);
 
-        CHECK(sf::BlendAdd.colorSrcFactor == sf::BlendMode::SrcAlpha);
-        CHECK(sf::BlendAdd.colorDstFactor == sf::BlendMode::One);
-        CHECK(sf::BlendAdd.colorEquation == sf::BlendMode::Add);
-        CHECK(sf::BlendAdd.alphaSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendAdd.alphaDstFactor == sf::BlendMode::One);
-        CHECK(sf::BlendAdd.alphaEquation == sf::BlendMode::Add);
+        CHECK(sf::BlendAdd.colorSrcFactor == sf::BlendMode::Factor::SrcAlpha);
+        CHECK(sf::BlendAdd.colorDstFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendAdd.colorEquation == sf::BlendMode::Equation::Add);
+        CHECK(sf::BlendAdd.alphaSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendAdd.alphaDstFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendAdd.alphaEquation == sf::BlendMode::Equation::Add);
 
-        CHECK(sf::BlendMultiply.colorSrcFactor == sf::BlendMode::DstColor);
-        CHECK(sf::BlendMultiply.colorDstFactor == sf::BlendMode::Zero);
-        CHECK(sf::BlendMultiply.colorEquation == sf::BlendMode::Add);
-        CHECK(sf::BlendMultiply.alphaSrcFactor == sf::BlendMode::DstColor);
-        CHECK(sf::BlendMultiply.alphaDstFactor == sf::BlendMode::Zero);
-        CHECK(sf::BlendMultiply.alphaEquation == sf::BlendMode::Add);
+        CHECK(sf::BlendMultiply.colorSrcFactor == sf::BlendMode::Factor::DstColor);
+        CHECK(sf::BlendMultiply.colorDstFactor == sf::BlendMode::Factor::Zero);
+        CHECK(sf::BlendMultiply.colorEquation == sf::BlendMode::Equation::Add);
+        CHECK(sf::BlendMultiply.alphaSrcFactor == sf::BlendMode::Factor::DstColor);
+        CHECK(sf::BlendMultiply.alphaDstFactor == sf::BlendMode::Factor::Zero);
+        CHECK(sf::BlendMultiply.alphaEquation == sf::BlendMode::Equation::Add);
 
-        CHECK(sf::BlendMin.colorSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMin.colorDstFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMin.colorEquation == sf::BlendMode::Min);
-        CHECK(sf::BlendMin.alphaSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMin.alphaDstFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMin.alphaEquation == sf::BlendMode::Min);
+        CHECK(sf::BlendMin.colorSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMin.colorDstFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMin.colorEquation == sf::BlendMode::Equation::Min);
+        CHECK(sf::BlendMin.alphaSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMin.alphaDstFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMin.alphaEquation == sf::BlendMode::Equation::Min);
 
-        CHECK(sf::BlendMax.colorSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMax.colorDstFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMax.colorEquation == sf::BlendMode::Max);
-        CHECK(sf::BlendMax.alphaSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMax.alphaDstFactor == sf::BlendMode::One);
-        CHECK(sf::BlendMax.alphaEquation == sf::BlendMode::Max);
+        CHECK(sf::BlendMax.colorSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMax.colorDstFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMax.colorEquation == sf::BlendMode::Equation::Max);
+        CHECK(sf::BlendMax.alphaSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMax.alphaDstFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendMax.alphaEquation == sf::BlendMode::Equation::Max);
 
-        CHECK(sf::BlendNone.colorSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendNone.colorDstFactor == sf::BlendMode::Zero);
-        CHECK(sf::BlendNone.colorEquation == sf::BlendMode::Add);
-        CHECK(sf::BlendNone.alphaSrcFactor == sf::BlendMode::One);
-        CHECK(sf::BlendNone.alphaDstFactor == sf::BlendMode::Zero);
-        CHECK(sf::BlendNone.alphaEquation == sf::BlendMode::Add);
+        CHECK(sf::BlendNone.colorSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendNone.colorDstFactor == sf::BlendMode::Factor::Zero);
+        CHECK(sf::BlendNone.colorEquation == sf::BlendMode::Equation::Add);
+        CHECK(sf::BlendNone.alphaSrcFactor == sf::BlendMode::Factor::One);
+        CHECK(sf::BlendNone.alphaDstFactor == sf::BlendMode::Factor::Zero);
+        CHECK(sf::BlendNone.alphaEquation == sf::BlendMode::Equation::Add);
     }
 }

--- a/test/Graphics/RenderStates.test.cpp
+++ b/test/Graphics/RenderStates.test.cpp
@@ -29,12 +29,12 @@ TEST_CASE("[Graphics] sf::RenderStates")
 
         SECTION("BlendMode constructor")
         {
-            const sf::BlendMode    blendMode(sf::BlendMode::Zero,
-                                          sf::BlendMode::SrcColor,
-                                          sf::BlendMode::ReverseSubtract,
-                                          sf::BlendMode::OneMinusDstAlpha,
-                                          sf::BlendMode::DstAlpha,
-                                          sf::BlendMode::Max);
+            const sf::BlendMode    blendMode(sf::BlendMode::Factor::Zero,
+                                          sf::BlendMode::Factor::SrcColor,
+                                          sf::BlendMode::Equation::ReverseSubtract,
+                                          sf::BlendMode::Factor::OneMinusDstAlpha,
+                                          sf::BlendMode::Factor::DstAlpha,
+                                          sf::BlendMode::Equation::Max);
             const sf::RenderStates renderStates(blendMode);
             CHECK(renderStates.blendMode == blendMode);
             CHECK(renderStates.transform == sf::Transform());
@@ -78,12 +78,12 @@ TEST_CASE("[Graphics] sf::RenderStates")
 
         SECTION("Verbose constructor")
         {
-            const sf::BlendMode    blendMode(sf::BlendMode::One,
-                                          sf::BlendMode::SrcColor,
-                                          sf::BlendMode::ReverseSubtract,
-                                          sf::BlendMode::OneMinusDstAlpha,
-                                          sf::BlendMode::DstAlpha,
-                                          sf::BlendMode::Max);
+            const sf::BlendMode    blendMode(sf::BlendMode::Factor::One,
+                                          sf::BlendMode::Factor::SrcColor,
+                                          sf::BlendMode::Equation::ReverseSubtract,
+                                          sf::BlendMode::Factor::OneMinusDstAlpha,
+                                          sf::BlendMode::Factor::DstAlpha,
+                                          sf::BlendMode::Equation::Max);
             const sf::Transform    transform(10, 2, 3, 4, 50, 40, 30, 20, 10);
             const sf::RenderStates renderStates(blendMode, transform, sf::CoordinateType::Normalized, nullptr, nullptr);
             CHECK(renderStates.blendMode == blendMode);

--- a/test/Graphics/VertexBuffer.test.cpp
+++ b/test/Graphics/VertexBuffer.test.cpp
@@ -35,7 +35,7 @@ TEST_CASE("[Graphics] sf::VertexBuffer", "[.display]")
             CHECK(vertexBuffer.getVertexCount() == 0);
             CHECK(vertexBuffer.getNativeHandle() == 0);
             CHECK(vertexBuffer.getPrimitiveType() == sf::PrimitiveType::Points);
-            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Stream);
+            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Usage::Stream);
         }
 
         SECTION("Primitive type constructor")
@@ -44,31 +44,31 @@ TEST_CASE("[Graphics] sf::VertexBuffer", "[.display]")
             CHECK(vertexBuffer.getVertexCount() == 0);
             CHECK(vertexBuffer.getNativeHandle() == 0);
             CHECK(vertexBuffer.getPrimitiveType() == sf::PrimitiveType::Triangles);
-            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Stream);
+            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Usage::Stream);
         }
 
         SECTION("Usage constructor")
         {
-            const sf::VertexBuffer vertexBuffer(sf::VertexBuffer::Static);
+            const sf::VertexBuffer vertexBuffer(sf::VertexBuffer::Usage::Static);
             CHECK(vertexBuffer.getVertexCount() == 0);
             CHECK(vertexBuffer.getNativeHandle() == 0);
             CHECK(vertexBuffer.getPrimitiveType() == sf::PrimitiveType::Points);
-            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Static);
+            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Usage::Static);
         }
 
         SECTION("Primitive type and usage constructor")
         {
-            const sf::VertexBuffer vertexBuffer(sf::PrimitiveType::LineStrip, sf::VertexBuffer::Dynamic);
+            const sf::VertexBuffer vertexBuffer(sf::PrimitiveType::LineStrip, sf::VertexBuffer::Usage::Dynamic);
             CHECK(vertexBuffer.getVertexCount() == 0);
             CHECK(vertexBuffer.getNativeHandle() == 0);
             CHECK(vertexBuffer.getPrimitiveType() == sf::PrimitiveType::LineStrip);
-            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Dynamic);
+            CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Usage::Dynamic);
         }
     }
 
     SECTION("Copy semantics")
     {
-        const sf::VertexBuffer vertexBuffer(sf::PrimitiveType::LineStrip, sf::VertexBuffer::Dynamic);
+        const sf::VertexBuffer vertexBuffer(sf::PrimitiveType::LineStrip, sf::VertexBuffer::Usage::Dynamic);
 
         SECTION("Construction")
         {
@@ -76,7 +76,7 @@ TEST_CASE("[Graphics] sf::VertexBuffer", "[.display]")
             CHECK(vertexBufferCopy.getVertexCount() == 0);
             CHECK(vertexBufferCopy.getNativeHandle() == 0);
             CHECK(vertexBufferCopy.getPrimitiveType() == sf::PrimitiveType::LineStrip);
-            CHECK(vertexBufferCopy.getUsage() == sf::VertexBuffer::Dynamic);
+            CHECK(vertexBufferCopy.getUsage() == sf::VertexBuffer::Usage::Dynamic);
         }
 
         SECTION("Assignment")
@@ -86,7 +86,7 @@ TEST_CASE("[Graphics] sf::VertexBuffer", "[.display]")
             CHECK(vertexBufferCopy.getVertexCount() == 0);
             CHECK(vertexBufferCopy.getNativeHandle() == 0);
             CHECK(vertexBufferCopy.getPrimitiveType() == sf::PrimitiveType::LineStrip);
-            CHECK(vertexBufferCopy.getUsage() == sf::VertexBuffer::Dynamic);
+            CHECK(vertexBufferCopy.getUsage() == sf::VertexBuffer::Usage::Dynamic);
         }
     }
 
@@ -146,10 +146,10 @@ TEST_CASE("[Graphics] sf::VertexBuffer", "[.display]")
 
     SECTION("swap()")
     {
-        sf::VertexBuffer vertexBuffer1(sf::PrimitiveType::LineStrip, sf::VertexBuffer::Dynamic);
+        sf::VertexBuffer vertexBuffer1(sf::PrimitiveType::LineStrip, sf::VertexBuffer::Usage::Dynamic);
         CHECK(vertexBuffer1.create(50));
 
-        sf::VertexBuffer vertexBuffer2(sf::PrimitiveType::TriangleStrip, sf::VertexBuffer::Stream);
+        sf::VertexBuffer vertexBuffer2(sf::PrimitiveType::TriangleStrip, sf::VertexBuffer::Usage::Stream);
         CHECK(vertexBuffer2.create(60));
 
         sf::swap(vertexBuffer1, vertexBuffer2);
@@ -157,12 +157,12 @@ TEST_CASE("[Graphics] sf::VertexBuffer", "[.display]")
         CHECK(vertexBuffer1.getVertexCount() == 60);
         CHECK(vertexBuffer1.getNativeHandle() != 0);
         CHECK(vertexBuffer1.getPrimitiveType() == sf::PrimitiveType::TriangleStrip);
-        CHECK(vertexBuffer1.getUsage() == sf::VertexBuffer::Stream);
+        CHECK(vertexBuffer1.getUsage() == sf::VertexBuffer::Usage::Stream);
 
         CHECK(vertexBuffer2.getVertexCount() == 50);
         CHECK(vertexBuffer2.getNativeHandle() != 0);
         CHECK(vertexBuffer2.getPrimitiveType() == sf::PrimitiveType::LineStrip);
-        CHECK(vertexBuffer2.getUsage() == sf::VertexBuffer::Dynamic);
+        CHECK(vertexBuffer2.getUsage() == sf::VertexBuffer::Usage::Dynamic);
     }
 
     SECTION("Set/get primitive type")
@@ -175,7 +175,7 @@ TEST_CASE("[Graphics] sf::VertexBuffer", "[.display]")
     SECTION("Set/get usage")
     {
         sf::VertexBuffer vertexBuffer;
-        vertexBuffer.setUsage(sf::VertexBuffer::Dynamic);
-        CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Dynamic);
+        vertexBuffer.setUsage(sf::VertexBuffer::Usage::Dynamic);
+        CHECK(vertexBuffer.getUsage() == sf::VertexBuffer::Usage::Dynamic);
     }
 }

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -11,9 +11,10 @@ namespace sf
 {
 std::ostream& operator<<(std::ostream& os, const BlendMode& blendMode)
 {
-    return os << "( " << blendMode.colorSrcFactor << ", " << blendMode.colorDstFactor << ", " << blendMode.colorEquation
-              << ", " << blendMode.alphaSrcFactor << ", " << blendMode.alphaDstFactor << ", " << blendMode.alphaEquation
-              << " )";
+    return os << "( " << static_cast<int>(blendMode.colorSrcFactor) << ", "
+              << static_cast<int>(blendMode.colorDstFactor) << ", " << static_cast<int>(blendMode.colorEquation) << ", "
+              << static_cast<int>(blendMode.alphaSrcFactor) << ", " << static_cast<int>(blendMode.alphaDstFactor)
+              << ", " << static_cast<int>(blendMode.alphaEquation) << " )";
 }
 
 std::ostream& operator<<(std::ostream& os, const Color& color)


### PR DESCRIPTION
Part of C++17 modernization for SFML 3, related to [SD: CPP 17 Support](https://github.com/SFML/SFML/wiki/SD%3A-CPP-17-Support#scoped-enumerations).
Continuation of #2131 and #2822.

I did not convert `sf::Text::Style` because it represents flags.