### PR TITLE
Fix bug on x11 where window close events were not propagated with certain window styles

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -574,7 +574,7 @@ m_cursorGrabbed(m_fullscreen)
             auto hints        = WMHints();
             hints.flags       = MWM_HINTS_FUNCTIONS | MWM_HINTS_DECORATIONS;
             hints.decorations = 0;
-            hints.functions   = 0;
+            hints.functions   = MWM_FUNC_CLOSE;
 
             if (style & Style::Titlebar)
             {


### PR DESCRIPTION
## Description

This is intended to fix https://github.com/SFML/SFML/issues/2943.

It's a single line change which adds a flag for x11 telling it to propagate close events for styles None, Resize, Titlebar.

In truth I do not understand x11 very well, but the behavior / fix seems to make sense to me at least. It fixes the bug on my machine, and doesn't visually impact the window decorations.

I've only confirmed the initial bug on Cinnamon. Flareon from the Discord confirmed it was present on KDE. 

I've only tested this PR Cinnamon.

## How to test this PR?
Make sure hotkey is bound which closes in-focus window, compile / run this code, press hotkey 
A) without this PR, the window will not get sf::Event::Close, the window will never close.
B) with this PR, the window will get sf::Event::Close, the window will successfully close.

```cpp
#include <SFML/Window.hpp>
 
int main()
{
    sf::Window window; // also happens with RenderWindow
 
    // The following are all not working: Titlebar, Resize, None
    window.create(sf::VideoMode({800, 600}), "My window", sf::Style::None);
 
    while (window.isOpen()) {
        sf::Event event{};
        while (window.pollEvent(event)) {
            // sf::Event::Closed is never given to us from window.pollEvent(event)
            if (event.type == sf::Event::Closed)
                window.close();
        }
 
        window.display();
    }
 
    return 0;
}
```
