### PR TITLE
Fix API documentation bugs

### DIFF
--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -109,7 +109,7 @@ public:
     /// The specified value is truncated to the bit width of
     /// the current stencil buffer.
     ///
-    /// \param value Stencil value to clear to
+    /// \param stencilValue Stencil value to clear to
     ///
     ////////////////////////////////////////////////////////////
     void clearStencil(StencilValue stencilValue);
@@ -120,8 +120,8 @@ public:
     /// The specified stencil value is truncated to the bit
     /// width of the current stencil buffer.
     ///
-    /// \param color Fill color to use to clear the render target
-    /// \param value Stencil value to clear to
+    /// \param color        Fill color to use to clear the render target
+    /// \param stencilValue Stencil value to clear to
     ///
     ////////////////////////////////////////////////////////////
     void clear(const Color& color, StencilValue stencilValue);

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -171,8 +171,7 @@ public:
     /// to bother with it.
     ///
     /// \param settings Creation parameters
-    /// \param width    Back buffer width
-    /// \param height   Back buffer height
+    /// \param size     Back buffer size
     ///
     ////////////////////////////////////////////////////////////
     Context(const ContextSettings& settings, const Vector2u& size);


### PR DESCRIPTION
## Description

I went through the Doxygen warnings and these stood out as particular trivial problems to fix. Most warnings are due to not documenting return values which is less trivial and can be dealt with in a later PR.