### PR TITLE
Replace `const char*` with `std::string_view`

### DIFF
--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -34,6 +34,7 @@
 #include <SFML/System/Vector2.hpp>
 
 #include <memory>
+#include <string_view>
 
 #include <cstdint>
 
@@ -126,7 +127,7 @@ public:
     /// \return True if available, false if unavailable
     ///
     ////////////////////////////////////////////////////////////
-    static bool isExtensionAvailable(const char* name);
+    static bool isExtensionAvailable(std::string_view name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the address of an OpenGL function

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -126,7 +126,7 @@ std::uint64_t Context::getActiveContextId()
 
 
 ////////////////////////////////////////////////////////////
-bool Context::isExtensionAvailable(const char* name)
+bool Context::isExtensionAvailable(std::string_view name)
 {
     return priv::GlContext::isExtensionAvailable(name);
 }

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -665,7 +665,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, co
 
 
 ////////////////////////////////////////////////////////////
-bool GlContext::isExtensionAvailable(const char* name)
+bool GlContext::isExtensionAvailable(std::string_view name)
 {
     // If this function is called before any context is available,
     // the shared context will be created for the duration of this call

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -138,7 +138,7 @@ public:
     /// \return True if available, false if unavailable
     ///
     ////////////////////////////////////////////////////////////
-    static bool isExtensionAvailable(const char* name);
+    static bool isExtensionAvailable(std::string_view name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the address of an OpenGL function


### PR DESCRIPTION
## Description

Similar to #3039 but much simpler. This string is used to search a `std::vector<std::string>` inside `sf::priv::GlContext::SharedContext`.