### PR TITLE
Fix assert not firing when only x index is out of bounds

### DIFF
--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -490,8 +490,10 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
 ////////////////////////////////////////////////////////////
 void Image::setPixel(const Vector2u& coords, const Color& color)
 {
-    const auto index = (coords.x + coords.y * m_size.x) * 4;
-    assert(index < m_pixels.size() && "Image::setPixel() cannot access out of bounds pixel");
+    assert(coords.x < m_size.x && "Image::setPixel() x coordinate is out of bounds");
+    assert(coords.y < m_size.y && "Image::setPixel() y coordinate is out of bounds");
+
+    const auto    index = (coords.x + coords.y * m_size.x) * 4;
     std::uint8_t* pixel = &m_pixels[index];
     *pixel++            = color.r;
     *pixel++            = color.g;
@@ -503,8 +505,10 @@ void Image::setPixel(const Vector2u& coords, const Color& color)
 ////////////////////////////////////////////////////////////
 Color Image::getPixel(const Vector2u& coords) const
 {
-    const auto index = (coords.x + coords.y * m_size.x) * 4;
-    assert(index < m_pixels.size() && "Image::getPixel() cannot access out of bounds pixel");
+    assert(coords.x < m_size.x && "Image::getPixel() x coordinate is out of bounds");
+    assert(coords.y < m_size.y && "Image::getPixel() y coordinate is out of bounds");
+
+    const auto          index = (coords.x + coords.y * m_size.x) * 4;
     const std::uint8_t* pixel = &m_pixels[index];
     return {pixel[0], pixel[1], pixel[2], pixel[3]};
 }


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [*] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [*] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed list them as tasks!
-->

## Description

Original protection to UB here was to simply check if the produced index is out of bounds, but that isn't entirely correct imo. What is correct is to fire if either the x or the y go out of bounds.

This shouldn't cause the UB problem to reappear, and be a little more "correct" from the user's perspective. I believe that the most correct way would be to use a boolean return in the setPixel(), and a std::optional and return None on a failed fetch for the getPixel() function. I don't know if ya'll are willing to do this, but this seems sufficient too. Atleast there is a clear place where the programs fails to work.

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->

<!-- Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start: -->

```cpp
#include "SFML/Graphics/Color.hpp"
#include "SFML/Graphics/Image.hpp"
#include "SFML/System/Vector2.hpp"
#include <SFML/Graphics.hpp>
#include <stdio.h>

const static sf::Vector2u IMAGE_SIZE = sf::Vector2u(64, 64);

int main()
{
    sf::Image black_image;
    black_image.create(IMAGE_SIZE, sf::Color::Black);

    for (int y = 0; y < 65; y++) {
        for (int x = 0; x < 65 ; x++) {
            sf::Color pixel = black_image.getPixel(sf::Vector2u(x,y));
            printf("[%u %u %u]", pixel.r, pixel.g, pixel.b);
        }
        printf("\n");
    }
    return 1;
}

```
