### PR TITLE
Disable display tests in OpenGL ES CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         - { name: Linux GCC,                      os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
         - { name: Linux Clang,                    os: ubuntu-22.04, flags: -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: Linux GCC DRM,                  os: ubuntu-22.04, flags: -DSFML_USE_DRM=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
-        - { name: Linux GCC OpenGL ES,            os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON -DSFML_RUN_DISPLAY_TESTS=ON -GNinja }
+        - { name: Linux GCC OpenGL ES,            os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
         - { name: macOS,                          os: macos-12, flags: -GNinja }
         - { name: macOS Xcode,                    os: macos-12, flags: -GXcode }
         - { name: iOS,                            os: macos-12, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
@@ -312,7 +312,7 @@ jobs:
         platform:
         - { name: Linux,               os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=ON }
         - { name: Linux DRM,           os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_USE_DRM=ON }
-        - { name: Linux GCC OpenGL ES, os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=ON -DSFML_OPENGL_ES=ON }
+        - { name: Linux GCC OpenGL ES, os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_OPENGL_ES=ON }
 
     steps:
     - name: Checkout Code


### PR DESCRIPTION
## Description

https://github.com/SFML/SFML/actions/runs/7922497960

I manually triggered CI on `master` and saw some new failures in our Linux OpenGL ES jobs. Something about the underlying runner must have changed in a way that broke things. Disabling the display-dependent tests fixes this problem. Because CI is failing on `master` we're forced to fix it ASAP as to not block all other PRs.