### PR TITLE
Restore Shader and Island examples back to equivalent pre-API-change functionality

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -97,6 +97,7 @@ int main()
     sf::Text                  hudText(font);
     sf::Text                  statusText(font);
     std::optional<sf::Shader> terrainShader;
+    sf::RenderStates          terrainStates;
     sf::VertexBuffer          terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Usage::Static);
 
     // Set up our text drawables
@@ -145,6 +146,9 @@ int main()
         generateTerrain(terrainStagingBuffer.data());
 
         statusText.setString("Generating Terrain...");
+
+        // Set up the render states
+        terrainStates = sf::RenderStates(&*terrainShader);
     }
 
     // Center the status text
@@ -233,7 +237,7 @@ int main()
                     }
 
                     terrainShader->setUniform("lightFactor", lightFactor);
-                    window.draw(terrain, sf::RenderStates(&*terrainShader));
+                    window.draw(terrain, terrainStates);
                 }
             }
 

--- a/examples/shader/Effect.hpp
+++ b/examples/shader/Effect.hpp
@@ -46,6 +46,8 @@ public:
         }
         else
         {
+            // Clear the target to grey to make sure the text is always readable
+            target.clear(sf::Color(50, 50, 50));
             sf::Text error(getFont(), "Shader not\nsupported");
             error.setPosition({320.f, 200.f});
             error.setCharacterSize(36);


### PR DESCRIPTION
Title.

It isn't very "friendly" when examples `abort` due to `bad_optional_access` being thrown. The mechanism that kicks in when shaders aren't supported already exists, it just has to be triggered like it was before.

Test on any system that doesn't support shaders (OpenGL ES systems basically).