### PR TITLE
Use `std::optional` rather than sentinel values

### DIFF
--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -931,9 +931,10 @@ public:
                 return;
             }
 
-            std::vector<std::uint32_t> buffer(static_cast<std::size_t>(file.getSize()) / sizeof(std::uint32_t));
+            const auto                 fileSize = file.getSize().value();
+            std::vector<std::uint32_t> buffer(fileSize / sizeof(std::uint32_t));
 
-            if (file.read(buffer.data(), file.getSize()) != file.getSize())
+            if (file.read(buffer.data(), fileSize) != file.getSize())
             {
                 vulkanAvailable = false;
                 return;
@@ -959,9 +960,10 @@ public:
                 return;
             }
 
-            std::vector<std::uint32_t> buffer(static_cast<std::size_t>(file.getSize()) / sizeof(std::uint32_t));
+            const auto                 fileSize = file.getSize().value();
+            std::vector<std::uint32_t> buffer(fileSize / sizeof(std::uint32_t));
 
-            if (file.read(buffer.data(), file.getSize()) != file.getSize())
+            if (file.read(buffer.data(), fileSize) != file.getSize())
             {
                 vulkanAvailable = false;
                 return;

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -111,36 +111,36 @@ public:
     /// \param data Buffer where to copy the read data
     /// \param size Desired number of bytes to read
     ///
-    /// \return The number of bytes actually read, or -1 on error
+    /// \return The number of bytes actually read, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::int64_t read(void* data, std::int64_t size) override;
+    [[nodiscard]] std::optional<std::size_t> read(void* data, std::size_t size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current reading position
     ///
     /// \param position The position to seek to, from the beginning
     ///
-    /// \return The position actually sought to, or -1 on error
+    /// \return The position actually sought to, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::int64_t seek(std::int64_t position) override;
+    [[nodiscard]] std::optional<std::size_t> seek(std::size_t position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current reading position in the stream
     ///
-    /// \return The current position, or -1 on error.
+    /// \return The current position, or `std::nullopt` on error.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::int64_t tell() override;
+    [[nodiscard]] std::optional<std::size_t> tell() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the stream
     ///
-    /// \return The total number of bytes available in the stream, or -1 on error
+    /// \return The total number of bytes available in the stream, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    std::int64_t getSize() override;
+    std::optional<std::size_t> getSize() override;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/System/InputStream.hpp
+++ b/include/SFML/System/InputStream.hpp
@@ -31,6 +31,8 @@
 
 #include <SFML/System/Export.hpp>
 
+#include <optional>
+
 #include <cstdint>
 
 
@@ -58,36 +60,36 @@ public:
     /// \param data Buffer where to copy the read data
     /// \param size Desired number of bytes to read
     ///
-    /// \return The number of bytes actually read, or -1 on error
+    /// \return The number of bytes actually read, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] virtual std::int64_t read(void* data, std::int64_t size) = 0;
+    [[nodiscard]] virtual std::optional<std::size_t> read(void* data, std::size_t size) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current reading position
     ///
     /// \param position The position to seek to, from the beginning
     ///
-    /// \return The position actually sought to, or -1 on error
+    /// \return The position actually sought to, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] virtual std::int64_t seek(std::int64_t position) = 0;
+    [[nodiscard]] virtual std::optional<std::size_t> seek(std::size_t position) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current reading position in the stream
     ///
-    /// \return The current position, or -1 on error.
+    /// \return The current position, or `std::nullopt` on error.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] virtual std::int64_t tell() = 0;
+    [[nodiscard]] virtual std::optional<std::size_t> tell() = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the stream
     ///
-    /// \return The total number of bytes available in the stream, or -1 on error
+    /// \return The total number of bytes available in the stream, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    virtual std::int64_t getSize() = 0;
+    virtual std::optional<std::size_t> getSize() = 0;
 };
 
 } // namespace sf
@@ -119,13 +121,13 @@ public:
 ///
 ///     [[nodiscard]] bool open(const std::filesystem::path& filename);
 ///
-///     [[nodiscard]] std::int64_t read(void* data, std::int64_t size);
+///     [[nodiscard]] std::optional<std::size_t> read(void* data, std::size_t size);
 ///
-///     [[nodiscard]] std::int64_t seek(std::int64_t position);
+///     [[nodiscard]] std::optional<std::size_t> seek(std::size_t position);
 ///
-///     [[nodiscard]] std::int64_t tell();
+///     [[nodiscard]] std::optional<std::size_t> tell();
 ///
-///     std::int64_t getSize();
+///     std::optional<std::size_t> getSize();
 ///
 /// private:
 ///

--- a/include/SFML/System/MemoryInputStream.hpp
+++ b/include/SFML/System/MemoryInputStream.hpp
@@ -64,44 +64,44 @@ public:
     /// \param data Buffer where to copy the read data
     /// \param size Desired number of bytes to read
     ///
-    /// \return The number of bytes actually read, or -1 on error
+    /// \return The number of bytes actually read, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::int64_t read(void* data, std::int64_t size) override;
+    [[nodiscard]] std::optional<std::size_t> read(void* data, std::size_t size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current reading position
     ///
     /// \param position The position to seek to, from the beginning
     ///
-    /// \return The position actually sought to, or -1 on error
+    /// \return The position actually sought to, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::int64_t seek(std::int64_t position) override;
+    [[nodiscard]] std::optional<std::size_t> seek(std::size_t position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current reading position in the stream
     ///
-    /// \return The current position, or -1 on error.
+    /// \return The current position, or `std::nullopt` on error.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::int64_t tell() override;
+    [[nodiscard]] std::optional<std::size_t> tell() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the stream
     ///
-    /// \return The total number of bytes available in the stream, or -1 on error
+    /// \return The total number of bytes available in the stream, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    std::int64_t getSize() override;
+    std::optional<std::size_t> getSize() override;
 
 private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     const std::byte* m_data{};   //!< Pointer to the data in memory
-    std::int64_t     m_size{};   //!< Total size of the data
-    std::int64_t     m_offset{}; //!< Current reading position
+    std::size_t      m_size{};   //!< Total size of the data
+    std::size_t      m_offset{}; //!< Current reading position
 };
 
 } // namespace sf

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -213,7 +213,7 @@ void InputSoundFile::seek(std::uint64_t sampleOffset)
 ////////////////////////////////////////////////////////////
 void InputSoundFile::seek(Time timeOffset)
 {
-    seek(static_cast<std::uint64_t>(timeOffset.asSeconds() * static_cast<float>(m_sampleRate)) * m_channelMap.size());
+    seek(static_cast<std::size_t>(timeOffset.asSeconds() * static_cast<float>(m_sampleRate)) * m_channelMap.size());
 }
 
 

--- a/src/SFML/Audio/SoundFileFactory.cpp
+++ b/src/SFML/Audio/SoundFileFactory.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromFilename(cons
     // Test the filename in all the registered factories
     for (const auto& [fpCreate, fpCheck] : getReaderFactoryMap())
     {
-        if (stream.seek(0) == -1)
+        if (!stream.seek(0).has_value())
         {
             err() << "Failed to seek sound stream" << std::endl;
             return nullptr;
@@ -84,7 +84,7 @@ std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromMemory(const 
     // Test the stream for all the registered factories
     for (const auto& [fpCreate, fpCheck] : getReaderFactoryMap())
     {
-        if (stream.seek(0) == -1)
+        if (!stream.seek(0).has_value())
         {
             err() << "Failed to seek sound stream" << std::endl;
             return nullptr;
@@ -106,7 +106,7 @@ std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromStream(InputS
     // Test the stream for all the registered factories
     for (const auto& [fpCreate, fpCheck] : getReaderFactoryMap())
     {
-        if (stream.seek(0) == -1)
+        if (!stream.seek(0).has_value())
         {
             err() << "Failed to seek sound stream" << std::endl;
             return nullptr;

--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -44,15 +44,17 @@ FLAC__StreamDecoderReadStatus streamRead(const FLAC__StreamDecoder*, FLAC__byte 
 {
     auto* data = static_cast<sf::priv::SoundFileReaderFlac::ClientData*>(clientData);
 
-    const std::int64_t count = data->stream->read(buffer, static_cast<std::int64_t>(*bytes));
-    if (count > 0)
+    if (const std::optional count = data->stream->read(buffer, *bytes))
     {
-        *bytes = static_cast<std::size_t>(count);
-        return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
-    }
-    else if (count == 0)
-    {
-        return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
+        if (*count > 0)
+        {
+            *bytes = *count;
+            return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+        }
+        else
+        {
+            return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
+        }
     }
     else
     {
@@ -64,8 +66,7 @@ FLAC__StreamDecoderSeekStatus streamSeek(const FLAC__StreamDecoder*, FLAC__uint6
 {
     auto* data = static_cast<sf::priv::SoundFileReaderFlac::ClientData*>(clientData);
 
-    const std::int64_t position = data->stream->seek(static_cast<std::int64_t>(absoluteByteOffset));
-    if (position >= 0)
+    if (data->stream->seek(static_cast<std::size_t>(absoluteByteOffset)).has_value())
         return FLAC__STREAM_DECODER_SEEK_STATUS_OK;
     else
         return FLAC__STREAM_DECODER_SEEK_STATUS_ERROR;
@@ -75,10 +76,9 @@ FLAC__StreamDecoderTellStatus streamTell(const FLAC__StreamDecoder*, FLAC__uint6
 {
     auto* data = static_cast<sf::priv::SoundFileReaderFlac::ClientData*>(clientData);
 
-    const std::int64_t position = data->stream->tell();
-    if (position >= 0)
+    if (const std::optional position = data->stream->tell())
     {
-        *absoluteByteOffset = static_cast<FLAC__uint64>(position);
+        *absoluteByteOffset = *position;
         return FLAC__STREAM_DECODER_TELL_STATUS_OK;
     }
     else
@@ -91,10 +91,9 @@ FLAC__StreamDecoderLengthStatus streamLength(const FLAC__StreamDecoder*, FLAC__u
 {
     auto* data = static_cast<sf::priv::SoundFileReaderFlac::ClientData*>(clientData);
 
-    const std::int64_t count = data->stream->getSize();
-    if (count >= 0)
+    if (const std::optional count = data->stream->getSize())
     {
-        *streamLength = static_cast<FLAC__uint64>(count);
+        *streamLength = *count;
         return FLAC__STREAM_DECODER_LENGTH_STATUS_OK;
     }
     else

--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -68,14 +68,14 @@ namespace
 std::size_t readCallback(void* ptr, std::size_t size, void* data)
 {
     auto* stream = static_cast<sf::InputStream*>(data);
-    return static_cast<std::size_t>(stream->read(ptr, static_cast<std::int64_t>(size)));
+    return stream->read(ptr, size).value_or(-1);
 }
 
 int seekCallback(std::uint64_t offset, void* data)
 {
-    auto*              stream   = static_cast<sf::InputStream*>(data);
-    const std::int64_t position = stream->seek(static_cast<std::int64_t>(offset));
-    return position < 0 ? -1 : 0;
+    auto*               stream   = static_cast<sf::InputStream*>(data);
+    const std::optional position = stream->seek(static_cast<std::size_t>(offset));
+    return position ? 0 : -1;
 }
 
 bool hasValidId3Tag(const std::uint8_t* header)
@@ -92,7 +92,7 @@ bool SoundFileReaderMp3::check(InputStream& stream)
 {
     std::uint8_t header[10];
 
-    if (static_cast<std::size_t>(stream.read(header, static_cast<std::int64_t>(sizeof(header)))) < sizeof(header))
+    if (stream.read(header, sizeof(header)) != sizeof(header))
         return false;
 
     if (hasValidId3Tag(header))

--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -43,13 +43,13 @@ namespace
 {
 ma_result onRead(ma_decoder* decoder, void* buffer, size_t bytesToRead, size_t* bytesRead)
 {
-    auto*      stream = static_cast<sf::InputStream*>(decoder->pUserData);
-    const auto count  = stream->read(buffer, static_cast<std::int64_t>(bytesToRead));
+    auto*               stream = static_cast<sf::InputStream*>(decoder->pUserData);
+    const std::optional count  = stream->read(buffer, bytesToRead);
 
-    if (count < 0)
+    if (!count.has_value())
         return MA_ERROR;
 
-    *bytesRead = static_cast<size_t>(count);
+    *bytesRead = static_cast<std::size_t>(*count);
     return MA_SUCCESS;
 }
 
@@ -61,19 +61,17 @@ ma_result onSeek(ma_decoder* decoder, ma_int64 byteOffset, ma_seek_origin origin
     {
         case ma_seek_origin_start:
         {
-            if (stream->seek(byteOffset) < 0)
+            if (!stream->seek(static_cast<std::size_t>(byteOffset)).has_value())
                 return MA_ERROR;
 
             return MA_SUCCESS;
         }
         case ma_seek_origin_current:
         {
-            const auto currentPosition = stream->tell();
-
-            if (currentPosition < 0)
+            if (!stream->tell().has_value())
                 return MA_ERROR;
 
-            if (stream->seek(stream->tell() + byteOffset) < 0)
+            if (!stream->seek(stream->tell().value() + static_cast<std::size_t>(byteOffset)).has_value())
                 return MA_ERROR;
 
             return MA_SUCCESS;

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -104,20 +104,20 @@ bool getFileContents(const std::filesystem::path& filename, std::vector<char>& b
 // Read the contents of a stream into an array of char
 bool getStreamContents(sf::InputStream& stream, std::vector<char>& buffer)
 {
-    bool               success = false;
-    const std::int64_t size    = stream.getSize();
-    if (size > 0)
+    bool                success = false;
+    const std::optional size    = stream.getSize();
+    if (size > std::size_t{0})
     {
-        buffer.resize(static_cast<std::size_t>(size));
+        buffer.resize(*size);
 
-        if (stream.seek(0) == -1)
+        if (!stream.seek(0).has_value())
         {
             sf::err() << "Failed to seek shader stream" << std::endl;
             return false;
         }
 
-        const std::int64_t read = stream.read(buffer.data(), size);
-        success                 = (read == size);
+        const std::optional read = stream.read(buffer.data(), *size);
+        success                  = (read == size);
     }
     buffer.push_back('\0');
     return success;

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -41,62 +41,41 @@ ResourceStream::ResourceStream(const std::filesystem::path& filename)
     ActivityStates&       states = getActivity();
     const std::lock_guard lock(states.mutex);
     m_file.reset(AAssetManager_open(states.activity->assetManager, filename.c_str(), AASSET_MODE_UNKNOWN));
+    assert(m_file && "Failed to initialize ResourceStream file");
 }
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t ResourceStream::read(void* data, std::int64_t size)
+std::optional<std::size_t> ResourceStream::read(void* data, std::size_t size)
 {
-    if (m_file)
-    {
-        return AAsset_read(m_file.get(), data, static_cast<std::size_t>(size));
-    }
-    else
-    {
-        return -1;
-    }
+    const auto numBytesRead = AAsset_read(m_file.get(), data, size);
+    if (numBytesRead < 0)
+        return std::nullopt;
+    return numBytesRead;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t ResourceStream::seek(std::int64_t position)
+std::optional<std::size_t> ResourceStream::seek(std::size_t position)
 {
-    if (m_file)
-    {
-        return AAsset_seek(m_file.get(), static_cast<off_t>(position), SEEK_SET);
-    }
-    else
-    {
-        return -1;
-    }
+    const auto newPosition = AAsset_seek(m_file.get(), static_cast<off_t>(position), SEEK_SET);
+    if (newPosition < 0)
+        return std::nullopt;
+    return newPosition;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t ResourceStream::tell()
+std::optional<std::size_t> ResourceStream::tell()
 {
-    if (m_file)
-    {
-        return getSize() - AAsset_getRemainingLength(m_file.get());
-    }
-    else
-    {
-        return -1;
-    }
+    return getSize().value() - static_cast<std::size_t>(AAsset_getRemainingLength(m_file.get()));
 }
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t ResourceStream::getSize()
+std::optional<std::size_t> ResourceStream::getSize()
 {
-    if (m_file)
-    {
-        return AAsset_getLength(m_file.get());
-    }
-    else
-    {
-        return -1;
-    }
+    return AAsset_getLength(m_file.get());
 }
 
 

--- a/src/SFML/System/Android/ResourceStream.hpp
+++ b/src/SFML/System/Android/ResourceStream.hpp
@@ -60,36 +60,36 @@ public:
     /// \param data Buffer where the asset data is copied
     /// \param size Number of bytes read
     ///
-    /// \return The number of bytes actually read, or -1 on error
+    /// \return The number of bytes actually read, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    std::int64_t read(void* data, std::int64_t size) override;
+    std::optional<std::size_t> read(void* data, std::size_t size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current reading position in the asset file
     ///
     /// \param position The position to seek to, from the beginning
     ///
-    /// \return The position actually sought to, or -1 on error
+    /// \return The position actually sought to, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    std::int64_t seek(std::int64_t position) override;
+    std::optional<std::size_t> seek(std::size_t position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current reading position in the asset file
     ///
-    /// \return The current position, or -1 on error.
+    /// \return The current position, or `std::nullopt` on error.
     ///
     ////////////////////////////////////////////////////////////
-    std::int64_t tell() override;
+    std::optional<std::size_t> tell() override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the asset file
     ///
-    /// \return The total number of bytes available in the asset, or -1 on error
+    /// \return The total number of bytes available in the asset, or `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    std::int64_t getSize() override;
+    std::optional<std::size_t> getSize() override;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/System/MemoryInputStream.cpp
+++ b/src/SFML/System/MemoryInputStream.cpp
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/MemoryInputStream.hpp>
 
+#include <algorithm>
+
 #include <cstring>
 
 
@@ -36,20 +38,18 @@ namespace sf
 void MemoryInputStream::open(const void* data, std::size_t sizeInBytes)
 {
     m_data   = static_cast<const std::byte*>(data);
-    m_size   = static_cast<std::int64_t>(sizeInBytes);
+    m_size   = sizeInBytes;
     m_offset = 0;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t MemoryInputStream::read(void* data, std::int64_t size)
+std::optional<std::size_t> MemoryInputStream::read(void* data, std::size_t size)
 {
     if (!m_data)
-        return -1;
+        return std::nullopt;
 
-    const std::int64_t endPosition = m_offset + size;
-    const std::int64_t count       = endPosition <= m_size ? size : m_size - m_offset;
-
+    const std::size_t count = std::min(size, m_size - m_offset);
     if (count > 0)
     {
         std::memcpy(data, m_data + m_offset, static_cast<std::size_t>(count));
@@ -61,10 +61,10 @@ std::int64_t MemoryInputStream::read(void* data, std::int64_t size)
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t MemoryInputStream::seek(std::int64_t position)
+std::optional<std::size_t> MemoryInputStream::seek(std::size_t position)
 {
     if (!m_data)
-        return -1;
+        return std::nullopt;
 
     m_offset = position < m_size ? position : m_size;
     return m_offset;
@@ -72,20 +72,20 @@ std::int64_t MemoryInputStream::seek(std::int64_t position)
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t MemoryInputStream::tell()
+std::optional<std::size_t> MemoryInputStream::tell()
 {
     if (!m_data)
-        return -1;
+        return std::nullopt;
 
     return m_offset;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::int64_t MemoryInputStream::getSize()
+std::optional<std::size_t> MemoryInputStream::getSize()
 {
     if (!m_data)
-        return -1;
+        return std::nullopt;
 
     return m_size;
 }

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -75,10 +75,10 @@ TEST_CASE("[System] sf::FileInputStream")
     SECTION("Default constructor")
     {
         sf::FileInputStream fileInputStream;
-        CHECK(fileInputStream.read(nullptr, 0) == -1);
-        CHECK(fileInputStream.seek(0) == -1);
-        CHECK(fileInputStream.tell() == -1);
-        CHECK(fileInputStream.getSize() == -1);
+        CHECK(fileInputStream.read(nullptr, 0) == std::nullopt);
+        CHECK(fileInputStream.seek(0) == std::nullopt);
+        CHECK(fileInputStream.tell() == std::nullopt);
+        CHECK(fileInputStream.getSize() == std::nullopt);
     }
 
     const TemporaryFile temporaryFile("Hello world");


### PR DESCRIPTION
## Description

`sf::InputStream` and derived classes have four functions whose return value operates in the same way, `open`, `read`, `seek`, and `tell`. Upon success, they return a non-negative number which means different things for different functions. Upon failure, they return `-1`. `-1` is a [sentinel value](https://en.wikipedia.org/wiki/Sentinel_value). This error value is incompatible with other successful return values. It's not valid to, for example, add `-1` to a non-negative return value from `getSize()`. However, _the type system allows this_. Because both return values are of type `std::int64_t` it's very easy to ignore a potential `-1` return value and instead write code that behaves unexpected in the face of errors.

This PR replaces those `std::int64_t` return values with `std::optional<std::size_t>`. Using `std::optional` forces all callers of these functions to reckon with a potential error. This has major type safety implications since it's no longer possible to silently ignore the possibility of `-1` being returned. 

As it turns out, there are places where these functions were called without taking into consideration the possibility of failure. For example the following snippet assumes that `file.getSize()` succeeds.

https://github.com/SFML/SFML/blob/73126c93a372d0ec867f9bc621b213094750ac40/examples/vulkan/Vulkan.cpp#L934

What happens if it does not succeed? In the case that `-1` is returned then that value is underflowed to the maximum value of `std::size_t`. When divided by `sizeof(std::uint32_t)` you end up with a value that is certainly too large to be successfully allocated. Failure to check this return value morphs into an allocation failure which is a confusing user experience.

Here's another example. The return values of `tell` and `getSize` are used without handling the potential error case. It is not valid to increment `offset` by `-1`. `-1` does not have any arithmetic meaning. It is a placeholder value. Subtracting the offset from `-1` leads to a number that is even more negative. Yet another nonsense value yet the existing API did nothing to force us to handle this error, highlighting its lack of safety.

https://github.com/SFML/SFML/blob/73126c93a372d0ec867f9bc621b213094750ac40/src/SFML/Audio/SoundFileReaderOgg.cpp#L55-L58

In this case I chose to use `.value()` to ensure that the optional has a value or else let `std::bad_optional_access` be thrown. We could instead simply use `operator*` but then we open ourselves up to undefined behavior in the event that the optional is null which seemed like a worse user experience that an uncaught exception causing a program exit.

In some places we're working with C APIs that still expect `-1` to signal error and those circumstances are still handled, albeit handled in a more explicit way that makes it clear that the C APIs handle errors differently than SFML itself.

In performing this refactor I reduced the number of `static_cast`s by a count of 19. Removing the need for casts is a good sign that `std::optional<std::size_t>` is a more natural fit than `std::int64_t`.