### PR TITLE
Implement Rect as position and size vectors

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -152,8 +152,7 @@ int main()
     }
 
     // Center the status text
-    statusText.setPosition({(windowWidth - statusText.getLocalBounds().size.x) / 2.f,
-                            (windowHeight - statusText.getLocalBounds().size.y) / 2.f});
+    statusText.setPosition((sf::Vector2f(windowWidth, windowHeight) - statusText.getLocalBounds().size) / 2.f);
 
     // Set up an array of pointers to our settings for arrow navigation
     constexpr std::array<Setting, 9> settings = {

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -152,8 +152,8 @@ int main()
     }
 
     // Center the status text
-    statusText.setPosition({(windowWidth - statusText.getLocalBounds().width) / 2.f,
-                            (windowHeight - statusText.getLocalBounds().height) / 2.f});
+    statusText.setPosition({(windowWidth - statusText.getLocalBounds().size.x) / 2.f,
+                            (windowHeight - statusText.getLocalBounds().size.y) / 2.f});
 
     // Set up an array of pointers to our settings for arrow navigation
     constexpr std::array<Setting, 9> settings = {

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -105,26 +105,6 @@ public:
     constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get the position of the rectangle's top-left corner
-    ///
-    /// \return Position of rectangle
-    ///
-    /// \see getSize, getCenter
-    ///
-    ////////////////////////////////////////////////////////////
-    constexpr Vector2<T> getPosition() const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the size of the rectangle
-    ///
-    /// \return Size of rectangle
-    ///
-    /// \see getPosition, getCenter
-    ///
-    ////////////////////////////////////////////////////////////
-    constexpr Vector2<T> getSize() const;
-
-    ////////////////////////////////////////////////////////////
     /// \brief Get the position of the center of the rectangle
     ///
     /// \return Center of rectangle

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -137,10 +137,8 @@ public:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    T left{};   //!< Left coordinate of the rectangle
-    T top{};    //!< Top coordinate of the rectangle
-    T width{};  //!< Width of the rectangle
-    T height{}; //!< Height of the rectangle
+    Vector2<T> position{}; //!< Position of the top-left corner of the rectangle
+    Vector2<T> size{};     //!< Size of the rectangle
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -109,8 +109,6 @@ public:
     ///
     /// \return Center of rectangle
     ///
-    /// \see getSize, getPosition
-    ///
     ////////////////////////////////////////////////////////////
     constexpr Vector2<T> getCenter() const;
 
@@ -166,18 +164,18 @@ using FloatRect = Rect<float>;
 ///
 /// A rectangle is defined by its top-left corner and its size.
 /// It is a very simple class defined for convenience, so
-/// its member variables (left, top, width and height) are public
+/// its member variables (position and size) are public
 /// and can be accessed directly, just like the vector classes
 /// (Vector2 and Vector3).
 ///
 /// To keep things simple, sf::Rect doesn't define
 /// functions to emulate the properties that are not directly
-/// members (such as right, bottom, center, etc.), it rather
+/// members (such as right, bottom, etc.), it rather
 /// only provides intersection functions.
 ///
 /// sf::Rect uses the usual rules for its boundaries:
 /// \li The left and top edges are included in the rectangle's area
-/// \li The right (left + width) and bottom (top + height) edges are excluded from the rectangle's area
+/// \li The right and bottom edges are excluded from the rectangle's area
 ///
 /// This means that sf::IntRect({0, 0}, {1, 1}) and sf::IntRect({1, 1}, {1, 1})
 /// don't intersect.
@@ -206,7 +204,7 @@ using FloatRect = Rect<float>;
 /// // Test the intersection between r1 and r2
 /// std::optional<sf::IntRect> result = r1.findIntersection(r2);
 /// // result.has_value() == true
-/// // result.value() == (4, 2, 16, 3)
+/// // result.value() == sf::IntRect({4, 2}, {16, 3})
 /// \endcode
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -125,14 +125,14 @@ public:
 ///
 /// This operator compares strict equality between two rectangles.
 ///
-/// \param left  Left operand (a rectangle)
-/// \param right Right operand (a rectangle)
+/// \param lhs Left operand (a rectangle)
+/// \param rhs Right operand (a rectangle)
 ///
-/// \return True if \a left is equal to \a right
+/// \return True if \a lhs is equal to \a rhs
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr bool operator==(const Rect<T>& left, const Rect<T>& right);
+[[nodiscard]] constexpr bool operator==(const Rect<T>& lhs, const Rect<T>& rhs);
 
 ////////////////////////////////////////////////////////////
 /// \relates Rect
@@ -140,14 +140,14 @@ template <typename T>
 ///
 /// This operator compares strict difference between two rectangles.
 ///
-/// \param left  Left operand (a rectangle)
-/// \param right Right operand (a rectangle)
+/// \param lhs Left operand (a rectangle)
+/// \param rhs Right operand (a rectangle)
 ///
-/// \return True if \a left is not equal to \a right
+/// \return True if \a lhs is not equal to \a rhs
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr bool operator!=(const Rect<T>& left, const Rect<T>& right);
+[[nodiscard]] constexpr bool operator!=(const Rect<T>& lhs, const Rect<T>& rhs);
 
 // Create type aliases for the most common types
 using IntRect   = Rect<int>;

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -112,25 +112,9 @@ constexpr std::optional<Rect<T>> Rect<T>::findIntersection(const Rect<T>& rectan
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> Rect<T>::getPosition() const
-{
-    return Vector2<T>(position.x, position.y);
-}
-
-
-////////////////////////////////////////////////////////////
-template <typename T>
-constexpr Vector2<T> Rect<T>::getSize() const
-{
-    return Vector2<T>(size.x, size.y);
-}
-
-
-////////////////////////////////////////////////////////////
-template <typename T>
 constexpr Vector2<T> Rect<T>::getCenter() const
 {
-    return getPosition() + getSize() / T{2};
+    return position + size / T{2};
 }
 
 

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -120,17 +120,17 @@ constexpr Vector2<T> Rect<T>::getCenter() const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr bool operator==(const Rect<T>& left, const Rect<T>& right)
+constexpr bool operator==(const Rect<T>& lhs, const Rect<T>& rhs)
 {
-    return (left.position == right.position) && (left.size == right.size);
+    return (lhs.position == rhs.position) && (lhs.size == rhs.size);
 }
 
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr bool operator!=(const Rect<T>& left, const Rect<T>& right)
+constexpr bool operator!=(const Rect<T>& lhs, const Rect<T>& rhs)
 {
-    return !(left == right);
+    return !(lhs == rhs);
 }
 
 } // namespace sf

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -37,11 +37,7 @@ constexpr Rect<T>::Rect() = default;
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Rect<T>::Rect(const Vector2<T>& position, const Vector2<T>& size) :
-left(position.x),
-top(position.y),
-width(size.x),
-height(size.y)
+constexpr Rect<T>::Rect(const Vector2<T>& thePosition, const Vector2<T>& theSize) : position(thePosition), size(theSize)
 {
 }
 
@@ -49,11 +45,7 @@ height(size.y)
 ////////////////////////////////////////////////////////////
 template <typename T>
 template <typename U>
-constexpr Rect<T>::Rect(const Rect<U>& rectangle) :
-left(static_cast<T>(rectangle.left)),
-top(static_cast<T>(rectangle.top)),
-width(static_cast<T>(rectangle.width)),
-height(static_cast<T>(rectangle.height))
+constexpr Rect<T>::Rect(const Rect<U>& rectangle) : position(rectangle.position), size(rectangle.size)
 {
 }
 
@@ -69,10 +61,10 @@ constexpr bool Rect<T>::contains(const Vector2<T>& point) const
     // Rectangles with negative dimensions are allowed, so we must handle them correctly
 
     // Compute the real min and max of the rectangle on both axes
-    const T minX = min(left, static_cast<T>(left + width));
-    const T maxX = max(left, static_cast<T>(left + width));
-    const T minY = min(top, static_cast<T>(top + height));
-    const T maxY = max(top, static_cast<T>(top + height));
+    const T minX = min(position.x, static_cast<T>(position.x + size.x));
+    const T maxX = max(position.x, static_cast<T>(position.x + size.x));
+    const T minY = min(position.y, static_cast<T>(position.y + size.y));
+    const T maxY = max(position.y, static_cast<T>(position.y + size.y));
 
     return (point.x >= minX) && (point.x < maxX) && (point.y >= minY) && (point.y < maxY);
 }
@@ -89,16 +81,16 @@ constexpr std::optional<Rect<T>> Rect<T>::findIntersection(const Rect<T>& rectan
     // Rectangles with negative dimensions are allowed, so we must handle them correctly
 
     // Compute the min and max of the first rectangle on both axes
-    const T r1MinX = min(left, static_cast<T>(left + width));
-    const T r1MaxX = max(left, static_cast<T>(left + width));
-    const T r1MinY = min(top, static_cast<T>(top + height));
-    const T r1MaxY = max(top, static_cast<T>(top + height));
+    const T r1MinX = min(position.x, static_cast<T>(position.x + size.x));
+    const T r1MaxX = max(position.x, static_cast<T>(position.x + size.x));
+    const T r1MinY = min(position.y, static_cast<T>(position.y + size.y));
+    const T r1MaxY = max(position.y, static_cast<T>(position.y + size.y));
 
     // Compute the min and max of the second rectangle on both axes
-    const T r2MinX = min(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
-    const T r2MaxX = max(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
-    const T r2MinY = min(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
-    const T r2MaxY = max(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
+    const T r2MinX = min(rectangle.position.x, static_cast<T>(rectangle.position.x + rectangle.size.x));
+    const T r2MaxX = max(rectangle.position.x, static_cast<T>(rectangle.position.x + rectangle.size.x));
+    const T r2MinY = min(rectangle.position.y, static_cast<T>(rectangle.position.y + rectangle.size.y));
+    const T r2MaxY = max(rectangle.position.y, static_cast<T>(rectangle.position.y + rectangle.size.y));
 
     // Compute the intersection boundaries
     const T interLeft   = max(r1MinX, r2MinX);
@@ -122,7 +114,7 @@ constexpr std::optional<Rect<T>> Rect<T>::findIntersection(const Rect<T>& rectan
 template <typename T>
 constexpr Vector2<T> Rect<T>::getPosition() const
 {
-    return Vector2<T>(left, top);
+    return Vector2<T>(position.x, position.y);
 }
 
 
@@ -130,7 +122,7 @@ constexpr Vector2<T> Rect<T>::getPosition() const
 template <typename T>
 constexpr Vector2<T> Rect<T>::getSize() const
 {
-    return Vector2<T>(width, height);
+    return Vector2<T>(size.x, size.y);
 }
 
 
@@ -146,8 +138,7 @@ constexpr Vector2<T> Rect<T>::getCenter() const
 template <typename T>
 constexpr bool operator==(const Rect<T>& left, const Rect<T>& right)
 {
-    return (left.left == right.left) && (left.width == right.width) && (left.top == right.top) &&
-           (left.height == right.height);
+    return (left.position == right.position) && (left.size == right.size);
 }
 
 

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -104,10 +104,11 @@ constexpr Vector2f Transform::transformPoint(const Vector2f& point) const
 constexpr FloatRect Transform::transformRect(const FloatRect& rectangle) const
 {
     // Transform the 4 corners of the rectangle
-    const std::array points = {transformPoint({rectangle.left, rectangle.top}),
-                               transformPoint({rectangle.left, rectangle.top + rectangle.height}),
-                               transformPoint({rectangle.left + rectangle.width, rectangle.top}),
-                               transformPoint({rectangle.left + rectangle.width, rectangle.top + rectangle.height})};
+    const std::array points = {transformPoint({rectangle.position.x, rectangle.position.y}),
+                               transformPoint({rectangle.position.x, rectangle.position.y + rectangle.size.y}),
+                               transformPoint({rectangle.position.x + rectangle.size.x, rectangle.position.y}),
+                               transformPoint(
+                                   {rectangle.position.x + rectangle.size.x, rectangle.position.y + rectangle.size.y})};
 
     // Compute the bounding rectangle of the transformed points
     float left   = points[0].x;

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -104,30 +104,27 @@ constexpr Vector2f Transform::transformPoint(const Vector2f& point) const
 constexpr FloatRect Transform::transformRect(const FloatRect& rectangle) const
 {
     // Transform the 4 corners of the rectangle
-    const std::array points = {transformPoint({rectangle.position.x, rectangle.position.y}),
-                               transformPoint({rectangle.position.x, rectangle.position.y + rectangle.size.y}),
-                               transformPoint({rectangle.position.x + rectangle.size.x, rectangle.position.y}),
-                               transformPoint(
-                                   {rectangle.position.x + rectangle.size.x, rectangle.position.y + rectangle.size.y})};
+    const std::array points = {transformPoint(rectangle.position),
+                               transformPoint(rectangle.position + Vector2f(0.f, rectangle.size.y)),
+                               transformPoint(rectangle.position + Vector2f(rectangle.size.x, 0.f)),
+                               transformPoint(rectangle.position + rectangle.size)};
 
     // Compute the bounding rectangle of the transformed points
-    float left   = points[0].x;
-    float top    = points[0].y;
-    float right  = points[0].x;
-    float bottom = points[0].y;
+    Vector2f pmin = points[0];
+    Vector2f pmax = points[0];
 
     for (std::size_t i = 1; i < points.size(); ++i)
     {
         // clang-format off
-        if      (points[i].x < left)   left   = points[i].x;
-        else if (points[i].x > right)  right  = points[i].x;
+        if      (points[i].x < pmin.x) pmin.x = points[i].x;
+        else if (points[i].x > pmax.x) pmax.x = points[i].x;
 
-        if      (points[i].y < top)    top    = points[i].y;
-        else if (points[i].y > bottom) bottom = points[i].y;
+        if      (points[i].y < pmin.y) pmin.y = points[i].y;
+        else if (points[i].y > pmax.y) pmax.y = points[i].y;
         // clang-format on
     }
 
-    return {{left, top}, {right - left, bottom - top}};
+    return {pmin, pmax - pmin};
 }
 
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -566,16 +566,16 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
 
         // Make sure the texture data is positioned in the center
         // of the allocated texture rectangle
-        glyph.textureRect.left += static_cast<int>(padding);
-        glyph.textureRect.top += static_cast<int>(padding);
-        glyph.textureRect.width -= static_cast<int>(2 * padding);
-        glyph.textureRect.height -= static_cast<int>(2 * padding);
+        glyph.textureRect.position.x += static_cast<int>(padding);
+        glyph.textureRect.position.y += static_cast<int>(padding);
+        glyph.textureRect.size.x -= static_cast<int>(2 * padding);
+        glyph.textureRect.size.y -= static_cast<int>(2 * padding);
 
         // Compute the glyph's bounding box
-        glyph.bounds.left   = static_cast<float>(bitmapGlyph->left);
-        glyph.bounds.top    = static_cast<float>(-bitmapGlyph->top);
-        glyph.bounds.width  = static_cast<float>(bitmap.width);
-        glyph.bounds.height = static_cast<float>(bitmap.rows);
+        glyph.bounds.position.x = static_cast<float>(bitmapGlyph->left);
+        glyph.bounds.position.y = static_cast<float>(-bitmapGlyph->top);
+        glyph.bounds.size.x     = static_cast<float>(bitmap.width);
+        glyph.bounds.size.y     = static_cast<float>(bitmap.rows);
 
         // Resize the pixel buffer to the new size and fill it with transparent white pixels
         m_pixelBuffer.resize(static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4);
@@ -623,10 +623,10 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
         }
 
         // Write the pixels to the texture
-        const unsigned int x = static_cast<unsigned int>(glyph.textureRect.left) - padding;
-        const unsigned int y = static_cast<unsigned int>(glyph.textureRect.top) - padding;
-        const unsigned int w = static_cast<unsigned int>(glyph.textureRect.width) + 2 * padding;
-        const unsigned int h = static_cast<unsigned int>(glyph.textureRect.height) + 2 * padding;
+        const unsigned int x = static_cast<unsigned int>(glyph.textureRect.position.x) - padding;
+        const unsigned int y = static_cast<unsigned int>(glyph.textureRect.position.y) - padding;
+        const unsigned int w = static_cast<unsigned int>(glyph.textureRect.size.x) + 2 * padding;
+        const unsigned int h = static_cast<unsigned int>(glyph.textureRect.size.y) + 2 * padding;
         page.texture.update(m_pixelBuffer.data(), {w, h}, {x, y});
     }
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -546,42 +546,36 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
     glyph.lsbDelta = static_cast<int>(face->glyph->lsb_delta);
     glyph.rsbDelta = static_cast<int>(face->glyph->rsb_delta);
 
-    unsigned int width  = bitmap.width;
-    unsigned int height = bitmap.rows;
+    Vector2u size(bitmap.width, bitmap.rows);
 
-    if ((width > 0) && (height > 0))
+    if ((size.x > 0) && (size.y > 0))
     {
         // Leave a small padding around characters, so that filtering doesn't
         // pollute them with pixels from neighbors
         const unsigned int padding = 2;
 
-        width += 2 * padding;
-        height += 2 * padding;
+        size += 2u * Vector2u(padding, padding);
 
         // Get the glyphs page corresponding to the character size
         Page& page = loadPage(characterSize);
 
         // Find a good position for the new glyph into the texture
-        glyph.textureRect = findGlyphRect(page, {width, height});
+        glyph.textureRect = findGlyphRect(page, size);
 
         // Make sure the texture data is positioned in the center
         // of the allocated texture rectangle
-        glyph.textureRect.position.x += static_cast<int>(padding);
-        glyph.textureRect.position.y += static_cast<int>(padding);
-        glyph.textureRect.size.x -= static_cast<int>(2 * padding);
-        glyph.textureRect.size.y -= static_cast<int>(2 * padding);
+        glyph.textureRect.position += Vector2i(padding, padding);
+        glyph.textureRect.size -= 2 * Vector2i(padding, padding);
 
         // Compute the glyph's bounding box
-        glyph.bounds.position.x = static_cast<float>(bitmapGlyph->left);
-        glyph.bounds.position.y = static_cast<float>(-bitmapGlyph->top);
-        glyph.bounds.size.x     = static_cast<float>(bitmap.width);
-        glyph.bounds.size.y     = static_cast<float>(bitmap.rows);
+        glyph.bounds.position = Vector2f(Vector2i(bitmapGlyph->left, -bitmapGlyph->top));
+        glyph.bounds.size     = Vector2f(Vector2u(bitmap.width, bitmap.rows));
 
         // Resize the pixel buffer to the new size and fill it with transparent white pixels
-        m_pixelBuffer.resize(static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 4);
+        m_pixelBuffer.resize(static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) * 4);
 
         std::uint8_t* current = m_pixelBuffer.data();
-        std::uint8_t* end     = current + width * height * 4;
+        std::uint8_t* end     = current + size.x * size.y * 4;
 
         while (current != end)
         {
@@ -596,12 +590,12 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
         if (bitmap.pixel_mode == FT_PIXEL_MODE_MONO)
         {
             // Pixels are 1 bit monochrome values
-            for (unsigned int y = padding; y < height - padding; ++y)
+            for (unsigned int y = padding; y < size.y - padding; ++y)
             {
-                for (unsigned int x = padding; x < width - padding; ++x)
+                for (unsigned int x = padding; x < size.x - padding; ++x)
                 {
                     // The color channels remain white, just fill the alpha channel
-                    const std::size_t index = x + y * width;
+                    const std::size_t index = x + y * size.x;
                     m_pixelBuffer[index * 4 + 3] = ((pixels[(x - padding) / 8]) & (1 << (7 - ((x - padding) % 8)))) ? 255 : 0;
                 }
                 pixels += bitmap.pitch;
@@ -610,12 +604,12 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
         else
         {
             // Pixels are 8 bits gray levels
-            for (unsigned int y = padding; y < height - padding; ++y)
+            for (unsigned int y = padding; y < size.y - padding; ++y)
             {
-                for (unsigned int x = padding; x < width - padding; ++x)
+                for (unsigned int x = padding; x < size.x - padding; ++x)
                 {
                     // The color channels remain white, just fill the alpha channel
-                    const std::size_t index      = x + y * width;
+                    const std::size_t index      = x + y * size.x;
                     m_pixelBuffer[index * 4 + 3] = pixels[x - padding];
                 }
                 pixels += bitmap.pitch;
@@ -623,11 +617,9 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
         }
 
         // Write the pixels to the texture
-        const unsigned int x = static_cast<unsigned int>(glyph.textureRect.position.x) - padding;
-        const unsigned int y = static_cast<unsigned int>(glyph.textureRect.position.y) - padding;
-        const unsigned int w = static_cast<unsigned int>(glyph.textureRect.size.x) + 2 * padding;
-        const unsigned int h = static_cast<unsigned int>(glyph.textureRect.size.y) + 2 * padding;
-        page.texture.update(m_pixelBuffer.data(), {w, h}, {x, y});
+        const auto dest       = Vector2u(glyph.textureRect.position) - Vector2u(padding, padding);
+        const auto updateSize = Vector2u(glyph.textureRect.size) + 2u * Vector2u(padding, padding);
+        page.texture.update(m_pixelBuffer.data(), updateSize, dest);
     }
 
     // Delete the FT glyph

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -389,13 +389,13 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
         return false;
 
     // Make sure the sourceRect components are non-negative before casting them to unsigned values
-    if (sourceRect.left < 0 || sourceRect.top < 0 || sourceRect.width < 0 || sourceRect.height < 0)
+    if (sourceRect.position.x < 0 || sourceRect.position.y < 0 || sourceRect.size.x < 0 || sourceRect.size.y < 0)
         return false;
 
     Rect<unsigned int> srcRect(sourceRect);
 
     // Use the whole source image as srcRect if the provided source rectangle is empty
-    if (srcRect.width == 0 || srcRect.height == 0)
+    if (srcRect.size.x == 0 || srcRect.size.y == 0)
     {
         srcRect = Rect<unsigned int>({0, 0}, source.m_size);
     }
@@ -404,7 +404,7 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
     {
         // Checking the bottom right corner is enough because
         // left and top are non-negative and width and height are positive.
-        if (source.m_size.x < srcRect.left + srcRect.width || source.m_size.y < srcRect.top + srcRect.height)
+        if (source.m_size.x < srcRect.position.x + srcRect.size.x || source.m_size.y < srcRect.position.y + srcRect.size.y)
             return false;
     }
 
@@ -413,14 +413,14 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
         return false;
 
     // Then find the valid size of the destination rectangle
-    const Vector2u dstSize(std::min(m_size.x - dest.x, srcRect.width), std::min(m_size.y - dest.y, srcRect.height));
+    const Vector2u dstSize(std::min(m_size.x - dest.x, srcRect.size.x), std::min(m_size.y - dest.y, srcRect.size.y));
 
     // Precompute as much as possible
     const std::size_t  pitch     = static_cast<std::size_t>(dstSize.x) * 4;
     const unsigned int srcStride = source.m_size.x * 4;
     const unsigned int dstStride = m_size.x * 4;
 
-    const std::uint8_t* srcPixels = source.m_pixels.data() + (srcRect.left + srcRect.top * source.m_size.x) * 4;
+    const std::uint8_t* srcPixels = source.m_pixels.data() + (srcRect.position.x + srcRect.position.y * source.m_size.x) * 4;
     std::uint8_t*       dstPixels = m_pixels.data() + (dest.x + dest.y * m_size.x) * 4;
 
     // Copy the pixels

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -308,7 +308,7 @@ Vector2f RenderTarget::mapPixelToCoords(const Vector2i& point, const View& view)
     // First, convert from viewport coordinates to homogeneous coordinates
     const FloatRect viewport   = FloatRect(getViewport(view));
     const Vector2f  normalized = Vector2f(-1, 1) +
-                                Vector2f(2, -2).cwiseMul(Vector2f(point) - viewport.getPosition()).cwiseDiv(viewport.getSize());
+                                Vector2f(2, -2).cwiseMul(Vector2f(point) - viewport.position).cwiseDiv(viewport.size);
 
     // Then transform by the inverse of the view matrix
     return view.getInverseTransform().transformPoint(normalized);
@@ -330,8 +330,8 @@ Vector2i RenderTarget::mapCoordsToPixel(const Vector2f& point, const View& view)
 
     // Then convert to viewport coordinates
     const FloatRect viewport = FloatRect(getViewport(view));
-    return Vector2i((normalized.cwiseMul({1, -1}) + sf::Vector2f(1, 1)).cwiseDiv({2, 2}).cwiseMul(viewport.getSize()) +
-                    viewport.getPosition());
+    return Vector2i((normalized.cwiseMul({1, -1}) + sf::Vector2f(1, 1)).cwiseDiv({2, 2}).cwiseMul(viewport.size) +
+                    viewport.position);
 }
 
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -279,8 +279,8 @@ IntRect RenderTarget::getViewport(const View& view) const
     const auto [width, height] = Vector2f(getSize());
     const FloatRect& viewport  = view.getViewport();
 
-    return IntRect(Rect<long>({std::lround(width * viewport.left), std::lround(height * viewport.top)},
-                              {std::lround(width * viewport.width), std::lround(height * viewport.height)}));
+    return IntRect(Rect<long>({std::lround(width * viewport.position.x), std::lround(height * viewport.position.y)},
+                              {std::lround(width * viewport.size.x), std::lround(height * viewport.size.y)}));
 }
 
 
@@ -290,8 +290,8 @@ IntRect RenderTarget::getScissor(const View& view) const
     const auto [width, height] = Vector2f(getSize());
     const FloatRect& scissor   = view.getScissor();
 
-    return IntRect(Rect<long>({std::lround(width * scissor.left), std::lround(height * scissor.top)},
-                              {std::lround(width * scissor.width), std::lround(height * scissor.height)}));
+    return IntRect(Rect<long>({std::lround(width * scissor.position.x), std::lround(height * scissor.position.y)},
+                              {std::lround(width * scissor.size.x), std::lround(height * scissor.size.y)}));
 }
 
 
@@ -656,8 +656,8 @@ void RenderTarget::applyCurrentView()
 {
     // Set the viewport
     const IntRect viewport    = getViewport(m_view);
-    const int     viewportTop = static_cast<int>(getSize().y) - (viewport.top + viewport.height);
-    glCheck(glViewport(viewport.left, viewportTop, viewport.width, viewport.height));
+    const int     viewportTop = static_cast<int>(getSize().y) - (viewport.position.y + viewport.size.y);
+    glCheck(glViewport(viewport.position.x, viewportTop, viewport.size.x, viewport.size.y));
 
     // Set the scissor rectangle and enable/disable scissor testing
     if (m_view.getScissor() == FloatRect({0, 0}, {1, 1}))
@@ -671,8 +671,8 @@ void RenderTarget::applyCurrentView()
     else
     {
         const IntRect pixelScissor = getScissor(m_view);
-        const int     scissorTop   = static_cast<int>(getSize().y) - (pixelScissor.top + pixelScissor.height);
-        glCheck(glScissor(pixelScissor.left, scissorTop, pixelScissor.width, pixelScissor.height));
+        const int     scissorTop   = static_cast<int>(getSize().y) - (pixelScissor.position.y + pixelScissor.size.y);
+        glCheck(glScissor(pixelScissor.position.x, scissorTop, pixelScissor.size.x, pixelScissor.size.y));
 
         if (!m_cache.scissorEnabled)
         {

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -267,11 +267,11 @@ void Shape::updateTexCoords()
 
     for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
     {
-        const float xratio      = m_insideBounds.width > 0
-                                      ? (m_vertices[i].position.x - m_insideBounds.left) / m_insideBounds.width
+        const float xratio      = m_insideBounds.size.x > 0
+                                      ? (m_vertices[i].position.x - m_insideBounds.position.x) / m_insideBounds.size.x
                                       : 0;
-        const float yratio      = m_insideBounds.height > 0
-                                      ? (m_vertices[i].position.y - m_insideBounds.top) / m_insideBounds.height
+        const float yratio      = m_insideBounds.size.y > 0
+                                      ? (m_vertices[i].position.y - m_insideBounds.position.y) / m_insideBounds.size.y
                                       : 0;
         m_vertices[i].texCoords = convertedTextureRect.getPosition() +
                                   convertedTextureRect.getSize().cwiseMul({xratio, yratio});

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -265,15 +265,14 @@ void Shape::updateTexCoords()
 {
     const FloatRect convertedTextureRect(m_textureRect);
 
+    // Make sure not to divide by zero when the points are aligned on a vertical or horizontal line
+    const Vector2f safeInsideSize(m_insideBounds.size.x > 0 ? m_insideBounds.size.x : 1.f,
+                                  m_insideBounds.size.y > 0 ? m_insideBounds.size.y : 1.f);
+
     for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
     {
-        const float xratio      = m_insideBounds.size.x > 0
-                                      ? (m_vertices[i].position.x - m_insideBounds.position.x) / m_insideBounds.size.x
-                                      : 0;
-        const float yratio      = m_insideBounds.size.y > 0
-                                      ? (m_vertices[i].position.y - m_insideBounds.position.y) / m_insideBounds.size.y
-                                      : 0;
-        m_vertices[i].texCoords = convertedTextureRect.position + convertedTextureRect.size.cwiseMul({xratio, yratio});
+        const Vector2f ratio    = (m_vertices[i].position - m_insideBounds.position).cwiseDiv(safeInsideSize);
+        m_vertices[i].texCoords = convertedTextureRect.position + convertedTextureRect.size.cwiseMul(ratio);
     }
 }
 

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -273,8 +273,7 @@ void Shape::updateTexCoords()
         const float yratio      = m_insideBounds.size.y > 0
                                       ? (m_vertices[i].position.y - m_insideBounds.position.y) / m_insideBounds.size.y
                                       : 0;
-        m_vertices[i].texCoords = convertedTextureRect.getPosition() +
-                                  convertedTextureRect.getSize().cwiseMul({xratio, yratio});
+        m_vertices[i].texCoords = convertedTextureRect.position + convertedTextureRect.size.cwiseMul({xratio, yratio});
     }
 }
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -128,28 +128,22 @@ void Sprite::draw(RenderTarget& target, RenderStates states) const
 ////////////////////////////////////////////////////////////
 void Sprite::updateVertices()
 {
-    const auto left   = static_cast<float>(m_textureRect.position.x);
-    const auto top    = static_cast<float>(m_textureRect.position.y);
-    const auto width  = static_cast<float>(m_textureRect.size.x);
-    const auto height = static_cast<float>(m_textureRect.size.y);
-    const auto right  = float{left + width};
-    const auto bottom = float{top + height};
+    const auto [position, size] = FloatRect(m_textureRect);
 
     // Absolute value is used to support negative texture rect sizes
-    const auto absWidth  = float{std::abs(width)};
-    const auto absHeight = float{std::abs(height)};
+    const Vector2f absSize(std::abs(size.x), std::abs(size.y));
 
     // Update positions
     m_vertices[0].position = {0.f, 0.f};
-    m_vertices[1].position = {0.f, absHeight};
-    m_vertices[2].position = {absWidth, 0.f};
-    m_vertices[3].position = {absWidth, absHeight};
+    m_vertices[1].position = {0.f, absSize.y};
+    m_vertices[2].position = {absSize.x, 0.f};
+    m_vertices[3].position = absSize;
 
     // Update texture coordinates
-    m_vertices[0].texCoords = {left, top};
-    m_vertices[1].texCoords = {left, bottom};
-    m_vertices[2].texCoords = {right, top};
-    m_vertices[3].texCoords = {right, bottom};
+    m_vertices[0].texCoords = position;
+    m_vertices[1].texCoords = position + Vector2f(0.f, size.y);
+    m_vertices[2].texCoords = position + Vector2f(size.x, 0.f);
+    m_vertices[3].texCoords = position + size;
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -128,10 +128,10 @@ void Sprite::draw(RenderTarget& target, RenderStates states) const
 ////////////////////////////////////////////////////////////
 void Sprite::updateVertices()
 {
-    const auto left   = static_cast<float>(m_textureRect.left);
-    const auto top    = static_cast<float>(m_textureRect.top);
-    const auto width  = static_cast<float>(m_textureRect.width);
-    const auto height = static_cast<float>(m_textureRect.height);
+    const auto left   = static_cast<float>(m_textureRect.position.x);
+    const auto top    = static_cast<float>(m_textureRect.position.y);
+    const auto width  = static_cast<float>(m_textureRect.size.x);
+    const auto height = static_cast<float>(m_textureRect.size.y);
     const auto right  = float{left + width};
     const auto bottom = float{top + height};
 

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -65,15 +65,15 @@ void addGlyphQuad(sf::VertexArray& vertices, sf::Vector2f position, const sf::Co
 {
     const float padding = 1.0;
 
-    const float left   = glyph.bounds.left - padding;
-    const float top    = glyph.bounds.top - padding;
-    const float right  = glyph.bounds.left + glyph.bounds.width + padding;
-    const float bottom = glyph.bounds.top + glyph.bounds.height + padding;
+    const float left   = glyph.bounds.position.x - padding;
+    const float top    = glyph.bounds.position.y - padding;
+    const float right  = glyph.bounds.position.x + glyph.bounds.size.x + padding;
+    const float bottom = glyph.bounds.position.y + glyph.bounds.size.y + padding;
 
-    const float u1 = static_cast<float>(glyph.textureRect.left) - padding;
-    const float v1 = static_cast<float>(glyph.textureRect.top) - padding;
-    const float u2 = static_cast<float>(glyph.textureRect.left + glyph.textureRect.width) + padding;
-    const float v2 = static_cast<float>(glyph.textureRect.top + glyph.textureRect.height) + padding;
+    const float u1 = static_cast<float>(glyph.textureRect.position.x) - padding;
+    const float v1 = static_cast<float>(glyph.textureRect.position.y) - padding;
+    const float u2 = static_cast<float>(glyph.textureRect.position.x + glyph.textureRect.size.x) + padding;
+    const float v2 = static_cast<float>(glyph.textureRect.position.y + glyph.textureRect.size.y) + padding;
 
     vertices.append({{position.x + left - italicShear * top, position.y + top}, color, {u1, v1}});
     vertices.append({{position.x + right - italicShear * top, position.y + top}, color, {u2, v1}});
@@ -478,10 +478,10 @@ void Text::ensureGeometryUpdate() const
         addGlyphQuad(m_vertices, Vector2f(x, y), m_fillColor, glyph, italicShear);
 
         // Update the current bounds
-        const float left   = glyph.bounds.left;
-        const float top    = glyph.bounds.top;
-        const float right  = glyph.bounds.left + glyph.bounds.width;
-        const float bottom = glyph.bounds.top + glyph.bounds.height;
+        const float left   = glyph.bounds.position.x;
+        const float top    = glyph.bounds.position.y;
+        const float right  = glyph.bounds.position.x + glyph.bounds.size.x;
+        const float bottom = glyph.bounds.position.y + glyph.bounds.size.y;
 
         minX = std::min(minX, x + left - italicShear * bottom);
         maxX = std::max(maxX, x + right - italicShear * top);
@@ -521,10 +521,10 @@ void Text::ensureGeometryUpdate() const
     }
 
     // Update the bounding rectangle
-    m_bounds.left   = minX;
-    m_bounds.top    = minY;
-    m_bounds.width  = maxX - minX;
-    m_bounds.height = maxY - minY;
+    m_bounds.position.x = minX;
+    m_bounds.position.y = minY;
+    m_bounds.size.x     = maxX - minX;
+    m_bounds.size.y     = maxY - minY;
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -300,11 +300,11 @@ std::optional<Texture> Texture::loadFromStream(InputStream& stream, bool sRgb, c
 std::optional<Texture> Texture::loadFromImage(const Image& image, bool sRgb, const IntRect& area)
 {
     // Retrieve the image size
-    const auto [width, height] = Vector2i(image.getSize());
+    const auto size = Vector2i(image.getSize());
 
     // Load the entire image if the source area is either empty or contains the whole image
     if (area.size.x == 0 || (area.size.y == 0) ||
-        ((area.position.x <= 0) && (area.position.y <= 0) && (area.size.x >= width) && (area.size.y >= height)))
+        ((area.position.x <= 0) && (area.position.y <= 0) && (area.size.x >= size.x) && (area.size.y >= size.y)))
     {
         // Load the entire image
         if (auto texture = sf::Texture::create(image.getSize(), sRgb))
@@ -326,8 +326,8 @@ std::optional<Texture> Texture::loadFromImage(const Image& image, bool sRgb, con
         IntRect rectangle    = area;
         rectangle.position.x = std::max(rectangle.position.x, 0);
         rectangle.position.y = std::max(rectangle.position.y, 0);
-        rectangle.size.x     = std::min(rectangle.size.x, width - rectangle.position.x);
-        rectangle.size.y     = std::min(rectangle.size.y, height - rectangle.position.y);
+        rectangle.size.x     = std::min(rectangle.size.x, size.x - rectangle.position.x);
+        rectangle.size.y     = std::min(rectangle.size.y, size.y - rectangle.position.y);
 
         // Create the texture and upload the pixels
         if (auto texture = sf::Texture::create(Vector2u(rectangle.size), sRgb))
@@ -338,12 +338,12 @@ std::optional<Texture> Texture::loadFromImage(const Image& image, bool sRgb, con
             const priv::TextureSaver save;
 
             // Copy the pixels to the texture, row by row
-            const std::uint8_t* pixels = image.getPixelsPtr() + 4 * (rectangle.position.x + (width * rectangle.position.y));
+            const std::uint8_t* pixels = image.getPixelsPtr() + 4 * (rectangle.position.x + (size.x * rectangle.position.y));
             glCheck(glBindTexture(GL_TEXTURE_2D, texture->m_texture));
             for (int i = 0; i < rectangle.size.y; ++i)
             {
                 glCheck(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, i, rectangle.size.x, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
-                pixels += 4 * width;
+                pixels += 4 * size.x;
             }
 
             glCheck(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST));

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -303,8 +303,8 @@ std::optional<Texture> Texture::loadFromImage(const Image& image, bool sRgb, con
     const auto [width, height] = Vector2i(image.getSize());
 
     // Load the entire image if the source area is either empty or contains the whole image
-    if (area.width == 0 || (area.height == 0) ||
-        ((area.left <= 0) && (area.top <= 0) && (area.width >= width) && (area.height >= height)))
+    if (area.size.x == 0 || (area.size.y == 0) ||
+        ((area.position.x <= 0) && (area.position.y <= 0) && (area.size.x >= width) && (area.size.y >= height)))
     {
         // Load the entire image
         if (auto texture = sf::Texture::create(image.getSize(), sRgb))
@@ -323,11 +323,11 @@ std::optional<Texture> Texture::loadFromImage(const Image& image, bool sRgb, con
         // Load a sub-area of the image
 
         // Adjust the rectangle to the size of the image
-        IntRect rectangle = area;
-        rectangle.left    = std::max(rectangle.left, 0);
-        rectangle.top     = std::max(rectangle.top, 0);
-        rectangle.width   = std::min(rectangle.width, width - rectangle.left);
-        rectangle.height  = std::min(rectangle.height, height - rectangle.top);
+        IntRect rectangle    = area;
+        rectangle.position.x = std::max(rectangle.position.x, 0);
+        rectangle.position.y = std::max(rectangle.position.y, 0);
+        rectangle.size.x     = std::min(rectangle.size.x, width - rectangle.position.x);
+        rectangle.size.y     = std::min(rectangle.size.y, height - rectangle.position.y);
 
         // Create the texture and upload the pixels
         if (auto texture = sf::Texture::create(Vector2u(rectangle.getSize()), sRgb))
@@ -338,11 +338,11 @@ std::optional<Texture> Texture::loadFromImage(const Image& image, bool sRgb, con
             const priv::TextureSaver save;
 
             // Copy the pixels to the texture, row by row
-            const std::uint8_t* pixels = image.getPixelsPtr() + 4 * (rectangle.left + (width * rectangle.top));
+            const std::uint8_t* pixels = image.getPixelsPtr() + 4 * (rectangle.position.x + (width * rectangle.position.y));
             glCheck(glBindTexture(GL_TEXTURE_2D, texture->m_texture));
-            for (int i = 0; i < rectangle.height; ++i)
+            for (int i = 0; i < rectangle.size.y; ++i)
             {
-                glCheck(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, i, rectangle.width, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
+                glCheck(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, i, rectangle.size.x, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixels));
                 pixels += 4 * width;
             }
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -330,7 +330,7 @@ std::optional<Texture> Texture::loadFromImage(const Image& image, bool sRgb, con
         rectangle.size.y     = std::min(rectangle.size.y, height - rectangle.position.y);
 
         // Create the texture and upload the pixels
-        if (auto texture = sf::Texture::create(Vector2u(rectangle.getSize()), sRgb))
+        if (auto texture = sf::Texture::create(Vector2u(rectangle.size), sRgb))
         {
             const TransientContextLock lock;
 

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -84,12 +84,12 @@ void View::setViewport(const FloatRect& viewport)
 ////////////////////////////////////////////////////////////
 void View::setScissor(const FloatRect& scissor)
 {
-    assert(scissor.left >= 0.0f && scissor.left <= 1.0f && "scissor.left must lie within [0, 1]");
-    assert(scissor.top >= 0.0f && scissor.top <= 1.0f && "scissor.top must lie within [0, 1]");
-    assert(scissor.width >= 0.0f && "scissor.width must lie within [0, 1]");
-    assert(scissor.height >= 0.0f && "scissor.height must lie within [0, 1]");
-    assert(scissor.left + scissor.width <= 1.0f && "scissor.left + scissor.width must lie within [0, 1]");
-    assert(scissor.top + scissor.height <= 1.0f && "scissor.top + scissor.height must lie within [0, 1]");
+    assert(scissor.position.x >= 0.0f && scissor.position.x <= 1.0f && "scissor.position.x must lie within [0, 1]");
+    assert(scissor.position.y >= 0.0f && scissor.position.y <= 1.0f && "scissor.position.y must lie within [0, 1]");
+    assert(scissor.size.x >= 0.0f && "scissor.size.x must lie within [0, 1]");
+    assert(scissor.size.y >= 0.0f && "scissor.size.y must lie within [0, 1]");
+    assert(scissor.position.x + scissor.size.x <= 1.0f && "scissor.position.x + scissor.size.x must lie within [0, 1]");
+    assert(scissor.position.y + scissor.size.y <= 1.0f && "scissor.position.y + scissor.size.y must lie within [0, 1]");
 
     m_scissor = scissor;
 }

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -34,7 +34,7 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-View::View(const FloatRect& rectangle) : m_center(rectangle.getCenter()), m_size(rectangle.getSize())
+View::View(const FloatRect& rectangle) : m_center(rectangle.getCenter()), m_size(rectangle.size)
 {
 }
 

--- a/test/Graphics/Rect.test.cpp
+++ b/test/Graphics/Rect.test.cpp
@@ -91,18 +91,6 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
         STATIC_CHECK_FALSE(rectangle.findIntersection(nonIntersectingRectangle).has_value());
     }
 
-    SECTION("getPosition()")
-    {
-        STATIC_CHECK(sf::Rect<TestType>({}, {}).getPosition() == sf::Vector2<TestType>());
-        STATIC_CHECK(sf::Rect<TestType>({1, 2}, {3, 4}).getPosition() == sf::Vector2<TestType>(1, 2));
-    }
-
-    SECTION("getSize()")
-    {
-        STATIC_CHECK(sf::Rect<TestType>({}, {}).getSize() == sf::Vector2<TestType>());
-        STATIC_CHECK(sf::Rect<TestType>({1, 2}, {3, 4}).getSize() == sf::Vector2<TestType>(3, 4));
-    }
-
     SECTION("getCenter()")
     {
         STATIC_CHECK(sf::Rect<TestType>({}, {}).getCenter() == sf::Vector2<TestType>());

--- a/test/Graphics/Rect.test.cpp
+++ b/test/Graphics/Rect.test.cpp
@@ -22,19 +22,8 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
         SECTION("Default constructor")
         {
             constexpr sf::Rect<TestType> rectangle;
-            STATIC_CHECK(rectangle.position.x == 0);
-            STATIC_CHECK(rectangle.position.y == 0);
-            STATIC_CHECK(rectangle.size.x == 0);
-            STATIC_CHECK(rectangle.size.y == 0);
-        }
-
-        SECTION("(left, top, width, height) constructor")
-        {
-            constexpr sf::Rect<TestType> rectangle({1, 2}, {3, 4});
-            STATIC_CHECK(rectangle.position.x == 1);
-            STATIC_CHECK(rectangle.position.y == 2);
-            STATIC_CHECK(rectangle.size.x == 3);
-            STATIC_CHECK(rectangle.size.y == 4);
+            STATIC_CHECK(rectangle.position == sf::Vector2<TestType>());
+            STATIC_CHECK(rectangle.size == sf::Vector2<TestType>());
         }
 
         SECTION("(Vector2, Vector2) constructor")
@@ -43,10 +32,8 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
             constexpr sf::Vector2<TestType> dimension(3, 4);
             constexpr sf::Rect<TestType>    rectangle(position, dimension);
 
-            STATIC_CHECK(rectangle.position.x == 1);
-            STATIC_CHECK(rectangle.position.y == 2);
-            STATIC_CHECK(rectangle.size.x == 3);
-            STATIC_CHECK(rectangle.size.y == 4);
+            STATIC_CHECK(rectangle.position == position);
+            STATIC_CHECK(rectangle.size == dimension);
         }
 
         SECTION("Conversion constructor")
@@ -54,10 +41,8 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
             constexpr sf::FloatRect sourceRectangle({1.0f, 2.0f}, {3.0f, 4.0f});
             constexpr sf::IntRect   rectangle(sourceRectangle);
 
-            STATIC_CHECK(rectangle.position.x == static_cast<int>(sourceRectangle.position.x));
-            STATIC_CHECK(rectangle.position.y == static_cast<int>(sourceRectangle.position.y));
-            STATIC_CHECK(rectangle.size.x == static_cast<int>(sourceRectangle.size.x));
-            STATIC_CHECK(rectangle.size.y == static_cast<int>(sourceRectangle.size.y));
+            STATIC_CHECK(rectangle.position == sf::Vector2i(1, 2));
+            STATIC_CHECK(rectangle.size == sf::Vector2i(3, 4));
         }
     }
 
@@ -82,10 +67,7 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
 
         constexpr auto intersectionResult = rectangle.findIntersection(intersectingRectangle);
         STATIC_REQUIRE(intersectionResult.has_value());
-        STATIC_CHECK(intersectionResult->position.x == 5);
-        STATIC_CHECK(intersectionResult->position.y == 5);
-        STATIC_CHECK(intersectionResult->size.x == 5);
-        STATIC_CHECK(intersectionResult->size.y == 5);
+        STATIC_CHECK(*intersectionResult == sf::Rect<TestType>({5, 5}, {5, 5}));
 
         constexpr sf::Rect<TestType> nonIntersectingRectangle({-5, -5}, {5, 5});
         STATIC_CHECK_FALSE(rectangle.findIntersection(nonIntersectingRectangle).has_value());

--- a/test/Graphics/Rect.test.cpp
+++ b/test/Graphics/Rect.test.cpp
@@ -22,19 +22,19 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
         SECTION("Default constructor")
         {
             constexpr sf::Rect<TestType> rectangle;
-            STATIC_CHECK(rectangle.left == 0);
-            STATIC_CHECK(rectangle.top == 0);
-            STATIC_CHECK(rectangle.width == 0);
-            STATIC_CHECK(rectangle.height == 0);
+            STATIC_CHECK(rectangle.position.x == 0);
+            STATIC_CHECK(rectangle.position.y == 0);
+            STATIC_CHECK(rectangle.size.x == 0);
+            STATIC_CHECK(rectangle.size.y == 0);
         }
 
         SECTION("(left, top, width, height) constructor")
         {
             constexpr sf::Rect<TestType> rectangle({1, 2}, {3, 4});
-            STATIC_CHECK(rectangle.left == 1);
-            STATIC_CHECK(rectangle.top == 2);
-            STATIC_CHECK(rectangle.width == 3);
-            STATIC_CHECK(rectangle.height == 4);
+            STATIC_CHECK(rectangle.position.x == 1);
+            STATIC_CHECK(rectangle.position.y == 2);
+            STATIC_CHECK(rectangle.size.x == 3);
+            STATIC_CHECK(rectangle.size.y == 4);
         }
 
         SECTION("(Vector2, Vector2) constructor")
@@ -43,10 +43,10 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
             constexpr sf::Vector2<TestType> dimension(3, 4);
             constexpr sf::Rect<TestType>    rectangle(position, dimension);
 
-            STATIC_CHECK(rectangle.left == 1);
-            STATIC_CHECK(rectangle.top == 2);
-            STATIC_CHECK(rectangle.width == 3);
-            STATIC_CHECK(rectangle.height == 4);
+            STATIC_CHECK(rectangle.position.x == 1);
+            STATIC_CHECK(rectangle.position.y == 2);
+            STATIC_CHECK(rectangle.size.x == 3);
+            STATIC_CHECK(rectangle.size.y == 4);
         }
 
         SECTION("Conversion constructor")
@@ -54,10 +54,10 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
             constexpr sf::FloatRect sourceRectangle({1.0f, 2.0f}, {3.0f, 4.0f});
             constexpr sf::IntRect   rectangle(sourceRectangle);
 
-            STATIC_CHECK(rectangle.left == static_cast<int>(sourceRectangle.left));
-            STATIC_CHECK(rectangle.top == static_cast<int>(sourceRectangle.top));
-            STATIC_CHECK(rectangle.width == static_cast<int>(sourceRectangle.width));
-            STATIC_CHECK(rectangle.height == static_cast<int>(sourceRectangle.height));
+            STATIC_CHECK(rectangle.position.x == static_cast<int>(sourceRectangle.position.x));
+            STATIC_CHECK(rectangle.position.y == static_cast<int>(sourceRectangle.position.y));
+            STATIC_CHECK(rectangle.size.x == static_cast<int>(sourceRectangle.size.x));
+            STATIC_CHECK(rectangle.size.y == static_cast<int>(sourceRectangle.size.y));
         }
     }
 
@@ -82,10 +82,10 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
 
         constexpr auto intersectionResult = rectangle.findIntersection(intersectingRectangle);
         STATIC_REQUIRE(intersectionResult.has_value());
-        STATIC_CHECK(intersectionResult->top == 5);
-        STATIC_CHECK(intersectionResult->left == 5);
-        STATIC_CHECK(intersectionResult->width == 5);
-        STATIC_CHECK(intersectionResult->height == 5);
+        STATIC_CHECK(intersectionResult->position.x == 5);
+        STATIC_CHECK(intersectionResult->position.y == 5);
+        STATIC_CHECK(intersectionResult->size.x == 5);
+        STATIC_CHECK(intersectionResult->size.y == 5);
 
         constexpr sf::Rect<TestType> nonIntersectingRectangle({-5, -5}, {5, 5});
         STATIC_CHECK_FALSE(rectangle.findIntersection(nonIntersectingRectangle).has_value());

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -92,7 +92,7 @@ std::ostream& operator<<(std::ostream& os, const Rect<T>& rect)
 {
     const auto flags = os.flags();
     setStreamPrecision(os, std::numeric_limits<T>::max_digits10);
-    os << "(left=" << rect.left << ", top=" << rect.top << ", width=" << rect.width << ", height=" << rect.height << ")";
+    os << "(position=" << rect.position << ", size=" << rect.size << ")";
     os.flags(flags);
     return os;
 }

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -32,6 +32,5 @@ bool operator==(const sf::Transform& lhs, const Approx<sf::Transform>& rhs);
 template <typename T>
 bool operator==(const sf::Rect<T>& lhs, const Approx<sf::Rect<T>>& rhs)
 {
-    return lhs.left == Approx(rhs.value.left) && lhs.top == Approx(rhs.value.top) &&
-           lhs.width == Approx(rhs.value.width) && lhs.height == Approx(rhs.value.height);
+    return lhs.position == Approx(rhs.value.position) && lhs.size == Approx(rhs.value.size);
 }


### PR DESCRIPTION
This groups `sf::Rect` members `left`, `top`, `width`, `height` into two vectors: `position` and `size`.

This makes `sf::Rect` more aligned with all SFML API working with `Vector2` instead of separate values.
Related: #2055, #2248