### PR TITLE
Add `<array>` to PCH.hpp

### DIFF
--- a/src/SFML/PCH.hpp
+++ b/src/SFML/PCH.hpp
@@ -45,6 +45,7 @@
 #include <SFML/System/Vector2.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <iostream>


### PR DESCRIPTION
`<array>` is used quite a lot now, especially after #2951, so it is worth adding it to `PCH.hpp`.