### PR TITLE
Use the SoundSource derived type specific status

### DIFF
--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -43,7 +43,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         CHECK(length == sf::Time::Zero);
         CHECK(music.getChannelCount() == 0);
         CHECK(music.getSampleRate() == 0);
-        CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+        CHECK(music.getStatus() == sf::Music::Status::Stopped);
         CHECK(music.getPlayingOffset() == sf::Time::Zero);
         CHECK(!music.getLoop());
     }
@@ -61,7 +61,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::Time::Zero);
             CHECK(music.getChannelCount() == 0);
             CHECK(music.getSampleRate() == 0);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }
@@ -75,7 +75,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::microseconds(1990884));
             CHECK(music.getChannelCount() == 1);
             CHECK(music.getSampleRate() == 44100);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }
@@ -95,7 +95,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::Time::Zero);
             CHECK(music.getChannelCount() == 0);
             CHECK(music.getSampleRate() == 0);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }
@@ -110,7 +110,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::microseconds(1990884));
             CHECK(music.getChannelCount() == 1);
             CHECK(music.getSampleRate() == 44100);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }
@@ -130,7 +130,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::Time::Zero);
             CHECK(music.getChannelCount() == 0);
             CHECK(music.getSampleRate() == 0);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }
@@ -145,7 +145,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::microseconds(24002176));
             CHECK(music.getChannelCount() == 2);
             CHECK(music.getSampleRate() == 44100);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }
@@ -158,21 +158,21 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
         // Wait for background thread to start
         music.play();
-        while (music.getStatus() == sf::SoundSource::Status::Stopped)
+        while (music.getStatus() == sf::Music::Status::Stopped)
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        CHECK(music.getStatus() == sf::SoundSource::Status::Playing);
+        CHECK(music.getStatus() == sf::Music::Status::Playing);
 
         // Wait for background thread to pause
         music.pause();
-        while (music.getStatus() == sf::SoundSource::Status::Playing)
+        while (music.getStatus() == sf::Music::Status::Playing)
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        CHECK(music.getStatus() == sf::SoundSource::Status::Paused);
+        CHECK(music.getStatus() == sf::Music::Status::Paused);
 
         // Wait for background thread to stop
         music.stop();
-        while (music.getStatus() == sf::SoundSource::Status::Paused)
+        while (music.getStatus() == sf::Music::Status::Paused)
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+        CHECK(music.getStatus() == sf::Music::Status::Stopped);
     }
 
     SECTION("setLoopPoints()")
@@ -187,7 +187,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::Time::Zero);
             CHECK(music.getChannelCount() == 0);
             CHECK(music.getSampleRate() == 0);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }
@@ -201,7 +201,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(length == sf::seconds(2));
             CHECK(music.getChannelCount() == 1);
             CHECK(music.getSampleRate() == 22050);
-            CHECK(music.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
             CHECK(!music.getLoop());
         }

--- a/test/Audio/Sound.test.cpp
+++ b/test/Audio/Sound.test.cpp
@@ -34,7 +34,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
         CHECK(&sound.getBuffer() == &soundBuffer);
         CHECK(!sound.getLoop());
         CHECK(sound.getPlayingOffset() == sf::Time::Zero);
-        CHECK(sound.getStatus() == sf::SoundSource::Status::Stopped);
+        CHECK(sound.getStatus() == sf::Sound::Status::Stopped);
     }
 
     SECTION("Copy semantics")
@@ -47,7 +47,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
             CHECK(&soundCopy.getBuffer() == &soundBuffer);
             CHECK(!soundCopy.getLoop());
             CHECK(soundCopy.getPlayingOffset() == sf::Time::Zero);
-            CHECK(soundCopy.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(soundCopy.getStatus() == sf::Sound::Status::Stopped);
         }
 
         SECTION("Assignment")
@@ -58,7 +58,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
             CHECK(&soundCopy.getBuffer() == &soundBuffer);
             CHECK(!soundCopy.getLoop());
             CHECK(soundCopy.getPlayingOffset() == sf::Time::Zero);
-            CHECK(soundCopy.getStatus() == sf::SoundSource::Status::Stopped);
+            CHECK(soundCopy.getStatus() == sf::Sound::Status::Stopped);
         }
     }
 

--- a/test/Audio/SoundStream.test.cpp
+++ b/test/Audio/SoundStream.test.cpp
@@ -45,7 +45,7 @@ TEST_CASE("[Audio] sf::SoundStream", runAudioDeviceTests())
         const SoundStream soundStream;
         CHECK(soundStream.getChannelCount() == 0);
         CHECK(soundStream.getSampleRate() == 0);
-        CHECK(soundStream.getStatus() == sf::SoundSource::Status::Stopped);
+        CHECK(soundStream.getStatus() == sf::SoundStream::Status::Stopped);
         CHECK(soundStream.getPlayingOffset() == sf::Time::Zero);
         CHECK(!soundStream.getLoop());
     }


### PR DESCRIPTION
## Description

I saw the this during the review of #2927, but thought it can't be done for some reason, until I realized that it works of course, because the Status enum is inherited in all the types.

## How to test this PR?

CI needs to succeed.