### PR TITLE
Fall back to using the NULL audio backend if the default backends don't provide any devices.

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -30,6 +30,7 @@
 #include <SFML/System/Err.hpp>
 
 #include <algorithm>
+#include <array>
 #include <ostream>
 
 
@@ -68,32 +69,51 @@ AudioDevice::AudioDevice()
     // Create the context
     m_context.emplace();
 
-    auto contextConfig = ma_context_config_init();
-    contextConfig.pLog = &*m_log;
+    auto contextConfig                                 = ma_context_config_init();
+    contextConfig.pLog                                 = &*m_log;
+    ma_uint32                              deviceCount = 0;
+    const auto                             nullBackend = ma_backend_null;
+    const std::array<const ma_backend*, 2> backendLists{nullptr, &nullBackend};
 
-    if (const auto result = ma_context_init(nullptr, 0, &contextConfig, &*m_context); result != MA_SUCCESS)
+    for (const auto* backendList : backendLists)
     {
-        m_context.reset();
-        err() << "Failed to initialize the audio context: " << ma_result_description(result) << std::endl;
-        return;
+        // We can set backendCount to 1 since it is ignored when backends is set to nullptr
+        if (const auto result = ma_context_init(backendList, 1, &contextConfig, &*m_context); result != MA_SUCCESS)
+        {
+            m_context.reset();
+            err() << "Failed to initialize the audio playback context: " << ma_result_description(result) << std::endl;
+            return;
+        }
+
+        // Count the playback devices
+        if (const auto result = ma_context_get_devices(&*m_context, nullptr, &deviceCount, nullptr, nullptr);
+            result != MA_SUCCESS)
+        {
+            err() << "Failed to get audio playback devices: " << ma_result_description(result) << std::endl;
+            return;
+        }
+
+        // Check if there are audio playback devices available on the system
+        if (deviceCount > 0)
+            break;
+
+        // Warn if no devices were found using the default backend list
+        if (backendList == nullptr)
+            err() << "No audio playback devices available on the system" << std::endl;
+
+        // Clean up the context if we didn't find any devices
+        ma_context_uninit(&*m_context);
     }
 
-    // Count the playback devices
-    ma_uint32 deviceCount = 0;
-
-    if (const auto result = ma_context_get_devices(&*m_context, nullptr, &deviceCount, nullptr, nullptr);
-        result != MA_SUCCESS)
-    {
-        err() << "Failed to get audio playback devices: " << ma_result_description(result) << std::endl;
-        return;
-    }
-
-    // Check if there are audio playback devices available on the system
+    // If the NULL audio backend also doesn't provide a device we give up
     if (deviceCount == 0)
     {
-        err() << "No audio playback devices available on the system" << std::endl;
+        m_context.reset();
         return;
     }
+
+    if (m_context->backend == ma_backend_null)
+        err() << "Using NULL audio backend for playback" << std::endl;
 
     // Create the playback device
     m_playbackDevice.emplace();


### PR DESCRIPTION
Title.

Because audio context creation will succeed even if the selected context cannot provide any devices, the NULL backend is never selected even on systems on which we know no audio device exists. We have to check for the existence of devices ourselves after creating a normal context and force miniaudio to create a NULL context if we determine a normal context would not provide us with any devices.

Should help with testing on audio device-less systems such as when running CI.