### PR TITLE
Fix CI deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Visual Studio Architecture
       if: contains(matrix.platform.name, 'Windows VS') && !contains(matrix.platform.name, 'MSBuild')
@@ -245,7 +245,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Format Code
       run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-14 -P cmake/Format.cmake
@@ -271,7 +271,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get CMake and Ninja
       uses: lukka/get-cmake@latest
@@ -316,7 +316,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get CMake and Ninja
       uses: lukka/get-cmake@latest


### PR DESCRIPTION
## Description

Who knew checking out a repo was so complicated but we're getting loads of deprecation warnings for using actions/checkout@v3 so I upgraded us to v4. 

<img width="1247" alt="Screenshot 2024-02-15 at 4 57 47 PM" src="https://github.com/SFML/SFML/assets/39244355/318b0b7d-11fc-49d7-bec1-45cb5ef1c089">
