### PR TITLE
Assume XrandR version >=1.3

### DIFF
--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -284,26 +284,21 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Check if a valid version of XRandR extension is present
     ///
-    /// \param xRandRMajor XRandR major version
-    /// \param xRandRMinor XRandR minor version
-    ///
     /// \return True if a valid XRandR version found, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool checkXRandR(int& xRandRMajor, int& xRandRMinor);
+    bool checkXRandR();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the RROutput of the primary monitor
     ///
     /// \param rootWindow the root window
     /// \param res screen resources
-    /// \param xRandRMajor XRandR major version
-    /// \param xRandRMinor XRandR minor version
     ///
     /// \return RROutput of the primary monitor
     ///
     ////////////////////////////////////////////////////////////
-    RROutput getOutputPrimary(::Window& rootWindow, XRRScreenResources* res, int xRandRMajor, int xRandRMinor);
+    RROutput getOutputPrimary(::Window& rootWindow, XRRScreenResources* res);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get coordinates of the primary monitor


### PR DESCRIPTION
## Description

As far as I can tell XrandR 1.3 was released in ~2009. It's safe to assume anyone using SFML 3 or newer will have this version installed. 

https://packages.ubuntu.com/search?keywords=libxrandr-dev

The oldest ubuntu version we target in SFML 3 is Ubuntu 22 and even Ubuntu 20 shipped with Xrandr 1.5.