### PR TITLE
Add more `sf::Context` tests

### DIFF
--- a/test/Window/Context.test.cpp
+++ b/test/Window/Context.test.cpp
@@ -165,4 +165,21 @@ TEST_CASE("[Window] sf::Context", runDisplayTests())
         SUCCEED(std::string("OpenGL renderer: ") + renderer);
         SUCCEED(std::string("OpenGL version: ") + version);
     }
+
+    SECTION("isExtensionAvailable()")
+    {
+        CHECK(!sf::Context::isExtensionAvailable("2024-04-01"));
+        CHECK(!sf::Context::isExtensionAvailable("let's assume this extension does not exist"));
+    }
+
+    SECTION("getFunction()")
+    {
+        const sf::Context context; // Windows requires an active context to use getFunction
+        CHECK(sf::Context::getFunction("glEnable"));
+        CHECK(sf::Context::getFunction("glGetError"));
+        CHECK(sf::Context::getFunction("glGetIntegerv"));
+        CHECK(sf::Context::getFunction("glGetString"));
+        CHECK(sf::Context::getFunction("glGetStringi"));
+        CHECK(sf::Context::getFunction("glIsEnabled"));
+    }
 }


### PR DESCRIPTION
## Description

I noticed some minor gaps in `sf::Context` test coverage that I wanted to fill. In doing so I found an oddity related to `sf::Context::getFunction` on Windows.

It appears that `sf::Context::getFunction` when called Windows using a non-OpenGL ES implementation has an undocumented requirement that a context must already be active. If you don't satisfy this requirement then [an assertion fails](https://github.com/SFML/SFML/actions/runs/8512681403/job/23314893528#step:18:61). Ideally the Windows implementation would not have this requirement but at a minimum it seems reasonable to document this fact since in release builds you simply get a SEGFAULT which is hard to reason about. You can't step into precompiled release builds of SFML to figure out what is causing this.