### PR TITLE
Use more type safe interfaces

### DIFF
--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -142,8 +142,8 @@ String ClipboardImpl::getStringImpl()
 
     const Clock clock;
 
-    // Wait for a response for up to 1000ms
-    while (!m_requestResponded && (clock.getElapsedTime().asMilliseconds() < 1000))
+    // Wait for a response for up to 1 second
+    while (!m_requestResponded && (clock.getElapsedTime() < sf::seconds(1)))
         processEvents();
 
     // If no response was received within the time period, clear our clipboard contents


### PR DESCRIPTION
## Description

`sf::Time::asMicroseconds`, `sf::Time::asMilliseconds`, and `sf::Time::asSeconds` are functions that break out of the type safety of `sf::Time`. Once you call these functions you're dealing with weakly typed numbers that can easily be misused.