### PR TITLE
Improve test coverage

### DIFF
--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -970,6 +970,14 @@ Shader::~Shader() = default;
 
 
 ////////////////////////////////////////////////////////////
+Shader::Shader(Shader&& source) noexcept = default;
+
+
+////////////////////////////////////////////////////////////
+Shader& Shader::operator=(Shader&& right) noexcept = default;
+
+
+////////////////////////////////////////////////////////////
 bool Shader::loadFromFile(const std::filesystem::path& /* filename */, Type /* type */)
 {
     return false;

--- a/test/Graphics/Font.test.cpp
+++ b/test/Graphics/Font.test.cpp
@@ -81,17 +81,7 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
 
         SECTION("Successful load")
         {
-            const auto memory = []()
-            {
-                std::ifstream file("Graphics/tuffy.ttf", std::ios::binary | std::ios::ate);
-                REQUIRE(file);
-                const auto size = file.tellg();
-                file.seekg(0, std::ios::beg);
-                std::vector<std::byte> buffer(static_cast<std::size_t>(size));
-                REQUIRE(file.read(reinterpret_cast<char*>(buffer.data()), size));
-                return buffer;
-            }();
-
+            const auto memory = loadIntoMemory("Graphics/tuffy.ttf");
             REQUIRE(font.loadFromMemory(memory.data(), memory.size()));
             CHECK(font.getInfo().family == "Tuffy");
             const auto& glyph = font.getGlyph(0x45, 16, false);
@@ -158,6 +148,7 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
     SECTION("Set/get smooth")
     {
         sf::Font font;
+        REQUIRE(font.loadFromFile("Graphics/tuffy.ttf"));
         font.setSmooth(false);
         CHECK(!font.isSmooth());
     }

--- a/test/Graphics/RenderTarget.test.cpp
+++ b/test/Graphics/RenderTarget.test.cpp
@@ -61,21 +61,30 @@ TEST_CASE("[Graphics] sf::RenderTarget")
         CHECK(renderTarget.setActive(true));
     }
 
+    const auto makeView = [](const auto& viewport)
+    {
+        sf::View view;
+        view.setViewport(viewport);
+        return view;
+    };
+
     SECTION("getViewport(const View&)")
     {
-        const auto makeView = [](const auto& viewport)
-        {
-            sf::View view;
-            view.setViewport(viewport);
-            return view;
-        };
-
         const RenderTarget renderTarget;
         CHECK(renderTarget.getViewport(makeView(sf::FloatRect({0, 0}, {1, 1}))) == sf::IntRect({0, 0}, {640, 480}));
         CHECK(renderTarget.getViewport(makeView(sf::FloatRect({1, 1}, {.5f, .25f}))) ==
               sf::IntRect({640, 480}, {320, 120}));
         CHECK(renderTarget.getViewport(makeView(sf::FloatRect({.5f, .5f}, {.25f, .75f}))) ==
               sf::IntRect({320, 240}, {160, 360}));
+    }
+
+    SECTION("getScissor(const View&)")
+    {
+        const RenderTarget renderTarget;
+        CHECK(renderTarget.getScissor(makeView(sf::FloatRect({0, 0}, {1, 1}))) == sf::IntRect({0, 0}, {640, 480}));
+        CHECK(renderTarget.getScissor(makeView(sf::FloatRect({1, 1}, {.5f, .25f}))) == sf::IntRect({0, 0}, {640, 480}));
+        CHECK(renderTarget.getScissor(makeView(sf::FloatRect({.5f, .5f}, {.25f, .75f}))) ==
+              sf::IntRect({0, 0}, {640, 480}));
     }
 
     SECTION("mapPixelToCoords(const Vector2i&)")

--- a/test/Graphics/Shader.test.cpp
+++ b/test/Graphics/Shader.test.cpp
@@ -172,6 +172,24 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
         CHECK(shader.getNativeHandle() == 0);
     }
 
+    SECTION("Move semantics")
+    {
+        SECTION("Construction")
+        {
+            sf::Shader       movedShader;
+            const sf::Shader shader = std::move(movedShader);
+            CHECK(shader.getNativeHandle() == 0);
+        }
+
+        SECTION("Assignment")
+        {
+            sf::Shader movedShader;
+            sf::Shader shader;
+            shader = std::move(movedShader);
+            CHECK(shader.getNativeHandle() == 0);
+        }
+    }
+
     SECTION("loadFromFile()")
     {
         sf::Shader shader;
@@ -229,19 +247,24 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
         sf::FileInputStream geometryShaderStream;
         REQUIRE(geometryShaderStream.open("Graphics/shader.geom"));
 
+        sf::FileInputStream emptyStream;
+
         SECTION("One shader")
         {
+            REQUIRE(!shader.loadFromStream(emptyStream, sf::Shader::Type::Vertex));
             REQUIRE(shader.loadFromStream(vertexShaderStream, sf::Shader::Type::Vertex) == sf::Shader::isAvailable());
+            REQUIRE(shader.loadFromStream(fragmentShaderStream, sf::Shader::Type::Fragment) == sf::Shader::isAvailable());
         }
 
         SECTION("Two shaders")
         {
+            REQUIRE(!shader.loadFromStream(emptyStream, fragmentShaderStream));
+            REQUIRE(!shader.loadFromStream(vertexShaderStream, emptyStream));
             REQUIRE(shader.loadFromStream(vertexShaderStream, fragmentShaderStream) == sf::Shader::isAvailable());
         }
 
         SECTION("Three shaders")
         {
-            sf::FileInputStream emptyStream;
             REQUIRE(!shader.loadFromStream(emptyStream, geometryShaderStream, fragmentShaderStream));
             REQUIRE(!shader.loadFromStream(vertexShaderStream, emptyStream, fragmentShaderStream));
             REQUIRE(!shader.loadFromStream(vertexShaderStream, geometryShaderStream, emptyStream));

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -32,6 +32,32 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         CHECK(texture.getNativeHandle() == 0);
     }
 
+    SECTION("Move semantics")
+    {
+        SECTION("Construction")
+        {
+            sf::Texture       movedTexture;
+            const sf::Texture texture = std::move(movedTexture);
+            CHECK(texture.getSize() == sf::Vector2u());
+            CHECK(!texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() == 0);
+        }
+
+        SECTION("Assignment")
+        {
+            sf::Texture movedTexture;
+            sf::Texture texture;
+            texture = std::move(movedTexture);
+            CHECK(texture.getSize() == sf::Vector2u());
+            CHECK(!texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() == 0);
+        }
+    }
+
     SECTION("create()")
     {
         sf::Texture texture;
@@ -61,6 +87,18 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
     {
         sf::Texture texture;
         REQUIRE(texture.loadFromFile("Graphics/sfml-logo-big.png"));
+        CHECK(texture.getSize() == sf::Vector2u(1001, 304));
+        CHECK(!texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() != 0);
+    }
+
+    SECTION("loadFromMemory()")
+    {
+        const auto  memory = loadIntoMemory("Graphics/sfml-logo-big.png");
+        sf::Texture texture;
+        REQUIRE(texture.loadFromMemory(memory.data(), memory.size()));
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());
         CHECK(!texture.isSrgb());

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -6,8 +6,11 @@
 
 #include <GraphicsUtil.hpp>
 #include <SystemUtil.hpp>
+#include <fstream>
 #include <limits>
 #include <ostream>
+
+#include <cassert>
 
 namespace sf
 {
@@ -112,4 +115,16 @@ bool operator==(const sf::Transform& lhs, const Approx<sf::Transform>& rhs)
            lhs.getMatrix()[3] == Approx(rhs.value.getMatrix()[3]) &&
            lhs.getMatrix()[7] == Approx(rhs.value.getMatrix()[7]) &&
            lhs.getMatrix()[15] == Approx(rhs.value.getMatrix()[15]);
+}
+
+std::vector<std::byte> loadIntoMemory(const std::filesystem::path& path)
+{
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    assert(file);
+    const auto size = file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::vector<std::byte>       buffer(static_cast<std::size_t>(size));
+    [[maybe_unused]] const auto& result = file.read(reinterpret_cast<char*>(buffer.data()), size);
+    assert(result);
+    return buffer;
 }

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -6,7 +6,11 @@
 #pragma once
 
 #include <SystemUtil.hpp>
+#include <filesystem>
 #include <iosfwd>
+#include <vector>
+
+#include <cstddef>
 
 namespace sf
 {
@@ -35,3 +39,5 @@ bool operator==(const sf::Rect<T>& lhs, const Approx<sf::Rect<T>>& rhs)
     return lhs.left == Approx(rhs.value.left) && lhs.top == Approx(rhs.value.top) &&
            lhs.width == Approx(rhs.value.width) && lhs.height == Approx(rhs.value.height);
 }
+
+[[nodiscard]] std::vector<std::byte> loadIntoMemory(const std::filesystem::path& path);


### PR DESCRIPTION
## Description

I use the new Coveralls code coverage report to find a few places we could increase coverage. Now that we've had Coveralls run once we ought to see coverage go up in this PR so this is also serves as a test of our new reporting system.

When writing this I discovered that we didn't define `sf::Shader` move operations for OpenGL ES so I defaulted those implementations so they now exist.