### PR TITLE
Remove `sf::View::reset` in favor of assignment operations

### DIFF
--- a/include/SFML/Graphics/View.hpp
+++ b/include/SFML/Graphics/View.hpp
@@ -144,18 +144,6 @@ public:
     void setScissor(const FloatRect& scissor);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Reset the view to the given rectangle
-    ///
-    /// Note that this function resets the rotation angle to 0.
-    ///
-    /// \param rectangle Rectangle defining the zone to display
-    ///
-    /// \see setCenter, setSize, setRotation
-    ///
-    ////////////////////////////////////////////////////////////
-    void reset(const FloatRect& rectangle);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Get the center of the view
     ///
     /// \return Center of the view
@@ -339,10 +327,9 @@ private:
 /// Usage example:
 /// \code
 /// sf::RenderWindow window;
-/// sf::View view;
 ///
 /// // Initialize the view to a rectangle located at (100, 100) and with a size of 400x200
-/// view.reset(sf::FloatRect({100, 100}, {400, 200}));
+/// sf::View view(sf::FloatRect({100, 100}, {400, 200}));
 ///
 /// // Rotate it by 45 degrees
 /// view.rotate(sf::degrees(45));

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -641,8 +641,8 @@ void RenderTarget::resetGLStates()
 void RenderTarget::initialize()
 {
     // Setup the default and current views
-    m_defaultView.reset(FloatRect({0, 0}, Vector2f(getSize())));
-    m_view = m_defaultView;
+    m_defaultView = View(FloatRect({0, 0}, Vector2f(getSize())));
+    m_view        = m_defaultView;
 
     // Set GL states only on first draw, so that we don't pollute user's states
     m_cache.glStatesSet = false;

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -34,9 +34,8 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-View::View(const FloatRect& rectangle)
+View::View(const FloatRect& rectangle) : m_center(rectangle.getCenter()), m_size(rectangle.getSize())
 {
-    reset(rectangle);
 }
 
 
@@ -53,6 +52,7 @@ void View::setCenter(const Vector2f& center)
     m_transformUpdated    = false;
     m_invTransformUpdated = false;
 }
+
 
 ////////////////////////////////////////////////////////////
 void View::setSize(const Vector2f& size)
@@ -92,18 +92,6 @@ void View::setScissor(const FloatRect& scissor)
     assert(scissor.top + scissor.height <= 1.0f && "scissor.top + scissor.height must lie within [0, 1]");
 
     m_scissor = scissor;
-}
-
-
-////////////////////////////////////////////////////////////
-void View::reset(const FloatRect& rectangle)
-{
-    m_center   = rectangle.getCenter();
-    m_size     = rectangle.getSize();
-    m_rotation = Angle::Zero;
-
-    m_transformUpdated    = false;
-    m_invTransformUpdated = false;
 }
 
 

--- a/test/Graphics/View.test.cpp
+++ b/test/Graphics/View.test.cpp
@@ -107,24 +107,6 @@ TEST_CASE("[Graphics] sf::View")
         CHECK(view.getViewport() == sf::FloatRect({0, 0}, {1, 1}));
     }
 
-    SECTION("reset()")
-    {
-        sf::View view;
-        view.setCenter({3.14f, 4.2f});
-        view.setSize({600, 900});
-        view.setRotation(sf::degrees(15));
-        view.setViewport({{150, 250}, {500, 750}});
-        view.setScissor({{0.2f, 0.3f}, {0.4f, 0.5f}});
-        view.reset({{1, 2}, {3, 4}});
-        CHECK(view.getCenter() == sf::Vector2f(2.5f, 4));
-        CHECK(view.getSize() == sf::Vector2f(3, 4));
-        CHECK(view.getRotation() == sf::Angle::Zero);
-        CHECK(view.getViewport() == sf::FloatRect({150, 250}, {500, 750}));
-        CHECK(view.getScissor() == sf::FloatRect({0.2f, 0.3f}, {0.4f, 0.5f}));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.666667f, 0, -1.66667f, 0, -0.5f, 2, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(1.5f, 0, 2.5f, 0, -2, 4, 0, 0, 1)));
-    }
-
     SECTION("move()")
     {
         sf::View view;


### PR DESCRIPTION
## Description
It's rare that a type truly needs a .reset function. Copy/move assignment typically accomplishes the same thing with less code and is easier to maintain since it doesn't require updating your .reset() function as new data members are added.

To reset a type is conceptually the same thing as simply assigning from a newly constructed instance of the same type.