### PR TITLE
'SoundFileFactory' implementation overhaul

### DIFF
--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -4,7 +4,6 @@
 #include <SFML/Audio.hpp>
 
 #include <iostream>
-#include <string>
 
 
 ////////////////////////////////////////////////////////////
@@ -22,7 +21,7 @@ void playSound()
     std::cout << "killdeer.wav:" << '\n'
               << " " << buffer.getDuration().asSeconds() << " seconds" << '\n'
               << " " << buffer.getSampleRate() << " samples / sec" << '\n'
-              << " " << buffer.getChannelCount() << " channels" << std::endl;
+              << " " << buffer.getChannelCount() << " channels" << '\n';
 
     // Create a sound instance and play it
     sf::Sound sound(buffer);
@@ -35,10 +34,10 @@ void playSound()
         sf::sleep(sf::milliseconds(100));
 
         // Display the playing position
-        std::cout << "\rPlaying... " << sound.getPlayingOffset().asSeconds() << " sec        ";
-        std::cout << std::flush;
+        std::cout << "\rPlaying... " << sound.getPlayingOffset().asSeconds() << " sec        " << std::flush;
     }
-    std::cout << std::endl << std::endl;
+
+    std::cout << '\n' << std::endl;
 }
 
 
@@ -57,7 +56,7 @@ void playMusic(const std::filesystem::path& filename)
     std::cout << filename << ":" << '\n'
               << " " << music.getDuration().asSeconds() << " seconds" << '\n'
               << " " << music.getSampleRate() << " samples / sec" << '\n'
-              << " " << music.getChannelCount() << " channels" << std::endl;
+              << " " << music.getChannelCount() << " channels" << '\n';
 
     // Play it
     music.play();
@@ -69,9 +68,9 @@ void playMusic(const std::filesystem::path& filename)
         sf::sleep(sf::milliseconds(100));
 
         // Display the playing position
-        std::cout << "\rPlaying... " << music.getPlayingOffset().asSeconds() << " sec        ";
-        std::cout << std::flush;
+        std::cout << "\rPlaying... " << music.getPlayingOffset().asSeconds() << " sec        " << std::flush;
     }
+
     std::cout << '\n' << std::endl;
 }
 

--- a/include/SFML/Audio/SoundFileFactory.inl
+++ b/include/SFML/Audio/SoundFileFactory.inl
@@ -46,18 +46,12 @@ std::unique_ptr<SoundFileWriter> createWriter()
 }
 } // namespace priv
 
+
 ////////////////////////////////////////////////////////////
 template <typename T>
 void SoundFileFactory::registerReader()
 {
-    // Make sure the same class won't be registered twice
-    unregisterReader<T>();
-
-    // Create a new factory with the functions provided by the class
-    const ReaderFactory factory{&T::check, &priv::createReader<T>};
-
-    // Add it
-    s_readers.push_back(factory);
+    getReaderFactoryMap()[&priv::createReader<T>] = &T::check;
 }
 
 
@@ -65,26 +59,23 @@ void SoundFileFactory::registerReader()
 template <typename T>
 void SoundFileFactory::unregisterReader()
 {
-    // Remove the instance(s) of the reader from the array of factories
-    s_readers.erase(std::remove_if(s_readers.begin(),
-                                   s_readers.end(),
-                                   [](const ReaderFactory& readerFactory)
-                                   { return readerFactory.create == &priv::createReader<T>; }),
-                    s_readers.end());
+    getReaderFactoryMap().erase(&priv::createReader<T>);
 }
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+bool SoundFileFactory::isReaderRegistered()
+{
+    return getReaderFactoryMap().count(&priv::createReader<T>) == 1;
+}
+
 
 ////////////////////////////////////////////////////////////
 template <typename T>
 void SoundFileFactory::registerWriter()
 {
-    // Make sure the same class won't be registered twice
-    unregisterWriter<T>();
-
-    // Create a new factory with the functions provided by the class
-    const WriterFactory factory{&T::check, &priv::createWriter<T>};
-
-    // Add it
-    s_writers.push_back(factory);
+    getWriterFactoryMap()[&priv::createWriter<T>] = &T::check;
 }
 
 
@@ -92,12 +83,15 @@ void SoundFileFactory::registerWriter()
 template <typename T>
 void SoundFileFactory::unregisterWriter()
 {
-    // Remove the instance(s) of the writer from the array of factories
-    s_writers.erase(std::remove_if(s_writers.begin(),
-                                   s_writers.end(),
-                                   [](const WriterFactory& writerFactory)
-                                   { return writerFactory.create == &priv::createWriter<T>; }),
-                    s_writers.end());
+    getWriterFactoryMap().erase(&priv::createWriter<T>);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+bool SoundFileFactory::isWriterRegistered()
+{
+    return getWriterFactoryMap().count(&priv::createWriter<T>) == 1;
 }
 
 } // namespace sf


### PR DESCRIPTION
tl;dr:

- Use `std::unordered_map` inside `SoundFileFactory` instead of re-implementing a bad version of it using `std::vector`.

- Use Meyers' Singletons for the maps instead of `inline static` variables (likely fixes #2866). This allows cleaner pre-population of the maps with

- Add `isReaderRegistered<T>` and `isWriterRegistered<T>` functions.

- Add tests for registration/deregistration of custom readers/writers.

- Some minor refactoring in the sound example.