### PR TITLE
`constexpr`-fy `sf::priv::Vector4`

### DIFF
--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Export.hpp>
 
+#include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Glsl.hpp> // NOLINT(misc-header-include-cycle)
 
 #include <cstddef>
@@ -34,7 +35,6 @@
 
 namespace sf
 {
-class Color;
 class Transform;
 } // namespace sf
 
@@ -55,13 +55,6 @@ void SFML_GRAPHICS_API copyMatrix(const Transform& source, Matrix<4, 4>& dest);
 ///
 ////////////////////////////////////////////////////////////
 void SFML_GRAPHICS_API copyMatrix(const float* source, std::size_t elements, float* dest);
-
-////////////////////////////////////////////////////////////
-/// \brief Helper functions to copy sf::Color to sf::Glsl::Vec4/Ivec4
-///
-////////////////////////////////////////////////////////////
-void SFML_GRAPHICS_API copyVector(const Color& source, Vector4<float>& dest);
-void SFML_GRAPHICS_API copyVector(const Color& source, Vector4<int>& dest);
 
 
 ////////////////////////////////////////////////////////////
@@ -112,7 +105,7 @@ struct Vector4
     /// \brief Default constructor, creates a zero vector
     ///
     ////////////////////////////////////////////////////////////
-    Vector4() = default;
+    constexpr Vector4() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct from 4 vector components
@@ -127,7 +120,7 @@ struct Vector4
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 #endif
-    Vector4(T x, T y, T z, T w) : x(x), y(y), z(z), w(w)
+    constexpr Vector4(T x, T y, T z, T w) : x(x), y(y), z(z), w(w)
     {
     }
 #if defined(__GNUC__)
@@ -141,7 +134,7 @@ struct Vector4
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    explicit Vector4(const Vector4<U>& other) :
+    constexpr explicit Vector4(const Vector4<U>& other) :
     x(static_cast<T>(other.x)),
     y(static_cast<T>(other.y)),
     z(static_cast<T>(other.z)),
@@ -150,21 +143,38 @@ struct Vector4
     }
 
     ////////////////////////////////////////////////////////////
-    /// \brief Construct float vector implicitly from color
+    /// \brief Construct vector implicitly from color
     ///
-    /// \param color Color instance. Is normalized to [0, 1]
-    ///              for floats, and left as-is for ints.
+    /// Vector is normalized to [0, 1] for floats, and left as-is
+    /// for ints. Not defined for other template arguments.
+    ///
+    /// \param color Color instance
     ///
     ////////////////////////////////////////////////////////////
-    Vector4(const Color& color)
-    {
-        copyVector(color, *this);
-    }
+    constexpr Vector4(const Color& color);
 
     T x{}; //!< 1st component (X) of the 4D vector
     T y{}; //!< 2nd component (Y) of the 4D vector
     T z{}; //!< 3rd component (Z) of the 4D vector
     T w{}; //!< 4th component (W) of the 4D vector
 };
+
+
+////////////////////////////////////////////////////////////
+template <>
+constexpr Vector4<float>::Vector4(const Color& color) :
+x(color.r / 255.f),
+y(color.g / 255.f),
+z(color.b / 255.f),
+w(color.a / 255.f)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <>
+constexpr Vector4<int>::Vector4(const Color& color) : x(color.r), y(color.g), z(color.b), w(color.a)
+{
+}
 
 } // namespace sf::priv

--- a/src/SFML/Graphics/Glsl.cpp
+++ b/src/SFML/Graphics/Glsl.cpp
@@ -69,24 +69,4 @@ void copyMatrix(const float* source, std::size_t elements, float* dest)
     std::copy(source, source + elements, dest);
 }
 
-
-////////////////////////////////////////////////////////////
-void copyVector(const Color& source, Vector4<float>& dest)
-{
-    dest.x = source.r / 255.f;
-    dest.y = source.g / 255.f;
-    dest.z = source.b / 255.f;
-    dest.w = source.a / 255.f;
-}
-
-
-////////////////////////////////////////////////////////////
-void copyVector(const Color& source, Vector4<int>& dest)
-{
-    dest.x = static_cast<int>(source.r);
-    dest.y = static_cast<int>(source.g);
-    dest.z = static_cast<int>(source.b);
-    dest.w = static_cast<int>(source.a);
-}
-
 } // namespace sf::priv

--- a/test/Graphics/Glsl.test.cpp
+++ b/test/Graphics/Glsl.test.cpp
@@ -126,30 +126,30 @@ TEST_CASE("[Graphics] sf::Glsl")
 
         SECTION("Verbose constructor")
         {
-            const sf::Glsl::Vec4 vec(1, 2, 3, 4);
-            CHECK(vec.x == 1);
-            CHECK(vec.y == 2);
-            CHECK(vec.z == 3);
-            CHECK(vec.w == 4);
+            constexpr sf::Glsl::Vec4 vec(1, 2, 3, 4);
+            STATIC_CHECK(vec.x == 1);
+            STATIC_CHECK(vec.y == 2);
+            STATIC_CHECK(vec.z == 3);
+            STATIC_CHECK(vec.w == 4);
         }
 
         SECTION("Conversion constructor")
         {
-            const sf::Glsl::Ivec4 ivec(10, 12, 14, 16);
-            const sf::Glsl::Vec4  vec(ivec);
-            CHECK(vec.x == 10);
-            CHECK(vec.y == 12);
-            CHECK(vec.z == 14);
-            CHECK(vec.w == 16);
+            constexpr sf::Glsl::Ivec4 ivec(10, 12, 14, 16);
+            constexpr sf::Glsl::Vec4  vec(ivec);
+            STATIC_CHECK(vec.x == 10);
+            STATIC_CHECK(vec.y == 12);
+            STATIC_CHECK(vec.z == 14);
+            STATIC_CHECK(vec.w == 16);
         }
 
         SECTION("Color constructor")
         {
-            const sf::Glsl::Vec4 vec(sf::Color(0, 128, 192, 255));
-            CHECK(vec.x == 0.f);
-            CHECK(vec.y == Approx(0.50196f));
-            CHECK(vec.z == Approx(0.75294f));
-            CHECK(vec.w == 1.f);
+            constexpr sf::Glsl::Vec4 vec = sf::Color(0, 128, 192, 255);
+            STATIC_CHECK(vec.x == 0.f);
+            STATIC_CHECK(vec.y == 128 / 255.f);
+            STATIC_CHECK(vec.z == 192 / 255.f);
+            STATIC_CHECK(vec.w == 1.f);
         }
     }
 
@@ -174,30 +174,30 @@ TEST_CASE("[Graphics] sf::Glsl")
 
         SECTION("Verbose constructor")
         {
-            const sf::Glsl::Ivec4 vec(1, 2, 3, 4);
-            CHECK(vec.x == 1);
-            CHECK(vec.y == 2);
-            CHECK(vec.z == 3);
-            CHECK(vec.w == 4);
+            constexpr sf::Glsl::Ivec4 vec(1, 2, 3, 4);
+            STATIC_CHECK(vec.x == 1);
+            STATIC_CHECK(vec.y == 2);
+            STATIC_CHECK(vec.z == 3);
+            STATIC_CHECK(vec.w == 4);
         }
 
         SECTION("Conversion constructor")
         {
-            const sf::Glsl::Bvec4 bvec(true, false, true, false);
-            const sf::Glsl::Ivec4 vec(bvec);
-            CHECK(vec.x == 1);
-            CHECK(vec.y == 0);
-            CHECK(vec.z == 1);
-            CHECK(vec.w == 0);
+            constexpr sf::Glsl::Bvec4 bvec(true, false, true, false);
+            constexpr sf::Glsl::Ivec4 vec(bvec);
+            STATIC_CHECK(vec.x == 1);
+            STATIC_CHECK(vec.y == 0);
+            STATIC_CHECK(vec.z == 1);
+            STATIC_CHECK(vec.w == 0);
         }
 
         SECTION("Color constructor")
         {
-            const sf::Glsl::Ivec4 vec(sf::Color(0, 128, 192, 255));
-            CHECK(vec.x == 0);
-            CHECK(vec.y == 128);
-            CHECK(vec.z == 192);
-            CHECK(vec.w == 255);
+            constexpr sf::Glsl::Ivec4 vec = sf::Color(0, 128, 192, 255);
+            STATIC_CHECK(vec.x == 0);
+            STATIC_CHECK(vec.y == 128);
+            STATIC_CHECK(vec.z == 192);
+            STATIC_CHECK(vec.w == 255);
         }
     }
 
@@ -222,21 +222,21 @@ TEST_CASE("[Graphics] sf::Glsl")
 
         SECTION("Verbose constructor")
         {
-            const sf::Glsl::Bvec4 vec(false, true, true, false);
-            CHECK(vec.x == false);
-            CHECK(vec.y == true);
-            CHECK(vec.z == true);
-            CHECK(vec.w == false);
+            constexpr sf::Glsl::Bvec4 vec(false, true, true, false);
+            STATIC_CHECK(vec.x == false);
+            STATIC_CHECK(vec.y == true);
+            STATIC_CHECK(vec.z == true);
+            STATIC_CHECK(vec.w == false);
         }
 
         SECTION("Conversion constructor")
         {
-            const sf::Glsl::Ivec4 ivec(0, -7, 2, 10);
-            const sf::Glsl::Bvec4 vec(ivec);
-            CHECK(vec.x == false);
-            CHECK(vec.y == true);
-            CHECK(vec.z == true);
-            CHECK(vec.w == true);
+            constexpr sf::Glsl::Ivec4 ivec(0, -7, 2, 10);
+            constexpr sf::Glsl::Bvec4 vec(ivec);
+            STATIC_CHECK(vec.x == false);
+            STATIC_CHECK(vec.y == true);
+            STATIC_CHECK(vec.z == true);
+            STATIC_CHECK(vec.w == true);
         }
     }
 


### PR DESCRIPTION
## Description

While writing #2930 I realized that `sf::priv::Vector4` had no `constexpr` support unlike `Vector2` and `Vector3` which support `constexpr` as much as possible. I had to make a slight refactor to pull this off but think the final implementation is even better.