### PR TITLE
Add support for macOS arm64 builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
         - { name: Linux Clang,                    os: ubuntu-22.04, flags: -DCMAKE_CXX_COMPILER=clang++ -DSFML_RUN_DISPLAY_TESTS=ON -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: Linux GCC DRM,                  os: ubuntu-22.04, flags: -DSFML_USE_DRM=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
         - { name: Linux GCC OpenGL ES,            os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
-        - { name: macOS,                          os: macos-12, flags: -GNinja }
-        - { name: macOS Xcode,                    os: macos-12, flags: -GXcode }
+        - { name: macOS x64,                      os: macos-12, flags: -GNinja }
+        - { name: macOS x64 Xcode,                os: macos-12, flags: -GXcode }
+        - { name: macOS arm64,                    os: macos-14, flags: -GNinja }
         - { name: iOS,                            os: macos-12, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
         - { name: iOS Xcode,                      os: macos-12, flags: -DCMAKE_SYSTEM_NAME=iOS -GXcode -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO }
         config:


### PR DESCRIPTION
## Description

The GitHub Actions runner image support for `macos-13-xlarge` and `macos-14` (beta) arm64 builds.
This PR updates all the macOS runner images to `macos-14`
Afaik we can't use the `macos-13-xlarge` ones, not sure if we want to wait for `macos-14` to get out of beta.

See also: https://github.com/actions/runner-images

## How to test this PR?

Have CI be green