### PR TITLE
Use `std::{min|max}`

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -276,8 +276,7 @@ float Text::getOutlineThickness() const
 Vector2f Text::findCharacterPos(std::size_t index) const
 {
     // Adjust the index if it's out of range
-    if (index > m_string.getSize())
-        index = m_string.getSize();
+    index = std::min(index, m_string.getSize());
 
     // Precompute the variables needed by the algorithm
     const bool  isBold          = m_style & Bold;

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -313,14 +313,10 @@ bool Texture::loadFromImage(const Image& image, const IntRect& area)
 
         // Adjust the rectangle to the size of the image
         IntRect rectangle = area;
-        if (rectangle.left < 0)
-            rectangle.left = 0;
-        if (rectangle.top < 0)
-            rectangle.top = 0;
-        if (rectangle.left + rectangle.width > width)
-            rectangle.width = width - rectangle.left;
-        if (rectangle.top + rectangle.height > height)
-            rectangle.height = height - rectangle.top;
+        rectangle.left    = std::max(rectangle.left, 0);
+        rectangle.top     = std::max(rectangle.top, 0);
+        rectangle.width   = std::min(rectangle.width, width - rectangle.left);
+        rectangle.height  = std::min(rectangle.height, height - rectangle.top);
 
         // Create the texture and upload the pixels
         if (create(Vector2u(rectangle.getSize())))


### PR DESCRIPTION
## Description

A new clang-tidy-18 check led me to this. These files already use \<algorithm\> so we might as well use these functions where appropriate.