### PR TITLE
Require that variables are initialized

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,7 +32,6 @@ Checks: >
   -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-non-const-global-variables,
-  -cppcoreguidelines-init-variables,
   -cppcoreguidelines-macro-to-enum,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-narrowing-conversions,

--- a/examples/sockets/Sockets.cpp
+++ b/examples/sockets/Sockets.cpp
@@ -22,12 +22,12 @@ int main()
     const unsigned short port = 50001;
 
     // TCP, UDP or connected UDP ?
-    char protocol;
+    char protocol = 0;
     std::cout << "Do you want to use TCP (t) or UDP (u)? ";
     std::cin >> protocol;
 
     // Client or server ?
-    char who;
+    char who = 0;
     std::cout << "Do you want to be a server (s) or a client (c)? ";
     std::cin >> who;
 

--- a/examples/sockets/TCP.cpp
+++ b/examples/sockets/TCP.cpp
@@ -39,7 +39,7 @@ void runTcpServer(unsigned short port)
 
     // Receive a message back from the client
     char        in[128];
-    std::size_t received;
+    std::size_t received = 0;
     if (socket.receive(in, sizeof(in), received) != sf::Socket::Status::Done)
         return;
     std::cout << "Answer received from the client: " << std::quoted(in) << std::endl;
@@ -71,7 +71,7 @@ void runTcpClient(unsigned short port)
 
     // Receive a message from the server
     char        in[128];
-    std::size_t received;
+    std::size_t received = 0;
     if (socket.receive(in, sizeof(in), received) != sf::Socket::Status::Done)
         return;
     std::cout << "Message received from the server: " << std::quoted(in) << std::endl;

--- a/examples/sockets/UDP.cpp
+++ b/examples/sockets/UDP.cpp
@@ -26,9 +26,9 @@ void runUdpServer(unsigned short port)
 
     // Wait for a message
     char                         in[128];
-    std::size_t                  received;
+    std::size_t                  received = 0;
     std::optional<sf::IpAddress> sender;
-    unsigned short               senderPort;
+    unsigned short               senderPort = 0;
     if (socket.receive(in, sizeof(in), received, sender, senderPort) != sf::Socket::Status::Done)
         return;
     std::cout << "Message received from client " << sender.value() << ": " << std::quoted(in) << std::endl;
@@ -66,9 +66,9 @@ void runUdpClient(unsigned short port)
 
     // Receive an answer from anyone (but most likely from the server)
     char                         in[128];
-    std::size_t                  received;
+    std::size_t                  received = 0;
     std::optional<sf::IpAddress> sender;
-    unsigned short               senderPort;
+    unsigned short               senderPort = 0;
     if (socket.receive(in, sizeof(in), received, sender, senderPort) != sf::Socket::Status::Done)
         return;
     std::cout << "Message received from " << sender.value() << ": " << std::quoted(in) << std::endl;

--- a/examples/sound_capture/SoundCapture.cpp
+++ b/examples/sound_capture/SoundCapture.cpp
@@ -48,7 +48,7 @@ int main()
     }
 
     // Choose the sample rate
-    unsigned int sampleRate;
+    unsigned int sampleRate = 0;
     std::cout << "Please choose the sample rate for sound capture (44100 is CD quality): ";
     std::cin >> sampleRate;
     std::cin.ignore(10000, '\n');
@@ -87,7 +87,7 @@ int main()
               << " " << buffer.getChannelCount() << " channels" << std::endl;
 
     // Choose what to do with the recorded sound data
-    char choice;
+    char choice = 0;
     std::cout << "What do you want to do with captured sound (p = play, s = save) ? ";
     std::cin >> choice;
     std::cin.ignore(10000, '\n');

--- a/examples/voip/Server.cpp
+++ b/examples/voip/Server.cpp
@@ -122,7 +122,7 @@ private:
                 break;
 
             // Extract the message ID
-            std::uint8_t id;
+            std::uint8_t id = 0;
             packet >> id;
 
             if (id == serverAudioData)

--- a/examples/voip/VoIP.cpp
+++ b/examples/voip/VoIP.cpp
@@ -24,7 +24,7 @@ int main()
     const unsigned short port = 2435;
 
     // Client or server ?
-    char who;
+    char who = 0;
     std::cout << "Do you want to be a server ('s') or a client ('c')? ";
     std::cin >> who;
 

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -1352,7 +1352,7 @@ public:
         commandBufferAllocateInfo.commandPool                 = commandPool;
         commandBufferAllocateInfo.commandBufferCount          = 1;
 
-        VkCommandBuffer commandBuffer;
+        VkCommandBuffer commandBuffer = nullptr;
 
         if (vkAllocateCommandBuffers(device, &commandBufferAllocateInfo, &commandBuffer) != VK_SUCCESS)
             return false;
@@ -1458,7 +1458,7 @@ public:
             return;
         }
 
-        void* ptr;
+        void* ptr = nullptr;
 
         // Map the buffer into our address space
         if (vkMapMemory(device, stagingBufferMemory, 0, sizeof(vertexData), 0, &ptr) != VK_SUCCESS)
@@ -1537,7 +1537,7 @@ public:
             return;
         }
 
-        void* ptr;
+        void* ptr = nullptr;
 
         // Map the buffer into our address space
         if (vkMapMemory(device, stagingBufferMemory, 0, sizeof(indexData), 0, &ptr) != VK_SUCCESS)
@@ -1689,7 +1689,7 @@ public:
         commandBufferAllocateInfo.commandPool                 = commandPool;
         commandBufferAllocateInfo.commandBufferCount          = 1;
 
-        VkCommandBuffer commandBuffer;
+        VkCommandBuffer commandBuffer = nullptr;
 
         if (vkAllocateCommandBuffers(device, &commandBufferAllocateInfo, &commandBuffer) != VK_SUCCESS)
         {
@@ -1820,7 +1820,7 @@ public:
                      stagingBuffer,
                      stagingBufferMemory);
 
-        void* ptr;
+        void* ptr = nullptr;
 
         // Map the buffer into our address space
         if (vkMapMemory(device, stagingBufferMemory, 0, imageSize, 0, &ptr) != VK_SUCCESS)
@@ -1862,7 +1862,7 @@ public:
         commandBufferAllocateInfo.commandPool                 = commandPool;
         commandBufferAllocateInfo.commandBufferCount          = 1;
 
-        VkCommandBuffer commandBuffer;
+        VkCommandBuffer commandBuffer = nullptr;
 
         if (vkAllocateCommandBuffers(device, &commandBufferAllocateInfo, &commandBuffer) != VK_SUCCESS)
         {
@@ -2431,7 +2431,7 @@ public:
 
         matrixPerspective(projection, fov, aspect, nearPlane, farPlane);
 
-        char* ptr;
+        char* ptr = nullptr;
 
         // Map the current frame's uniform buffer into our address space
         if (vkMapMemory(device, uniformBuffersMemory[currentFrame], 0, sizeof(Matrix) * 3, 0, reinterpret_cast<void**>(&ptr)) !=

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -158,7 +158,7 @@ Out Utf<8>::encode(std::uint32_t input, Out output, std::uint8_t replacement)
 template <typename In>
 In Utf<8>::next(In begin, In end)
 {
-    std::uint32_t codepoint;
+    std::uint32_t codepoint = 0;
     return decode(begin, end, codepoint);
 }
 
@@ -225,9 +225,9 @@ Out Utf<8>::toAnsi(In begin, In end, Out output, char replacement, const std::lo
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin  = decode(begin, end, codepoint);
-        output = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        output                  = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
     }
 
     return output;
@@ -240,9 +240,9 @@ Out Utf<8>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin  = decode(begin, end, codepoint);
-        output = Utf<32>::encodeWide(codepoint, output, replacement);
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        output                  = Utf<32>::encodeWide(codepoint, output, replacement);
     }
 
     return output;
@@ -257,9 +257,9 @@ Out Utf<8>::toLatin1(In begin, In end, Out output, char replacement)
     // and can thus be treated as (a sub-range of) UTF-32
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin     = decode(begin, end, codepoint);
-        *output++ = codepoint < 256 ? static_cast<char>(codepoint) : replacement;
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        *output++               = codepoint < 256 ? static_cast<char>(codepoint) : replacement;
     }
 
     return output;
@@ -280,9 +280,9 @@ Out Utf<8>::toUtf16(In begin, In end, Out output)
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin  = decode(begin, end, codepoint);
-        output = Utf<16>::encode(codepoint, output);
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        output                  = Utf<16>::encode(codepoint, output);
     }
 
     return output;
@@ -295,9 +295,9 @@ Out Utf<8>::toUtf32(In begin, In end, Out output)
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin     = decode(begin, end, codepoint);
-        *output++ = codepoint;
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        *output++               = codepoint;
     }
 
     return output;
@@ -385,7 +385,7 @@ Out Utf<16>::encode(std::uint32_t input, Out output, std::uint16_t replacement)
 template <typename In>
 In Utf<16>::next(In begin, In end)
 {
-    std::uint32_t codepoint;
+    std::uint32_t codepoint = 0;
     return decode(begin, end, codepoint);
 }
 
@@ -449,9 +449,9 @@ Out Utf<16>::toAnsi(In begin, In end, Out output, char replacement, const std::l
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin  = decode(begin, end, codepoint);
-        output = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        output                  = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
     }
 
     return output;
@@ -464,9 +464,9 @@ Out Utf<16>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin  = decode(begin, end, codepoint);
-        output = Utf<32>::encodeWide(codepoint, output, replacement);
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        output                  = Utf<32>::encodeWide(codepoint, output, replacement);
     }
 
     return output;
@@ -495,9 +495,9 @@ Out Utf<16>::toUtf8(In begin, In end, Out output)
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin  = decode(begin, end, codepoint);
-        output = Utf<8>::encode(codepoint, output);
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        output                  = Utf<8>::encode(codepoint, output);
     }
 
     return output;
@@ -518,9 +518,9 @@ Out Utf<16>::toUtf32(In begin, In end, Out output)
 {
     while (begin < end)
     {
-        std::uint32_t codepoint;
-        begin     = decode(begin, end, codepoint);
-        *output++ = codepoint;
+        std::uint32_t codepoint = 0;
+        begin                   = decode(begin, end, codepoint);
+        *output++               = codepoint;
     }
 
     return output;

--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -79,7 +79,7 @@ AudioDevice::AudioDevice()
     }
 
     // Count the playback devices
-    ma_uint32 deviceCount;
+    ma_uint32 deviceCount = 0;
 
     if (auto result = ma_context_get_devices(&*m_context, nullptr, &deviceCount, nullptr, nullptr); result != MA_SUCCESS)
     {

--- a/src/SFML/Audio/MiniaudioUtils.cpp
+++ b/src/SFML/Audio/MiniaudioUtils.cpp
@@ -72,9 +72,9 @@ struct SavedSettings
 ////////////////////////////////////////////////////////////
 SavedSettings saveSettings(const ma_sound& sound)
 {
-    float innerAngle;
-    float outerAngle;
-    float outerGain;
+    float innerAngle = 0;
+    float outerAngle = 0;
+    float outerGain  = 0;
     ma_sound_get_cone(&sound, &innerAngle, &outerAngle, &outerGain);
 
     return SavedSettings{ma_sound_get_pitch(&sound),

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -125,8 +125,8 @@ struct SoundRecorder::Impl
         }
 
         // Enumerate the capture devices
-        ma_device_info* deviceInfos;
-        ma_uint32       deviceCount;
+        ma_device_info* deviceInfos = nullptr;
+        ma_uint32       deviceCount = 0;
 
         if (auto result = ma_context_get_devices(&context, nullptr, nullptr, &deviceInfos, &deviceCount);
             result != MA_SUCCESS)

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -143,7 +143,7 @@ bool Font::loadFromFile(const std::filesystem::path& filename)
     }
 
     // Load the new font face from the specified file
-    FT_Face face;
+    FT_Face face = nullptr;
     if (FT_New_Face(fontHandles->library, filename.string().c_str(), 0, &face) != 0)
     {
         err() << "Failed to load font (failed to create the font face)\n" << formatDebugPathInfo(filename) << std::endl;
@@ -201,7 +201,7 @@ bool Font::loadFromMemory(const void* data, std::size_t sizeInBytes)
     }
 
     // Load the new font face from the specified file
-    FT_Face face;
+    FT_Face face = nullptr;
     if (FT_New_Memory_Face(fontHandles->library,
                            reinterpret_cast<const FT_Byte*>(data),
                            static_cast<FT_Long>(sizeInBytes),
@@ -276,7 +276,7 @@ bool Font::loadFromStream(InputStream& stream)
     args.driver = nullptr;
 
     // Load the new font face from the specified stream
-    FT_Face face;
+    FT_Face face = nullptr;
     if (FT_Open_Face(fontHandles->library, &args, 0, &face) != 0)
     {
         err() << "Failed to load font from stream (failed to create the font face)" << std::endl;
@@ -520,7 +520,7 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
         return glyph;
 
     // Retrieve the glyph
-    FT_Glyph glyphDesc;
+    FT_Glyph glyphDesc = nullptr;
     if (FT_Get_Glyph(face->glyph, &glyphDesc) != 0)
         return glyph;
 

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -430,7 +430,7 @@ bool RenderTextureImplFBO::createFrameBuffer()
     glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_textureId, 0));
 
     // A final check, just to be sure...
-    GLenum status;
+    GLenum status = 0;
     glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
     if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
     {

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -801,20 +801,20 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
     m_uniforms.clear();
 
     // Create the program
-    GLEXT_GLhandle shaderProgram;
+    GLEXT_GLhandle shaderProgram{};
     glCheck(shaderProgram = GLEXT_glCreateProgramObject());
 
     // Create the vertex shader if needed
     if (vertexShaderCode)
     {
         // Create and compile the shader
-        GLEXT_GLhandle vertexShader;
+        GLEXT_GLhandle vertexShader{};
         glCheck(vertexShader = GLEXT_glCreateShaderObject(GLEXT_GL_VERTEX_SHADER));
         glCheck(GLEXT_glShaderSource(vertexShader, 1, &vertexShaderCode, nullptr));
         glCheck(GLEXT_glCompileShader(vertexShader));
 
         // Check the compile log
-        GLint success;
+        GLint success = 0;
         glCheck(GLEXT_glGetObjectParameteriv(vertexShader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
         if (success == GL_FALSE)
         {
@@ -840,7 +840,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
         glCheck(GLEXT_glCompileShader(geometryShader));
 
         // Check the compile log
-        GLint success;
+        GLint success = 0;
         glCheck(GLEXT_glGetObjectParameteriv(geometryShader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
         if (success == GL_FALSE)
         {
@@ -861,13 +861,13 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
     if (fragmentShaderCode)
     {
         // Create and compile the shader
-        GLEXT_GLhandle fragmentShader;
+        GLEXT_GLhandle fragmentShader{};
         glCheck(fragmentShader = GLEXT_glCreateShaderObject(GLEXT_GL_FRAGMENT_SHADER));
         glCheck(GLEXT_glShaderSource(fragmentShader, 1, &fragmentShaderCode, nullptr));
         glCheck(GLEXT_glCompileShader(fragmentShader));
 
         // Check the compile log
-        GLint success;
+        GLint success = 0;
         glCheck(GLEXT_glGetObjectParameteriv(fragmentShader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
         if (success == GL_FALSE)
         {
@@ -888,7 +888,7 @@ bool Shader::compile(const char* vertexShaderCode, const char* geometryShaderCod
     glCheck(GLEXT_glLinkProgram(shaderProgram));
 
     // Check the link log
-    GLint success;
+    GLint success = 0;
     glCheck(GLEXT_glGetObjectParameteriv(shaderProgram, GLEXT_GL_OBJECT_LINK_STATUS, &success));
     if (success == GL_FALSE)
     {

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -186,7 +186,7 @@ bool Texture::create(const Vector2u& size)
     // Create the OpenGL texture if it doesn't exist yet
     if (!m_texture)
     {
-        GLuint texture;
+        GLuint texture = 0;
         glCheck(glGenTextures(1, &texture));
         m_texture = texture;
     }
@@ -382,7 +382,7 @@ Image Texture::copyToImage() const
     glCheck(GLEXT_glGenFramebuffers(1, &frameBuffer));
     if (frameBuffer)
     {
-        GLint previousFrameBuffer;
+        GLint previousFrameBuffer = 0;
         glCheck(glGetIntegerv(GLEXT_GL_FRAMEBUFFER_BINDING, &previousFrameBuffer));
 
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, frameBuffer));
@@ -570,10 +570,10 @@ void Texture::update(const Texture& texture, const Vector2u& dest)
             GLEXT_glFramebufferTexture2D(GLEXT_GL_DRAW_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0));
 
         // A final check, just to be sure...
-        GLenum sourceStatus;
+        GLenum sourceStatus = 0;
         glCheck(sourceStatus = GLEXT_glCheckFramebufferStatus(GLEXT_GL_READ_FRAMEBUFFER));
 
-        GLenum destStatus;
+        GLenum destStatus = 0;
         glCheck(destStatus = GLEXT_glCheckFramebufferStatus(GLEXT_GL_DRAW_FRAMEBUFFER));
 
         if ((sourceStatus == GLEXT_GL_FRAMEBUFFER_COMPLETE) && (destStatus == GLEXT_GL_FRAMEBUFFER_COMPLETE))

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -382,7 +382,7 @@ Ftp::Response Ftp::getResponse()
     {
         // Receive the response from the server
         char        buffer[1024];
-        std::size_t length;
+        std::size_t length = 0;
 
         if (m_receiveBuffer.empty())
         {
@@ -401,11 +401,11 @@ Ftp::Response Ftp::getResponse()
         while (in)
         {
             // Try to extract the code
-            unsigned int code;
+            unsigned int code = 0;
             if (in >> code)
             {
                 // Extract the separator
-                char separator;
+                char separator = 0;
                 in.get(separator);
 
                 // The '-' character means a multiline response
@@ -587,7 +587,7 @@ void Ftp::DataChannel::receive(std::ostream& stream)
 {
     // Receive data
     char        buffer[1024];
-    std::size_t received;
+    std::size_t received = 0;
     while (m_dataSocket.receive(buffer, sizeof(buffer), received) == Socket::Status::Done)
     {
         stream.write(buffer, static_cast<std::streamsize>(received));
@@ -609,7 +609,7 @@ void Ftp::DataChannel::send(std::istream& stream)
 {
     // Send data
     char        buffer[1024];
-    std::size_t count;
+    std::size_t count = 0;
 
     for (;;)
     {

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -209,7 +209,7 @@ void Http::Response::parse(const std::string& data)
     }
 
     // Extract the status code from the first line
-    int status;
+    int status = 0;
     if (in >> status)
     {
         m_status = static_cast<Status>(status);
@@ -238,7 +238,7 @@ void Http::Response::parse(const std::string& data)
     else
     {
         // Chunked - have to read chunk by chunk
-        std::size_t length;
+        std::size_t length = 0;
 
         // Read all chunks, identified by a chunk-size not being 0
         while (in >> std::hex >> length)

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -96,7 +96,7 @@ Packet::operator bool() const
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator>>(bool& data)
 {
-    std::uint8_t value;
+    std::uint8_t value = 0;
     if (*this >> value)
         data = (value != 0);
 

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -227,7 +227,7 @@ Socket::Status TcpSocket::send(const void* data, std::size_t size)
     if (!isBlocking())
         err() << "Warning: Partial sends might not be handled properly." << std::endl;
 
-    std::size_t sent;
+    std::size_t sent = 0;
 
     return send(data, size, sent);
 }
@@ -347,7 +347,7 @@ Socket::Status TcpSocket::send(Packet& packet)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
     // Send the data block
-    std::size_t  sent;
+    std::size_t  sent   = 0;
     const Status status = send(m_blockToSendBuffer.data() + packet.m_sendPos,
                                static_cast<priv::SocketImpl::Size>(m_blockToSendBuffer.size() - packet.m_sendPos),
                                sent);

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -329,7 +329,7 @@ int WindowImplAndroid::processEvent(int /* fd */, int /* events */, void* /* dat
 int WindowImplAndroid::processScrollEvent(AInputEvent* inputEvent, ActivityStates& states)
 {
     // Prepare the Java virtual machine
-    jint lResult;
+    jint lResult = 0;
 
     JavaVM* lJavaVM = states.activity->vm;
     JNIEnv* lJNIEnv = states.activity->env;
@@ -714,7 +714,7 @@ int WindowImplAndroid::getUnicode(AInputEvent* event)
     const std::lock_guard lock(states.mutex);
 
     // Initializes JNI
-    jint lResult;
+    jint lResult = 0;
 
     JavaVM* lJavaVM = states.activity->vm;
     JNIEnv* lJNIEnv = states.activity->env;

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -254,7 +254,7 @@ int getResources(int fd, drmModeResPtr& resources)
 
 int hasMonitorConnected(int fd, drmModeRes& resources)
 {
-    drmModeConnectorPtr connector;
+    drmModeConnectorPtr connector = nullptr;
     for (int i = 0; i < resources.count_connectors; ++i)
     {
         connector = drmModeGetConnector(fd, resources.connectors[i]);
@@ -314,7 +314,7 @@ int findDrmDevice(drmModeResPtr& resources)
 
 int initDrm(sf::priv::Drm& drm, const char* device, const char* modeStr, unsigned int vrefresh)
 {
-    drmModeResPtr resources;
+    drmModeResPtr resources = nullptr;
 
     if (device)
     {
@@ -486,8 +486,8 @@ EGLDisplay getInitializedDisplay()
 
         eglCheck(display = eglGetDisplay(reinterpret_cast<EGLNativeDisplayType>(gbmDevice)));
 
-        EGLint major;
-        EGLint minor;
+        EGLint major = 0;
+        EGLint minor = 0;
         eglCheck(eglInitialize(display, &major, &minor));
 
         gladLoaderLoadEGL(display);
@@ -576,7 +576,7 @@ DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, cons
 DRMContext::~DRMContext()
 {
     // Deactivate the current context
-    EGLContext currentContext;
+    EGLContext currentContext = nullptr;
     eglCheck(currentContext = eglGetCurrentContext());
 
     if (currentContext == m_context)
@@ -692,7 +692,7 @@ void DRMContext::createContext(DRMContext* shared)
 {
     const EGLint contextVersion[] = {EGL_CONTEXT_CLIENT_VERSION, 1, EGL_NONE};
 
-    EGLContext toShared;
+    EGLContext toShared = nullptr;
 
     if (shared)
         toShared = shared->m_context;
@@ -785,7 +785,7 @@ EGLConfig DRMContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
 #endif
       EGL_NONE };
 
-    EGLint    configCount;
+    EGLint    configCount = 0;
     EGLConfig configs[1];
 
     // Ask EGL for the best config matching our video settings
@@ -798,7 +798,7 @@ EGLConfig DRMContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
 ////////////////////////////////////////////////////////////
 void DRMContext::updateSettings()
 {
-    EGLint tmp;
+    EGLint tmp = 0;
 
     // Update the internal context settings with the current config
     eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_DEPTH_SIZE, &tmp));

--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -374,7 +374,7 @@ bool eventProcess(sf::Event& event)
         return true;
     }
 
-    ssize_t bytesRead;
+    ssize_t bytesRead = 0;
 
     // Check all the open file descriptors for the next event
     for (auto& fileDescriptor : fileDescriptors)

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -262,7 +262,7 @@ void EglContext::createContext(EglContext* shared)
 {
     const EGLint contextVersion[] = {EGL_CONTEXT_CLIENT_VERSION, 1, EGL_NONE};
 
-    EGLContext toShared;
+    EGLContext toShared = nullptr;
 
     if (shared)
         toShared = shared->m_context;
@@ -301,7 +301,7 @@ EGLConfig EglContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
     EglContextImpl::ensureInit();
 
     // Determine the number of available configs
-    EGLint configCount;
+    EGLint configCount = 0;
     eglCheck(eglGetConfigs(display, nullptr, 0, &configCount));
 
     // Retrieve the list of available configs
@@ -316,23 +316,23 @@ EGLConfig EglContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
     for (std::size_t i = 0; i < static_cast<std::size_t>(configCount); ++i)
     {
         // Check mandatory attributes
-        int surfaceType;
-        int renderableType;
+        int surfaceType    = 0;
+        int renderableType = 0;
         eglCheck(eglGetConfigAttrib(display, configs[i], EGL_SURFACE_TYPE, &surfaceType));
         eglCheck(eglGetConfigAttrib(display, configs[i], EGL_RENDERABLE_TYPE, &renderableType));
         if (!(surfaceType & (EGL_WINDOW_BIT | EGL_PBUFFER_BIT)) || !(renderableType & EGL_OPENGL_ES_BIT))
             continue;
 
         // Extract the components of the current config
-        int red;
-        int green;
-        int blue;
-        int alpha;
-        int depth;
-        int stencil;
-        int multiSampling;
-        int samples;
-        int caveat;
+        int red           = 0;
+        int green         = 0;
+        int blue          = 0;
+        int alpha         = 0;
+        int depth         = 0;
+        int stencil       = 0;
+        int multiSampling = 0;
+        int samples       = 0;
+        int caveat        = 0;
         eglCheck(eglGetConfigAttrib(display, configs[i], EGL_RED_SIZE, &red));
         eglCheck(eglGetConfigAttrib(display, configs[i], EGL_GREEN_SIZE, &green));
         eglCheck(eglGetConfigAttrib(display, configs[i], EGL_BLUE_SIZE, &blue));
@@ -344,8 +344,15 @@ EGLConfig EglContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
         eglCheck(eglGetConfigAttrib(display, configs[i], EGL_CONFIG_CAVEAT, &caveat));
 
         // Evaluate the config
-        int color = red + green + blue + alpha;
-        int score = evaluateFormat(bitsPerPixel, settings, color, depth, stencil, multiSampling ? samples : 0, caveat == EGL_NONE, false);
+        const int color = red + green + blue + alpha;
+        const int score = evaluateFormat(bitsPerPixel,
+                                         settings,
+                                         color,
+                                         depth,
+                                         stencil,
+                                         multiSampling ? samples : 0,
+                                         caveat == EGL_NONE,
+                                         false);
 
         // If it's better than the current best, make it the new best
         if (score < bestScore)
@@ -410,7 +417,7 @@ XVisualInfo EglContext::selectBestVisual(::Display* xDisplay, unsigned int bitsP
     EGLConfig config = getBestConfig(display, bitsPerPixel, settings);
 
     // Retrieve the visual id associated with this EGL config
-    EGLint nativeVisualId;
+    EGLint nativeVisualId = 0;
 
     eglCheck(eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &nativeVisualId));
 

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -216,11 +216,11 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
             if ((selectionEvent.property == None) || (selectionEvent.selection != m_clipboard))
                 break;
 
-            Atom           type;
-            int            format;
-            unsigned long  items;
-            unsigned long  remainingBytes;
-            unsigned char* data = nullptr;
+            Atom           type           = 0;
+            int            format         = 0;
+            unsigned long  items          = 0;
+            unsigned long  remainingBytes = 0;
+            unsigned char* data           = nullptr;
 
             // The selection owner should have wrote the selection
             // data to the specified window property

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -170,7 +170,7 @@ bool CursorImpl::loadFromSystem(Cursor::Type type)
 {
     release();
 
-    unsigned int shape;
+    unsigned int shape = 0;
 
     // clang-format off
     switch (type)

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<_XIM> openXim()
         // We need the default (environment) locale and X locale for opening
         // the IM and properly receiving text
         // First save the previous ones (this might be able to be written more elegantly?)
-        const char*       p;
+        const char*       p = nullptr;
         const std::string prevLoc((p = std::setlocale(LC_ALL, nullptr)) ? p : "");
         const std::string prevXLoc((p = XSetLocaleModifiers(nullptr)) ? p : "");
 

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -312,7 +312,7 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
     const int screen = DefaultScreen(display);
 
     // Retrieve all the visuals
-    int  count;
+    int  count   = 0;
     auto visuals = X11Ptr<XVisualInfo[]>(XGetVisualInfo(display, 0, nullptr, &count));
     if (visuals)
     {
@@ -326,21 +326,21 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
                 continue;
 
             // Check mandatory attributes
-            int doubleBuffer;
+            int doubleBuffer = 0;
             glXGetConfig(display, &visuals[i], GLX_DOUBLEBUFFER, &doubleBuffer);
             if (!doubleBuffer)
                 continue;
 
             // Extract the components of the current visual
-            int red;
-            int green;
-            int blue;
-            int alpha;
-            int depth;
-            int stencil;
-            int multiSampling;
-            int samples;
-            int sRgb;
+            int red           = 0;
+            int green         = 0;
+            int blue          = 0;
+            int alpha         = 0;
+            int depth         = 0;
+            int stencil       = 0;
+            int multiSampling = 0;
+            int samples       = 0;
+            int sRgb          = 0;
             glXGetConfig(display, &visuals[i], GLX_RED_SIZE, &red);
             glXGetConfig(display, &visuals[i], GLX_GREEN_SIZE, &green);
             glXGetConfig(display, &visuals[i], GLX_BLUE_SIZE, &blue);
@@ -406,11 +406,11 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
 void GlxContext::updateSettingsFromVisualInfo(XVisualInfo* visualInfo)
 {
     // Update the creation settings from the chosen format
-    int depth;
-    int stencil;
-    int multiSampling;
-    int samples;
-    int sRgb;
+    int depth         = 0;
+    int stencil       = 0;
+    int multiSampling = 0;
+    int samples       = 0;
+    int sRgb          = 0;
     glXGetConfig(m_display.get(), visualInfo, GLX_DEPTH_SIZE, &depth);
     glXGetConfig(m_display.get(), visualInfo, GLX_STENCIL_SIZE, &stencil);
 

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -88,12 +88,12 @@ bool isMouseButtonPressed(Mouse::Button button)
     const auto display = openDisplay();
 
     // we don't care about these but they are required
-    ::Window root;
-    ::Window child;
-    int      wx;
-    int      wy;
-    int      gx;
-    int      gy;
+    ::Window root  = 0;
+    ::Window child = 0;
+    int      wx    = 0;
+    int      wy    = 0;
+    int      gx    = 0;
+    int      gy    = 0;
 
     unsigned int buttons = 0;
     XQueryPointer(display.get(), DefaultRootWindow(display.get()), &root, &child, &gx, &gy, &wx, &wy, &buttons);
@@ -122,11 +122,11 @@ Vector2i getMousePosition()
     const auto display = openDisplay();
 
     // we don't care about these but they are required
-    ::Window     root;
-    ::Window     child;
-    int          x;
-    int          y;
-    unsigned int buttons;
+    ::Window     root    = 0;
+    ::Window     child   = 0;
+    int          x       = 0;
+    int          y       = 0;
+    unsigned int buttons = 0;
 
     int gx = 0;
     int gy = 0;
@@ -146,11 +146,11 @@ Vector2i getMousePosition(const WindowBase& relativeTo)
         const auto display = openDisplay();
 
         // we don't care about these but they are required
-        ::Window     root;
-        ::Window     child;
-        int          gx;
-        int          gy;
-        unsigned int buttons;
+        ::Window     root    = 0;
+        ::Window     child   = 0;
+        int          gx      = 0;
+        int          gy      = 0;
+        unsigned int buttons = 0;
 
         int x = 0;
         int y = 0;

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -208,7 +208,7 @@ void updatePluggedList(udev_device* udevDevice = nullptr)
     }
 
     udev_list_entry* devices = udev_enumerate_get_list_entry(udevEnumerator);
-    udev_list_entry* device;
+    udev_list_entry* device  = nullptr;
 
     udev_list_entry_foreach(device, devices)
     {
@@ -589,14 +589,14 @@ JoystickCaps JoystickImpl::getCapabilities() const
         return caps;
 
     // Get the number of buttons
-    char buttonCount;
+    char buttonCount = 0;
     ioctl(m_file, JSIOCGBUTTONS, &buttonCount);
     caps.buttonCount = static_cast<unsigned int>(buttonCount);
     if (caps.buttonCount > Joystick::ButtonCount)
         caps.buttonCount = Joystick::ButtonCount;
 
     // Get the supported axes
-    char axesCount;
+    char axesCount = 0;
     ioctl(m_file, JSIOCGAXES, &axesCount);
     for (int i = 0; i < axesCount; ++i)
     {

--- a/src/SFML/Window/Unix/VideoModeImpl.cpp
+++ b/src/SFML/Window/Unix/VideoModeImpl.cpp
@@ -64,7 +64,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
         const int screen = DefaultScreen(display.get());
 
         // Check if the XRandR extension is present
-        int version;
+        int version = 0;
         if (XQueryExtension(display.get(), "RANDR", &version, &version, &version))
         {
             // Get the current configuration
@@ -72,8 +72,8 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
             if (config)
             {
                 // Get the available screen sizes
-                int            nbSizes;
-                XRRScreenSize* sizes = XRRConfigSizes(config.get(), &nbSizes);
+                int            nbSizes = 0;
+                XRRScreenSize* sizes   = XRRConfigSizes(config.get(), &nbSizes);
                 if (sizes && (nbSizes > 0))
                 {
                     // Get the list of supported depths
@@ -91,7 +91,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
                                                 static_cast<unsigned int>(sizes[j].height)},
                                                static_cast<unsigned int>(depths[i]));
 
-                                Rotation currentRotation;
+                                Rotation currentRotation = 0;
                                 XRRConfigRotations(config.get(), &currentRotation);
 
                                 if (currentRotation == RR_Rotate_90 || currentRotation == RR_Rotate_270)
@@ -141,7 +141,7 @@ VideoMode VideoModeImpl::getDesktopMode()
         const int screen = DefaultScreen(display.get());
 
         // Check if the XRandR extension is present
-        int version;
+        int version = 0;
         if (XQueryExtension(display.get(), "RANDR", &version, &version, &version))
         {
             // Get the current configuration
@@ -149,19 +149,19 @@ VideoMode VideoModeImpl::getDesktopMode()
             if (config)
             {
                 // Get the current video mode
-                Rotation  currentRotation;
-                const int currentMode = XRRConfigCurrentConfiguration(config.get(), &currentRotation);
+                Rotation  currentRotation = 0;
+                const int currentMode     = XRRConfigCurrentConfiguration(config.get(), &currentRotation);
 
                 // Get the available screen sizes
-                int            nbSizes;
-                XRRScreenSize* sizes = XRRConfigSizes(config.get(), &nbSizes);
+                int            nbSizes = 0;
+                XRRScreenSize* sizes   = XRRConfigSizes(config.get(), &nbSizes);
                 if (sizes && (nbSizes > 0))
                 {
                     desktopMode = VideoMode({static_cast<unsigned int>(sizes[currentMode].width),
                                              static_cast<unsigned int>(sizes[currentMode].height)},
                                             static_cast<unsigned int>(DefaultDepth(display.get(), screen)));
 
-                    Rotation modeRotation;
+                    Rotation modeRotation = 0;
                     XRRConfigRotations(config.get(), &modeRotation);
 
                     if (modeRotation == RR_Rotate_90 || modeRotation == RR_Rotate_270)

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -169,11 +169,11 @@ bool ewmhSupported()
 
     const auto display = sf::priv::openDisplay();
 
-    Atom           actualType;
-    int            actualFormat;
-    unsigned long  numItems;
-    unsigned long  numBytes;
-    unsigned char* data;
+    Atom           actualType   = 0;
+    int            actualFormat = 0;
+    unsigned long  numItems     = 0;
+    unsigned long  numBytes     = 0;
+    unsigned char* data         = nullptr;
 
     int result = XGetWindowProperty(display.get(),
                                     DefaultRootWindow(display.get()),
@@ -289,10 +289,10 @@ bool ewmhSupported()
 // Get the parent window.
 ::Window getParentWindow(::Display* disp, ::Window win)
 {
-    ::Window     root;
-    ::Window     parent;
-    ::Window*    children = nullptr;
-    unsigned int numChildren;
+    ::Window     root        = 0;
+    ::Window     parent      = 0;
+    ::Window*    children    = nullptr;
+    unsigned int numChildren = 0;
 
     XQueryTree(disp, win, &root, &parent, &children, &numChildren);
 
@@ -315,11 +315,11 @@ bool getEWMHFrameExtents(::Display* disp, ::Window win, long& xFrameExtent, long
         return false;
 
     bool           gotFrameExtents = false;
-    Atom           actualType;
-    int            actualFormat;
-    unsigned long  numItems;
-    unsigned long  numBytesLeft;
-    unsigned char* data = nullptr;
+    Atom           actualType      = 0;
+    int            actualFormat    = 0;
+    unsigned long  numItems        = 0;
+    unsigned long  numBytesLeft    = 0;
+    unsigned char* data            = nullptr;
 
     const int result = XGetWindowProperty(disp,
                                           win,
@@ -781,9 +781,9 @@ Vector2i WindowImplX11::getPosition() const
     // window actually is, but not necessarily to where we told it to
     // go using setPosition() and XMoveWindow(). To have the two match
     // as expected, we may have to subtract decorations and borders.
-    ::Window child;
-    int      xAbsRelToRoot;
-    int      yAbsRelToRoot;
+    ::Window child         = 0;
+    int      xAbsRelToRoot = 0;
+    int      yAbsRelToRoot = 0;
 
     XTranslateCoordinates(m_display.get(), m_window, DefaultRootWindow(m_display.get()), 0, 0, &xAbsRelToRoot, &yAbsRelToRoot, &child);
 
@@ -796,8 +796,8 @@ Vector2i WindowImplX11::getPosition() const
     // CASE 2: most modern WMs support EWMH and can define _NET_FRAME_EXTENTS
     // with the exact frame size to subtract, so if present, we prefer it and
     // query it first. According to spec, this already includes any borders.
-    long xFrameExtent;
-    long yFrameExtent;
+    long xFrameExtent = 0;
+    long yFrameExtent = 0;
 
     if (getEWMHFrameExtents(m_display.get(), m_window, xFrameExtent, yFrameExtent))
     {
@@ -830,12 +830,12 @@ Vector2i WindowImplX11::getPosition() const
 
     // Get final X/Y coordinates: take the relative position to
     // the root of the furthest ancestor window.
-    int          xRelToRoot;
-    int          yRelToRoot;
-    unsigned int width;
-    unsigned int height;
-    unsigned int borderWidth;
-    unsigned int depth;
+    int          xRelToRoot  = 0;
+    int          yRelToRoot  = 0;
+    unsigned int width       = 0;
+    unsigned int height      = 0;
+    unsigned int borderWidth = 0;
+    unsigned int depth       = 0;
 
     XGetGeometry(m_display.get(), ancestor, &root, &xRelToRoot, &yRelToRoot, &width, &height, &borderWidth, &depth);
 
@@ -1272,8 +1272,8 @@ void WindowImplX11::setVideoMode(const VideoMode& mode)
         return;
 
     // Check if the XRandR extension is present
-    int xRandRMajor;
-    int xRandRMinor;
+    int xRandRMajor = 0;
+    int xRandRMinor = 0;
     if (!checkXRandR(xRandRMajor, xRandRMinor))
     {
         // XRandR extension is not supported: we cannot use fullscreen mode
@@ -1312,7 +1312,7 @@ void WindowImplX11::setVideoMode(const VideoMode& mode)
 
     // Find RRMode to set
     bool   modeFound = false;
-    RRMode xRandMode;
+    RRMode xRandMode = 0;
 
     for (int i = 0; (i < res->nmode) && !modeFound; ++i)
     {
@@ -1363,8 +1363,8 @@ void WindowImplX11::resetVideoMode()
     {
         // Try to set old configuration
         // Check if the XRandR extension
-        int xRandRMajor;
-        int xRandRMinor;
+        int xRandRMajor = 0;
+        int xRandRMinor = 0;
         if (checkXRandR(xRandRMajor, xRandRMinor))
         {
             auto res = X11Ptr<XRRScreenResources>(
@@ -1383,7 +1383,7 @@ void WindowImplX11::resetVideoMode()
                 return;
             }
 
-            RROutput output;
+            RROutput output = 0;
 
             // if version >= 1.3 get the primary screen else take the first screen
             if ((xRandRMajor == 1 && xRandRMinor >= 3) || xRandRMajor > 1)
@@ -1841,7 +1841,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
 #ifdef X_HAVE_UTF8_STRING
                 if (m_inputContext)
                 {
-                    Status       status;
+                    Status       status = 0;
                     std::uint8_t keyBuffer[64];
 
                     const int length = Xutf8LookupString(m_inputContext,
@@ -2089,7 +2089,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
 bool WindowImplX11::checkXRandR(int& xRandRMajor, int& xRandRMinor)
 {
     // Check if the XRandR extension is present
-    int version;
+    int version = 0;
     if (!XQueryExtension(m_display.get(), "RANDR", &version, &version, &version))
     {
         err() << "XRandR extension is not supported" << std::endl;
@@ -2145,8 +2145,8 @@ Vector2i WindowImplX11::getPrimaryMonitorPosition()
     }
 
     // Get xRandr version
-    int xRandRMajor;
-    int xRandRMinor;
+    int xRandRMajor = 0;
+    int xRandRMinor = 0;
     if (!checkXRandR(xRandRMajor, xRandRMinor))
         xRandRMajor = xRandRMinor = 0;
 

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -120,7 +120,7 @@ bool lazyUpdates = false;
 // Get a system error string from an error code
 std::string getErrorString(DWORD error)
 {
-    PTCHAR buffer;
+    PTCHAR buffer = nullptr;
 
     if (FormatMessage(FORMAT_MESSAGE_MAX_WIDTH_MASK | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
                       nullptr,
@@ -142,9 +142,9 @@ sf::String getDeviceName(unsigned int index, JOYCAPS caps)
     // Give the joystick a default name
     sf::String joystickDescription = "Unknown Joystick";
 
-    LONG                     result;
-    HKEY                     rootKey;
-    HKEY                     currentKey;
+    LONG                     result     = 0;
+    HKEY                     rootKey    = nullptr;
+    HKEY                     currentKey = nullptr;
     std::basic_string<TCHAR> subkey;
 
     subkey = REGSTR_PATH_JOYCONFIG;

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -103,7 +103,7 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 String getErrorString(DWORD errorCode)
 {
-    PTCHAR buffer;
+    PTCHAR buffer = nullptr;
     if (FormatMessage(FORMAT_MESSAGE_MAX_WIDTH_MASK | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
                           FORMAT_MESSAGE_IGNORE_INSERTS,
                       nullptr,

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -428,8 +428,8 @@ void WindowImplWin32::setKeyRepeatEnabled(bool enabled)
 void WindowImplWin32::requestFocus()
 {
     // Allow focus stealing only within the same process; compare PIDs of current and foreground window
-    DWORD thisPid;
-    DWORD foregroundPid;
+    DWORD thisPid       = 0;
+    DWORD foregroundPid = 0;
     GetWindowThreadProcessId(m_handle, &thisPid);
     GetWindowThreadProcessId(GetForegroundWindow(), &foregroundPid);
 

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -212,8 +212,8 @@ void EaglContext::recreateRenderBuffers(SFView* glView)
                                   : GL_DEPTH_COMPONENT16_OES;
 
         // Get the size of the color-buffer (which fits the current size of the GL view)
-        GLint width;
-        GLint height;
+        GLint width  = 0;
+        GLint height = 0;
         glGetRenderbufferParameterivOESFunc(GL_RENDERBUFFER_OES, GL_RENDERBUFFER_WIDTH_OES, &width);
         glGetRenderbufferParameterivOESFunc(GL_RENDERBUFFER_OES, GL_RENDERBUFFER_HEIGHT_OES, &height);
 

--- a/src/SFML/Window/iOS/SFView.mm
+++ b/src/SFML/Window/iOS/SFView.mm
@@ -80,8 +80,8 @@
     const char* end = utf8 + std::strlen(utf8);
     while (utf8 < end)
     {
-        std::uint32_t character;
-        utf8 = sf::Utf8::decode(utf8, end, character);
+        std::uint32_t character = 0;
+        utf8                    = sf::Utf8::decode(utf8, end, character);
         [[SFAppDelegate getInstance] notifyCharacter:character];
     }
 }
@@ -90,7 +90,7 @@
 ////////////////////////////////////////////////////////////
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event
 {
-    for (UITouch* touch in touches)
+    for (UITouch* touch in touches) // NOLINT(cppcoreguidelines-init-variables)
     {
         // find an empty slot for the new touch
         NSUInteger index = [self.touches indexOfObject:[NSNull null]];
@@ -117,7 +117,7 @@
 ////////////////////////////////////////////////////////////
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event
 {
-    for (UITouch* touch in touches)
+    for (UITouch* touch in touches) // NOLINT(cppcoreguidelines-init-variables)
     {
         // find the touch
         NSUInteger index = [self.touches indexOfObject:touch];
@@ -137,7 +137,7 @@
 ////////////////////////////////////////////////////////////
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event
 {
-    for (UITouch* touch in touches)
+    for (UITouch* touch in touches) // NOLINT(cppcoreguidelines-init-variables)
     {
         // find the touch
         NSUInteger index = [self.touches indexOfObject:touch];

--- a/src/SFML/Window/macOS/HIDInputManager.mm
+++ b/src/SFML/Window/macOS/HIDInputManager.mm
@@ -755,7 +755,7 @@ void HIDInputManager::initializeKeyboard()
     }
 
     auto* const keyboards = static_cast<NSSet*>(underlying); // Toll-Free Bridge
-    for (id keyboard in keyboards)
+    for (id keyboard in keyboards)                           // NOLINT(cppcoreguidelines-init-variables)
         loadKeyboard(static_cast<IOHIDDeviceRef>(keyboard));
 
     CFRelease(underlying);
@@ -776,7 +776,7 @@ void HIDInputManager::loadKeyboard(IOHIDDeviceRef keyboard)
     }
 
     auto* const keys = static_cast<NSArray*>(underlying); // Toll-Free Bridge
-    for (id key in keys)
+    for (id key in keys)                                  // NOLINT(cppcoreguidelines-init-variables)
     {
         auto* elem = static_cast<IOHIDElementRef>(key);
         if (IOHIDElementGetUsagePage(elem) == kHIDPage_KeyboardOrKeypad)

--- a/src/SFML/Window/macOS/InputImpl.mm
+++ b/src/SFML/Window/macOS/InputImpl.mm
@@ -71,7 +71,7 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const sf::WindowBase& window)
             if ([view isKindOfClass:[NSView class]])
             {
                 NSArray* const subviews = [view subviews];
-                for (NSView* subview in subviews)
+                for (NSView* subview in subviews) // NOLINT(cppcoreguidelines-init-variables)
                 {
                     if ([subview isKindOfClass:[SFOpenGLView class]])
                     {
@@ -92,7 +92,7 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const sf::WindowBase& window)
     {
         // If system handle is a view then from a subview of kind SFOpenGLView.
         NSArray* const subviews = [nsHandle subviews];
-        for (NSView* subview in subviews)
+        for (NSView* subview in subviews) // NOLINT(cppcoreguidelines-init-variables)
         {
             if ([subview isKindOfClass:[SFOpenGLView class]])
             {

--- a/src/SFML/Window/macOS/JoystickImpl.cpp
+++ b/src/SFML/Window/macOS/JoystickImpl.cpp
@@ -71,7 +71,7 @@ unsigned int getDeviceUint(IOHIDDeviceRef ref, CFStringRef prop, unsigned int in
     CFTypeRef typeRef = IOHIDDeviceGetProperty(ref, prop);
     if (typeRef && (CFGetTypeID(typeRef) == CFNumberGetTypeID()))
     {
-        SInt32 value;
+        SInt32 value = 0;
         CFNumberGetValue(static_cast<CFNumberRef>(typeRef), kCFNumberSInt32Type, &value);
         return static_cast<unsigned int>(value);
     }

--- a/src/SFML/Window/macOS/WindowImplCocoa.mm
+++ b/src/SFML/Window/macOS/WindowImplCocoa.mm
@@ -60,7 +60,7 @@ NSString* sfStringToNSString(const sf::String& string)
     const auto  length = static_cast<std::uint32_t>(string.getSize() * sizeof(std::uint32_t));
     const void* data   = reinterpret_cast<const void*>(string.getData());
 
-    NSStringEncoding encoding;
+    NSStringEncoding encoding = 0;
     if (NSHostByteOrder() == NS_LittleEndian)
         encoding = NSUTF32LittleEndianStringEncoding;
     else

--- a/test/Network/Packet.test.cpp
+++ b/test/Network/Packet.test.cpp
@@ -271,7 +271,7 @@ TEST_CASE("[Network] sf::Packet")
     SECTION("onSend")
     {
         Packet      packet;
-        std::size_t size;
+        std::size_t size = 0;
         CHECK(packet.onSend(size) == nullptr);
         CHECK(size == 0);
 


### PR DESCRIPTION
## Description

This new automated check is a good step towards systematically eliminating uninitialized reads. The only weird part was that I had to add some `NOLINT`s to Objecive-C++ code due to clang-tidy not entirely understanding Objective-C loops.