### PR TITLE
Enable `bugprone-suspicious-include`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,6 @@ Checks: >
   -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
   -bugprone-string-integer-assignment,
-  -bugprone-suspicious-include,
   -bugprone-switch-missing-default-case,
   -bugprone-unchecked-optional-access,
   -clang-analyzer-nullability.NullablePassedToNonnull,


### PR DESCRIPTION
## Description

We already comply with this check so we ought to include it. I'm not sure why we previously had to disable this.