### PR TITLE
Fix pkgconfig files install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,13 +213,13 @@ if(SFML_INSTALL_PKGCONFIG_FILES)
 
     # set pkgconfig install directory
     # this could be e.g. macports on mac or msys2 on windows etc.
-    set(SFML_PKGCONFIG_DIR "/${SFML_RELATIVE_INSTALL_LIBDIR}/pkgconfig")
+    set(SFML_PKGCONFIG_DIR "${SFML_RELATIVE_INSTALL_LIBDIR}/pkgconfig")
 
     if(SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
-        set(SFML_PKGCONFIG_DIR "/libdata/pkgconfig")
+        set(SFML_PKGCONFIG_DIR "libdata/pkgconfig")
     endif()
 
-    sfml_set_option(SFML_PKGCONFIG_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/${SFML_PKGCONFIG_DIR}" PATH "Install directory for SFML's pkg-config .pc files")
+    sfml_set_option(SFML_PKGCONFIG_INSTALL_DIR "${SFML_PKGCONFIG_DIR}" PATH "Install directory for SFML's pkg-config .pc files")
 
     foreach(sfml_module IN ITEMS all system window graphics audio network)
         configure_file(
@@ -227,7 +227,7 @@ if(SFML_INSTALL_PKGCONFIG_FILES)
             "tools/pkg-config/sfml-${sfml_module}.pc"
             @ONLY)
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tools/pkg-config/sfml-${sfml_module}.pc"
-            DESTINATION "${SFML_PKGCONFIG_INSTALL_PREFIX}")
+            DESTINATION "${SFML_PKGCONFIG_INSTALL_DIR}")
     endforeach()
 endif()
 


### PR DESCRIPTION
## Description

When running CMake without setting CMAKE_INSTALL_PREFIX, and then running CMake again with a different prefix, the install path for the pkgconfig files still points to the old location.

Because the default `/usr/local` prefix on Linux requires root access, installing SFML without sudo will fail with an error like this:
```
-- Install configuration: "Release"
-- Installing: /home/texus/Documents/SFML/whatever/lib/libsfml-system-s.a
-- Installing: /home/texus/Documents/SFML/whatever/lib/libsfml-window-s.a
-- Installing: /home/texus/Documents/SFML/whatever/lib/libsfml-network-s.a
-- Installing: /home/texus/Documents/SFML/whatever/lib/libsfml-graphics-s.a
-- Installing: /home/texus/Documents/SFML/whatever/lib/libsfml-audio-s.a
-- Installing: /usr/local/lib/pkgconfig/sfml-all.pc
CMake Error at build/cmake_install.cmake:59 (file):
  file INSTALL cannot copy file
  "/home/texus/Documents/SFML/build/tools/pkg-config/sfml-all.pc" to
  "/usr/local/lib/pkgconfig/sfml-all.pc": Permission denied.
```

This was fixed in the CSFML project a few weeks ago (see https://github.com/SFML/CSFML/issues/233 and https://github.com/SFML/CSFML/pull/234), this PR applies the same fix to SFML.

This change is NOT backwards compatible. The existing `SFML_PKGCONFIG_INSTALL_PREFIX` variable will no longer work and is being replaced with a new `SFML_PKGCONFIG_INSTALL_DIR` variable in cmake.

## Tasks

-   [x] Tested on Linux

## How to test this PR?

On linux you can run the following commands to get the error:
```bash
cmake -S . -B build
cmake --build build
cmake --install build --prefix whatever
```

On other platforms you can probably also witness the files being installed to the wrong directory, but you will need to set `SFML_INSTALL_PKGCONFIG_FILES` to `ON` yourself because it is only enabled by default on Linux and BSD.