### PR TITLE
Reflect account name change in asset_licenses.md.

### DIFF
--- a/examples/asset_licenses.md
+++ b/examples/asset_licenses.md
@@ -5,8 +5,8 @@ All assets are under public domain (CC0):
 | Name                            | Author                    | Link                       |
 | ------------------------------- | ------------------------- | -------------------------- |
 | Tuffy 1.1 font                  | Thatcher Ulrich           | [Ulrich's fonts][1]        |
-| sounds/resources/doodle_pop.ogg | MrZeusTheCoder            | [public-domain][2]         |
-| tennis/resources/ball.wav       | MrZeusTheCoder            | [public-domain][2]         |
+| sounds/resources/doodle_pop.ogg | Elijah Hopp               | [public-domain][2]         |
+| tennis/resources/ball.wav       | Elijah Hopp               | [public-domain][2]         |
 | opengl/resources/background.jpg | Nidhoggn                  | [Open Game Art][3]         |
 | shader/resources/background.jpg | Arcana Dea                | [Public Domain Images][4]  |
 | shader/resources/devices.png    | Kenny.nl                  | [Game Icons Pack][5]       |
@@ -17,7 +17,7 @@ All assets are under public domain (CC0):
 | sound/resources/killdeer.wav    | US National Park Services | [Bird sounds][8]           |
 
 [1]: http://tulrich.com/fonts/
-[2]: https://github.com/MrZeusTheCoder/public-domain
+[2]: https://github.com/elijahfhopp/public-domain
 [3]: https://opengameart.org/content/backgrounds-3
 [4]: https://www.publicdomainpictures.net/en/view-image.php?image=10979&picture=monarch-butterfly
 [5]: https://www.kenney.nl/assets/game-icons


### PR DESCRIPTION
## Description

I (MrZeusTheCoder) recently changed my Github account name to "elijahfhopp" (wonder where I came up with that). Thus my public-domain repo had its name changed. SFML makes reference to my repo in the `asset_licenses.md` file. I updated the link/name accordingly.

This PR is related to the PR #1718 .

❤️ to all you SFML folks. It's been a minute.
