### PR TITLE
Refactor usage of 'err()' with miniaudio results

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Audio/AudioDevice.hpp>
+#include <SFML/Audio/MiniaudioUtils.hpp>
 
 #include <SFML/System/Err.hpp>
 
@@ -49,7 +50,7 @@ AudioDevice::AudioDevice()
     if (const auto result = ma_log_init(nullptr, &*m_log); result != MA_SUCCESS)
     {
         m_log.reset();
-        err() << "Failed to initialize the audio log: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to initialize the audio log");
         return;
     }
 
@@ -64,7 +65,7 @@ AudioDevice::AudioDevice()
                                                          },
                                                          nullptr));
         result != MA_SUCCESS)
-        err() << "Failed to register audio log callback: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to register audio log callback");
 
     // Create the context
     m_context.emplace();
@@ -81,7 +82,7 @@ AudioDevice::AudioDevice()
         if (const auto result = ma_context_init(backendList, 1, &contextConfig, &*m_context); result != MA_SUCCESS)
         {
             m_context.reset();
-            err() << "Failed to initialize the audio playback context: " << ma_result_description(result) << std::endl;
+            MiniaudioUtils::printErr(result, "Failed to initialize the audio playback context");
             return;
         }
 
@@ -89,7 +90,7 @@ AudioDevice::AudioDevice()
         if (const auto result = ma_context_get_devices(&*m_context, nullptr, &deviceCount, nullptr, nullptr);
             result != MA_SUCCESS)
         {
-            err() << "Failed to get audio playback devices: " << ma_result_description(result) << std::endl;
+            MiniaudioUtils::printErr(result, "Failed to get audio playback devices");
             return;
         }
 
@@ -127,7 +128,7 @@ AudioDevice::AudioDevice()
         {
             if (const auto result = ma_engine_read_pcm_frames(&*audioDevice.m_engine, output, frameCount, nullptr);
                 result != MA_SUCCESS)
-                err() << "Failed to read PCM frames from audio engine: " << ma_result_description(result) << std::endl;
+                MiniaudioUtils::printErr(result, "Failed to read PCM frames from audio engine");
         }
     };
     playbackDeviceConfig.pUserData       = this;
@@ -136,7 +137,7 @@ AudioDevice::AudioDevice()
     if (const auto result = ma_device_init(&*m_context, &playbackDeviceConfig, &*m_playbackDevice); result != MA_SUCCESS)
     {
         m_playbackDevice.reset();
-        err() << "Failed to initialize the audio playback device: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to initialize the audio playback device");
         return;
     }
 
@@ -151,7 +152,7 @@ AudioDevice::AudioDevice()
     if (const auto result = ma_engine_init(&engineConfig, &*m_engine); result != MA_SUCCESS)
     {
         m_engine.reset();
-        err() << "Failed to initialize the audio engine: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to initialize the audio engine");
         return;
     }
 
@@ -159,7 +160,7 @@ AudioDevice::AudioDevice()
     if (const auto result = ma_device_set_master_volume(ma_engine_get_device(&*m_engine),
                                                         getListenerProperties().volume * 0.01f);
         result != MA_SUCCESS)
-        err() << "Failed to set audio device master volume: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to set audio device master volume");
 
     ma_engine_listener_set_position(&*m_engine,
                                     0,
@@ -234,7 +235,7 @@ void AudioDevice::setGlobalVolume(float volume)
 
     if (const auto result = ma_device_set_master_volume(ma_engine_get_device(&*instance->m_engine), volume * 0.01f);
         result != MA_SUCCESS)
-        err() << "Failed to set audio device master volume: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to set audio device master volume");
 }
 
 

--- a/src/SFML/Audio/MiniaudioUtils.cpp
+++ b/src/SFML/Audio/MiniaudioUtils.cpp
@@ -129,7 +129,7 @@ void initializeDataSource(ma_data_source_base& dataSourceBase, const ma_data_sou
     config.vtable                = &vtable;
 
     if (const ma_result result = ma_data_source_init(&config, &dataSourceBase); result != MA_SUCCESS)
-        err() << "Failed to initialize audio data source: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to initialize audio data source");
 }
 } // namespace
 
@@ -191,7 +191,7 @@ Time MiniaudioUtils::getPlayingOffset(ma_sound& sound)
 
     if (const ma_result result = ma_sound_get_cursor_in_seconds(&sound, &cursor); result != MA_SUCCESS)
     {
-        err() << "Failed to get sound cursor: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to get sound cursor");
         return {};
     }
 
@@ -206,12 +206,12 @@ ma_uint64 MiniaudioUtils::getFrameIndex(ma_sound& sound, Time timeOffset)
 
     if (const ma_result result = ma_sound_get_data_format(&sound, nullptr, nullptr, &sampleRate, nullptr, 0);
         result != MA_SUCCESS)
-        err() << "Failed to get sound data format: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to get sound data format");
 
     const auto frameIndex = static_cast<ma_uint64>(timeOffset.asSeconds() * static_cast<float>(sampleRate));
 
     if (const ma_result result = ma_sound_seek_to_pcm_frame(&sound, frameIndex); result != MA_SUCCESS)
-        err() << "Failed to seek sound to pcm frame: " << ma_result_description(result) << std::endl;
+        MiniaudioUtils::printErr(result, "Failed to seek sound to pcm frame");
 
     return frameIndex;
 }
@@ -240,6 +240,13 @@ void MiniaudioUtils::initializeSound(const ma_data_source_vtable& vtable,
     // Initialize sound structure and set default settings
     initializeFn();
     applySettings(sound, SavedSettings{});
+}
+
+
+////////////////////////////////////////////////////////////
+void MiniaudioUtils::printErr(ma_result result, const char* msg)
+{
+    err() << msg << ": " << ma_result_description(result) << std::endl;
 }
 
 } // namespace sf::priv

--- a/src/SFML/Audio/MiniaudioUtils.hpp
+++ b/src/SFML/Audio/MiniaudioUtils.hpp
@@ -53,5 +53,7 @@ void initializeSound(const ma_data_source_vtable& vtable,
                      ma_data_source_base&         dataSourceBase,
                      ma_sound&                    sound,
                      const std::function<void()>& initializeFn);
+
+void printErr(ma_result result, const char* msg);
 } // namespace priv::MiniaudioUtils
 } // namespace sf

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -81,12 +81,12 @@ struct Sound::Impl
 
             // Seek back to the start of the sound when it finishes playing
             if (const ma_result result = ma_sound_seek_to_pcm_frame(soundPtr, 0); result != MA_SUCCESS)
-                err() << "Failed to seek sound to frame 0: " << ma_result_description(result) << std::endl;
+                priv::MiniaudioUtils::printErr(result, "Failed to seek sound to frame 0");
         };
 
         if (const ma_result result = ma_sound_init_ex(engine, &soundConfig, &sound); result != MA_SUCCESS)
         {
-            err() << "Failed to initialize sound: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to initialize sound");
             return;
         }
 
@@ -254,7 +254,7 @@ void Sound::play()
 
     if (const ma_result result = ma_sound_start(&m_impl->sound); result != MA_SUCCESS)
     {
-        err() << "Failed to start playing sound: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to start playing sound");
     }
     else
     {
@@ -268,7 +268,7 @@ void Sound::pause()
 {
     if (const ma_result result = ma_sound_stop(&m_impl->sound); result != MA_SUCCESS)
     {
-        err() << "Failed to stop playing sound: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to stop playing sound");
     }
     else
     {
@@ -283,7 +283,7 @@ void Sound::stop()
 {
     if (const ma_result result = ma_sound_stop(&m_impl->sound); result != MA_SUCCESS)
     {
-        err() << "Failed to stop playing sound: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to stop playing sound");
     }
     else
     {

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Audio/MiniaudioUtils.hpp>
 #include <SFML/Audio/SoundRecorder.hpp>
 
 #include <SFML/System/Err.hpp>
@@ -94,7 +95,7 @@ struct SoundRecorder::Impl
                 // If the derived class wants to stop, stop the capture
                 if (const auto result = ma_device_stop(device); result != MA_SUCCESS)
                 {
-                    err() << "Failed to stop audio capture device: " << ma_result_description(result) << std::endl;
+                    priv::MiniaudioUtils::printErr(result, "Failed to stop audio capture device");
                     return;
                 }
             }
@@ -103,7 +104,7 @@ struct SoundRecorder::Impl
         if (const auto result = ma_device_init(&*context, &captureDeviceConfig, &*captureDevice); result != MA_SUCCESS)
         {
             captureDevice.reset();
-            err() << "Failed to initialize the audio capture device: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to initialize the audio capture device");
             return false;
         }
 
@@ -121,7 +122,7 @@ struct SoundRecorder::Impl
 
         if (const auto result = ma_context_init(nullptr, 0, &contextConfig, &context); result != MA_SUCCESS)
         {
-            err() << "Failed to initialize the audio context: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to initialize the audio context");
             return deviceList;
         }
 
@@ -132,7 +133,7 @@ struct SoundRecorder::Impl
         if (const auto result = ma_context_get_devices(&context, nullptr, nullptr, &deviceInfos, &deviceCount);
             result != MA_SUCCESS)
         {
-            err() << "Failed to get audio capture devices: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to get audio capture devices");
             ma_context_uninit(&context);
             return deviceList;
         }
@@ -168,7 +169,7 @@ SoundRecorder::SoundRecorder() : m_impl(std::make_unique<Impl>(this))
     if (const auto result = ma_log_init(nullptr, &*m_impl->log); result != MA_SUCCESS)
     {
         m_impl->log.reset();
-        err() << "Failed to initialize the audio log: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to initialize the audio log");
         return;
     }
 
@@ -183,7 +184,7 @@ SoundRecorder::SoundRecorder() : m_impl(std::make_unique<Impl>(this))
                                                          },
                                                          nullptr));
         result != MA_SUCCESS)
-        err() << "Failed to register audio log callback: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to register audio log callback");
 
     // Create the context
     m_impl->context.emplace();
@@ -200,7 +201,7 @@ SoundRecorder::SoundRecorder() : m_impl(std::make_unique<Impl>(this))
         if (const auto result = ma_context_init(backendList, 1, &contextConfig, &*m_impl->context); result != MA_SUCCESS)
         {
             m_impl->context.reset();
-            err() << "Failed to initialize the audio capture context: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to initialize the audio capture context");
             return;
         }
 
@@ -208,7 +209,7 @@ SoundRecorder::SoundRecorder() : m_impl(std::make_unique<Impl>(this))
         if (const auto result = ma_context_get_devices(&*m_impl->context, nullptr, nullptr, nullptr, &deviceCount);
             result != MA_SUCCESS)
         {
-            err() << "Failed to get audio capture devices: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to get audio capture devices");
             return;
         }
 
@@ -309,7 +310,7 @@ bool SoundRecorder::start(unsigned int sampleRate)
         // Start the capture
         if (const auto result = ma_device_start(&*m_impl->captureDevice); result != MA_SUCCESS)
         {
-            err() << "Failed to start audio capture device: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to start audio capture device");
             return false;
         }
 
@@ -329,7 +330,7 @@ void SoundRecorder::stop()
         // Stop the capture
         if (const auto result = ma_device_stop(&*m_impl->captureDevice); result != MA_SUCCESS)
         {
-            err() << "Failed to stop audio capture device: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to stop audio capture device");
             return;
         }
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -82,12 +82,12 @@ struct SoundStream::Impl
             impl.status    = Status::Stopped;
 
             if (const ma_result result = ma_sound_seek_to_pcm_frame(soundPtr, 0); result != MA_SUCCESS)
-                err() << "Failed to seek sound to frame 0: " << ma_result_description(result) << std::endl;
+                priv::MiniaudioUtils::printErr(result, "Failed to seek sound to frame 0");
         };
 
         if (const ma_result result = ma_sound_init_ex(engine, &soundConfig, &sound); result != MA_SUCCESS)
         {
-            err() << "Failed to initialize sound: " << ma_result_description(result) << std::endl;
+            priv::MiniaudioUtils::printErr(result, "Failed to initialize sound");
             return;
         }
 
@@ -284,7 +284,7 @@ void SoundStream::play()
 
     if (const ma_result result = ma_sound_start(&m_impl->sound); result != MA_SUCCESS)
     {
-        err() << "Failed to start playing sound: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to start playing sound");
     }
     else
     {
@@ -298,7 +298,7 @@ void SoundStream::pause()
 {
     if (const ma_result result = ma_sound_stop(&m_impl->sound); result != MA_SUCCESS)
     {
-        err() << "Failed to stop playing sound: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to stop playing sound");
     }
     else
     {
@@ -313,7 +313,7 @@ void SoundStream::stop()
 {
     if (const ma_result result = ma_sound_stop(&m_impl->sound); result != MA_SUCCESS)
     {
-        err() << "Failed to stop playing sound: " << ma_result_description(result) << std::endl;
+        priv::MiniaudioUtils::printErr(result, "Failed to stop playing sound");
     }
     else
     {


### PR DESCRIPTION
Refactors the commonly used 

```cpp
err() << "...message..." << ma_result_description(result) << std::endl;
```

pattern into 

```cpp
MiniaudioUtils::printErr(result, "...message...");
```

This is not only nice to avoid some repetition and gain conciseness, but I am planning to make future changes to the `err` API that, after this PR, would only need to be applied once for all miniaudio error reporting code.
