### PR TITLE
Fix findCharacterPos not using local bounds

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -347,6 +347,8 @@ Vector2f Text::findCharacterPos(std::size_t index) const
         position.x += m_font->getGlyph(curChar, m_characterSize, isBold).advance + letterSpacing;
     }
 
+    // Aligns the character position with the text's internal bounds
+    position += getLocalBounds().getPosition();
     // Transform the position to global coordinates
     position = getTransform().transformPoint(position);
 


### PR DESCRIPTION
findCharacterPos was giving me a weird offset in it's return result. This fixes the miscalculation the function was returning

## Description

findcharactorPos calculation was taking into consideration local bounds before spitting out it's result. Fix is to include this. I believe this should be done in 2.6.x as it literally makes this function unusable.

[This PR is related to the issue #
](https://github.com/SFML/SFML/issues/2988)

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run this code, click the screen and see where the box around the letter lands. Also, probably should do a review on this test code.
```cpp
#include "SFML/Graphics/CircleShape.hpp"
#include "SFML/Graphics/Color.hpp"
#include "SFML/Graphics/Font.hpp"
#include "SFML/Graphics/Rect.hpp"
#include "SFML/Graphics/RectangleShape.hpp"
#include "SFML/Graphics/RenderWindow.hpp"
#include "SFML/Graphics/Text.hpp"
#include "SFML/System/Vector2.hpp"
#include "SFML/Window/Event.hpp"
#include "SFML/Window/VideoMode.hpp"
#include <cstddef>
#include <cstdio>
#include <optional>

void print_float_rect(const sf::FloatRect &rect) {
  printf("top: %lf left: %lf width: %lf height: %lf\n", rect.top, rect.left,
         rect.width, rect.height);
}

void print_float_vector(const sf::Vector2f &vec) {
  printf("x: %lf y:%lf\n", vec.x, vec.y);
}

std::optional<float> get_character_width_at_idx(const sf::Text &text,
                                                size_t idx) {
  float width = text.findCharacterPos(idx + 1).x - text.findCharacterPos(idx).x;
  if (width < 0) {
    return {};
  }

  return {width};
}

int main() {
  sf::RenderWindow window(sf::VideoMode(200, 200), "SFML Works!");
  window.setFramerateLimit(60);

  sf::Font font;
  if (!font.loadFromFile("SourceCodePro-SemiBold.ttf")) {
    printf("Failed to load font!\n");
    return 1;
  }

  sf::Text text;
  text.setFont(font);
  text.setCharacterSize(32);
  text.setString("M");
  text.setPosition(sf::Vector2f(100, 100));

  sf::CircleShape mouse_dot;
  mouse_dot.setFillColor(sf::Color::Red);
  float radius = 3;
  mouse_dot.setRadius(radius);
  mouse_dot.setOrigin(radius / 2, radius / 2);
  mouse_dot.setPosition(sf::Vector2f(-100, -100));

  sf::RectangleShape letter_box;
  letter_box.setOutlineColor(sf::Color::Blue);
  letter_box.setOutlineThickness(2);
  letter_box.setFillColor(sf::Color::Transparent);
  letter_box.setPosition(sf::Vector2f(-100, -100));

  while (window.isOpen()) {
    sf::Event event;
    while (window.pollEvent(event)) {
      switch (event.type) {
      case sf::Event::Closed:
        window.close();
        break;
      case sf::Event::MouseButtonPressed: {
        sf::Vector2f position(event.mouseButton.x, event.mouseButton.y);
        sf::Vector2f char_pos = text.findCharacterPos(0);
        sf::FloatRect rect(char_pos.x, char_pos.y,
                           get_character_width_at_idx(text, 0).value_or(0),
                           text.getGlobalBounds().height);

        print_float_rect(rect);
        print_float_vector(position);
        printf("letter contains mouse %s\n",
               rect.contains(position) ? "true" : "false");

        letter_box.setSize(rect.getSize());
        letter_box.setPosition(rect.getPosition());
        mouse_dot.setPosition(position);
      } break;
      default:
        break;
      }
    }
    window.clear(sf::Color::Black);
    window.draw(text);
    window.draw(mouse_dot);
    window.draw(letter_box);
    window.display();
  }

  return 0;
}

```
