### PR TITLE
Address clang-tidy-18 warnings on Linux

### DIFF
--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -108,10 +108,10 @@ std::shared_ptr<_XIM> openXim()
         xim = sharedXIM;
 
         // Restore the previous locale
-        if (prevLoc.length() != 0)
+        if (!prevLoc.empty())
             std::setlocale(LC_ALL, prevLoc.c_str());
 
-        if (prevXLoc.length() != 0)
+        if (!prevXLoc.empty())
             XSetLocaleModifiers(prevXLoc.c_str());
     }
 

--- a/src/SFML/Window/Unix/Utils.hpp
+++ b/src/SFML/Window/Unix/Utils.hpp
@@ -48,7 +48,7 @@ struct XDeleter
 {
     void operator()(T* data) const
     {
-        XFree(data);
+        XFree(data); // NOLINT(bugprone-multi-level-implicit-pointer-conversion)
     }
 };
 


### PR DESCRIPTION
## Description

Ubuntu 24 LTS dropped today. I ran clang-tidy-18 on the Linux and Linux DRM codepaths to find a few new warnings that need to be addressed.