### PR TITLE
`Event::operator bool`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
 
                   while (window.isOpen())
                   {
-                      for (sf::Event event; window.pollEvent(event);)
+                      while (const auto event = window.pollEvent())
                       {
                           if (event.is<sf::Event::Closed>())
                               window.close();

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -54,7 +54,7 @@ body:
 
                   while (window.isOpen())
                   {
-                      for (sf::Event event; window.pollEvent(event);)
+                      while (const auto event = window.pollEvent())
                       {
                           if (event.is<sf::Event::Closed>())
                               window.close();

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,7 +39,7 @@ int main()
 
     while (window.isOpen())
     {
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             if (event.is<sf::Event::Closed>())
                 window.close();

--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -44,7 +44,7 @@
 ///     while (window.isOpen())
 ///     {
 ///         // Process events
-///         for (sf::Event event; window.pollEvent(event);)
+///         while (const auto event = window.pollEvent())
 ///         {
 ///             // Close window: exit
 ///             if (event.is<sf::Event::Closed>())

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* argv[])
 
     while (window.isOpen())
     {
-        for (sf::Event event; active ? window.pollEvent(event) : window.waitEvent(event);)
+        while (const auto event = active ? window.pollEvent() : window.waitEvent())
         {
             if (event.is<sf::Event::Closed>())
             {

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -179,7 +179,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed or escape key pressed: exit
             if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -158,7 +158,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed or escape key pressed: exit
             if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -208,7 +208,7 @@ int main()
         while (window.isOpen())
         {
             // Process events
-            for (sf::Event event; window.pollEvent(event);)
+            while (const auto event = window.pollEvent())
             {
                 // Close window: exit
                 if (event.is<sf::Event::Closed>())

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -389,7 +389,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -677,7 +677,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/examples/stencil/Stencil.cpp
+++ b/examples/stencil/Stencil.cpp
@@ -40,7 +40,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed: exit
             if (event.is<sf::Event::Closed>())

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -115,7 +115,7 @@ int main()
     while (window.isOpen())
     {
         // Handle events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Window closed or escape key pressed: exit
             if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -2542,7 +2542,7 @@ public:
         while (window.isOpen())
         {
             // Process events
-            for (sf::Event event; window.pollEvent(event);)
+            while (const auto event = window.pollEvent())
             {
                 // Close window: exit
                 if (event.is<sf::Event::Closed>())

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -141,7 +141,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -237,7 +237,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    for (sf::Event event; window.pollEvent(event);)
+///    while (const auto event = window.pollEvent())
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())

--- a/include/SFML/Window/Clipboard.hpp
+++ b/include/SFML/Window/Clipboard.hpp
@@ -91,7 +91,7 @@ SFML_WINDOW_API void setString(const String& text);
 /// sf::String string = sf::Clipboard::getString();
 ///
 /// // or use it in the event loop
-/// for (sf::Event event; window.pollEvent(event);)
+/// while (const auto event = window.pollEvent())
 /// {
 ///     if(event.is<sf::Event::Closed>())
 ///         window.close();

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -276,6 +276,17 @@ public:
     template <typename T>
     [[nodiscard]] const T* getIf() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if current event type is not `Empty`
+    ///
+    /// \return True if current event type is not `Empty`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] explicit operator bool() const
+    {
+        return !is<Empty>();
+    }
+
 private:
     ////////////////////////////////////////////////////////////
     // Member data
@@ -345,7 +356,7 @@ private:
 /// any of the corresponding event data.
 ///
 /// \code
-/// for (sf::Event event; window.pollEvent(event);)
+/// while (const auto event = window.pollEvent())
 /// {
 ///     // Request for closing the window
 ///     if (event.is<sf::Event::Closed>())

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -347,7 +347,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    for (sf::Event event; window.pollEvent(event);)
+///    while (const auto event = window.pollEvent())
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -180,52 +180,46 @@ public:
     /// \brief Pop the next event from the front of the FIFO event queue, if any, and return it
     ///
     /// This function is not blocking: if there's no pending event then
-    /// it will return false and leave \a event unmodified.
-    /// Note that more than one event may be present in the event queue,
-    /// thus you should always call this function in a loop
-    /// to make sure that you process every pending event.
+    /// it will return an empty event. Note that more than one event
+    /// may be present in the event queue, thus you should always call
+    /// this function in a loop to make sure that you process every
+    /// pending event.
     /// \code
-    /// for (sf::Event event; window.pollEvent(event);)
+    /// while (const auto event = window.pollEvent())
     /// {
     ///    // process event...
     /// }
     /// \endcode
     ///
-    /// \param event Event to be returned
-    ///
-    /// \return True if an event was returned, or false if the event queue was empty
+    /// \return The event; will be `Empty` (convertible to `false`) if no events are pending
     ///
     /// \see waitEvent
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool pollEvent(Event& event);
+    [[nodiscard]] Event pollEvent();
 
     ////////////////////////////////////////////////////////////
     /// \brief Wait for an event and return it
     ///
     /// This function is blocking: if there's no pending event then
-    /// it will wait until an event is received.
-    /// After this function returns (and no error occurred),
-    /// the \a event object is always valid and filled properly.
-    /// This function is typically used when you have a thread that
-    /// is dedicated to events handling: you want to make this thread
-    /// sleep as long as no new event is received.
+    /// it will wait until an event is received. After this function
+    /// returns if no error occurred, the returned event will not be
+    /// empty. This function is typically used when you have a thread
+    /// that is dedicated to events handling: you want to make this
+    /// thread sleep as long as no new event is received.
     /// \code
-    /// sf::Event event;
-    /// if (window.waitEvent(event))
+    /// if (const auto event = window.waitEvent())
     /// {
     ///    // process event...
     /// }
     /// \endcode
     ///
-    /// \param event Event to be returned
-    ///
-    /// \return False if any error occurred
+    /// \return The event
     ///
     /// \see pollEvent
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool waitEvent(Event& event);
+    [[nodiscard]] Event waitEvent();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -563,7 +557,7 @@ private:
 /// while (window.isOpen())
 /// {
 ///    // Event processing
-///    for (sf::Event event; window.pollEvent(event);)
+///    while (const auto event = window.pollEvent())
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -136,32 +136,22 @@ bool WindowBase::isOpen() const
 
 
 ////////////////////////////////////////////////////////////
-bool WindowBase::pollEvent(Event& event)
+Event WindowBase::pollEvent()
 {
-    if (m_impl && m_impl->popEvent(event, false))
-    {
+    sf::Event event;
+    if (m_impl && (event = m_impl->popEvent(false)))
         filterEvent(event);
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return event;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool WindowBase::waitEvent(Event& event)
+Event WindowBase::waitEvent()
 {
-    if (m_impl && m_impl->popEvent(event, true))
-    {
+    sf::Event event;
+    if (m_impl && (event = m_impl->popEvent(true)))
         filterEvent(event);
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return event;
 }
 
 

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -176,7 +176,7 @@ void WindowImpl::setMaximumSize(const std::optional<Vector2u>& maximumSize)
 
 
 ////////////////////////////////////////////////////////////
-bool WindowImpl::popEvent(Event& event, bool block)
+Event WindowImpl::popEvent(bool block)
 {
     // If the event queue is empty, let's first check if new events are available from the OS
     if (m_events.empty())
@@ -202,16 +202,16 @@ bool WindowImpl::popEvent(Event& event, bool block)
         }
     }
 
+    sf::Event event;
+
     // Pop the first event of the queue, if it is not empty
     if (!m_events.empty())
     {
         event = m_events.front();
         m_events.pop();
-
-        return true;
     }
 
-    return false;
+    return event;
 }
 
 

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -128,13 +128,14 @@ public:
     /// The \a block parameter controls the behavior of the function
     /// if no event is available: if it is true then the function
     /// doesn't return until a new event is triggered; otherwise it
-    /// returns false to indicate that no event is available.
+    /// returns an empty event to indicate that no event is available.
     ///
-    /// \param event Event to be returned
     /// \param block Use true to block the thread until an event arrives
     ///
+    /// \return The event; can be `Empty` (convertible to `false`) if not blocking
+    ///
     ////////////////////////////////////////////////////////////
-    bool popEvent(Event& event, bool block);
+    Event popEvent(bool block);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the OS-specific handle of the window

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -19,6 +19,7 @@ TEST_CASE("[Window] sf::Event")
         SECTION("Default constructor")
         {
             const sf::Event event;
+            CHECK(!event);
             CHECK(event.is<sf::Event::Empty>());
             CHECK(event.getIf<sf::Event::Empty>());
         }
@@ -26,6 +27,7 @@ TEST_CASE("[Window] sf::Event")
         SECTION("Template constructor")
         {
             const sf::Event event = sf::Event::Resized{{1, 2}};
+            CHECK(event);
             CHECK(event.is<sf::Event::Resized>());
             CHECK(event.getIf<sf::Event::Resized>());
             const auto& resized = *event.getIf<sf::Event::Resized>();
@@ -37,30 +39,36 @@ TEST_CASE("[Window] sf::Event")
     {
         sf::Event event;
         event = sf::Event::Closed{};
+        CHECK(event);
         CHECK(event.is<sf::Event::Closed>());
         CHECK(event.getIf<sf::Event::Closed>());
 
         event = sf::Event::Resized{{1, 2}};
+        CHECK(event);
         CHECK(event.is<sf::Event::Resized>());
         CHECK(event.getIf<sf::Event::Resized>());
         const auto& resized = *event.getIf<sf::Event::Resized>();
         CHECK(resized.size == sf::Vector2u(1, 2));
 
         event = sf::Event::FocusLost{};
+        CHECK(event);
         CHECK(event.is<sf::Event::FocusLost>());
         CHECK(event.getIf<sf::Event::FocusLost>());
 
         event = sf::Event::FocusGained{};
+        CHECK(event);
         CHECK(event.is<sf::Event::FocusGained>());
         CHECK(event.getIf<sf::Event::FocusGained>());
 
         event = sf::Event::TextEntered{123456};
+        CHECK(event);
         CHECK(event.is<sf::Event::TextEntered>());
         CHECK(event.getIf<sf::Event::TextEntered>());
         const auto& textEntered = *event.getIf<sf::Event::TextEntered>();
         CHECK(textEntered.unicode == 123456);
 
         event = sf::Event::KeyPressed{sf::Keyboard::Key::C, sf::Keyboard::Scan::C, true, true, true, true};
+        CHECK(event);
         CHECK(event.is<sf::Event::KeyPressed>());
         CHECK(event.getIf<sf::Event::KeyPressed>());
         const auto& keyPressed = *event.getIf<sf::Event::KeyPressed>();
@@ -72,6 +80,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(keyPressed.system);
 
         event = sf::Event::KeyReleased{sf::Keyboard::Key::D, sf::Keyboard::Scan::D, true, true, true, true};
+        CHECK(event);
         CHECK(event.is<sf::Event::KeyReleased>());
         CHECK(event.getIf<sf::Event::KeyReleased>());
         const auto& keyReleased = *event.getIf<sf::Event::KeyReleased>();
@@ -83,6 +92,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(keyReleased.system);
 
         event = sf::Event::MouseWheelScrolled{sf::Mouse::Wheel::Horizontal, 3.14f, {4, 5}};
+        CHECK(event);
         CHECK(event.is<sf::Event::MouseWheelScrolled>());
         CHECK(event.getIf<sf::Event::MouseWheelScrolled>());
         const auto& mouseWheelScrolled = *event.getIf<sf::Event::MouseWheelScrolled>();
@@ -91,6 +101,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(mouseWheelScrolled.position == sf::Vector2i(4, 5));
 
         event = sf::Event::MouseButtonPressed{sf::Mouse::Button::Middle, {6, 7}};
+        CHECK(event);
         CHECK(event.is<sf::Event::MouseButtonPressed>());
         CHECK(event.getIf<sf::Event::MouseButtonPressed>());
         const auto& mouseButtonPressed = *event.getIf<sf::Event::MouseButtonPressed>();
@@ -98,6 +109,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(mouseButtonPressed.position == sf::Vector2i(6, 7));
 
         event = sf::Event::MouseButtonReleased{sf::Mouse::Button::Extra1, {8, 9}};
+        CHECK(event);
         CHECK(event.is<sf::Event::MouseButtonReleased>());
         CHECK(event.getIf<sf::Event::MouseButtonReleased>());
         const auto& mouseButtonReleased = *event.getIf<sf::Event::MouseButtonReleased>();
@@ -105,20 +117,24 @@ TEST_CASE("[Window] sf::Event")
         CHECK(mouseButtonReleased.position == sf::Vector2i(8, 9));
 
         event = sf::Event::MouseMoved{{4, 2}};
+        CHECK(event);
         CHECK(event.is<sf::Event::MouseMoved>());
         CHECK(event.getIf<sf::Event::MouseMoved>());
         const auto& mouseMoved = *event.getIf<sf::Event::MouseMoved>();
         CHECK(mouseMoved.position == sf::Vector2i(4, 2));
 
         event = sf::Event::MouseEntered{};
+        CHECK(event);
         CHECK(event.is<sf::Event::MouseEntered>());
         CHECK(event.getIf<sf::Event::MouseEntered>());
 
         event = sf::Event::MouseLeft{};
+        CHECK(event);
         CHECK(event.is<sf::Event::MouseLeft>());
         CHECK(event.getIf<sf::Event::MouseLeft>());
 
         event = sf::Event::JoystickButtonPressed{100, 200};
+        CHECK(event);
         CHECK(event.is<sf::Event::JoystickButtonPressed>());
         CHECK(event.getIf<sf::Event::JoystickButtonPressed>());
         const auto& joystickButtonPressed = *event.getIf<sf::Event::JoystickButtonPressed>();
@@ -126,6 +142,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(joystickButtonPressed.button == 200);
 
         event = sf::Event::JoystickButtonReleased{300, 400};
+        CHECK(event);
         CHECK(event.is<sf::Event::JoystickButtonReleased>());
         CHECK(event.getIf<sf::Event::JoystickButtonReleased>());
         const auto& joystickButtonReleased = *event.getIf<sf::Event::JoystickButtonReleased>();
@@ -133,6 +150,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(joystickButtonReleased.button == 400);
 
         event = sf::Event::JoystickMoved{300, sf::Joystick::Axis::Z, 1.23f};
+        CHECK(event);
         CHECK(event.is<sf::Event::JoystickMoved>());
         CHECK(event.getIf<sf::Event::JoystickMoved>());
         const auto& joystickMoved = *event.getIf<sf::Event::JoystickMoved>();
@@ -141,18 +159,21 @@ TEST_CASE("[Window] sf::Event")
         CHECK(joystickMoved.position == 1.23f);
 
         event = sf::Event::JoystickConnected{42};
+        CHECK(event);
         CHECK(event.is<sf::Event::JoystickConnected>());
         CHECK(event.getIf<sf::Event::JoystickConnected>());
         const auto& joystickConnected = *event.getIf<sf::Event::JoystickConnected>();
         CHECK(joystickConnected.joystickId == 42);
 
         event = sf::Event::JoystickDisconnected{43};
+        CHECK(event);
         CHECK(event.is<sf::Event::JoystickDisconnected>());
         CHECK(event.getIf<sf::Event::JoystickDisconnected>());
         const auto& joystickDisconnected = *event.getIf<sf::Event::JoystickDisconnected>();
         CHECK(joystickDisconnected.joystickId == 43);
 
         event = sf::Event::TouchBegan{99, {98, 97}};
+        CHECK(event);
         CHECK(event.is<sf::Event::TouchBegan>());
         CHECK(event.getIf<sf::Event::TouchBegan>());
         const auto& touchBegan = *event.getIf<sf::Event::TouchBegan>();
@@ -160,6 +181,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(touchBegan.position == sf::Vector2i(98, 97));
 
         event = sf::Event::TouchMoved{96, {95, 94}};
+        CHECK(event);
         CHECK(event.is<sf::Event::TouchMoved>());
         CHECK(event.getIf<sf::Event::TouchMoved>());
         const auto& touchMoved = *event.getIf<sf::Event::TouchMoved>();
@@ -167,6 +189,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(touchMoved.position == sf::Vector2i(95, 94));
 
         event = sf::Event::TouchEnded{93, {92, 91}};
+        CHECK(event);
         CHECK(event.is<sf::Event::TouchEnded>());
         CHECK(event.getIf<sf::Event::TouchEnded>());
         const auto& touchEnded = *event.getIf<sf::Event::TouchEnded>();
@@ -174,6 +197,7 @@ TEST_CASE("[Window] sf::Event")
         CHECK(touchEnded.position == sf::Vector2i(92, 91));
 
         event = sf::Event::SensorChanged{sf::Sensor::Type::Gravity, {1.2f, 3.4f, 5.6f}};
+        CHECK(event);
         CHECK(event.is<sf::Event::SensorChanged>());
         CHECK(event.getIf<sf::Event::SensorChanged>());
         const auto& sensorChanged = *event.getIf<sf::Event::SensorChanged>();

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -105,15 +105,13 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
     SECTION("pollEvent()")
     {
         sf::WindowBase windowBase;
-        sf::Event      event;
-        CHECK(!windowBase.pollEvent(event));
+        CHECK(!windowBase.pollEvent());
     }
 
     SECTION("waitEvent()")
     {
         sf::WindowBase windowBase;
-        sf::Event      event;
-        CHECK(!windowBase.waitEvent(event));
+        CHECK(!windowBase.waitEvent());
     }
 
     SECTION("Set/get position")

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -64,7 +64,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -62,7 +62,7 @@ int main()
     while (window.isOpen())
     {
         // Process events
-        for (sf::Event event; window.pollEvent(event);)
+        while (const auto event = window.pollEvent())
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before? **Yes, it was discussed in the Discord server.**
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->
This PR aims to simplify the usage of `Event` when polling events from a `RenderWindow`. Instead of having to initialize an `Event` on the stack and pass it by reference to `pollEvent`/`waitEvent`, this PR makes the methods return an `Event`, which can be converted to a `bool` based on whether its subtype is `Empty`.

There was discussion about having `pollEvent` and `waitEvent` return `std::optional<Event>`, but considering `Event` already uses subtyping to determine if it contains event data, letting `Event` be convertible to `bool` (based on whether the inner data was of type `Event::Empty`) sounded like the better option. Plus, we can avoid the clunky `->` syntax used for accessing members of an `std::optional`'s inner type.

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->
Use an `sf::RenderWindow` while processing events.

<!-- Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the follow template as a start: -->

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        while (const auto event = window.pollEvent())
        {
            if (event.is<sf::Event::Closed>())
                window.close();
        }

        window.clear();
        window.display();
    }
}
```
