### PR TITLE
Fix geometry shader example

### DIFF
--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -277,10 +277,16 @@ public:
         if (!m_logoTexture.loadFromFile("resources/logo.png"))
             return false;
 
-        m_shader.setUniform("texture", sf::Shader::CurrentTexture);
+        // Load the shader
+        m_shader = sf::Shader::loadFromFile("resources/billboard.vert",
+                                            "resources/billboard.geom",
+                                            "resources/billboard.frag");
+        if (!m_shader)
+            return false;
+        m_shader->setUniform("texture", sf::Shader::CurrentTexture);
 
         // Set the render resolution (used for proper scaling)
-        m_shader.setUniform("resolution", sf::Vector2f(800, 600));
+        m_shader->setUniform("resolution", sf::Vector2f(800, 600));
 
         return true;
     }
@@ -298,13 +304,13 @@ public:
         const float size = 25 + std::abs(y) * 50;
 
         // Update the shader parameter
-        m_shader.setUniform("size", sf::Vector2f(size, size));
+        m_shader->setUniform("size", sf::Vector2f(size, size));
     }
 
     void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
     {
         // Prepare the render state
-        states.shader    = &m_shader;
+        states.shader    = &*m_shader;
         states.texture   = &m_logoTexture;
         states.transform = m_transform;
 
@@ -313,11 +319,10 @@ public:
     }
 
 private:
-    sf::Texture   m_logoTexture;
-    sf::Transform m_transform;
-    sf::Shader    m_shader{
-        sf::Shader::loadFromFile("resources/billboard.vert", "resources/billboard.geom", "resources/billboard.frag").value()};
-    sf::VertexArray m_pointCloud;
+    sf::Texture               m_logoTexture;
+    sf::Transform             m_transform;
+    std::optional<sf::Shader> m_shader;
+    sf::VertexArray           m_pointCloud;
 };
 
 


### PR DESCRIPTION
##Description

This geometry shader is optional since it may be skipped on hardware where geometry shaders are not supported. The way I rewrote it in 7234fc1 resulted in the shader still being attempted to be loaded even when geometry shaders were not supported leading to the whole program crashing.

My bad.