### PR TITLE
Simplify implementations of types without an empty state

### DIFF
--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -38,6 +38,7 @@
 #include <ostream>
 #include <utility>
 
+#include <cassert>
 #include <cstdint>
 
 
@@ -197,7 +198,9 @@ std::uint64_t InputSoundFile::getSampleOffset() const
 ////////////////////////////////////////////////////////////
 void InputSoundFile::seek(std::uint64_t sampleOffset)
 {
-    if (m_reader && !m_channelMap.empty())
+    assert(m_reader);
+
+    if (!m_channelMap.empty())
     {
         // The reader handles an overrun gracefully, but we
         // pre-check to keep our known position consistent
@@ -217,8 +220,10 @@ void InputSoundFile::seek(Time timeOffset)
 ////////////////////////////////////////////////////////////
 std::uint64_t InputSoundFile::read(std::int16_t* samples, std::uint64_t maxCount)
 {
+    assert(m_reader);
+
     std::uint64_t readSamples = 0;
-    if (m_reader && samples && maxCount)
+    if (samples && maxCount)
         readSamples = m_reader->read(samples, maxCount);
     m_sampleOffset += readSamples;
     return readSamples;

--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -29,6 +29,8 @@
 #include <SFML/Audio/SoundFileFactory.hpp>
 #include <SFML/Audio/SoundFileWriter.hpp>
 
+#include <cassert>
+
 
 namespace sf
 {
@@ -57,7 +59,9 @@ std::optional<OutputSoundFile> OutputSoundFile::openFromFile(
 ////////////////////////////////////////////////////////////
 void OutputSoundFile::write(const std::int16_t* samples, std::uint64_t count)
 {
-    if (m_writer && samples && count)
+    assert(m_writer);
+
+    if (samples && count)
         m_writer->write(samples, count);
 }
 


### PR DESCRIPTION
## Description

Now that these types have no default empty state, we can make assumptions about certain data members which allow us to skip doing certain checks.

I discovered this while iterating on #3032. It was something I overlooked in previous PRs.