### PR TITLE
Added \param field to sf::Keyboard::getDescription(Scancode code) as it was missing from the docs

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -401,6 +401,8 @@ SFML_WINDOW_API Scancode delocalize(Key key);
 /// interpret the scancode: for example, sf::Keyboard::Key::Semicolon is
 /// mapped to ";" for layout and to "é" for others.
 ///
+/// \param code Scancode to check
+///
 /// \return The localized description of the code
 ///
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Title. The \param field was missing, so I copied the \param field from isKeyPressed(Scancode code) to getDescription(Scancode code) because they have the same parameter values.

Let me know if there is anything to fix.