### PR TITLE
Make user aware that findCharactarPos returns top of the line position

### DIFF
--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -372,8 +372,9 @@ public:
     ///
     /// This function computes the visual position of a character
     /// from its index in the string. The returned position is
-    /// in global coordinates (translation, rotation, scale and
-    /// origin are applied).
+    /// at the character's ascender height in global coordinates
+    /// (translation, rotation, scale and origin are applied).
+    ///
     /// If \a index is out of range, the position of the end of
     /// the string is returned.
     ///


### PR DESCRIPTION
This doesn't need any testing, just documentation changes. I really do think a lot of this confusion may be avoided if we atleast mention this "top of the line" stuff