### PR TITLE
Remove unnecessary `sf::` namespace usage

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -304,8 +304,8 @@ void AudioDevice::setCone(const Listener::Cone& cone)
 
     ma_engine_listener_set_cone(&*instance->m_engine,
                                 0,
-                                std::clamp(cone.innerAngle.asRadians(), 0.f, sf::degrees(360).asRadians()),
-                                std::clamp(cone.outerAngle.asRadians(), 0.f, sf::degrees(360).asRadians()),
+                                std::clamp(cone.innerAngle.asRadians(), 0.f, degrees(360).asRadians()),
+                                std::clamp(cone.outerAngle.asRadians(), 0.f, degrees(360).asRadians()),
                                 cone.outerGain);
 }
 

--- a/src/SFML/Audio/AudioDevice.hpp
+++ b/src/SFML/Audio/AudioDevice.hpp
@@ -228,11 +228,11 @@ private:
     struct ListenerProperties
     {
         float          volume{100.f};
-        sf::Vector3f   position{0, 0, 0};
-        sf::Vector3f   direction{0, 0, -1};
-        sf::Vector3f   velocity{0, 0, 0};
-        Listener::Cone cone{sf::degrees(360), sf::degrees(360), 1};
-        sf::Vector3f   upVector{0, 1, 0};
+        Vector3f       position{0, 0, 0};
+        Vector3f       direction{0, 0, -1};
+        Vector3f       velocity{0, 0, 0};
+        Listener::Cone cone{degrees(360), degrees(360), 1};
+        Vector3f       upVector{0, 1, 0};
     };
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Audio/AudioResource.cpp
+++ b/src/SFML/Audio/AudioResource.cpp
@@ -41,8 +41,8 @@ m_device(
     {
         // Ensure we only ever create a single instance of an
         // AudioDevice that is shared between all AudioResources
-        static std::mutex                           mutex;
-        static std::weak_ptr<sf::priv::AudioDevice> weakAudioDevice;
+        static std::mutex                       mutex;
+        static std::weak_ptr<priv::AudioDevice> weakAudioDevice;
 
         const std::lock_guard lock(mutex);
 

--- a/src/SFML/Audio/MiniaudioUtils.cpp
+++ b/src/SFML/Audio/MiniaudioUtils.cpp
@@ -63,8 +63,8 @@ struct SavedSettings
     float          minGain{0.f};
     float          maxGain{1.f};
     float          rollOff{1.f};
-    float          innerAngle{sf::degrees(360).asRadians()};
-    float          outerAngle{sf::degrees(360).asRadians()};
+    float          innerAngle{degrees(360).asRadians()};
+    float          outerAngle{degrees(360).asRadians()};
     float          outerGain{0.f};
 };
 
@@ -135,7 +135,7 @@ void initializeDataSource(ma_data_source_base& dataSourceBase, const ma_data_sou
 
 
 ////////////////////////////////////////////////////////////
-ma_channel MiniaudioUtils::soundChannelToMiniaudioChannel(sf::SoundChannel soundChannel)
+ma_channel MiniaudioUtils::soundChannelToMiniaudioChannel(SoundChannel soundChannel)
 {
     switch (soundChannel)
     {

--- a/src/SFML/Audio/MiniaudioUtils.hpp
+++ b/src/SFML/Audio/MiniaudioUtils.hpp
@@ -41,11 +41,10 @@
 namespace sf
 {
 class Time;
-}
 
-namespace sf::priv::MiniaudioUtils
+namespace priv::MiniaudioUtils
 {
-[[nodiscard]] ma_channel soundChannelToMiniaudioChannel(sf::SoundChannel soundChannel);
+[[nodiscard]] ma_channel soundChannelToMiniaudioChannel(SoundChannel soundChannel);
 [[nodiscard]] Time       getPlayingOffset(ma_sound& sound);
 [[nodiscard]] ma_uint64  getFrameIndex(ma_sound& sound, Time timeOffset);
 
@@ -54,4 +53,5 @@ void initializeSound(const ma_data_source_vtable& vtable,
                      ma_data_source_base&         dataSourceBase,
                      ma_sound&                    sound,
                      const std::function<void()>& initializeFn);
-} // namespace sf::priv::MiniaudioUtils
+} // namespace priv::MiniaudioUtils
+} // namespace sf

--- a/src/SFML/Audio/SoundFileReaderFlac.hpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.hpp
@@ -69,7 +69,7 @@ public:
     /// \return Properties of the loaded sound if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::optional<Info> open(sf::InputStream& stream) override;
+    [[nodiscard]] std::optional<Info> open(InputStream& stream) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset

--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -142,16 +142,16 @@ std::optional<SoundFileReader::Info> SoundFileReaderMp3::open(InputStream& strea
     switch (info.channelCount)
     {
         case 0:
-            sf::err() << "No channels in MP3 file" << std::endl;
+            err() << "No channels in MP3 file" << std::endl;
             break;
         case 1:
-            info.channelMap = {sf::SoundChannel::Mono};
+            info.channelMap = {SoundChannel::Mono};
             break;
         case 2:
-            info.channelMap = {sf::SoundChannel::SideLeft, sf::SoundChannel::SideRight};
+            info.channelMap = {SoundChannel::SideLeft, SoundChannel::SideRight};
             break;
         default:
-            sf::err() << "MP3 files with more than 2 channels not supported" << std::endl;
+            err() << "MP3 files with more than 2 channels not supported" << std::endl;
             assert(false);
             break;
     }

--- a/src/SFML/Audio/SoundFileReaderWav.hpp
+++ b/src/SFML/Audio/SoundFileReaderWav.hpp
@@ -66,7 +66,7 @@ public:
     /// \return Properties of the loaded sound if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::optional<Info> open(sf::InputStream& stream) override;
+    [[nodiscard]] std::optional<Info> open(InputStream& stream) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset

--- a/src/SFML/Audio/SoundSource.cpp
+++ b/src/SFML/Audio/SoundSource.cpp
@@ -88,8 +88,8 @@ void SoundSource::setCone(const Cone& cone)
 {
     if (auto* sound = static_cast<ma_sound*>(getSound()))
         ma_sound_set_cone(sound,
-                          std::clamp(cone.innerAngle, sf::degrees(0), sf::degrees(360)).asRadians(),
-                          std::clamp(cone.outerAngle, sf::degrees(0), sf::degrees(360)).asRadians(),
+                          std::clamp(cone.innerAngle, degrees(0), degrees(360)).asRadians(),
+                          std::clamp(cone.outerAngle, degrees(0), degrees(360)).asRadians(),
                           cone.outerGain);
 }
 
@@ -241,12 +241,12 @@ SoundSource::Cone SoundSource::getCone() const
         float outerAngle = 0.f;
         Cone  cone;
         ma_sound_get_cone(sound, &innerAngle, &outerAngle, &cone.outerGain);
-        cone.innerAngle = sf::radians(innerAngle);
-        cone.outerAngle = sf::radians(outerAngle);
+        cone.innerAngle = radians(innerAngle);
+        cone.outerAngle = radians(outerAngle);
         return cone;
     }
 
-    return Cone{sf::radians(0), sf::radians(0), 0.f};
+    return Cone{radians(0), radians(0), 0.f};
 }
 
 

--- a/src/SFML/Graphics/CircleShape.cpp
+++ b/src/SFML/Graphics/CircleShape.cpp
@@ -71,7 +71,7 @@ std::size_t CircleShape::getPointCount() const
 ////////////////////////////////////////////////////////////
 Vector2f CircleShape::getPoint(std::size_t index) const
 {
-    const Angle angle = static_cast<float>(index) / static_cast<float>(m_pointCount) * sf::degrees(360) - sf::degrees(90);
+    const Angle angle = static_cast<float>(index) / static_cast<float>(m_pointCount) * degrees(360) - degrees(90);
     return Vector2f(m_radius, m_radius) + Vector2f(m_radius, angle);
 }
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -784,7 +784,7 @@ bool Font::setCurrentSize(unsigned int characterSize) const
 Font::Page::Page(bool smooth)
 {
     // Make sure that the texture is initialized by default
-    sf::Image image;
+    Image image;
     image.create({128, 128}, Color::Transparent);
 
     // Reserve a 2x2 white square for texturing underlines

--- a/src/SFML/Graphics/GLExtensions.cpp
+++ b/src/SFML/Graphics/GLExtensions.cpp
@@ -61,9 +61,9 @@ void ensureExtensionsInit()
         initialized = true;
 
 #ifdef SFML_OPENGL_ES
-        gladLoadGLES1(sf::Context::getFunction);
+        gladLoadGLES1(Context::getFunction);
 #else
-        gladLoadGL(sf::Context::getFunction);
+        gladLoadGL(Context::getFunction);
 #endif
 
         // Retrieve the context version number

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -740,7 +740,7 @@ bool Shader::isAvailable()
         const TransientContextLock contextLock;
 
         // Make sure that extensions are initialized
-        sf::priv::ensureExtensionsInit();
+        priv::ensureExtensionsInit();
 
         return GLEXT_multitexture && GLEXT_shading_language_100 && GLEXT_shader_objects && GLEXT_vertex_shader &&
                GLEXT_fragment_shader;
@@ -758,7 +758,7 @@ bool Shader::isGeometryAvailable()
         const TransientContextLock contextLock;
 
         // Make sure that extensions are initialized
-        sf::priv::ensureExtensionsInit();
+        priv::ensureExtensionsInit();
 
         return isAvailable() && (GLEXT_geometry_shader4 || GLEXT_GL_VERSION_3_2);
     }();

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -381,7 +381,7 @@ void Text::ensureGeometryUpdate() const
     const bool  isBold             = m_style & Bold;
     const bool  isUnderlined       = m_style & Underlined;
     const bool  isStrikeThrough    = m_style & StrikeThrough;
-    const float italicShear        = (m_style & Italic) ? sf::degrees(12).asRadians() : 0.f;
+    const float italicShear        = (m_style & Italic) ? degrees(12).asRadians() : 0.f;
     const float underlineOffset    = m_font->getUnderlinePosition(m_characterSize);
     const float underlineThickness = m_font->getUnderlineThickness(m_characterSize);
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -921,7 +921,7 @@ unsigned int Texture::getMaximumSize()
         GLint value = 0;
 
         // Make sure that extensions are initialized
-        sf::priv::ensureExtensionsInit();
+        priv::ensureExtensionsInit();
 
         glCheck(glGetIntegerv(GL_MAX_TEXTURE_SIZE, &value));
 

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -264,10 +264,10 @@ std::wstring String::toWideString() const
 
 
 ////////////////////////////////////////////////////////////
-sf::U8String String::toUtf8() const
+U8String String::toUtf8() const
 {
     // Prepare the output string
-    sf::U8String output;
+    U8String output;
     output.reserve(m_string.length());
 
     // Convert

--- a/src/SFML/Window/Android/ClipboardImpl.cpp
+++ b/src/SFML/Window/Android/ClipboardImpl.cpp
@@ -38,7 +38,7 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 String ClipboardImpl::getString()
 {
-    sf::err() << "Clipboard API not implemented for Android.\n";
+    err() << "Clipboard API not implemented for Android.\n";
     return {};
 }
 
@@ -46,7 +46,7 @@ String ClipboardImpl::getString()
 ////////////////////////////////////////////////////////////
 void ClipboardImpl::setString(const String& /* text */)
 {
-    sf::err() << "Clipboard API not implemented for Android.\n";
+    err() << "Clipboard API not implemented for Android.\n";
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/Unix/JoystickImpl.hpp
+++ b/src/SFML/Window/Unix/JoystickImpl.hpp
@@ -105,10 +105,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    int                          m_file{-1};                ///< File descriptor of the joystick
-    char                         m_mapping[ABS_MAX + 1]{0}; ///< Axes mapping (index to axis id)
-    JoystickState                m_state;                   ///< Current state of the joystick
-    sf::Joystick::Identification m_identification;          ///< Identification of the joystick
+    int                      m_file{-1};                ///< File descriptor of the joystick
+    char                     m_mapping[ABS_MAX + 1]{0}; ///< Axes mapping (index to axis id)
+    JoystickState            m_state;                   ///< Current state of the joystick
+    Joystick::Identification m_identification;          ///< Identification of the joystick
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -138,7 +138,7 @@ bool WindowBase::isOpen() const
 ////////////////////////////////////////////////////////////
 Event WindowBase::pollEvent()
 {
-    sf::Event event;
+    Event event;
     if (m_impl && (event = m_impl->popEvent(false)))
         filterEvent(event);
     return event;
@@ -148,7 +148,7 @@ Event WindowBase::pollEvent()
 ////////////////////////////////////////////////////////////
 Event WindowBase::waitEvent()
 {
-    sf::Event event;
+    Event event;
     if (m_impl && (event = m_impl->popEvent(true)))
         filterEvent(event);
     return event;

--- a/src/SFML/Window/WindowImpl.cpp
+++ b/src/SFML/Window/WindowImpl.cpp
@@ -131,7 +131,7 @@ WindowImpl::WindowImpl() : m_joystickStatesImpl(std::make_unique<JoystickStatesI
     }
 
     // Get the initial sensor states
-    for (sf::Vector3f& vec : m_sensorValue)
+    for (Vector3f& vec : m_sensorValue)
         vec = Vector3f(0, 0, 0);
 }
 
@@ -202,7 +202,7 @@ Event WindowImpl::popEvent(bool block)
         }
     }
 
-    sf::Event event;
+    Event event;
 
     // Pop the first event of the queue, if it is not empty
     if (!m_events.empty())

--- a/src/SFML/Window/macOS/JoystickImpl.hpp
+++ b/src/SFML/Window/macOS/JoystickImpl.hpp
@@ -111,7 +111,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     using Location      = long;
-    using AxisMap       = std::unordered_map<sf::Joystick::Axis, IOHIDElementRef>;
+    using AxisMap       = std::unordered_map<Joystick::Axis, IOHIDElementRef>;
     using ButtonsVector = std::vector<IOHIDElementRef>;
 
     AxisMap                  m_axis;           ///< Axes (but not POV/Hat) of the joystick
@@ -121,7 +121,7 @@ private:
     Joystick::Identification m_identification; ///< Joystick identification
 
     // NOLINTNEXTLINE(readability-identifier-naming)
-    static inline Location m_locationIDs[sf::Joystick::Count]{}; ///< Global Joystick register
+    static inline Location m_locationIDs[Joystick::Count]{}; ///< Global Joystick register
     /// For a corresponding SFML index, m_locationIDs is either some USB
     /// location or 0 if there isn't currently a connected joystick device
 };

--- a/src/SFML/Window/macOS/SFContext.mm
+++ b/src/SFML/Window/macOS/SFContext.mm
@@ -229,7 +229,7 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
     {
         if (!(m_settings.attributeFlags & ContextSettings::Core))
         {
-            sf::err() << "Warning. Compatibility profile not supported on this platform." << std::endl;
+            err() << "Warning. Compatibility profile not supported on this platform." << std::endl;
             m_settings.attributeFlags |= ContextSettings::Core;
         }
         m_settings.majorVersion = 3;
@@ -240,7 +240,7 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
 
     if (m_settings.attributeFlags & ContextSettings::Debug)
     {
-        sf::err() << "Warning. OpenGL debugging not supported on this platform." << std::endl;
+        err() << "Warning. OpenGL debugging not supported on this platform." << std::endl;
         m_settings.attributeFlags &= ~static_cast<unsigned int>(ContextSettings::Debug);
     }
 
@@ -254,7 +254,7 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
 
     if (pixFmt == nil)
     {
-        sf::err() << "Error. Unable to find a suitable pixel format." << std::endl;
+        err() << "Error. Unable to find a suitable pixel format." << std::endl;
         return;
     }
 
@@ -267,7 +267,7 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
 
         if (sharedContext == [NSOpenGLContext currentContext])
         {
-            sf::err() << "Failed to deactivate shared context before sharing" << std::endl;
+            err() << "Failed to deactivate shared context before sharing" << std::endl;
             return;
         }
     }
@@ -277,13 +277,13 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
 
     if (m_context == nil)
     {
-        sf::err() << "Error. Unable to create the context. Retrying without shared context." << std::endl;
+        err() << "Error. Unable to create the context. Retrying without shared context." << std::endl;
         m_context = [[NSOpenGLContext alloc] initWithFormat:pixFmt shareContext:nil];
 
         if (m_context == nil)
-            sf::err() << "Error. Unable to create the context." << std::endl;
+            err() << "Error. Unable to create the context." << std::endl;
         else
-            sf::err() << "Warning. New context created without shared context." << std::endl;
+            err() << "Warning. New context created without shared context." << std::endl;
     }
 
     // Free up.


### PR DESCRIPTION
## Description

We've long made a point to not use `sf::` when writing code already within `namespace sf { }`. This PR finds many more places where we can omit writing `sf::`.