### PR TITLE
Spend longer attempting to get codecov upload to succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,8 @@ jobs:
       uses: nick-fields/retry@v3
       with:
         timeout_seconds: 30
-        max_attempts: 10
-        retry_wait_seconds: 60
+        max_attempts: 25
+        retry_wait_seconds: 120
         warning_on_retry: false
         shell: bash
         command: |


### PR DESCRIPTION
## Description

If this fails then we're on the hook to manually retrigger CI. I'd rather just spend more time waiting on codecov to work because most times it fails it succeeds as soon as we re-trigger. GitHub Actions won't let you restart a failed CI job until all jobs have succeeded which further wastes time when we're waiting on a few codecov uploads to succeed.

25 attempts at 2 minutes between attempt mean we're allowing for about an hour for codecov to work. That should be long enough to deal with intermittant network failures or rate limiting in most cases.
