### PR TITLE
Add clarification about the RenderTexture state after creation

### DIFF
--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -72,10 +72,14 @@ public:
     /// Before calling this function, the render-texture is in
     /// an invalid state, thus it is mandatory to call it before
     /// doing anything with the render-texture.
+    ///
     /// The last parameter, \a depthBuffer, is useful if you want
     /// to use the render-texture for 3D OpenGL rendering that requires
     /// a depth buffer. Otherwise it is unnecessary, and you should
     /// leave this parameter to false (which is its default value).
+    ///
+    /// After creation, the contents of the render-texture are undefined.
+    /// Call `RenderTexture::clear` first to ensure a single color fill.
     ///
     /// \param width       Width of the render-texture
     /// \param height      Height of the render-texture
@@ -94,10 +98,14 @@ public:
     /// Before calling this function, the render-texture is in
     /// an invalid state, thus it is mandatory to call it before
     /// doing anything with the render-texture.
+    ///
     /// The last parameter, \a settings, is useful if you want to enable
     /// multi-sampling or use the render-texture for OpenGL rendering that
     /// requires a depth or stencil buffer. Otherwise it is unnecessary, and
     /// you should leave this parameter at its default value.
+    ///
+    /// After creation, the contents of the render-texture are undefined.
+    /// Call `RenderTexture::clear` first to ensure a single color fill.
     ///
     /// \param width    Width of the render-texture
     /// \param height   Height of the render-texture


### PR DESCRIPTION
## Description

Add clarification

Closes #2604 

![image](https://github.com/SFML/SFML/assets/920861/fa351ab3-a265-4d3e-a160-ee4912e5a5bd)

## How to test this PR?

Generate the documentation