### PR TITLE
Replace C arrays with `std::array`

### DIFF
--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -33,6 +33,8 @@
 
 #include <SFML/System/Vector2.hpp>
 
+#include <array>
+
 
 namespace sf
 {
@@ -267,10 +269,10 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     // clang-format off
-    float m_matrix[16]{1.f, 0.f, 0.f, 0.f,
-                       0.f, 1.f, 0.f, 0.f,
-                       0.f, 0.f, 1.f, 0.f,
-                       0.f, 0.f, 0.f, 1.f}; //!< 4x4 matrix defining the transformation
+    std::array<float, 16> m_matrix{1.f, 0.f, 0.f, 0.f,
+                                   0.f, 1.f, 0.f, 0.f,
+                                   0.f, 0.f, 1.f, 0.f,
+                                   0.f, 0.f, 0.f, 1.f}; //!< 4x4 matrix defining the transformation
     // clang-format off
 };
 

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -55,7 +55,7 @@ constexpr Transform::Transform(float a00, float a01, float a02,
 ////////////////////////////////////////////////////////////
 constexpr const float* Transform::getMatrix() const
 {
-    return m_matrix;
+    return m_matrix.data();
 }
 
 
@@ -133,8 +133,8 @@ constexpr FloatRect Transform::transformRect(const FloatRect& rectangle) const
 ////////////////////////////////////////////////////////////
 constexpr Transform& Transform::combine(const Transform& transform)
 {
-    const float* a = m_matrix;
-    const float* b = transform.m_matrix;
+    const auto& a = m_matrix;
+    const auto& b = transform.m_matrix;
 
     // clang-format off
     *this = Transform(a[0] * b[0]  + a[4] * b[1]  + a[12] * b[3],

--- a/include/SFML/System/Utf.hpp
+++ b/include/SFML/System/Utf.hpp
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 
+#include <array>
 #include <locale>
 
 #include <cstdint>

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -56,7 +56,7 @@ In Utf<8>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replace
 {
     // clang-format off
     // Some useful precomputed data
-    static constexpr int trailing[256] =
+    static constexpr std::array<std::uint8_t, 256> trailing =
     {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -68,14 +68,14 @@ In Utf<8>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replace
         2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5
     };
 
-    static constexpr std::uint32_t offsets[6] =
+    static constexpr std::array<std::uint32_t, 6> offsets =
     {
         0x00000000, 0x00003080, 0x000E2080, 0x03C82080, 0xFA082080, 0x82082080
     };
     // clang-format on
 
     // decode the character
-    const int trailingBytes = trailing[static_cast<std::uint8_t>(*begin)];
+    const auto trailingBytes = trailing[static_cast<std::uint8_t>(*begin)];
     if (trailingBytes < std::distance(begin, end))
     {
         output = 0;
@@ -110,7 +110,7 @@ template <typename Out>
 Out Utf<8>::encode(std::uint32_t input, Out output, std::uint8_t replacement)
 {
     // Some useful precomputed data
-    static constexpr std::uint8_t firstBytes[7] = {0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC};
+    static constexpr std::array<std::uint8_t, 7> firstBytes = {0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC};
 
     // encode the character
     if ((input > 0x0010FFFF) || ((input >= 0xD800) && (input <= 0xDBFF)))
@@ -134,7 +134,7 @@ Out Utf<8>::encode(std::uint32_t input, Out output, std::uint8_t replacement)
         // clang-format on
 
         // Extract the bytes to write
-        std::byte bytes[4];
+        std::array<std::byte, 4> bytes{};
 
         // clang-format off
         switch (bytestoWrite)
@@ -147,7 +147,7 @@ Out Utf<8>::encode(std::uint32_t input, Out output, std::uint8_t replacement)
         // clang-format on
 
         // Add them to the output
-        output = priv::copy(bytes, bytes + bytestoWrite, output);
+        output = priv::copy(bytes.data(), bytes.data() + bytestoWrite, output);
     }
 
     return output;

--- a/src/SFML/Audio/SoundFileWriterOgg.hpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.hpp
@@ -31,6 +31,7 @@
 
 #include <vorbis/vorbisenc.h>
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 
@@ -103,12 +104,12 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int     m_channelCount{};  //!< Channel count of the sound being written
-    std::size_t      m_remapTable[8]{}; //!< Table we use to remap source to target channel order
-    std::ofstream    m_file;            //!< Output file
-    ogg_stream_state m_ogg{};           //!< OGG stream
-    vorbis_info      m_vorbis{};        //!< Vorbis handle
-    vorbis_dsp_state m_state{};         //!< Current encoding state
+    unsigned int               m_channelCount{}; //!< Channel count of the sound being written
+    std::array<std::size_t, 8> m_remapTable{};   //!< Table we use to remap source to target channel order
+    std::ofstream              m_file;           //!< Output file
+    ogg_stream_state           m_ogg{};          //!< OGG stream
+    vorbis_info                m_vorbis{};       //!< Vorbis handle
+    vorbis_dsp_state           m_state{};        //!< Current encoding state
 };
 
 } // namespace sf::priv

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -31,6 +31,7 @@
 #include <SFML/System/Utils.hpp>
 
 #include <algorithm>
+#include <array>
 #include <ostream>
 
 #include <cassert>
@@ -45,25 +46,25 @@ namespace
 
 void encode(std::ostream& stream, std::int16_t value)
 {
-    const std::byte bytes[] = {static_cast<std::byte>(value & 0xFF), static_cast<std::byte>(value >> 8)};
-    stream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    const std::array bytes = {static_cast<char>(value & 0xFF), static_cast<char>(value >> 8)};
+    stream.write(bytes.data(), bytes.size());
 }
 
 void encode(std::ostream& stream, std::uint16_t value)
 {
-    const std::byte bytes[] = {static_cast<std::byte>(value & 0xFF), static_cast<std::byte>(value >> 8)};
-    stream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    const std::array bytes = {static_cast<char>(value & 0xFF), static_cast<char>(value >> 8)};
+    stream.write(bytes.data(), bytes.size());
 }
 
 void encode(std::ostream& stream, std::uint32_t value)
 {
-    const std::byte bytes[] = {
-        static_cast<std::byte>(value & 0x000000FF),
-        static_cast<std::byte>((value & 0x0000FF00) >> 8),
-        static_cast<std::byte>((value & 0x00FF0000) >> 16),
-        static_cast<std::byte>((value & 0xFF000000) >> 24),
+    const std::array bytes = {
+        static_cast<char>(value & 0x000000FF),
+        static_cast<char>((value & 0x0000FF00) >> 8),
+        static_cast<char>((value & 0x00FF0000) >> 16),
+        static_cast<char>((value & 0xFF000000) >> 24),
     };
-    stream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    stream.write(bytes.data(), bytes.size());
 }
 } // namespace
 
@@ -247,17 +248,17 @@ void SoundFileWriterWav::writeHeader(unsigned int sampleRate, unsigned int chann
     assert(m_file.good() && "Most recent I/O operation failed");
 
     // Write the main chunk ID
-    char mainChunkId[4] = {'R', 'I', 'F', 'F'};
-    m_file.write(mainChunkId, sizeof(mainChunkId));
+    std::array mainChunkId = {'R', 'I', 'F', 'F'};
+    m_file.write(mainChunkId.data(), mainChunkId.size());
 
     // Write the main chunk header
     encode(m_file, static_cast<std::uint32_t>(0)); // 0 is a placeholder, will be written later
-    char mainChunkFormat[4] = {'W', 'A', 'V', 'E'};
-    m_file.write(mainChunkFormat, sizeof(mainChunkFormat));
+    std::array mainChunkFormat = {'W', 'A', 'V', 'E'};
+    m_file.write(mainChunkFormat.data(), mainChunkFormat.size());
 
     // Write the sub-chunk 1 ("format") id and size
-    char fmtChunkId[4] = {'f', 'm', 't', ' '};
-    m_file.write(fmtChunkId, sizeof(fmtChunkId));
+    std::array fmtChunkId = {'f', 'm', 't', ' '};
+    m_file.write(fmtChunkId.data(), fmtChunkId.size());
 
     if (channelCount > 2)
     {
@@ -295,14 +296,14 @@ void SoundFileWriterWav::writeHeader(unsigned int sampleRate, unsigned int chann
         encode(m_file, bitsPerSample);
         encode(m_file, channelMask);
         // Write the subformat (PCM)
-        char subformat[16] =
+        std::array subformat =
             {'\x01', '\x00', '\x00', '\x00', '\x00', '\x00', '\x10', '\x00', '\x80', '\x00', '\x00', '\xAA', '\x00', '\x38', '\x9B', '\x71'};
-        m_file.write(subformat, sizeof(subformat));
+        m_file.write(subformat.data(), subformat.size());
     }
 
     // Write the sub-chunk 2 ("data") id and size
-    char dataChunkId[4] = {'d', 'a', 't', 'a'};
-    m_file.write(dataChunkId, sizeof(dataChunkId));
+    std::array dataChunkId = {'d', 'a', 't', 'a'};
+    m_file.write(dataChunkId.data(), dataChunkId.size());
     const std::uint32_t dataChunkSize = 0; // placeholder, will be written later
     encode(m_file, dataChunkSize);
 }

--- a/src/SFML/Audio/SoundFileWriterWav.hpp
+++ b/src/SFML/Audio/SoundFileWriterWav.hpp
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/SoundFileWriter.hpp>
 
+#include <array>
 #include <filesystem>
 #include <fstream>
 
@@ -105,9 +106,9 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::ofstream m_file;             //!< File stream to write to
-    unsigned int  m_channelCount{};   //!< Channel count of the sound being written
-    std::size_t   m_remapTable[18]{}; //!< Table we use to remap source to target channel order
+    std::ofstream               m_file;           //!< File stream to write to
+    unsigned int                m_channelCount{}; //!< Channel count of the sound being written
+    std::array<std::size_t, 18> m_remapTable{};   //!< Table we use to remap source to target channel order
 };
 
 } // namespace sf::priv

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -37,6 +37,7 @@
 #include <SFML/System/Err.hpp>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <ostream>
 #include <utility>
@@ -861,10 +862,10 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
         if ((coordinateType == CoordinateType::Pixels) || texture->m_pixelsFlipped)
         {
             // clang-format off
-            GLfloat matrix[16] = {1.f, 0.f, 0.f, 0.f,
-                                  0.f, 1.f, 0.f, 0.f,
-                                  0.f, 0.f, 1.f, 0.f,
-                                  0.f, 0.f, 0.f, 1.f};
+            std::array matrix = {1.f, 0.f, 0.f, 0.f,
+                                 0.f, 1.f, 0.f, 0.f,
+                                 0.f, 0.f, 1.f, 0.f,
+                                 0.f, 0.f, 0.f, 1.f};
             // clang-format on
 
             // If non-normalized coordinates (= pixels) are requested, we need to
@@ -884,7 +885,7 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
 
             // Load the matrix
             glCheck(glMatrixMode(GL_TEXTURE));
-            glCheck(glLoadMatrixf(matrix));
+            glCheck(glLoadMatrixf(matrix.data()));
         }
         else
         {

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -31,6 +31,8 @@
 #include <SFML/System/String.hpp>
 #include <SFML/System/Utils.hpp>
 
+#include <array>
+
 #include <cstring>
 #include <cwchar>
 
@@ -212,8 +214,8 @@ Packet& Packet::operator>>(std::uint64_t& data)
     {
         // Since ntohll is not available everywhere, we have to convert
         // to network byte order (big endian) manually
-        std::byte bytes[sizeof(data)];
-        std::memcpy(bytes, &m_data[m_readPos], sizeof(data));
+        std::array<std::byte, sizeof(data)> bytes{};
+        std::memcpy(bytes.data(), &m_data[m_readPos], sizeof(data));
 
         data = toInteger<std::uint64_t>(bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]);
 
@@ -427,14 +429,14 @@ Packet& Packet::operator<<(std::int64_t data)
     // Since htonll is not available everywhere, we have to convert
     // to network byte order (big endian) manually
 
-    std::uint8_t toWrite[] = {static_cast<std::uint8_t>((data >> 56) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 48) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 40) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 32) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 24) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 16) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 8) & 0xFF),
-                              static_cast<std::uint8_t>((data)&0xFF)};
+    std::array toWrite = {static_cast<std::uint8_t>((data >> 56) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 48) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 40) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 32) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 24) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 16) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 8) & 0xFF),
+                          static_cast<std::uint8_t>((data)&0xFF)};
 
     append(&toWrite, sizeof(toWrite));
     return *this;
@@ -447,14 +449,14 @@ Packet& Packet::operator<<(std::uint64_t data)
     // Since htonll is not available everywhere, we have to convert
     // to network byte order (big endian) manually
 
-    std::uint8_t toWrite[] = {static_cast<std::uint8_t>((data >> 56) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 48) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 40) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 32) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 24) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 16) & 0xFF),
-                              static_cast<std::uint8_t>((data >> 8) & 0xFF),
-                              static_cast<std::uint8_t>((data)&0xFF)};
+    std::array toWrite = {static_cast<std::uint8_t>((data >> 56) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 48) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 40) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 32) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 24) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 16) & 0xFF),
+                          static_cast<std::uint8_t>((data >> 8) & 0xFF),
+                          static_cast<std::uint8_t>((data)&0xFF)};
 
     append(&toWrite, sizeof(toWrite));
     return *this;

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -33,6 +33,7 @@
 #include <SFML/System/Err.hpp>
 
 #include <algorithm>
+#include <array>
 #include <ostream>
 
 #include <cstring>
@@ -401,12 +402,12 @@ Socket::Status TcpSocket::receive(Packet& packet)
     }
 
     // Loop until we receive all the packet data
-    char buffer[1024];
+    std::array<char, 1024> buffer{};
     while (m_pendingPacket.data.size() < packetSize)
     {
         // Receive a chunk of data
         const std::size_t sizeToGet = std::min(packetSize - m_pendingPacket.data.size(), sizeof(buffer));
-        const Status      status    = receive(buffer, sizeToGet, received);
+        const Status      status    = receive(buffer.data(), sizeToGet, received);
         if (status != Status::Done)
             return status;
 
@@ -415,7 +416,7 @@ Socket::Status TcpSocket::receive(Packet& packet)
         {
             m_pendingPacket.data.resize(m_pendingPacket.data.size() + received);
             std::byte* begin = m_pendingPacket.data.data() + m_pendingPacket.data.size() - received;
-            std::memcpy(begin, buffer, received);
+            std::memcpy(begin, buffer.data(), received);
         }
     }
 

--- a/src/SFML/Window/JoystickImpl.hpp
+++ b/src/SFML/Window/JoystickImpl.hpp
@@ -55,7 +55,7 @@ struct JoystickState
 {
     bool                                                  connected{}; //!< Is the joystick currently connected?
     EnumArray<Joystick::Axis, float, Joystick::AxisCount> axes{};      //!< Position of each axis, in range [-100, 100]
-    bool buttons[Joystick::ButtonCount]{};                             //!< Status of each button (true = pressed)
+    std::array<bool, Joystick::ButtonCount>               buttons{};   //!< Status of each button (true = pressed)
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/JoystickManager.hpp
+++ b/src/SFML/Window/JoystickManager.hpp
@@ -30,6 +30,8 @@
 #include <SFML/Window/Joystick.hpp>
 #include <SFML/Window/JoystickImpl.hpp>
 
+#include <array>
+
 
 namespace sf::priv
 {
@@ -124,7 +126,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Item m_joysticks[Joystick::Count]; //!< Joysticks information and state
+    std::array<Item, Joystick::Count> m_joysticks; //!< Joysticks information and state
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -33,6 +33,7 @@
 
 #include <SFML/System/Err.hpp>
 
+#include <array>
 #include <mutex>
 #include <ostream>
 #include <vector>
@@ -513,10 +514,10 @@ void GlxContext::createSurface(GlxContext* shared, const Vector2u& size, unsigne
 
             if (config)
             {
-                int attributes[] =
+                std::array attributes =
                     {GLX_PBUFFER_WIDTH, static_cast<int>(size.x), GLX_PBUFFER_HEIGHT, static_cast<int>(size.y), 0, 0};
 
-                m_pbuffer = glXCreatePbuffer(m_display.get(), *config, attributes);
+                m_pbuffer = glXCreatePbuffer(m_display.get(), *config, attributes.data());
 
                 updateSettingsFromVisualInfo(&visualInfo);
 
@@ -578,11 +579,11 @@ void GlxContext::createContext(GlxContext* shared)
 
         glXQueryDrawable(m_display.get(), m_pbuffer, GLX_FBCONFIG_ID, &fbConfigId);
 
-        int attributes[] = {GLX_FBCONFIG_ID, static_cast<int>(fbConfigId), 0, 0};
+        std::array attributes = {GLX_FBCONFIG_ID, static_cast<int>(fbConfigId), 0, 0};
 
         int        count    = 0;
         const auto fbconfig = X11Ptr<GLXFBConfig>(
-            glXChooseFBConfig(m_display.get(), DefaultScreen(m_display.get()), attributes, &count));
+            glXChooseFBConfig(m_display.get(), DefaultScreen(m_display.get()), attributes.data(), &count));
 
         if (count == 1)
             visualInfo = X11Ptr<XVisualInfo>(glXGetVisualFromFBConfig(m_display.get(), *fbconfig));

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -400,14 +400,13 @@ std::string getJoystickName(unsigned int index)
     if (fd >= 0)
     {
         // Get the name
-        char name[128] = {};
-
-        const int result = ioctl(fd, JSIOCGNAME(sizeof(name)), name);
+        std::array<char, 128> name{};
+        const int             result = ioctl(fd, JSIOCGNAME(name.size()), name.data());
 
         ::close(fd);
 
         if (result >= 0)
-            return name;
+            return name.data();
     }
 
     // Fall back to manual USB chain walk via udev
@@ -600,7 +599,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
     ioctl(m_file, JSIOCGAXES, &axesCount);
     for (int i = 0; i < axesCount; ++i)
     {
-        switch (m_mapping[i])
+        switch (m_mapping[static_cast<std::size_t>(i)])
         {
             // clang-format off
             case ABS_X:        caps.axes[Joystick::Axis::X]    = true; break;
@@ -650,7 +649,7 @@ JoystickState JoystickImpl::JoystickImpl::update()
             {
                 const float value = joyState.value * 100.f / 32767.f;
 
-                if (joyState.number < ABS_MAX + 1)
+                if (joyState.number < m_mapping.size())
                 {
                     switch (m_mapping[joyState.number])
                     {

--- a/src/SFML/Window/Unix/JoystickImpl.hpp
+++ b/src/SFML/Window/Unix/JoystickImpl.hpp
@@ -105,10 +105,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int                      m_file{-1};                ///< File descriptor of the joystick
-    char                     m_mapping[ABS_MAX + 1]{0}; ///< Axes mapping (index to axis id)
-    JoystickState            m_state;                   ///< Current state of the joystick
-    Joystick::Identification m_identification;          ///< Identification of the joystick
+    int                       m_file{-1};       ///< File descriptor of the joystick
+    std::array<char, ABS_CNT> m_mapping{};      ///< Axes mapping (index to axis id)
+    JoystickState             m_state;          ///< Current state of the joystick
+    Joystick::Identification  m_identification; ///< Identification of the joystick
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -34,6 +34,7 @@
 #include <SFML/System/Sleep.hpp>
 #include <SFML/System/Time.hpp>
 
+#include <array>
 #include <memory>
 
 #include <cmath>
@@ -96,7 +97,7 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 struct WindowImpl::JoystickStatesImpl
 {
-    JoystickState states[Joystick::Count]{}; //!< Previous state of the joysticks
+    std::array<JoystickState, Joystick::Count> states{}; //!< Previous state of the joysticks
 };
 
 

--- a/src/SFML/Window/macOS/HIDJoystickManager.cpp
+++ b/src/SFML/Window/macOS/HIDJoystickManager.cpp
@@ -29,6 +29,8 @@
 #include <SFML/Window/macOS/HIDInputManager.hpp>
 #include <SFML/Window/macOS/HIDJoystickManager.hpp>
 
+#include <array>
+
 ////////////////////////////////////////////////////////////
 // Private data
 ////////////////////////////////////////////////////////////
@@ -75,11 +77,8 @@ HIDJoystickManager::HIDJoystickManager()
 
     CFDictionaryRef mask1 = HIDInputManager::copyDevicesMask(kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
 
-    CFDictionaryRef maskArray[2];
-    maskArray[0] = mask0;
-    maskArray[1] = mask1;
-
-    CFArrayRef mask = CFArrayCreate(nullptr, reinterpret_cast<const void**>(maskArray), 2, nullptr);
+    std::array maskArray = {mask0, mask1};
+    CFArrayRef mask = CFArrayCreate(nullptr, reinterpret_cast<const void**>(maskArray.data()), maskArray.size(), nullptr);
 
     IOHIDManagerSetDeviceMatchingMultiple(m_manager, mask);
     CFRelease(mask);

--- a/src/SFML/Window/macOS/JoystickImpl.hpp
+++ b/src/SFML/Window/macOS/JoystickImpl.hpp
@@ -121,7 +121,7 @@ private:
     Joystick::Identification m_identification; ///< Joystick identification
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    static inline Location m_locationIDs[Joystick::Count]{}; ///< Global Joystick register
+    static inline std::array<Location, Joystick::Count> m_locationIDs{}; ///< Global Joystick register
     /// For a corresponding SFML index, m_locationIDs is either some USB
     /// location or 0 if there isn't currently a connected joystick device
 };

--- a/test/System/MemoryInputStream.test.cpp
+++ b/test/System/MemoryInputStream.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <ostream>
 #include <string_view>
 
@@ -32,9 +33,9 @@ TEST_CASE("[System] sf::MemoryInputStream")
         sf::MemoryInputStream mis;
         mis.open(memoryContents.data(), sizeof(char) * memoryContents.size());
 
-        char buffer[32];
-        CHECK(mis.read(buffer, 5) == 5);
-        CHECK(std::string_view(buffer, 5) == std::string_view(memoryContents.data(), 5));
+        std::array<char, 32> buffer{};
+        CHECK(mis.read(buffer.data(), 5) == 5);
+        CHECK(std::string_view(buffer.data(), 5) == std::string_view(memoryContents.data(), 5));
         CHECK(mis.seek(10) == 10);
         CHECK(mis.tell() == 10);
         CHECK(mis.getSize() == 11);


### PR DESCRIPTION
## Description

SFML uses C style arrays quite a lot so I wanted to start chipping away at replacing them with `std::array`. I chose to start with instances where switching to `std::array` was particularly straightforward. Eventually it would be nice to enable the clang-tidy check that forbids C arrays.

For more reading on why C style arrays are not ideal, see the C++ Core Guidelines. 

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#slcon1-prefer-using-stl-array-or-vector-instead-of-a-c-array