### PR TITLE
Add tests for `sf::SoundFileReader` and `sf::SoundFileWriter`

### DIFF
--- a/test/Audio/SoundFileReader.test.cpp
+++ b/test/Audio/SoundFileReader.test.cpp
@@ -1,0 +1,24 @@
+#include <SFML/Audio/SoundFileReader.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[Audio] sf::SoundFileReader")
+{
+    SECTION("Type traits")
+    {
+        STATIC_CHECK(!std::is_constructible_v<sf::SoundFileReader>);
+        STATIC_CHECK(!std::is_copy_constructible_v<sf::SoundFileReader>);
+        STATIC_CHECK(std::is_copy_assignable_v<sf::SoundFileReader>);
+        STATIC_CHECK(!std::is_nothrow_move_constructible_v<sf::SoundFileReader>);
+        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::SoundFileReader>);
+        STATIC_CHECK(std::has_virtual_destructor_v<sf::SoundFileReader>);
+    }
+
+    SECTION("Info")
+    {
+        const sf::SoundFileReader::Info info;
+        CHECK(info.sampleCount == 0);
+        CHECK(info.channelCount == 0);
+        CHECK(info.sampleRate == 0);
+    }
+}

--- a/test/Audio/SoundFileWriter.test.cpp
+++ b/test/Audio/SoundFileWriter.test.cpp
@@ -1,0 +1,10 @@
+#include <SFML/Audio/SoundFileWriter.hpp>
+
+#include <type_traits>
+
+static_assert(!std::is_constructible_v<sf::SoundFileWriter>);
+static_assert(!std::is_copy_constructible_v<sf::SoundFileWriter>);
+static_assert(std::is_copy_assignable_v<sf::SoundFileWriter>);
+static_assert(!std::is_nothrow_move_constructible_v<sf::SoundFileWriter>);
+static_assert(std::is_nothrow_move_assignable_v<sf::SoundFileWriter>);
+static_assert(std::has_virtual_destructor_v<sf::SoundFileWriter>);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,6 +138,7 @@ set(AUDIO_SRC
     Audio/SoundBuffer.test.cpp
     Audio/SoundBufferRecorder.test.cpp
     Audio/SoundFileFactory.test.cpp
+    Audio/SoundFileReader.test.cpp
     Audio/SoundRecorder.test.cpp
     Audio/SoundSource.test.cpp
     Audio/SoundStream.test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,6 +139,7 @@ set(AUDIO_SRC
     Audio/SoundBufferRecorder.test.cpp
     Audio/SoundFileFactory.test.cpp
     Audio/SoundFileReader.test.cpp
+    Audio/SoundFileWriter.test.cpp
     Audio/SoundRecorder.test.cpp
     Audio/SoundSource.test.cpp
     Audio/SoundStream.test.cpp


### PR DESCRIPTION
## Description

While just an interface class, `sf::SoundFileReader` still deserves its own test .cpp file to check some initial values, types traits, and ensure this header compiles on its own to ensure there are no missing inclusions.

`sf::SoundFileWriter` is even simple so it doesn't even get a `TEST_CASE`. It gets treated like other untestable Audio module types and only gets a few static assertions but this still tests the header for all proper inclusions so it has some value.