### PR TITLE
Fixed coverage data not being collected for MinGW builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,12 @@ jobs:
         verbose: 2
         key: ${{ matrix.platform.name }}-${{ matrix.config.name }}-${{ matrix.type.name }}
 
+    - name: Install Gcovr for MinGW
+      if: matrix.type.name == 'Debug' && contains(matrix.platform.name, 'MinGW')
+      uses: threeal/pipx-install-action@v1.0.0
+      with:
+        packages: gcovr
+
     - name: Cache OpenCppCoverage
       if: matrix.type.name == 'Debug' && runner.os == 'Windows'
       id: opencppcoverage-cache
@@ -193,11 +199,11 @@ jobs:
         find build/bin -name test-sfml-window -or -name test-sfml-window.exe -exec sh -c "{} *sf::Context* --section=\"Version String\" --success | grep OpenGL" \;
 
     - name: Test
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && !contains(matrix.platform.name, 'MinGW')
       run: cmake --build build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
     - name: Test
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' || contains(matrix.platform.name, 'MinGW')
       run: |
         ctest --test-dir build --output-on-failure -C ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --repeat until-pass:3
         # Run gcovr to extract coverage information from the test run

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -152,7 +152,7 @@ if(SFML_OS_WINDOWS AND NOT SFML_USE_SYSTEM_DEPS)
         VERBATIM)
 endif()
 
-if(SFML_ENABLE_COVERAGE AND SFML_OS_WINDOWS)
+if(SFML_ENABLE_COVERAGE AND SFML_OS_WINDOWS AND NOT SFML_COMPILER_GCC)
     # Try to find and use OpenCppCoverage for coverage reporting when building with MSVC
     find_program(OpenCppCoverage_BINARY "OpenCppCoverage.exe")
 


### PR DESCRIPTION
OpenCPPCoverage relies on pdb data being available. These are generated by MSVC and recently LLVM on Windows as well. When building with GCC on MinGW it will use GCC's native debugging information which is incompatible with OpenCPPCoverage.

This change just makes use of Gcovr to collect the GCC profiling information on MinGW just like is already done for GCC on Linux.