### PR TITLE
Remove default empty state of `sf::InputSoundFile` and `sf::OutputSoundFile`

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -33,6 +33,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <cstddef>
@@ -64,10 +65,10 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \return True if the file was successfully opened
+    /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool openFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<InputSoundFile> openFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a sound file in memory for reading
@@ -78,10 +79,10 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \return True if the file was successfully opened
+    /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool openFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] static std::optional<InputSoundFile> openFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a sound file from a custom stream for reading
@@ -91,10 +92,10 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return True if the file was successfully opened
+    /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool openFromStream(InputStream& stream);
+    [[nodiscard]] static std::optional<InputSoundFile> openFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total number of audio samples in the file
@@ -212,6 +213,14 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Useful for implementing close()
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile() = default;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Deleter for input streams that only conditionally deletes
     ///
     ////////////////////////////////////////////////////////////
@@ -227,6 +236,16 @@ private:
 
         bool owned{true};
     };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Constructor from reader, stream, and attributes
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile(std::unique_ptr<SoundFileReader>&&            reader,
+                   std::unique_ptr<InputStream, StreamDeleter>&& stream,
+                   std::uint64_t                                 sampleCount,
+                   unsigned int                                  sampleRate,
+                   std::vector<SoundChannel>&&                   channelMap);
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -248,10 +248,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    InputSoundFile            m_file;     //!< The streamed music file
-    std::vector<std::int16_t> m_samples;  //!< Temporary buffer of samples
-    std::recursive_mutex      m_mutex;    //!< Mutex protecting the data
-    Span<std::uint64_t>       m_loopSpan; //!< Loop Range Specifier
+    std::optional<InputSoundFile> m_file;     //!< The streamed music file
+    std::vector<std::int16_t>     m_samples;  //!< Temporary buffer of samples
+    std::recursive_mutex          m_mutex;    //!< Mutex protecting the data
+    Span<std::uint64_t>           m_loopSpan; //!< Loop Range Specifier
 };
 
 } // namespace sf

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -34,6 +34,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <cstdint>
@@ -58,13 +59,14 @@ public:
     /// \param channelCount Number of channels in the sound
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \return True if the file was successfully opened
+    /// \return Output sound file if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool openFromFile(const std::filesystem::path&     filename,
-                                    unsigned int                     sampleRate,
-                                    unsigned int                     channelCount,
-                                    const std::vector<SoundChannel>& channelMap);
+    [[nodiscard]] static std::optional<OutputSoundFile> openFromFile(
+        const std::filesystem::path&     filename,
+        unsigned int                     sampleRate,
+        unsigned int                     channelCount,
+        const std::vector<SoundChannel>& channelMap);
 
     ////////////////////////////////////////////////////////////
     /// \brief Write audio samples to the file
@@ -82,6 +84,12 @@ public:
     void close();
 
 private:
+    ////////////////////////////////////////////////////////////
+    /// \brief Constructor from writer
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit OutputSoundFile(std::unique_ptr<SoundFileWriter>&& writer);
+
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -70,9 +70,8 @@ SoundBuffer::~SoundBuffer()
 ////////////////////////////////////////////////////////////
 std::optional<SoundBuffer> SoundBuffer::loadFromFile(const std::filesystem::path& filename)
 {
-    InputSoundFile file;
-    if (file.openFromFile(filename))
-        return initialize(file);
+    if (auto file = InputSoundFile::openFromFile(filename))
+        return initialize(*file);
     else
         return std::nullopt;
 }
@@ -81,9 +80,8 @@ std::optional<SoundBuffer> SoundBuffer::loadFromFile(const std::filesystem::path
 ////////////////////////////////////////////////////////////
 std::optional<SoundBuffer> SoundBuffer::loadFromMemory(const void* data, std::size_t sizeInBytes)
 {
-    InputSoundFile file;
-    if (file.openFromMemory(data, sizeInBytes))
-        return initialize(file);
+    if (auto file = InputSoundFile::openFromMemory(data, sizeInBytes))
+        return initialize(*file);
     else
         return std::nullopt;
 }
@@ -92,9 +90,8 @@ std::optional<SoundBuffer> SoundBuffer::loadFromMemory(const void* data, std::si
 ////////////////////////////////////////////////////////////
 std::optional<SoundBuffer> SoundBuffer::loadFromStream(InputStream& stream)
 {
-    InputSoundFile file;
-    if (file.openFromStream(stream))
-        return initialize(file);
+    if (auto file = InputSoundFile::openFromStream(stream))
+        return initialize(*file);
     else
         return std::nullopt;
 }
@@ -136,11 +133,10 @@ std::optional<SoundBuffer> SoundBuffer::loadFromSamples(
 bool SoundBuffer::saveToFile(const std::filesystem::path& filename) const
 {
     // Create the sound file in write mode
-    OutputSoundFile file;
-    if (file.openFromFile(filename, getSampleRate(), getChannelCount(), getChannelMap()))
+    if (auto file = OutputSoundFile::openFromFile(filename, getSampleRate(), getChannelCount(), getChannelMap()))
     {
         // Write the samples to the opened file
-        file.write(m_samples.data(), m_samples.size());
+        file->write(m_samples.data(), m_samples.size());
 
         return true;
     }

--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -15,37 +15,25 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 {
     SECTION("Type traits")
     {
+        STATIC_CHECK(!std::is_default_constructible_v<sf::InputSoundFile>);
         STATIC_CHECK(!std::is_copy_constructible_v<sf::InputSoundFile>);
         STATIC_CHECK(!std::is_copy_assignable_v<sf::InputSoundFile>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::InputSoundFile>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::InputSoundFile>);
     }
 
-    SECTION("Construction")
-    {
-        const sf::InputSoundFile inputSoundFile;
-        CHECK(inputSoundFile.getSampleCount() == 0);
-        CHECK(inputSoundFile.getChannelCount() == 0);
-        CHECK(inputSoundFile.getSampleRate() == 0);
-        CHECK(inputSoundFile.getDuration() == sf::Time::Zero);
-        CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-        CHECK(inputSoundFile.getSampleOffset() == 0);
-    }
-
     SECTION("openFromFile()")
     {
-        sf::InputSoundFile inputSoundFile;
-
         SECTION("Invalid file")
         {
-            CHECK(!inputSoundFile.openFromFile("does/not/exist.wav"));
+            CHECK(!sf::InputSoundFile::openFromFile("does/not/exist.wav"));
         }
 
         SECTION("Valid file")
         {
             SECTION("flac")
             {
-                REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
+                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -56,7 +44,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("mp3")
             {
-                REQUIRE(inputSoundFile.openFromFile("Audio/ding.mp3"));
+                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.mp3").value();
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -67,7 +55,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("ogg")
             {
-                REQUIRE(inputSoundFile.openFromFile("Audio/doodle_pop.ogg"));
+                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/doodle_pop.ogg").value();
                 CHECK(inputSoundFile.getSampleCount() == 2'116'992);
                 CHECK(inputSoundFile.getChannelCount() == 2);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -78,7 +66,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("wav")
             {
-                REQUIRE(inputSoundFile.openFromFile("Audio/killdeer.wav"));
+                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/killdeer.wav").value();
                 CHECK(inputSoundFile.getSampleCount() == 112'941);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 22'050);
@@ -91,9 +79,8 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("openFromMemory()")
     {
-        const auto         memory = loadIntoMemory("Audio/killdeer.wav");
-        sf::InputSoundFile inputSoundFile;
-        REQUIRE(inputSoundFile.openFromMemory(memory.data(), memory.size()));
+        const auto memory         = loadIntoMemory("Audio/killdeer.wav");
+        const auto inputSoundFile = sf::InputSoundFile::openFromMemory(memory.data(), memory.size()).value();
         CHECK(inputSoundFile.getSampleCount() == 112'941);
         CHECK(inputSoundFile.getChannelCount() == 1);
         CHECK(inputSoundFile.getSampleRate() == 22'050);
@@ -104,12 +91,11 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("openFromStream()")
     {
-        sf::InputSoundFile  inputSoundFile;
         sf::FileInputStream stream;
 
         SECTION("Invalid stream")
         {
-            CHECK(!inputSoundFile.openFromStream(stream));
+            CHECK(!sf::InputSoundFile::openFromStream(stream));
         }
 
         SECTION("Valid stream")
@@ -117,7 +103,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
             SECTION("flac")
             {
                 REQUIRE(stream.open("Audio/ding.flac"));
-                REQUIRE(inputSoundFile.openFromStream(stream));
+                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -129,7 +115,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
             SECTION("mp3")
             {
                 REQUIRE(stream.open("Audio/ding.mp3"));
-                REQUIRE(inputSoundFile.openFromStream(stream));
+                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -141,7 +127,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
             SECTION("ogg")
             {
                 REQUIRE(stream.open("Audio/doodle_pop.ogg"));
-                REQUIRE(inputSoundFile.openFromStream(stream));
+                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
                 CHECK(inputSoundFile.getSampleCount() == 2'116'992);
                 CHECK(inputSoundFile.getChannelCount() == 2);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -153,7 +139,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
             SECTION("wav")
             {
                 REQUIRE(stream.open("Audio/killdeer.wav"));
-                REQUIRE(inputSoundFile.openFromStream(stream));
+                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
                 CHECK(inputSoundFile.getSampleCount() == 112'941);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 22'050);
@@ -166,11 +152,9 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("seek(std::uint64_t)")
     {
-        sf::InputSoundFile inputSoundFile;
-
         SECTION("flac")
         {
-            REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
+            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(22'675));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -178,7 +162,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("mp3")
         {
-            REQUIRE(inputSoundFile.openFromFile("Audio/ding.mp3"));
+            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.mp3").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(22'675));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -186,7 +170,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("ogg")
         {
-            REQUIRE(inputSoundFile.openFromFile("Audio/doodle_pop.ogg"));
+            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/doodle_pop.ogg").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(11'337));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -194,7 +178,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("wav")
         {
-            REQUIRE(inputSoundFile.openFromFile("Audio/killdeer.wav"));
+            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/killdeer.wav").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(45'351));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -203,8 +187,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("seek(Time)")
     {
-        sf::InputSoundFile inputSoundFile;
-        REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
+        auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
         inputSoundFile.seek(sf::milliseconds(100));
         CHECK(inputSoundFile.getSampleCount() == 87'798);
         CHECK(inputSoundFile.getChannelCount() == 1);
@@ -216,20 +199,14 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("read()")
     {
-        sf::InputSoundFile          inputSoundFile;
-        std::array<std::int16_t, 4> samples{};
-
-        SECTION("Unloaded file")
-        {
-            CHECK(inputSoundFile.read(samples.data(), samples.size()) == 0);
-        }
-
-        REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
+        auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
 
         SECTION("Null address")
         {
             CHECK(inputSoundFile.read(nullptr, 10) == 0);
         }
+
+        std::array<std::int16_t, 4> samples{};
 
         SECTION("Zero count")
         {
@@ -240,7 +217,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
         {
             SECTION("flac")
             {
-                REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
+                inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{0, 1, -1, 4});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -249,7 +226,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("mp3")
             {
-                REQUIRE(inputSoundFile.openFromFile("Audio/ding.mp3"));
+                inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.mp3").value();
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{0, -2, 0, 2});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -258,7 +235,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("ogg")
             {
-                REQUIRE(inputSoundFile.openFromFile("Audio/doodle_pop.ogg"));
+                inputSoundFile = sf::InputSoundFile::openFromFile("Audio/doodle_pop.ogg").value();
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{-827, -985, -1168, -1319});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -274,8 +251,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("close()")
     {
-        sf::InputSoundFile inputSoundFile;
-        REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
+        auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
         inputSoundFile.close();
         CHECK(inputSoundFile.getSampleCount() == 0);
         CHECK(inputSoundFile.getChannelCount() == 0);

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -37,7 +37,6 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
     SECTION("Construction")
     {
         const sf::Music music;
-        CHECK(music.getDuration() == sf::Time::Zero);
         const auto [offset, length] = music.getLoopPoints();
         CHECK(offset == sf::Time::Zero);
         CHECK(length == sf::Time::Zero);
@@ -55,7 +54,6 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         SECTION("Invalid file")
         {
             REQUIRE(!music.openFromFile("does/not/exist.wav"));
-            CHECK(music.getDuration() == sf::Time::Zero);
             const auto [offset, length] = music.getLoopPoints();
             CHECK(offset == sf::Time::Zero);
             CHECK(length == sf::Time::Zero);
@@ -89,7 +87,6 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         SECTION("Invalid buffer")
         {
             REQUIRE(!music.openFromMemory(memory.data(), memory.size()));
-            CHECK(music.getDuration() == sf::Time::Zero);
             const auto [offset, length] = music.getLoopPoints();
             CHECK(offset == sf::Time::Zero);
             CHECK(length == sf::Time::Zero);
@@ -124,7 +121,6 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         SECTION("Invalid stream")
         {
             CHECK(!music.openFromStream(stream));
-            CHECK(music.getDuration() == sf::Time::Zero);
             const auto [offset, length] = music.getLoopPoints();
             CHECK(offset == sf::Time::Zero);
             CHECK(length == sf::Time::Zero);
@@ -178,32 +174,15 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
     SECTION("setLoopPoints()")
     {
         sf::Music music;
-
-        SECTION("No file")
-        {
-            music.setLoopPoints({sf::Time::Zero, sf::Time::Zero});
-            const auto [offset, length] = music.getLoopPoints();
-            CHECK(offset == sf::Time::Zero);
-            CHECK(length == sf::Time::Zero);
-            CHECK(music.getChannelCount() == 0);
-            CHECK(music.getSampleRate() == 0);
-            CHECK(music.getStatus() == sf::Music::Status::Stopped);
-            CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
-        }
-
-        SECTION("Loaded file")
-        {
-            REQUIRE(music.openFromFile("Audio/killdeer.wav"));
-            music.setLoopPoints({sf::seconds(1), sf::seconds(2)});
-            const auto [offset, length] = music.getLoopPoints();
-            CHECK(offset == sf::seconds(1));
-            CHECK(length == sf::seconds(2));
-            CHECK(music.getChannelCount() == 1);
-            CHECK(music.getSampleRate() == 22050);
-            CHECK(music.getStatus() == sf::Music::Status::Stopped);
-            CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
-        }
+        REQUIRE(music.openFromFile("Audio/killdeer.wav"));
+        music.setLoopPoints({sf::seconds(1), sf::seconds(2)});
+        const auto [offset, length] = music.getLoopPoints();
+        CHECK(offset == sf::seconds(1));
+        CHECK(length == sf::seconds(2));
+        CHECK(music.getChannelCount() == 1);
+        CHECK(music.getSampleRate() == 22050);
+        CHECK(music.getStatus() == sf::Music::Status::Stopped);
+        CHECK(music.getPlayingOffset() == sf::Time::Zero);
+        CHECK(!music.getLoop());
     }
 }

--- a/test/Audio/OutputSoundFile.test.cpp
+++ b/test/Audio/OutputSoundFile.test.cpp
@@ -2,6 +2,7 @@
 
 #include <type_traits>
 
+static_assert(!std::is_default_constructible_v<sf::OutputSoundFile>);
 static_assert(!std::is_copy_constructible_v<sf::OutputSoundFile>);
 static_assert(!std::is_copy_assignable_v<sf::OutputSoundFile>);
 static_assert(std::is_nothrow_move_constructible_v<sf::OutputSoundFile>);

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -8,7 +8,6 @@
 int main()
 {
     // Audio
-    [[maybe_unused]] const sf::InputSoundFile      inputSoundFile;
     [[maybe_unused]] const sf::SoundBufferRecorder soundBufferRecorder;
     [[maybe_unused]] const sf::Music               music;
 


### PR DESCRIPTION
## Description

The one place this got a little messy was `sf::Music`. Its default constructor requires all data members to also be default constructible so I had to make `m_file` optional. In the future this complication should go away once we remove `sf::Music` default constructor. I added asserts to ensure we don't try to dereference a null optional.