### PR TITLE
Use `std::optional` to express functions that may not return a value

### DIFF
--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -213,10 +213,10 @@ protected:
     /// the seek position for a loop. We then determine whether we are looping on a
     /// loop point or the end-of-file, perform the seek, and return the new position.
     ///
-    /// \return The seek position after looping (or -1 if there's no loop)
+    /// \return The seek position after looping (or std::nullopt if there's no loop)
     ///
     ////////////////////////////////////////////////////////////
-    std::int64_t onLoop() override;
+    std::optional<std::uint64_t> onLoop() override;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -35,6 +35,7 @@
 #include <SFML/System/Time.hpp>
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <cstddef>
@@ -194,9 +195,6 @@ public:
     bool getLoop() const;
 
 protected:
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static constexpr std::int64_t NoLoop = -1; //!< "Invalid" onLoop return value, telling us to continue uninterrupted
-
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
@@ -259,10 +257,10 @@ protected:
     /// allow implementation of custom loop points. Otherwise,
     /// it just calls onSeek(Time::Zero) and returns 0.
     ///
-    /// \return The seek position after looping (or -1 if there's no loop)
+    /// \return The seek position after looping (or std::nullopt if there's no loop)
     ///
     ////////////////////////////////////////////////////////////
-    virtual std::int64_t onLoop();
+    virtual std::optional<std::uint64_t> onLoop();
 
 private:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -204,7 +204,7 @@ void Music::onSeek(Time timeOffset)
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t Music::onLoop()
+std::optional<std::uint64_t> Music::onLoop()
 {
     // Called by underlying SoundStream so we can determine where to loop.
     const std::lock_guard lock(m_mutex);
@@ -222,7 +222,7 @@ std::int64_t Music::onLoop()
         m_file.seek(0);
         return 0;
     }
-    return NoLoop;
+    return std::nullopt;
 }
 
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -158,10 +158,10 @@ struct SoundStream::Impl
                 // If we are looping and at the end of the loop, set the cursor back to the beginning of the loop
                 if (!impl.streaming && impl.loop)
                 {
-                    if (const auto seekPositionAfterLoop = owner->onLoop(); seekPositionAfterLoop != NoLoop)
+                    if (const auto seekPositionAfterLoop = owner->onLoop())
                     {
                         impl.streaming        = true;
-                        impl.samplesProcessed = static_cast<std::uint64_t>(seekPositionAfterLoop);
+                        impl.samplesProcessed = *seekPositionAfterLoop;
                     }
                 }
             }
@@ -396,7 +396,7 @@ bool SoundStream::getLoop() const
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t SoundStream::onLoop()
+std::optional<std::uint64_t> SoundStream::onLoop()
 {
     onSeek(Time::Zero);
     return 0;


### PR DESCRIPTION
## Description

`NoLoop` is just a sentinel value to express a lack of a return value. `std::optional` does a much better job capturing that. In doing so we get to remove a constant, simplify a condition, and remove a static cast which are all signs that this is the better API.