### PR TITLE
Fix missing include of <algorithm>

### DIFF
--- a/src/SFML/Window/macOS/JoystickImpl.cpp
+++ b/src/SFML/Window/macOS/JoystickImpl.cpp
@@ -33,6 +33,7 @@
 
 #include <SFML/System/Err.hpp>
 
+#include <algorithm>
 #include <ostream>
 
 

--- a/src/SFML/Window/macOS/SFOpenGLView+mouse.mm
+++ b/src/SFML/Window/macOS/SFOpenGLView+mouse.mm
@@ -30,6 +30,8 @@
 #import <SFML/Window/macOS/SFOpenGLView.h>
 #include <SFML/Window/macOS/WindowImplCocoa.hpp>
 
+#include <algorithm>
+
 #include <cmath>
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [x] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->
I found that some macOS specific sources are missing dependency includes to `<algorithm>`.

This makes it unable to build SFML on C++23 using Apple Clang 15, shown on GitHub actions run below.
[Run 1](https://github.com/copyrat90/cmake-sfml-project/actions/runs/9218346641/job/25361730111#step:5:1)
[Run 2](https://github.com/copyrat90/cmake-sfml-project/actions/runs/9218419416/job/25361928099#step:5:1)

This commit adds the missing includes to `<algorithm>` to fix this.
[Run 3 (fixed)](https://github.com/copyrat90/cmake-sfml-project/actions/runs/9218449250/job/25362008003#step:5:1)

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Try to build SFML on macOS with Apple Clang 15 with C++23