### PR TITLE
Close the clipboard if we fail to empty it

### DIFF
--- a/src/SFML/System/Unix/ThreadImpl.cpp
+++ b/src/SFML/System/Unix/ThreadImpl.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Unix/ThreadImpl.hpp>
+#include <SFML/System/Err.hpp>
 #include <SFML/System/Thread.hpp>
 #include <iostream>
 #include <cassert>
@@ -42,7 +43,7 @@ m_isActive(true)
     m_isActive = pthread_create(&m_thread, NULL, &ThreadImpl::entryPoint, owner) == 0;
 
     if (!m_isActive)
-        std::cerr << "Failed to create thread" << std::endl;
+        err() << "Failed to create thread" << std::endl;
 }
 
 

--- a/src/SFML/Window/Win32/ClipboardImpl.cpp
+++ b/src/SFML/Window/Win32/ClipboardImpl.cpp
@@ -26,6 +26,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Win32/ClipboardImpl.hpp>
+#include <SFML/System/Err.hpp>
 #include <SFML/System/String.hpp>
 #include <iostream>
 #include <windows.h>
@@ -42,13 +43,13 @@ String ClipboardImpl::getString()
 
     if (!IsClipboardFormatAvailable(CF_UNICODETEXT))
     {
-        std::cerr << "Failed to get the clipboard data in Unicode format." << std::endl;
+        err() << "Failed to get the clipboard data in Unicode format." << std::endl;
         return text;
     }
 
     if (!OpenClipboard(NULL))
     {
-        std::cerr << "Failed to open the Win32 clipboard." << std::endl;
+        err() << "Failed to open the Win32 clipboard." << std::endl;
         return text;
     }
 
@@ -56,7 +57,7 @@ String ClipboardImpl::getString()
 
     if (!clipboard_handle)
     {
-        std::cerr << "Failed to get Win32 handle for clipboard content." << std::endl;
+        err() << "Failed to get Win32 handle for clipboard content." << std::endl;
         CloseClipboard();
         return text;
     }
@@ -74,13 +75,13 @@ void ClipboardImpl::setString(const String& text)
 {
     if (!OpenClipboard(NULL))
     {
-        std::cerr << "Failed to open the Win32 clipboard." << std::endl;
+        err() << "Failed to open the Win32 clipboard." << std::endl;
         return;
     }
 
     if (!EmptyClipboard())
     {
-        std::cerr << "Failed to empty the Win32 clipboard." << std::endl;
+        err() << "Failed to empty the Win32 clipboard." << std::endl;
         CloseClipboard();
         return;
     }

--- a/src/SFML/Window/Win32/ClipboardImpl.cpp
+++ b/src/SFML/Window/Win32/ClipboardImpl.cpp
@@ -31,6 +31,21 @@
 #include <iostream>
 #include <windows.h>
 
+namespace
+{
+    std::string getErrorString(DWORD error)
+    {
+        PTCHAR buffer;
+
+        if (FormatMessage(FORMAT_MESSAGE_MAX_WIDTH_MASK | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, error, 0, reinterpret_cast<PTCHAR>(&buffer), 0, NULL) == 0)
+            return "Unknown error.";
+
+        sf::String message = buffer;
+        LocalFree(buffer);
+        return message.toAnsiString();
+    }
+}
+
 
 namespace sf
 {
@@ -43,13 +58,13 @@ String ClipboardImpl::getString()
 
     if (!IsClipboardFormatAvailable(CF_UNICODETEXT))
     {
-        err() << "Failed to get the clipboard data in Unicode format." << std::endl;
+        err() << "Failed to get the clipboard data in Unicode format: " << getErrorString(GetLastError()) << std::endl;
         return text;
     }
 
     if (!OpenClipboard(NULL))
     {
-        err() << "Failed to open the Win32 clipboard." << std::endl;
+        err() << "Failed to open the Win32 clipboard: " << getErrorString(GetLastError()) << std::endl;
         return text;
     }
 
@@ -57,7 +72,7 @@ String ClipboardImpl::getString()
 
     if (!clipboard_handle)
     {
-        err() << "Failed to get Win32 handle for clipboard content." << std::endl;
+        err() << "Failed to get Win32 handle for clipboard content: " << getErrorString(GetLastError()) << std::endl;
         CloseClipboard();
         return text;
     }
@@ -75,13 +90,13 @@ void ClipboardImpl::setString(const String& text)
 {
     if (!OpenClipboard(NULL))
     {
-        err() << "Failed to open the Win32 clipboard." << std::endl;
+        err() << "Failed to open the Win32 clipboard: " << getErrorString(GetLastError()) << std::endl;
         return;
     }
 
     if (!EmptyClipboard())
     {
-        err() << "Failed to empty the Win32 clipboard." << std::endl;
+        err() << "Failed to empty the Win32 clipboard: " << getErrorString(GetLastError()) << std::endl;
         CloseClipboard();
         return;
     }

--- a/src/SFML/Window/Win32/ClipboardImpl.cpp
+++ b/src/SFML/Window/Win32/ClipboardImpl.cpp
@@ -81,6 +81,7 @@ void ClipboardImpl::setString(const String& text)
     if (!EmptyClipboard())
     {
         std::cerr << "Failed to empty the Win32 clipboard." << std::endl;
+        CloseClipboard();
         return;
     }
 


### PR DESCRIPTION
## Description

Noticed that we're not closing the clipboard on Windows if `EmptyClipboard()` fails.

Which then made me notice that on `2.6.x` we still have some direct calls to `std::cerr` instead of `sf::err()`.

And finally made sure, we're returning the Windows error from `GetLastError()`, when any of the clipboard functions fail.

## How to test this PR?

Can't exactly force `EmptyClipboard()` to fail, but `OpenClipboard()` quite regularly fails, when running the tests locally. Something like:

```cpp
#include <SFML/Window/Clipboard.hpp>
#include <SFML/System/String.hpp>

#include <iostream>

int main()
{
    const auto currentClipboard = sf::Clipboard::getString();

    sf::Clipboard::setString("Welcome to SFML!");
    if (sf::Clipboard::getString() == "Welcome to SFML!")
    {
        std::cout << "Success!\n";
    }

    sf::Clipboard::setString(currentClipboard);
    if (sf::Clipboard::getString() == currentClipboard)
    {
        std::cout << "Success!\n";
    }
}
```
