### PR TITLE
Make 'Event.inl' self-contained

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -329,9 +329,9 @@ private:
     static constexpr bool isEventType = isInParameterPack<T>(decltype(m_data)());
 };
 
-#include <SFML/Window/Event.inl>
-
 } // namespace sf
+
+#include <SFML/Window/Event.inl>
 
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -31,6 +31,14 @@
 // an incorrect template parameter is provided.
 
 ////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Event.hpp> // NOLINT(misc-header-include-cycle)
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
 template <typename T>
 Event::Event(const T& t)
 {
@@ -58,3 +66,5 @@ const T* Event::getIf() const
     if constexpr (isEventType<T>)
         return std::get_if<T>(&m_data);
 }
+
+} // namespace sf


### PR DESCRIPTION
Same as all the other `.inl` files, good for IDEs and auto-completion.