### PR TITLE
Fixed CMAKE_CXX_FLAGS being treated as a list when SFML_ENABLE_SANITIZERS is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ endif()
 
 option(SFML_ENABLE_SANITIZERS "Enable sanitizers" OFF)
 if(SFML_ENABLE_SANITIZERS)
-    list(APPEND CMAKE_CXX_FLAGS "-fno-omit-frame-pointer -fno-sanitize-recover=all -fsanitize=undefined")
+    string(APPEND CMAKE_CXX_FLAGS " -fno-omit-frame-pointer -fno-sanitize-recover=all -fsanitize=undefined")
 endif()
 
 # set the output directory for SFML DLLs and executables


### PR DESCRIPTION
Title.

If `CMAKE_CXX_FLAGS` already contains something and is appended as a list, CMake will insert semicolons between list items when converting it back into a string representation. The semicolon gets passed verbatim to the compiler invocations causing errors when building.

To test, try defining `CMAKE_CXX_FLAGS` to something e.g. `-fsanitize=address`, enable `SFML_ENABLE_SANITIZERS` and witness what happens when trying to build with GCC/Clang.