### PR TITLE
Use `std::` namespace

### DIFF
--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -166,7 +166,7 @@ String::String(const char* ansiString, const std::locale& locale)
 {
     if (ansiString)
     {
-        const std::size_t length = strlen(ansiString);
+        const std::size_t length = std::strlen(ansiString);
         if (length > 0)
         {
             m_string.reserve(length + 1);


### PR DESCRIPTION
## Description

Found another use of a C standard library function instead of its C++ equivalent. One day when we can use `import std;` this will pay off because `import std;` does not include any C standard library functions and thus calling `strlen` would be a compiler error.