### PR TITLE
Implement the empty event state with `std::monostate`

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -49,14 +49,6 @@ class SFML_WINDOW_API Event
 {
 public:
     ////////////////////////////////////////////////////////////
-    /// \brief Empty event
-    ///
-    ////////////////////////////////////////////////////////////
-    struct Empty
-    {
-    };
-
-    ////////////////////////////////////////////////////////////
     /// \brief Closed event
     ///
     ////////////////////////////////////////////////////////////
@@ -244,7 +236,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
-    /// Sets the event to sf::Event::Empty
+    /// Sets the event to an empty state
     ///
     ////////////////////////////////////////////////////////////
     Event() = default;
@@ -277,21 +269,21 @@ public:
     [[nodiscard]] const T* getIf() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Check if current event type is not `Empty`
+    /// \brief Check if current event type is not empty
     ///
-    /// \return True if current event type is not `Empty`
+    /// \return True if current event type is not empty
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] explicit operator bool() const
     {
-        return !is<Empty>();
+        return !is<std::monostate>();
     }
 
 private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::variant<Empty,
+    std::variant<std::monostate,
                  Closed,
                  Resized,
                  FocusLost,

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -191,7 +191,7 @@ public:
     /// }
     /// \endcode
     ///
-    /// \return The event; will be `Empty` (convertible to `false`) if no events are pending
+    /// \return The event; will be empty (convertible to `false`) if no events are pending
     ///
     /// \see waitEvent
     ///

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -132,7 +132,7 @@ public:
     ///
     /// \param block Use true to block the thread until an event arrives
     ///
-    /// \return The event; can be `Empty` (convertible to `false`) if not blocking
+    /// \return The event; can be empty (convertible to `false`) if not blocking
     ///
     ////////////////////////////////////////////////////////////
     Event popEvent(bool block);

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -20,8 +20,8 @@ TEST_CASE("[Window] sf::Event")
         {
             const sf::Event event;
             CHECK(!event);
-            CHECK(event.is<sf::Event::Empty>());
-            CHECK(event.getIf<sf::Event::Empty>());
+            CHECK(event.is<std::monostate>());
+            CHECK(event.getIf<std::monostate>());
         }
 
         SECTION("Template constructor")
@@ -208,7 +208,6 @@ TEST_CASE("[Window] sf::Event")
     SECTION("Subtypes")
     {
         // Empty structs
-        STATIC_CHECK(std::is_empty_v<sf::Event::Empty>);
         STATIC_CHECK(std::is_empty_v<sf::Event::Closed>);
         STATIC_CHECK(std::is_empty_v<sf::Event::FocusLost>);
         STATIC_CHECK(std::is_empty_v<sf::Event::FocusGained>);


### PR DESCRIPTION
## Description

The idiomatic way of representing a default empty state of a `std::variant` is to use `std::monostate` also from the `<variant>` header. This is a change that users should not notice since users already should not be using `sf::Event::Empty`. This saves us a bit of code that we don't need to write.