### PR TITLE
[2.6.x] [Window] Fix joystickButton being used for Joystick(Dis)Connected event

### DIFF
--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -200,7 +200,7 @@ void WindowImpl::processJoystickEvents()
         {
             Event event;
             event.type = connected ? Event::JoystickConnected : Event::JoystickDisconnected;
-            event.joystickButton.joystickId = i;
+            event.joystickConnect.joystickId = i;
             pushEvent(event);
 
             // Clear previous axes positions


### PR DESCRIPTION
Fixes logical "issue" with joystickButton being used instead of joystickConnect to store the joystickId for (dis)connection events.
Tested on Linux, and it works fine.

Do note that I say "issue" because in reality the two structs (declared here: https://github.com/SFML/SFML/blob/b0e25088a291772fad8364372bcff9728512579c/include/SFML/Window/Event.hpp#L136 ) have joystickId in the same position. So, while the code was technically wrong, the data was still being placed in the proper place (at least, from my tests), meaning that users were still able to read the proper id.