### PR TITLE
Simplify `Event` usage by implementing `Event::operator bool`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
 
                   while (window.isOpen())
                   {
-                      for (sf::Event event; window.pollEvent(event);)
+                      while (const auto event = window.pollEvent())
                       {
                           if (event.is<sf::Event::Closed>())
                               window.close();

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -54,7 +54,7 @@ body:
 
                   while (window.isOpen())
                   {
-                      for (sf::Event event; window.pollEvent(event);)
+                      while (const auto event = window.pollEvent())
                       {
                           if (event.is<sf::Event::Closed>())
                               window.close();

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,7 +39,7 @@ int main()
 
     while (window.isOpen())
     {
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             if (event.is<sf::Event::Closed>())
                 window.close();

--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -44,7 +44,7 @@
 ///     while (window.isOpen())
 ///     {
 ///         // Process events
-///         for (sf::Event event; window.pollEvent(event);)
+///         while (const auto event = window.pollEvent())
 ///         {
 ///             // Close window: exit
 ///             if (event.is<sf::Event::Closed>())

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -179,7 +179,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed or escape key pressed: exit
             if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -158,7 +158,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed or escape key pressed: exit
             if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -208,7 +208,7 @@ int main()
         while (window.isOpen())
         {
             // Process events
-            for (sf::Event event; window.pollEvent(event);)
+            while (const auto event = window.pollEvent())
             {
                 // Close window: exit
                 if (event.is<sf::Event::Closed>())

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -389,7 +389,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -677,7 +677,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/examples/stencil/Stencil.cpp
+++ b/examples/stencil/Stencil.cpp
@@ -40,7 +40,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed: exit
             if (event.is<sf::Event::Closed>())

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -115,7 +115,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed or escape key pressed: exit
             if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -2542,7 +2542,7 @@ public:
         while (window.isOpen())
         {
             // Process events
-            for (sf::Event event; window.pollEvent(event);)
+            while (const auto event = window.pollEvent())
             {
                 // Close window: exit
                 if (event.is<sf::Event::Closed>())

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -141,7 +141,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -237,7 +237,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    for (sf::Event event; window.pollEvent(event);)
+///    while (const auto event = window.pollEvent())
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())

--- a/include/SFML/Window/Clipboard.hpp
+++ b/include/SFML/Window/Clipboard.hpp
@@ -91,7 +91,7 @@ SFML_WINDOW_API void setString(const String& text);
 /// sf::String string = sf::Clipboard::getString();
 ///
 /// // or use it in the event loop
-/// for (sf::Event event; window.pollEvent(event);)
+/// while (const auto event = window.pollEvent())
 /// {
 ///     if(event.is<sf::Event::Closed>())
 ///         window.close();

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -276,6 +276,15 @@ public:
     template <typename T>
     [[nodiscard]] const T* getIf() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if the event type is not `Empty`
+    ///
+    /// \return True if this event's type is not `Empty`
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    operator bool() const;
+
 private:
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -125,8 +125,8 @@ public:
     struct MouseWheelScrolled
     {
         Mouse::Wheel wheel{}; //!< Which wheel (for mice with multiple ones)
-        float        delta{}; //!< Wheel offset (positive is up/left, negative is down/right). High-precision mice may use non-integral offsets.
-        Vector2i     position; //!< Position of the mouse pointer, relative to the top left of the owner window
+        float delta{}; //!< Wheel offset (positive is up/left, negative is down/right). High-precision mice may use non-integral offsets.
+        Vector2i position; //!< Position of the mouse pointer, relative to the top left of the owner window
     };
 
     ////////////////////////////////////////////////////////////
@@ -282,8 +282,10 @@ public:
     /// \return True if this event's type is not `Empty`
     ///
     ////////////////////////////////////////////////////////////
-    template <typename T>
-    operator bool() const;
+    [[nodiscard]] operator bool() const
+    {
+        return !is<Empty>();
+    }
 
 private:
     ////////////////////////////////////////////////////////////
@@ -354,7 +356,7 @@ private:
 /// any of the corresponding event data.
 ///
 /// \code
-/// for (sf::Event event; window.pollEvent(event);)
+/// while (const auto event = window.pollEvent())
 /// {
 ///     // Request for closing the window
 ///     if (event.is<sf::Event::Closed>())

--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -58,10 +58,3 @@ const T* Event::getIf() const
     if constexpr (isEventType<T>)
         return std::get_if<T>(&m_data);
 }
-
-////////////////////////////////////////////////////////////
-template <typename T>
-Event::operator bool() const
-{
-    return !is<Empty>();
-}

--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -58,3 +58,10 @@ const T* Event::getIf() const
     if constexpr (isEventType<T>)
         return std::get_if<T>(&m_data);
 }
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Event::operator bool() const
+{
+    return !is<Empty>();
+}

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -347,7 +347,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    for (sf::Event event; window.pollEvent(event);)
+///    while (const auto event = window.pollEvent())
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -180,25 +180,23 @@ public:
     /// \brief Pop the next event from the front of the FIFO event queue, if any, and return it
     ///
     /// This function is not blocking: if there's no pending event then
-    /// it will return false and leave \a event unmodified.
+	/// it will return an empty event, implying `event.is<sf::Event::Empty>()`.
     /// Note that more than one event may be present in the event queue,
     /// thus you should always call this function in a loop
     /// to make sure that you process every pending event.
     /// \code
-    /// for (sf::Event event; window.pollEvent(event);)
+    /// while (const auto event = window.pollEvent())
     /// {
     ///    // process event...
     /// }
     /// \endcode
     ///
-    /// \param event Event to be returned
-    ///
-    /// \return True if an event was returned, or false if the event queue was empty
+    /// \return The event
     ///
     /// \see waitEvent
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool pollEvent(Event& event);
+    [[nodiscard]] Event pollEvent();
 
     ////////////////////////////////////////////////////////////
     /// \brief Wait for an event and return it
@@ -211,21 +209,18 @@ public:
     /// is dedicated to events handling: you want to make this thread
     /// sleep as long as no new event is received.
     /// \code
-    /// sf::Event event;
-    /// if (window.waitEvent(event))
+    /// if (const auto event = window.waitEvent())
     /// {
     ///    // process event...
     /// }
     /// \endcode
     ///
-    /// \param event Event to be returned
-    ///
-    /// \return False if any error occurred
+    /// \return The event; will be empty (converts to `false`) if any error occurred
     ///
     /// \see pollEvent
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool waitEvent(Event& event);
+    [[nodiscard]] Event waitEvent();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -558,7 +558,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    for (sf::Event event; window.pollEvent(event);)
+///    while (const auto event = window.pollEvent())
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -136,32 +136,22 @@ bool WindowBase::isOpen() const
 
 
 ////////////////////////////////////////////////////////////
-bool WindowBase::pollEvent(Event& event)
+Event WindowBase::pollEvent()
 {
+    sf::Event event; // subtype is `Empty` by default
     if (m_impl && m_impl->popEvent(event, false))
-    {
         filterEvent(event);
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return event; // either `Empty` or whatever was popped from the queue
 }
 
 
 ////////////////////////////////////////////////////////////
-bool WindowBase::waitEvent(Event& event)
+Event WindowBase::waitEvent()
 {
+    sf::Event event; // subtype is `Empty` by default
     if (m_impl && m_impl->popEvent(event, true))
-    {
         filterEvent(event);
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return event; // either `Empty` on error or whatever was popped from the queue
 }
 
 

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -105,15 +105,13 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
     SECTION("pollEvent()")
     {
         sf::WindowBase windowBase;
-        sf::Event      event;
-        CHECK(!windowBase.pollEvent(event));
+        CHECK(!windowBase.pollEvent());
     }
 
     SECTION("waitEvent()")
     {
         sf::WindowBase windowBase;
-        sf::Event      event;
-        CHECK(!windowBase.waitEvent(event));
+        CHECK(!windowBase.waitEvent());
     }
 
     SECTION("Set/get position")

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -64,7 +64,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -62,7 +62,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before? **Yes, it was discussed in the Discord server.**
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->
This PR aims to simplify the usage of `Event` when polling events from a `RenderWindow`. Instead of having to initialize an `Event` on the stack and pass it by reference to `pollEvent`/`waitEvent`, this PR makes the methods return an `Event`, which can be converted to a `bool` based on whether its subtype is `Empty`.

There was discussion about having `RenderWindow::pollEvent` and `RenderWindow::waitEvent` return `std::optional<Event>`, but considering `Event` already uses subtyping to determine if it contains event data, letting `Event` be convertible to `bool` (based on whether the inner data was of type `Event::Empty`) sounded like the better option. Plus, we can avoid the clunky `->` syntax used for accessing members of an `std::optional`'s inner type.

Most of the changed files are changing comments containing example code of using `pollEvent`/`waitEvent`. The relevant change is in [this commit](https://github.com/SFML/SFML/commit/9c6d7d646c8113a7ca2ffa2d58ffab49289204bb).

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->
Use an `sf::RenderWindow` while processing events.

<!-- Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start: -->

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        while (const auto event = window.pollEvent())
        {
            if (event.is<sf::Event::Closed>())
                window.close();
        }

        window.clear();
        window.display();
    }
}
```
