### PR TITLE
Use scoped enumerations in Audio module

### DIFF
--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -28,7 +28,7 @@ void playSound()
     sound.play();
 
     // Loop while the sound is playing
-    while (sound.getStatus() == sf::Sound::Playing)
+    while (sound.getStatus() == sf::Sound::Status::Playing)
     {
         // Leave some CPU time for other processes
         sf::sleep(sf::milliseconds(100));
@@ -62,7 +62,7 @@ void playMusic(const std::filesystem::path& filename)
     music.play();
 
     // Loop while the music is playing
-    while (music.getStatus() == sf::Music::Playing)
+    while (music.getStatus() == sf::Music::Status::Playing)
     {
         // Leave some CPU time for other processes
         sf::sleep(sf::milliseconds(100));

--- a/examples/sound_capture/SoundCapture.cpp
+++ b/examples/sound_capture/SoundCapture.cpp
@@ -110,7 +110,7 @@ int main()
         sound.play();
 
         // Wait until finished
-        while (sound.getStatus() == sf::Sound::Playing)
+        while (sound.getStatus() == sf::Sound::Status::Playing)
         {
             // Display the playing position
             std::cout << "\rPlaying... " << sound.getPlayingOffset().asSeconds() << " sec        ";

--- a/examples/voip/Server.cpp
+++ b/examples/voip/Server.cpp
@@ -179,7 +179,7 @@ void doServer(unsigned short port)
     audioStream.start(port);
 
     // Loop until the sound playback is finished
-    while (audioStream.getStatus() != sf::SoundStream::Stopped)
+    while (audioStream.getStatus() != sf::SoundStream::Status::Stopped)
     {
         // Leave some CPU time for other threads
         sf::sleep(sf::milliseconds(100));
@@ -195,7 +195,7 @@ void doServer(unsigned short port)
     audioStream.play();
 
     // Loop until the sound playback is finished
-    while (audioStream.getStatus() != sf::SoundStream::Stopped)
+    while (audioStream.getStatus() != sf::SoundStream::Status::Stopped)
     {
         // Leave some CPU time for other threads
         sf::sleep(sf::milliseconds(100));

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -49,7 +49,7 @@ public:
     /// \brief Enumeration of the sound source states
     ///
     ////////////////////////////////////////////////////////////
-    enum Status
+    enum class Status
     {
         Stopped, //!< Sound is not playing
         Paused,  //!< Sound is paused

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -194,10 +194,8 @@ public:
     bool getLoop() const;
 
 protected:
-    enum
-    {
-        NoLoop = -1 //!< "Invalid" endSeeks value, telling us to continue uninterrupted
-    };
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static constexpr std::int64_t NoLoop = -1; //!< "Invalid" onLoop return value, telling us to continue uninterrupted
 
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -164,7 +164,7 @@ void Music::setLoopPoints(TimeSpan timePoints)
         setPlayingOffset(oldPos);
 
     // Resume
-    if (oldStatus == Playing)
+    if (oldStatus == Status::Playing)
         play();
 }
 

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -77,7 +77,7 @@ struct Sound::Impl
         soundConfig.endCallback          = [](void* userData, ma_sound* soundPtr)
         {
             auto& impl  = *static_cast<Impl*>(userData);
-            impl.status = Stopped;
+            impl.status = Status::Stopped;
 
             // Seek back to the start of the sound when it finishes playing
             if (const ma_result result = ma_sound_seek_to_pcm_frame(soundPtr, 0); result != MA_SUCCESS)
@@ -214,7 +214,7 @@ struct Sound::Impl
     std::size_t             cursor{};        //!< The current playing position
     bool                    looping{};       //!< True if we are looping the sound
     const SoundBuffer*      buffer{};        //!< Sound buffer bound to the source
-    Status                  status{Stopped}; //!< The status
+    Status                  status{Status::Stopped}; //!< The status
 };
 
 
@@ -249,7 +249,7 @@ Sound::~Sound()
 ////////////////////////////////////////////////////////////
 void Sound::play()
 {
-    if (m_impl->status == Playing)
+    if (m_impl->status == Status::Playing)
         setPlayingOffset(Time::Zero);
 
     if (const ma_result result = ma_sound_start(&m_impl->sound); result != MA_SUCCESS)
@@ -258,7 +258,7 @@ void Sound::play()
     }
     else
     {
-        m_impl->status = Playing;
+        m_impl->status = Status::Playing;
     }
 }
 
@@ -272,8 +272,8 @@ void Sound::pause()
     }
     else
     {
-        if (m_impl->status == Playing)
-            m_impl->status = Paused;
+        if (m_impl->status == Status::Playing)
+            m_impl->status = Status::Paused;
     }
 }
 
@@ -288,7 +288,7 @@ void Sound::stop()
     else
     {
         setPlayingOffset(Time::Zero);
-        m_impl->status = Stopped;
+        m_impl->status = Status::Stopped;
     }
 }
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -79,7 +79,7 @@ struct SoundStream::Impl
             // Seek back to the start of the sound when it finishes playing
             auto& impl     = *static_cast<Impl*>(userData);
             impl.streaming = true;
-            impl.status    = Stopped;
+            impl.status    = Status::Stopped;
 
             if (const ma_result result = ma_sound_seek_to_pcm_frame(soundPtr, 0); result != MA_SUCCESS)
                 err() << "Failed to seek sound to frame 0: " << ma_result_description(result) << std::endl;
@@ -242,15 +242,15 @@ struct SoundStream::Impl
     SoundStream* const      owner;        //!< Owning SoundStream object
     std::vector<ma_channel> soundChannelMap; //!< The map of position in sample frame to sound channel (miniaudio channels)
     ma_sound                sound{};         //!< The sound
-    std::vector<std::int16_t> sampleBuffer;         //!< Our temporary sample buffer
-    std::size_t               sampleBufferCursor{}; //!< The current read position in the temporary sample buffer
-    std::uint64_t             samplesProcessed{};   //!< Number of samples processed since beginning of the stream
-    unsigned int              channelCount{};       //!< Number of channels (1 = mono, 2 = stereo, ...)
-    unsigned int              sampleRate{};         //!< Frequency (samples / second)
-    std::vector<SoundChannel> channelMap{};         //!< The map of position in sample frame to sound channel
-    bool                      loop{};               //!< Loop flag (true to loop, false to play once)
-    bool                      streaming{true};      //!< True if we are still streaming samples from the source
-    Status                    status{Stopped};      //!< The status
+    std::vector<std::int16_t> sampleBuffer;            //!< Our temporary sample buffer
+    std::size_t               sampleBufferCursor{};    //!< The current read position in the temporary sample buffer
+    std::uint64_t             samplesProcessed{};      //!< Number of samples processed since beginning of the stream
+    unsigned int              channelCount{};          //!< Number of channels (1 = mono, 2 = stereo, ...)
+    unsigned int              sampleRate{};            //!< Frequency (samples / second)
+    std::vector<SoundChannel> channelMap{};            //!< The map of position in sample frame to sound channel
+    bool                      loop{};                  //!< Loop flag (true to loop, false to play once)
+    bool                      streaming{true};         //!< True if we are still streaming samples from the source
+    Status                    status{Status::Stopped}; //!< The status
 };
 
 
@@ -279,7 +279,7 @@ void SoundStream::initialize(unsigned int channelCount, unsigned int sampleRate,
 ////////////////////////////////////////////////////////////
 void SoundStream::play()
 {
-    if (m_impl->status == Playing)
+    if (m_impl->status == Status::Playing)
         setPlayingOffset(Time::Zero);
 
     if (const ma_result result = ma_sound_start(&m_impl->sound); result != MA_SUCCESS)
@@ -288,7 +288,7 @@ void SoundStream::play()
     }
     else
     {
-        m_impl->status = Playing;
+        m_impl->status = Status::Playing;
     }
 }
 
@@ -302,8 +302,8 @@ void SoundStream::pause()
     }
     else
     {
-        if (m_impl->status == Playing)
-            m_impl->status = Paused;
+        if (m_impl->status == Status::Playing)
+            m_impl->status = Status::Paused;
     }
 }
 
@@ -318,7 +318,7 @@ void SoundStream::stop()
     else
     {
         setPlayingOffset(Time::Zero);
-        m_impl->status = Stopped;
+        m_impl->status = Status::Stopped;
     }
 }
 


### PR DESCRIPTION
Last bit of C++17 enum modernization for SFML 3, related to [SD: CPP 17 Support](https://github.com/SFML/SFML/wiki/SD%3A-CPP-17-Support#scoped-enumerations).
Continuation of #2131, #2822 and #2891.
