### PR TITLE
Reduce required maths for transfrom by hardcoding the bottom row

### DIFF
--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -57,6 +57,7 @@ public:
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct a transform from a 3x3 matrix
+    ///        The bottom row is always 0 0 1.
     ///
     /// \param a00 Element (0, 0) of the matrix
     /// \param a01 Element (0, 1) of the matrix
@@ -64,12 +65,9 @@ public:
     /// \param a10 Element (1, 0) of the matrix
     /// \param a11 Element (1, 1) of the matrix
     /// \param a12 Element (1, 2) of the matrix
-    /// \param a20 Element (2, 0) of the matrix
-    /// \param a21 Element (2, 1) of the matrix
-    /// \param a22 Element (2, 2) of the matrix
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Transform(float a00, float a01, float a02, float a10, float a11, float a12, float a20, float a21, float a22);
+    constexpr Transform(float a00, float a01, float a02, float a10, float a11, float a12);
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the transform as a 4x4 matrix

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -131,11 +131,11 @@ constexpr Transform& Transform::combine(const Transform& transform)
     const auto& b = transform.m_matrix;
 
     // clang-format off
-    *this = Transform(a[0] * b[0]  + a[4] * b[1]         ,
-                      a[0] * b[4]  + a[4] * b[5]         ,
+    *this = Transform(a[0] * b[0]  + a[4] * b[1],
+                      a[0] * b[4]  + a[4] * b[5],
                       a[0] * b[12] + a[4] * b[13] + a[12],
-                      a[1] * b[0]  + a[5] * b[1]         ,
-                      a[1] * b[4]  + a[5] * b[5]         ,
+                      a[1] * b[0]  + a[5] * b[1],
+                      a[1] * b[4]  + a[5] * b[5],
                       a[1] * b[12] + a[5] * b[13] + a[13]);
     // clang-format on
 

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -132,11 +132,11 @@ constexpr Transform& Transform::combine(const Transform& transform)
 
     // clang-format off
     *this = Transform(a[0] * b[0]  + a[4] * b[1]         ,
-+                      a[0] * b[4]  + a[4] * b[5]         ,
-+                      a[0] * b[12] + a[4] * b[13] + a[12],
-+                      a[1] * b[0]  + a[5] * b[1]         ,
-+                      a[1] * b[4]  + a[5] * b[5]         ,
-+                      a[1] * b[12] + a[5] * b[13] + a[13]);
+                      a[0] * b[4]  + a[4] * b[5]         ,
+                      a[0] * b[12] + a[4] * b[13] + a[12],
+                      a[1] * b[0]  + a[5] * b[1]         ,
+                      a[1] * b[4]  + a[5] * b[5]         ,
+                      a[1] * b[12] + a[5] * b[13] + a[13]);
     // clang-format on
 
     return *this;

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -43,8 +43,7 @@ Transform& Transform::rotate(Angle angle)
 
     // clang-format off
     const Transform rotation(cos, -sin, 0,
-                             sin,  cos, 0,
-                             0,    0,   1);
+                             sin,  cos, 0);
     // clang-format on
 
     return combine(rotation);
@@ -60,8 +59,7 @@ Transform& Transform::rotate(Angle angle, const Vector2f& center)
 
     // clang-format off
     const Transform rotation(cos, -sin, center.x * (1 - cos) + center.y * sin,
-                             sin,  cos, center.y * (1 - cos) - center.x * sin,
-                             0,    0,   1);
+                             sin,  cos, center.y * (1 - cos) - center.x * sin);
     // clang-format on
 
     return combine(rotation);

--- a/src/SFML/Graphics/Transformable.cpp
+++ b/src/SFML/Graphics/Transformable.cpp
@@ -136,8 +136,7 @@ const Transform& Transformable::getTransform() const
 
         // clang-format off
         m_transform = Transform( sxc, sys, tx,
-                                -sxs, syc, ty,
-                                 0.f, 0.f, 1.f);
+                                -sxs, syc, ty);
         // clang-format on
         m_transformNeedUpdate = false;
     }

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -185,8 +185,7 @@ const Transform& View::getTransform() const
         // Rebuild the projection matrix
         // clang-format off
         m_transform = Transform( a * cosine, a * sine,   a * tx + c,
-                                -b * sine,   b * cosine, b * ty + d,
-                                 0.f,        0.f,        1.f);
+                                -b * sine,   b * cosine, b * ty + d);
         // clang-format on
         m_transformUpdated = true;
     }

--- a/test/Graphics/Glsl.test.cpp
+++ b/test/Graphics/Glsl.test.cpp
@@ -252,7 +252,7 @@ TEST_CASE("[Graphics] sf::Glsl")
 
         SECTION("Array constructor")
         {
-            static constexpr std::array<float, 9> data = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+            static constexpr std::array<float, 9> data = {1, 2, 3, 4, 5, 6};
             const sf::Glsl::Mat3                  mat(data.data());
             CHECK(mat.array[0] == 1);
             CHECK(mat.array[1] == 2);
@@ -260,24 +260,24 @@ TEST_CASE("[Graphics] sf::Glsl")
             CHECK(mat.array[3] == 4);
             CHECK(mat.array[4] == 5);
             CHECK(mat.array[5] == 6);
-            CHECK(mat.array[6] == 7);
-            CHECK(mat.array[7] == 8);
-            CHECK(mat.array[8] == 9);
+            CHECK(mat.array[6] == 0);
+            CHECK(mat.array[7] == 0);
+            CHECK(mat.array[8] == 1);
         }
 
         SECTION("Transform constructor")
         {
-            constexpr sf::Transform transform(10, 11, 12, 13, 14, 15, 16, 17, 18);
+            constexpr sf::Transform transform(10, 11, 12, 13, 14, 15);
             const sf::Glsl::Mat3    mat = transform;
             CHECK(mat.array[0] == 10);
             CHECK(mat.array[1] == 13);
-            CHECK(mat.array[2] == 16);
+            CHECK(mat.array[2] == 0);
             CHECK(mat.array[3] == 11);
             CHECK(mat.array[4] == 14);
-            CHECK(mat.array[5] == 17);
+            CHECK(mat.array[5] == 0);
             CHECK(mat.array[6] == 12);
             CHECK(mat.array[7] == 15);
-            CHECK(mat.array[8] == 18);
+            CHECK(mat.array[8] == 1);
         }
     }
 
@@ -313,16 +313,16 @@ TEST_CASE("[Graphics] sf::Glsl")
 
     SECTION("Transform constructor")
     {
-        constexpr sf::Transform transform(10, 11, 12, 13, 14, 15, 16, 17, 18);
+        constexpr sf::Transform transform(10, 11, 12, 13, 14, 15);
         const sf::Glsl::Mat4    mat = transform;
         CHECK(mat.array[0] == 10);
         CHECK(mat.array[1] == 13);
         CHECK(mat.array[2] == 0);
-        CHECK(mat.array[3] == 16);
+        CHECK(mat.array[3] == 0);
         CHECK(mat.array[4] == 11);
         CHECK(mat.array[5] == 14);
         CHECK(mat.array[6] == 0);
-        CHECK(mat.array[7] == 17);
+        CHECK(mat.array[7] == 0);
         CHECK(mat.array[8] == 0);
         CHECK(mat.array[9] == 0);
         CHECK(mat.array[10] == 1);
@@ -330,6 +330,6 @@ TEST_CASE("[Graphics] sf::Glsl")
         CHECK(mat.array[12] == 12);
         CHECK(mat.array[13] == 15);
         CHECK(mat.array[14] == 0);
-        CHECK(mat.array[15] == 18);
+        CHECK(mat.array[15] == 1);
     }
 }

--- a/test/Graphics/Glsl.test.cpp
+++ b/test/Graphics/Glsl.test.cpp
@@ -252,7 +252,7 @@ TEST_CASE("[Graphics] sf::Glsl")
 
         SECTION("Array constructor")
         {
-            static constexpr std::array<float, 9> data = {1, 2, 3, 4, 5, 6};
+            static constexpr std::array<float, 9> data = {1, 2, 3, 4, 5, 6, 7, 8, 9};
             const sf::Glsl::Mat3                  mat(data.data());
             CHECK(mat.array[0] == 1);
             CHECK(mat.array[1] == 2);
@@ -260,9 +260,9 @@ TEST_CASE("[Graphics] sf::Glsl")
             CHECK(mat.array[3] == 4);
             CHECK(mat.array[4] == 5);
             CHECK(mat.array[5] == 6);
-            CHECK(mat.array[6] == 0);
-            CHECK(mat.array[7] == 0);
-            CHECK(mat.array[8] == 1);
+            CHECK(mat.array[6] == 7);
+            CHECK(mat.array[7] == 8);
+            CHECK(mat.array[8] == 9);
         }
 
         SECTION("Transform constructor")

--- a/test/Graphics/RenderStates.test.cpp
+++ b/test/Graphics/RenderStates.test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("[Graphics] sf::RenderStates")
 
         SECTION("Transform constructor")
         {
-            const sf::Transform    transform(10, 9, 8, 7, 6, 5, 4, 3, 2);
+            const sf::Transform    transform(10, 9, 8, 7, 6, 5);
             const sf::RenderStates renderStates(transform);
             CHECK(renderStates.blendMode == sf::BlendMode());
             CHECK(renderStates.stencilMode == sf::StencilMode{});
@@ -101,7 +101,7 @@ TEST_CASE("[Graphics] sf::RenderStates")
                                           sf::BlendMode::Factor::DstAlpha,
                                           sf::BlendMode::Equation::Max);
             const sf::StencilMode stencilMode{sf::StencilComparison::Equal, sf::StencilUpdateOperation::Replace, 1, 0u, true};
-            const sf::Transform transform(10, 2, 3, 4, 50, 40, 30, 20, 10);
+            const sf::Transform transform(10, 2, 3, 4, 50, 40);
             const sf::RenderStates renderStates(blendMode, stencilMode, transform, sf::CoordinateType::Normalized, nullptr, nullptr);
             CHECK(renderStates.blendMode == blendMode);
             CHECK(renderStates.stencilMode == stencilMode);

--- a/test/Graphics/RenderTarget.test.cpp
+++ b/test/Graphics/RenderTarget.test.cpp
@@ -36,12 +36,12 @@ TEST_CASE("[Graphics] sf::RenderTarget")
         CHECK(renderTarget.getView().getSize() == sf::Vector2f(1000, 1000));
         CHECK(renderTarget.getView().getRotation() == sf::Angle::Zero);
         CHECK(renderTarget.getView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
-        CHECK(renderTarget.getView().getTransform() == sf::Transform(.002f, 0, -1, 0, -.002f, 1, 0, 0, 1));
+        CHECK(renderTarget.getView().getTransform() == sf::Transform(.002f, 0, -1, 0, -.002f, 1));
         CHECK(renderTarget.getDefaultView().getCenter() == sf::Vector2f(500, 500));
         CHECK(renderTarget.getDefaultView().getSize() == sf::Vector2f(1000, 1000));
         CHECK(renderTarget.getDefaultView().getRotation() == sf::Angle::Zero);
         CHECK(renderTarget.getDefaultView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
-        CHECK(renderTarget.getDefaultView().getTransform() == sf::Transform(.002f, 0, -1, 0, -.002f, 1, 0, 0, 1));
+        CHECK(renderTarget.getDefaultView().getTransform() == sf::Transform(.002f, 0, -1, 0, -.002f, 1));
         CHECK(!renderTarget.isSrgb());
     }
 

--- a/test/Graphics/RenderWindow.test.cpp
+++ b/test/Graphics/RenderWindow.test.cpp
@@ -43,7 +43,7 @@ TEST_CASE("[Graphics] sf::RenderWindow", runDisplayTests())
             CHECK(window.getView().getSize() == sf::Vector2f(256, 256));
             CHECK(window.getView().getRotation() == sf::Angle::Zero);
             CHECK(window.getView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(window.getView().getTransform() == sf::Transform(0.0078125f, 0, -1, 0, -0.0078125f, 1, 0, 0, 1));
+            CHECK(window.getView().getTransform() == sf::Transform(0.0078125f, 0, -1, 0, -0.0078125f, 1));
         }
 
         SECTION("State and settings")
@@ -62,7 +62,7 @@ TEST_CASE("[Graphics] sf::RenderWindow", runDisplayTests())
             CHECK(window.getView().getRotation() == sf::Angle::Zero);
             CHECK(window.getView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
             CHECK(window.getView().getTransform() ==
-                  Approx(sf::Transform(0.00833333f, 0, -1, 0, -0.00666667f, 1, 0, 0, 1)));
+                  Approx(sf::Transform(0.00833333f, 0, -1, 0, -0.00666667f, 1)));
         }
     }
 

--- a/test/Graphics/RenderWindow.test.cpp
+++ b/test/Graphics/RenderWindow.test.cpp
@@ -61,8 +61,7 @@ TEST_CASE("[Graphics] sf::RenderWindow", runDisplayTests())
             CHECK(window.getView().getSize() == sf::Vector2f(240, 300));
             CHECK(window.getView().getRotation() == sf::Angle::Zero);
             CHECK(window.getView().getViewport() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(window.getView().getTransform() ==
-                  Approx(sf::Transform(0.00833333f, 0, -1, 0, -0.00666667f, 1)));
+            CHECK(window.getView().getTransform() == Approx(sf::Transform(0.00833333f, 0, -1, 0, -0.00666667f, 1)));
         }
     }
 

--- a/test/Graphics/Transform.test.cpp
+++ b/test/Graphics/Transform.test.cpp
@@ -8,7 +8,6 @@
 #include <sstream>
 #include <type_traits>
 #include <vector>
-#include <iostream>
 
 #include <cassert>
 

--- a/test/Graphics/Transform.test.cpp
+++ b/test/Graphics/Transform.test.cpp
@@ -47,8 +47,7 @@ TEST_CASE("[Graphics] sf::Transform")
     SECTION("getInverse()")
     {
         STATIC_CHECK(sf::Transform::Identity.getInverse() == sf::Transform::Identity);
-        STATIC_CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 8.0f, 6.0f).getInverse() ==
-                     sf::Transform::Identity);
+        STATIC_CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 8.0f, 6.0f).getInverse() == sf::Transform::Identity);
         STATIC_CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 5.0f, 2.0f, 4.0f).getInverse() ==
                      sf::Transform(-0.25f, 0.25f, -0.25f, 0.625f, -0.125f, -1.375f));
     }
@@ -153,8 +152,7 @@ TEST_CASE("[Graphics] sf::Transform")
             constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
             STATIC_CHECK(sf::Transform::Identity * transform == transform);
             STATIC_CHECK(transform * sf::Transform::Identity == transform);
-            STATIC_CHECK(transform * transform ==
-                         sf::Transform(9.0f, 12.0f, 14.0f, 24.0f, 33.0f, 36.0f));
+            STATIC_CHECK(transform * transform == sf::Transform(9.0f, 12.0f, 14.0f, 24.0f, 33.0f, 36.0f));
             STATIC_CHECK(transform * sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f) ==
                          sf::Transform(18.0f, 102.0f, 86.0f, 60.0f, 258.0f, 216.0f));
         }
@@ -202,12 +200,10 @@ TEST_CASE("[Graphics] sf::Transform")
             STATIC_CHECK_FALSE(sf::Transform::Identity != sf::Transform::Identity);
             STATIC_CHECK_FALSE(sf::Transform() != sf::Transform());
             STATIC_CHECK_FALSE(sf::Transform(0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
-            STATIC_CHECK_FALSE(
-                sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f) !=
-                sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
-            STATIC_CHECK_FALSE(
-                sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f) !=
-                sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
+            STATIC_CHECK_FALSE(sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f) !=
+                               sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
+            STATIC_CHECK_FALSE(sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f) !=
+                               sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
 
             STATIC_CHECK(sf::Transform(1, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
             STATIC_CHECK(sf::Transform(0, 1, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));

--- a/test/Graphics/Transform.test.cpp
+++ b/test/Graphics/Transform.test.cpp
@@ -30,10 +30,10 @@ TEST_CASE("[Graphics] sf::Transform")
 
         SECTION("3x3 matrix constructor")
         {
-            constexpr sf::Transform transform(10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f, 17.0f, 18.0f);
+            constexpr sf::Transform transform(10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f);
             const std::vector       matrix(transform.getMatrix(), transform.getMatrix() + 16);
             CHECK(matrix ==
-                  std::vector{10.0f, 13.0f, 0.0f, 16.0f, 11.0f, 14.0f, 0.0f, 17.0f, 0.0f, 0.0f, 1.0f, 0.0f, 12.0f, 15.0f, 0.0f, 18.0f});
+                  std::vector{10.0f, 13.0f, 0.0f, 0.0f, 11.0f, 14.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 12.0f, 15.0f, 0.0f, 1.0f});
         }
     }
 
@@ -47,10 +47,10 @@ TEST_CASE("[Graphics] sf::Transform")
     SECTION("getInverse()")
     {
         STATIC_CHECK(sf::Transform::Identity.getInverse() == sf::Transform::Identity);
-        STATIC_CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f).getInverse() ==
+        STATIC_CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 8.0f, 6.0f).getInverse() ==
                      sf::Transform::Identity);
-        STATIC_CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f).getInverse() ==
-                     sf::Transform(0.375f, -0.5f, 0.875f, -1.0f, 1.0f, -1.0f, 0.875f, -0.5f, 0.375f));
+        STATIC_CHECK(sf::Transform(1.0f, 2.0f, 3.0f, 5.0f, 2.0f, 4.0f).getInverse() ==
+                     sf::Transform(-0.25f, 0.25f, -0.25f, 0.625f, -0.125f, -1.375f));
     }
 
     SECTION("transformPoint()")
@@ -63,7 +63,7 @@ TEST_CASE("[Graphics] sf::Transform")
         STATIC_CHECK(sf::Transform::Identity.transformPoint({1.0f, 1.0f}) == sf::Vector2f(1.0f, 1.0f));
         STATIC_CHECK(sf::Transform::Identity.transformPoint({10.0f, 10.0f}) == sf::Vector2f(10.0f, 10.0f));
 
-        constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+        constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
         STATIC_CHECK(transform.transformPoint({-1.0f, -1.0f}) == sf::Vector2f(0.0f, -5.0f));
         STATIC_CHECK(transform.transformPoint({0.0f, 0.0f}) == sf::Vector2f(3.0f, 4.0f));
         STATIC_CHECK(transform.transformPoint({1.0f, 1.0f}) == sf::Vector2f(6.0f, 13.0f));
@@ -78,7 +78,7 @@ TEST_CASE("[Graphics] sf::Transform")
         STATIC_CHECK(sf::Transform::Identity.transformRect({{100.0f, 100.0f}, {200.0f, 200.0f}}) ==
                      sf::FloatRect({100.0f, 100.0f}, {200.0f, 200.0f}));
 
-        constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+        constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
         STATIC_CHECK(transform.transformRect({{-100.0f, -100.0f}, {200.0f, 200.0f}}) ==
                      sf::FloatRect({-297.0f, -896.0f}, {600.0f, 1800.0f}));
         STATIC_CHECK(transform.transformRect({{0.0f, 0.0f}, {0.0f, 0.0f}}) == sf::FloatRect({3.0f, 4.0f}, {0.0f, 0.0f}));
@@ -92,19 +92,19 @@ TEST_CASE("[Graphics] sf::Transform")
         CHECK(identity.combine(sf::Transform::Identity) == sf::Transform::Identity);
         CHECK(identity.combine(sf::Transform::Identity).combine(sf::Transform::Identity) == sf::Transform::Identity);
 
-        sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+        sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
         CHECK(identity.combine(transform) == transform);
         CHECK(transform.combine(sf::Transform::Identity) == transform);
-        CHECK(transform.combine(transform) == sf::Transform(18.0f, 18.0f, 14.0f, 36.0f, 41.0f, 36.0f, 14.0f, 18.0f, 18.0f));
-        CHECK(transform.combine(sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f, 30.0f, 20.0f, 10.0f)) ==
-              sf::Transform(672.0f, 1216.0f, 914.0f, 1604.0f, 2842.0f, 2108.0f, 752.0f, 1288.0f, 942.0f));
+        CHECK(transform.combine(transform) == sf::Transform(18.0f, 18.0f, 14.0f, 36.0f, 41.0f, 36.0f));
+        CHECK(transform.combine(sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f)) ==
+              sf::Transform(672.0f, 1216.0f, 914.0f, 1604.0f, 2842.0f, 2108.0f));
     }
 
     SECTION("translate()")
     {
-        sf::Transform transform(9, 8, 7, 6, 5, 4, 3, 2, 1);
-        CHECK(transform.translate({10.0f, 20.0f}) == sf::Transform(9, 8, 257, 6, 5, 164, 3, 2, 71));
-        CHECK(transform.translate({10.0f, 20.0f}) == sf::Transform(9, 8, 507, 6, 5, 324, 3, 2, 141));
+        sf::Transform transform(9, 8, 7, 6, 5, 4);
+        CHECK(transform.translate({10.0f, 20.0f}) == sf::Transform(9, 8, 257, 6, 5, 164));
+        CHECK(transform.translate({10.0f, 20.0f}) == sf::Transform(9, 8, 507, 6, 5, 324));
     }
 
     SECTION("rotate()")
@@ -113,14 +113,14 @@ TEST_CASE("[Graphics] sf::Transform")
         {
             sf::Transform transform;
             transform.rotate(sf::degrees(90));
-            CHECK(transform == Approx(sf::Transform(0, -1, 0, 1, 0, 0, 0, 0, 1)));
+            CHECK(transform == Approx(sf::Transform(0, -1, 0, 1, 0, 0)));
         }
 
         SECTION("Around custom point")
         {
             sf::Transform transform;
             transform.rotate(sf::degrees(90), {1.0f, 0.0f});
-            CHECK(transform == Approx(sf::Transform(0, -1, 1, 1, 0, -1, 0, 0, 1)));
+            CHECK(transform == Approx(sf::Transform(0, -1, 1, 1, 0, -1)));
         }
     }
 
@@ -128,17 +128,17 @@ TEST_CASE("[Graphics] sf::Transform")
     {
         SECTION("About origin")
         {
-            sf::Transform transform(1, 2, 3, 4, 5, 4, 3, 2, 1);
-            CHECK(transform.scale({2.0f, 4.0f}) == sf::Transform(2, 8, 3, 8, 20, 4, 6, 8, 1));
-            CHECK(transform.scale({0.0f, 0.0f}) == sf::Transform(0, 0, 3, 0, 0, 4, 0, 0, 1));
-            CHECK(transform.scale({10.0f, 10.0f}) == sf::Transform(0, 0, 3, 0, 0, 4, 0, 0, 1));
+            sf::Transform transform(1, 2, 3, 4, 5, 4);
+            CHECK(transform.scale({2.0f, 4.0f}) == sf::Transform(2, 8, 3, 8, 20, 4));
+            CHECK(transform.scale({0.0f, 0.0f}) == sf::Transform(0, 0, 3, 0, 0, 4));
+            CHECK(transform.scale({10.0f, 10.0f}) == sf::Transform(0, 0, 3, 0, 0, 4));
         }
 
         SECTION("About custom point")
         {
-            sf::Transform transform(1, 2, 3, 4, 5, 4, 3, 2, 1);
-            CHECK(transform.scale({1.0f, 2.0f}, {1.0f, 0.0f}) == sf::Transform(1, 4, 3, 4, 10, 4, 3, 4, 1));
-            CHECK(transform.scale({0.0f, 0.0f}, {1.0f, 0.0f}) == sf::Transform(0, 0, 4, 0, 0, 8, 0, 0, 4));
+            sf::Transform transform(1, 2, 3, 4, 5, 4);
+            CHECK(transform.scale({1.0f, 2.0f}, {1.0f, 0.0f}) == sf::Transform(1, 4, 3, 4, 10, 4));
+            CHECK(transform.scale({0.0f, 0.0f}, {1.0f, 0.0f}) == sf::Transform(0, 0, 4, 0, 0, 8));
         }
     }
 
@@ -150,24 +150,24 @@ TEST_CASE("[Graphics] sf::Transform")
             STATIC_CHECK(sf::Transform::Identity * sf::Transform::Identity * sf::Transform::Identity ==
                          sf::Transform::Identity);
 
-            constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+            constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
             STATIC_CHECK(sf::Transform::Identity * transform == transform);
             STATIC_CHECK(transform * sf::Transform::Identity == transform);
             STATIC_CHECK(transform * transform ==
-                         sf::Transform(18.0f, 18.0f, 14.0f, 36.0f, 41.0f, 36.0f, 14.0f, 18.0f, 18.0f));
-            STATIC_CHECK(transform * sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f, 30.0f, 20.0f, 10.0f) ==
-                         sf::Transform(108.0f, 162.0f, 113.0f, 180.0f, 338.0f, 252.0f, 68.0f, 126.0f, 99.0f));
+                         sf::Transform(9.0f, 12.0f, 14.0f, 24.0f, 33.0f, 36.0f));
+            STATIC_CHECK(transform * sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f) ==
+                         sf::Transform(18.0f, 102.0f, 86.0f, 60.0f, 258.0f, 216.0f));
         }
 
         SECTION("operator*=")
         {
-            sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+            sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
             transform *= sf::Transform::Identity;
-            CHECK(transform == sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f));
+            CHECK(transform == sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f));
             transform *= transform;
-            CHECK(transform == sf::Transform(18.0f, 18.0f, 14.0f, 36.0f, 41.0f, 36.0f, 14.0f, 18.0f, 18.0f));
-            transform *= sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f, 30.0f, 20.0f, 10.0f);
-            CHECK(transform == sf::Transform(672.0f, 1216.0f, 914.0f, 1604.0f, 2842.0f, 2108.0f, 752.0f, 1288.0f, 942.0f));
+            CHECK(transform == sf::Transform(18.0f, 18.0f, 14.0f, 36.0f, 41.0f, 36.0f));
+            transform *= sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f);
+            CHECK(transform == sf::Transform(672.0f, 1216.0f, 914.0f, 1604.0f, 2842.0f, 2108.0f));
         }
 
         SECTION("operator* with vector")
@@ -180,7 +180,7 @@ TEST_CASE("[Graphics] sf::Transform")
             STATIC_CHECK(sf::Transform::Identity * sf::Vector2f(1.0f, 1.0f) == sf::Vector2f(1.0f, 1.0f));
             STATIC_CHECK(sf::Transform::Identity * sf::Vector2f(10.0f, 10.0f) == sf::Vector2f(10.0f, 10.0f));
 
-            constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f);
+            constexpr sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
             STATIC_CHECK(transform * sf::Vector2f(-1.0f, -1.0f) == sf::Vector2f(0.0f, -5.0f));
             STATIC_CHECK(transform * sf::Vector2f(0.0f, 0.0f) == sf::Vector2f(3.0f, 4.0f));
             STATIC_CHECK(transform * sf::Vector2f(1.0f, 1.0f) == sf::Vector2f(6.0f, 13.0f));
@@ -190,34 +190,31 @@ TEST_CASE("[Graphics] sf::Transform")
         {
             STATIC_CHECK(sf::Transform::Identity == sf::Transform::Identity);
             STATIC_CHECK(sf::Transform() == sf::Transform());
-            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0) == sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f) ==
-                         sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
-            STATIC_CHECK(sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f) ==
-                         sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
+            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 0, 0) == sf::Transform(0, 0, 0, 0, 0, 0));
+            STATIC_CHECK(sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f) ==
+                         sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
+            STATIC_CHECK(sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f) ==
+                         sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
         }
 
         SECTION("operator!=")
         {
             STATIC_CHECK_FALSE(sf::Transform::Identity != sf::Transform::Identity);
             STATIC_CHECK_FALSE(sf::Transform() != sf::Transform());
-            STATIC_CHECK_FALSE(sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
+            STATIC_CHECK_FALSE(sf::Transform(0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
             STATIC_CHECK_FALSE(
-                sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f) !=
-                sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
+                sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f) !=
+                sf::Transform(0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f, 0.0001f));
             STATIC_CHECK_FALSE(
-                sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f) !=
-                sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
+                sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f) !=
+                sf::Transform(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f, 1000.0f));
 
-            STATIC_CHECK(sf::Transform(1, 0, 0, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 1, 0, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 0, 1, 0, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 0, 0, 1, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 1, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 0, 1, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 1, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 0, 1, 0) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
-            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 1) != sf::Transform(0, 0, 0, 0, 0, 0, 0, 0, 0));
+            STATIC_CHECK(sf::Transform(1, 0, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
+            STATIC_CHECK(sf::Transform(0, 1, 0, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
+            STATIC_CHECK(sf::Transform(0, 0, 1, 0, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
+            STATIC_CHECK(sf::Transform(0, 0, 0, 1, 0, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
+            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 1, 0) != sf::Transform(0, 0, 0, 0, 0, 0));
+            STATIC_CHECK(sf::Transform(0, 0, 0, 0, 0, 1) != sf::Transform(0, 0, 0, 0, 0, 0));
         }
     }
 }

--- a/test/Graphics/Transform.test.cpp
+++ b/test/Graphics/Transform.test.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <type_traits>
 #include <vector>
+#include <iostream>
 
 #include <cassert>
 
@@ -95,9 +96,9 @@ TEST_CASE("[Graphics] sf::Transform")
         sf::Transform transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f);
         CHECK(identity.combine(transform) == transform);
         CHECK(transform.combine(sf::Transform::Identity) == transform);
-        CHECK(transform.combine(transform) == sf::Transform(18.0f, 18.0f, 14.0f, 36.0f, 41.0f, 36.0f));
+        CHECK(transform.combine(transform) == sf::Transform(9.0f, 12.0f, 14.0f, 24.0f, 33.0f, 36.0f));
         CHECK(transform.combine(sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f)) ==
-              sf::Transform(672.0f, 1216.0f, 914.0f, 1604.0f, 2842.0f, 2108.0f));
+              sf::Transform(138.0f, 618.0f, 521.0f, 372.0f, 1698.0f, 1428.0f));
     }
 
     SECTION("translate()")
@@ -165,9 +166,9 @@ TEST_CASE("[Graphics] sf::Transform")
             transform *= sf::Transform::Identity;
             CHECK(transform == sf::Transform(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 4.0f));
             transform *= transform;
-            CHECK(transform == sf::Transform(18.0f, 18.0f, 14.0f, 36.0f, 41.0f, 36.0f));
+            CHECK(transform == sf::Transform(9.0f, 12.0f, 14.0f, 24.0f, 33.0f, 36.0f));
             transform *= sf::Transform(10.0f, 2.0f, 3.0f, 4.0f, 50.0f, 40.0f);
-            CHECK(transform == sf::Transform(672.0f, 1216.0f, 914.0f, 1604.0f, 2842.0f, 2108.0f));
+            CHECK(transform == sf::Transform(138.0f, 618.0f, 521.0f, 372.0f, 1698.0f, 1428.0f));
         }
 
         SECTION("operator* with vector")

--- a/test/Graphics/View.test.cpp
+++ b/test/Graphics/View.test.cpp
@@ -79,14 +79,12 @@ TEST_CASE("[Graphics] sf::View")
         CHECK(view.getRotation() == Approx(sf::degrees(15)));
         CHECK(view.getTransform() ==
               Approx(sf::Transform(0.00193185f, 0.000517638f, -1.22474f, 0.000517638f, -0.00193185f, 0.707107f)));
-        CHECK(view.getInverseTransform() ==
-              Approx(sf::Transform(482.963f, 129.41f, 500, 129.41f, -482.963f, 500)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(482.963f, 129.41f, 500, 129.41f, -482.963f, 500)));
         view.setRotation(sf::degrees(400));
         CHECK(view.getRotation() == Approx(sf::degrees(40)));
         CHECK(view.getTransform() ==
               Approx(sf::Transform(0.00153209f, 0.00128558f, -1.40883f, 0.00128558f, -0.00153209f, 0.123257f)));
-        CHECK(view.getInverseTransform() ==
-              Approx(sf::Transform(383.022f, 321.394f, 500, 321.394f, -383.022f, 500)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(383.022f, 321.394f, 500, 321.394f, -383.022f, 500)));
     }
 
     SECTION("Set/get viewport")

--- a/test/Graphics/View.test.cpp
+++ b/test/Graphics/View.test.cpp
@@ -25,8 +25,8 @@ TEST_CASE("[Graphics] sf::View")
             CHECK(view.getRotation() == sf::Angle::Zero);
             CHECK(view.getViewport() == sf::FloatRect({0, 0}, {1, 1}));
             CHECK(view.getScissor() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(view.getTransform() == sf::Transform(0.002f, 0, -1, 0, -0.002f, 1, 0, 0, 1));
-            CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 500, 0, -500, 500, 0, 0, 1)));
+            CHECK(view.getTransform() == sf::Transform(0.002f, 0, -1, 0, -0.002f, 1));
+            CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 500, 0, -500, 500)));
         }
 
         SECTION("Rectangle constructor")
@@ -37,8 +37,8 @@ TEST_CASE("[Graphics] sf::View")
             CHECK(view.getRotation() == sf::Angle::Zero);
             CHECK(view.getViewport() == sf::FloatRect({0, 0}, {1, 1}));
             CHECK(view.getScissor() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(view.getTransform() == Approx(sf::Transform(0.005f, 0, -1.05f, 0, -0.00333333f, 1.06667f, 0, 0, 1)));
-            CHECK(view.getInverseTransform() == Approx(sf::Transform(200, 0, 210, 0, -300, 320, 0, 0, 1)));
+            CHECK(view.getTransform() == Approx(sf::Transform(0.005f, 0, -1.05f, 0, -0.00333333f, 1.06667f)));
+            CHECK(view.getInverseTransform() == Approx(sf::Transform(200, 0, 210, 0, -300, 320)));
         }
 
         SECTION("Center + size constructor")
@@ -49,8 +49,8 @@ TEST_CASE("[Graphics] sf::View")
             CHECK(view.getRotation() == sf::Angle::Zero);
             CHECK(view.getViewport() == sf::FloatRect({0, 0}, {1, 1}));
             CHECK(view.getScissor() == sf::FloatRect({0, 0}, {1, 1}));
-            CHECK(view.getTransform() == Approx(sf::Transform(0.00185185f, 0, -0.962963f, 0, -0.00104167f, 1, 0, 0, 1)));
-            CHECK(view.getInverseTransform() == Approx(sf::Transform(540, 0, 520, 0, -960, 960, 0, 0, 1)));
+            CHECK(view.getTransform() == Approx(sf::Transform(0.00185185f, 0, -0.962963f, 0, -0.00104167f, 1)));
+            CHECK(view.getInverseTransform() == Approx(sf::Transform(540, 0, 520, 0, -960, 960)));
         }
     }
 
@@ -59,8 +59,8 @@ TEST_CASE("[Graphics] sf::View")
         sf::View view;
         view.setCenter({3.14f, 4.2f});
         CHECK(view.getCenter() == sf::Vector2f(3.14f, 4.2f));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -0.00628f, 0, -0.002f, 0.0084f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 3.14f, 0, -500, 4.2f, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -0.00628f, 0, -0.002f, 0.0084f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 3.14f, 0, -500, 4.2f)));
     }
 
     SECTION("Set/get size")
@@ -68,8 +68,8 @@ TEST_CASE("[Graphics] sf::View")
         sf::View view;
         view.setSize({600, 900});
         CHECK(view.getSize() == sf::Vector2f(600, 900));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.00333333f, 0, -1.66667f, 0, -0.00222222f, 1.11111f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(300, 0, 500, 0, -450, 500, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.00333333f, 0, -1.66667f, 0, -0.00222222f, 1.11111f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(300, 0, 500, 0, -450, 500)));
     }
 
     SECTION("Set/get rotation")
@@ -78,15 +78,15 @@ TEST_CASE("[Graphics] sf::View")
         view.setRotation(sf::degrees(-345));
         CHECK(view.getRotation() == Approx(sf::degrees(15)));
         CHECK(view.getTransform() ==
-              Approx(sf::Transform(0.00193185f, 0.000517638f, -1.22474f, 0.000517638f, -0.00193185f, 0.707107f, 0, 0, 1)));
+              Approx(sf::Transform(0.00193185f, 0.000517638f, -1.22474f, 0.000517638f, -0.00193185f, 0.707107f)));
         CHECK(view.getInverseTransform() ==
-              Approx(sf::Transform(482.963f, 129.41f, 500, 129.41f, -482.963f, 500, 0, 0, 1)));
+              Approx(sf::Transform(482.963f, 129.41f, 500, 129.41f, -482.963f, 500)));
         view.setRotation(sf::degrees(400));
         CHECK(view.getRotation() == Approx(sf::degrees(40)));
         CHECK(view.getTransform() ==
-              Approx(sf::Transform(0.00153209f, 0.00128558f, -1.40883f, 0.00128558f, -0.00153209f, 0.123257f, 0, 0, 1)));
+              Approx(sf::Transform(0.00153209f, 0.00128558f, -1.40883f, 0.00128558f, -0.00153209f, 0.123257f)));
         CHECK(view.getInverseTransform() ==
-              Approx(sf::Transform(383.022f, 321.394f, 500, 321.394f, -383.022f, 500, 0, 0, 1)));
+              Approx(sf::Transform(383.022f, 321.394f, 500, 321.394f, -383.022f, 500)));
     }
 
     SECTION("Set/get viewport")
@@ -94,8 +94,8 @@ TEST_CASE("[Graphics] sf::View")
         sf::View view;
         view.setViewport({{150, 250}, {500, 750}});
         CHECK(view.getViewport() == sf::FloatRect({150, 250}, {500, 750}));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -1, 0, -0.002f, 1, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 500, 0, -500, 500, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -1, 0, -0.002f, 1)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 500, 0, -500, 500)));
         CHECK(view.getScissor() == sf::FloatRect({0, 0}, {1, 1}));
     }
 
@@ -121,8 +121,8 @@ TEST_CASE("[Graphics] sf::View")
         CHECK(view.getRotation() == sf::Angle::Zero);
         CHECK(view.getViewport() == sf::FloatRect({150, 250}, {500, 750}));
         CHECK(view.getScissor() == sf::FloatRect({0.2f, 0.3f}, {0.4f, 0.5f}));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.666667f, 0, -1.66667f, 0, -0.5f, 2, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(1.5f, 0, 2.5f, 0, -2, 4, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.666667f, 0, -1.66667f, 0, -0.5f, 2)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(1.5f, 0, 2.5f, 0, -2, 4)));
     }
 
     SECTION("move()")
@@ -131,8 +131,8 @@ TEST_CASE("[Graphics] sf::View")
         view.setCenter({25, 25});
         view.move({15, 25});
         CHECK(view.getCenter() == sf::Vector2f(40, 50));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -0.08f, 0, -0.002f, 0.1f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 40, 0, -500, 50, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.002f, 0, -0.08f, 0, -0.002f, 0.1f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(500, 0, 40, 0, -500, 50)));
     }
 
     SECTION("rotate()")
@@ -142,8 +142,8 @@ TEST_CASE("[Graphics] sf::View")
         view.rotate(sf::degrees(-15));
         CHECK(view.getRotation() == Approx(sf::degrees(30)));
         CHECK(view.getTransform() ==
-              Approx(sf::Transform(0.00173205f, 0.001f, -1.36603f, 0.001f, -0.00173205f, 0.366025f, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(433.013f, 250, 500, 250, -433.013f, 500, 0, 0, 1)));
+              Approx(sf::Transform(0.00173205f, 0.001f, -1.36603f, 0.001f, -0.00173205f, 0.366025f)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(433.013f, 250, 500, 250, -433.013f, 500)));
     }
 
     SECTION("zoom()")
@@ -152,7 +152,7 @@ TEST_CASE("[Graphics] sf::View")
         view.setSize({25, 25});
         view.zoom(4);
         CHECK(view.getSize() == sf::Vector2f(100, 100));
-        CHECK(view.getTransform() == Approx(sf::Transform(0.02f, 0, -10, 0, -0.02f, 10, 0, 0, 1)));
-        CHECK(view.getInverseTransform() == Approx(sf::Transform(50, 0, 500, 0, -50, 500, 0, 0, 1)));
+        CHECK(view.getTransform() == Approx(sf::Transform(0.02f, 0, -10, 0, -0.02f, 10)));
+        CHECK(view.getInverseTransform() == Approx(sf::Transform(50, 0, 500, 0, -50, 500)));
     }
 }


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before? (discord)
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [x] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed list them as tasks!
-->

## Description

Earlier I noted that all the constructors of `sf::Transform` in SFML follow the property of the bottom row being 0, 0, 1.  
All available operations on any `Transform`s with this property, results in the property also holding true for the resulting `Transform`. This includes the dot product `Transform::combine()` and `Transform.getInverse()`.  
The only way to break this property, is if the API user manually uses the `Transform::Transform(...)` constructor to create a Transform with a different bottom row. I could not find any useseful use cases for this.

This property can be exploited to significantly optimize the math of the operators of `Transform`. Especially in the heavily used `Transform::combine()` but also notably in `Transform::getInverse()`.

I did this because I could on a branch and have been using it in my own game for some time now. I understand that this is the lowest priority of low priority PR's, but since I already made the change I at least wanted to bring up the discussion rather than letting it go to waste.

## Tasks

-   [ ] Tested on Linux
-   [X] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Open for suggestions.
