### PR TITLE
Prohibit use of malloc

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,7 +35,6 @@ Checks: >
   -cppcoreguidelines-macro-to-enum,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-narrowing-conversions,
-  -cppcoreguidelines-no-malloc,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-prefer-member-initializer,

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -957,8 +957,10 @@ void WindowImplX11::setIcon(const Vector2u& size, const std::uint8_t* pixels)
 {
     // X11 wants BGRA pixels: swap red and blue channels
     // Note: this memory will be freed by X11Ptr<XImage> deleter
+    // NOLINTBEGIN(cppcoreguidelines-no-malloc)
     auto* iconPixels = static_cast<std::uint8_t*>(
         std::malloc(static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) * 4));
+    // NOLINTEND(cppcoreguidelines-no-malloc)
     for (std::size_t i = 0; i < static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y); ++i)
     {
         iconPixels[i * 4 + 0] = pixels[i * 4 + 2];


### PR DESCRIPTION
## Description

We only use `std::malloc` in one place due to a C API requiring it. In the past [we used to have more `malloc`s](https://github.com/SFML/SFML/pull/2743) so lets prohibit any further use.