### PR TITLE
Return `nullptr` when `sf::Context::getFunction` is called on Windows without an active context

### DIFF
--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -131,6 +131,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the address of an OpenGL function
     ///
+    /// On Windows when not using OpenGL ES, a context must be
+    /// active for this function to succeed.
+    ///
     /// \param name Name of the function to get the address of
     ///
     /// \return Address of the OpenGL function, 0 on failure

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -203,8 +203,8 @@ WglContext::~WglContext()
 ////////////////////////////////////////////////////////////
 GlFunctionPointer WglContext::getFunction(const char* name)
 {
-    assert(WglContextImpl::currentContext != nullptr &&
-           "Current WGL context cannot be null. Call WglContext::makeCurrent() to initialize it.");
+    if (WglContextImpl::currentContext == nullptr)
+        return nullptr;
 
     // If we are using the generic GDI implementation, skip to loading directly from OpenGL32.dll since it doesn't support extensions
     if (!WglContextImpl::currentContext->m_isGeneric)


### PR DESCRIPTION
This converts termination in Debug and a SEGFAULT in Release builds into defined behavior. This assert is better than nothing but we can just as easily use the function's return channel to signal this error which seems more reasonable. Now a segfault in SFML code can be a segfault in user code yay!
