### PR TITLE
Remove default empty state of `sf::SoundBuffer`

### DIFF
--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -13,9 +13,7 @@
 void playSound()
 {
     // Load a sound buffer from a wav file
-    sf::SoundBuffer buffer;
-    if (!buffer.loadFromFile("resources/killdeer.wav"))
-        return;
+    const auto buffer = sf::SoundBuffer::loadFromFile("resources/killdeer.wav").value();
 
     // Display sound information
     std::cout << "killdeer.wav:" << '\n'

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -49,10 +49,8 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the sounds used in the game
-    sf::SoundBuffer ballSoundBuffer;
-    if (!ballSoundBuffer.loadFromFile(resourcesDir() / "ball.wav"))
-        return EXIT_FAILURE;
-    sf::Sound ballSound(ballSoundBuffer);
+    const auto ballSoundBuffer = sf::SoundBuffer::loadFromFile(resourcesDir() / "ball.wav").value();
+    sf::Sound  ballSound(ballSoundBuffer);
 
     // Create the SFML logo texture:
     sf::Texture sfmlLogoTexture;

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -274,12 +274,7 @@ private:
 ///
 /// Usage example:
 /// \code
-/// sf::SoundBuffer buffer;
-/// if (!buffer.loadFromFile("sound.wav"))
-/// {
-///     // Handle error...
-/// }
-///
+/// const auto buffer = sf::SoundBuffer::loadFromFile("sound.wav").value();
 /// sf::Sound sound(buffer);
 /// sound.play();
 /// \endcode

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -34,6 +34,7 @@
 #include <SFML/System/Time.hpp>
 
 #include <filesystem>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -54,12 +55,6 @@ class InputStream;
 class SFML_AUDIO_API SoundBuffer
 {
 public:
-    ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    SoundBuffer() = default;
-
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
     ///
@@ -82,12 +77,12 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \return True if loading succeeded, false if it failed
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
     ///
     /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<SoundBuffer> loadFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from a file in memory
@@ -98,12 +93,12 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \return True if loading succeeded, false if it failed
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
     ///
     /// \see loadFromFile, loadFromStream, loadFromSamples
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] static std::optional<SoundBuffer> loadFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from a custom stream
@@ -113,12 +108,12 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return True if loading succeeded, false if it failed
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
     ///
     /// \see loadFromFile, loadFromMemory, loadFromSamples
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromStream(InputStream& stream);
+    [[nodiscard]] static std::optional<SoundBuffer> loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from an array of audio samples
@@ -131,16 +126,17 @@ public:
     /// \param sampleRate   Sample rate (number of samples to play per second)
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \return True if loading succeeded, false if it failed
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
     ///
     /// \see loadFromFile, loadFromMemory, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromSamples(const std::int16_t*              samples,
-                                       std::uint64_t                    sampleCount,
-                                       unsigned int                     channelCount,
-                                       unsigned int                     sampleRate,
-                                       const std::vector<SoundChannel>& channelMap);
+    [[nodiscard]] static std::optional<SoundBuffer> loadFromSamples(
+        const std::int16_t*              samples,
+        std::uint64_t                    sampleCount,
+        unsigned int                     channelCount,
+        unsigned int                     sampleRate,
+        const std::vector<SoundChannel>& channelMap);
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the sound buffer to an audio file
@@ -248,6 +244,12 @@ private:
     friend class Sound;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct from vector of samples
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit SoundBuffer(std::vector<std::int16_t>&& samples);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Initialize the internal state after loading a new sound
     ///
     /// \param file Sound file providing access to the new loaded sound
@@ -255,7 +257,7 @@ private:
     /// \return True on successful initialization, false on failure
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool initialize(InputSoundFile& file);
+    [[nodiscard]] static std::optional<SoundBuffer> initialize(InputSoundFile& file);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the internal buffer with the cached audio samples
@@ -341,14 +343,8 @@ private:
 ///
 /// Usage example:
 /// \code
-/// // Declare a new sound buffer
-/// sf::SoundBuffer buffer;
-///
-/// // Load it from a file
-/// if (!buffer.loadFromFile("sound.wav"))
-/// {
-///     // error...
-/// }
+/// // Load a new sound buffer from a file
+/// const auto buffer = sf::SoundBuffer::loadFromFile("sound.wav").value();
 ///
 /// // Create a sound source bound to the buffer
 /// sf::Sound sound1(buffer);

--- a/include/SFML/Audio/SoundBufferRecorder.hpp
+++ b/include/SFML/Audio/SoundBufferRecorder.hpp
@@ -97,8 +97,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::vector<std::int16_t> m_samples; //!< Temporary sample buffer to hold the recorded data
-    SoundBuffer               m_buffer;  //!< Sound buffer that will contain the recorded data
+    std::vector<std::int16_t>  m_samples; //!< Temporary sample buffer to hold the recorded data
+    std::optional<SoundBuffer> m_buffer;  //!< Sound buffer that will contain the recorded data
 };
 
 } // namespace sf

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -48,7 +48,7 @@ SoundBufferRecorder::~SoundBufferRecorder()
 bool SoundBufferRecorder::onStart()
 {
     m_samples.clear();
-    m_buffer = SoundBuffer();
+    m_buffer.reset();
 
     return true;
 }
@@ -69,7 +69,12 @@ void SoundBufferRecorder::onStop()
     if (m_samples.empty())
         return;
 
-    if (!m_buffer.loadFromSamples(m_samples.data(), m_samples.size(), getChannelCount(), getSampleRate(), getChannelMap()))
+    m_buffer = sf::SoundBuffer::loadFromSamples(m_samples.data(),
+                                                m_samples.size(),
+                                                getChannelCount(),
+                                                getSampleRate(),
+                                                getChannelMap());
+    if (!m_buffer)
         err() << "Failed to stop capturing audio data" << std::endl;
 }
 
@@ -77,7 +82,8 @@ void SoundBufferRecorder::onStop()
 ////////////////////////////////////////////////////////////
 const SoundBuffer& SoundBufferRecorder::getBuffer() const
 {
-    return m_buffer;
+    assert(m_buffer && "SoundBufferRecorder::getBuffer() Cannot return reference to null buffer");
+    return *m_buffer;
 }
 
 } // namespace sf

--- a/test/Audio/Sound.test.cpp
+++ b/test/Audio/Sound.test.cpp
@@ -25,8 +25,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
         STATIC_CHECK(std::has_virtual_destructor_v<sf::Sound>);
     }
 
-    sf::SoundBuffer soundBuffer;
-    REQUIRE(soundBuffer.loadFromFile("Audio/ding.flac"));
+    const auto soundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();
 
     SECTION("Construction")
     {
@@ -52,8 +51,8 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
 
         SECTION("Assignment")
         {
-            const sf::SoundBuffer emptySoundBuffer;
-            sf::Sound             soundCopy(emptySoundBuffer);
+            const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();
+            sf::Sound             soundCopy(otherSoundBuffer);
             soundCopy = sound;
             CHECK(&soundCopy.getBuffer() == &soundBuffer);
             CHECK(!soundCopy.getLoop());
@@ -64,7 +63,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
 
     SECTION("Set/get buffer")
     {
-        const sf::SoundBuffer otherSoundBuffer;
+        const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();
         sf::Sound             sound(soundBuffer);
         sound.setBuffer(otherSoundBuffer);
         CHECK(&sound.getBuffer() == &otherSoundBuffer);


### PR DESCRIPTION
## Description

Sister PR to #3020 and #3021. The rationale from those two PRs carries over here too.
