### PR TITLE
Perform sanity checks on OpenGL extensions to make sure the required entry points are actually available

### DIFF
--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -41,28 +41,43 @@
 // All functionality beyond that is optional
 // and has to be checked for prior to use
 
+namespace sf::priv
+{
+// Stand-ins for desktop OpenGL feature-check flags
+// NOLINTBEGIN(readability-identifier-naming)
+inline int SF_GL_OES_multitexture         = 1;
+inline int SF_GL_OES_vertex_buffer_object = 1;
+// NOLINTEND(readability-identifier-naming)
+} // namespace sf::priv
+
 // Core since 1.0
-#define GLEXT_multitexture           true
-#define GLEXT_texture_edge_clamp     true
-#define GLEXT_EXT_texture_edge_clamp true
-#define GLEXT_glClientActiveTexture  glClientActiveTexture
-#define GLEXT_glActiveTexture        glActiveTexture
-#define GLEXT_GL_TEXTURE0            GL_TEXTURE0
-#define GLEXT_GL_CLAMP               GL_CLAMP_TO_EDGE
-#define GLEXT_GL_CLAMP_TO_EDGE       GL_CLAMP_TO_EDGE
+#define GLEXT_multitexture          ::sf::priv::SF_GL_OES_multitexture
+#define GLEXT_glClientActiveTexture glClientActiveTexture
+#define GLEXT_glActiveTexture       glActiveTexture
+#define GLEXT_GL_TEXTURE0           GL_TEXTURE0
+
+#define GLEXT_multitexture_dependencies ::sf::priv::SF_GL_OES_multitexture, glClientActiveTexture, glActiveTexture
+
+// Core since 1.0
+#define GLEXT_texture_edge_clamp true
+#define GLEXT_GL_CLAMP           GL_CLAMP_TO_EDGE
+#define GLEXT_GL_CLAMP_TO_EDGE   GL_CLAMP_TO_EDGE
 
 // Core since 1.1
 // 1.1 does not support GL_STREAM_DRAW so we just define it to GL_DYNAMIC_DRAW
-#define GLEXT_vertex_buffer_object true
-#define GLEXT_GL_ARRAY_BUFFER      GL_ARRAY_BUFFER
-#define GLEXT_GL_DYNAMIC_DRAW      GL_DYNAMIC_DRAW
-#define GLEXT_GL_STATIC_DRAW       GL_STATIC_DRAW
-#define GLEXT_GL_STREAM_DRAW       GL_DYNAMIC_DRAW
+#define GLEXT_vertex_buffer_object ::sf::priv::SF_GL_OES_vertex_buffer_object
 #define GLEXT_glBindBuffer         glBindBuffer
 #define GLEXT_glBufferData         glBufferData
 #define GLEXT_glBufferSubData      glBufferSubData
 #define GLEXT_glDeleteBuffers      glDeleteBuffers
 #define GLEXT_glGenBuffers         glGenBuffers
+#define GLEXT_GL_ARRAY_BUFFER      GL_ARRAY_BUFFER
+#define GLEXT_GL_DYNAMIC_DRAW      GL_DYNAMIC_DRAW
+#define GLEXT_GL_STATIC_DRAW       GL_STATIC_DRAW
+#define GLEXT_GL_STREAM_DRAW       GL_DYNAMIC_DRAW
+
+#define GLEXT_vertex_buffer_object_dependencies \
+    ::sf::priv::SF_GL_OES_vertex_buffer_object, glBindBuffer, glBufferData, glBufferSubData, glDeleteBuffers, glGenBuffers
 
 // The following extensions are listed chronologically
 // Extension macro first, followed by tokens then
@@ -71,11 +86,15 @@
 // The following extensions are required.
 
 // Core since 2.0 - OES_blend_subtract
+// glBlendEquation is provided by both OES_blend_subtract and EXT_blend_minmax
+// If, for whatever reason, one entry point couldn't be loaded, try the other
 #define GLEXT_blend_subtract           SF_GLAD_GL_OES_blend_subtract
-#define GLEXT_glBlendEquation          glBlendEquationOES
+#define GLEXT_glBlendEquation          (glBlendEquationOES ? glBlendEquationOES : glBlendEquationEXT)
 #define GLEXT_GL_FUNC_ADD              GL_FUNC_ADD_OES
 #define GLEXT_GL_FUNC_SUBTRACT         GL_FUNC_SUBTRACT_OES
 #define GLEXT_GL_FUNC_REVERSE_SUBTRACT GL_FUNC_REVERSE_SUBTRACT_OES
+
+#define GLEXT_OES_blend_subtract_dependencies SF_GLAD_GL_OES_blend_subtract, glBlendEquationOES
 
 // The following extensions are optional.
 
@@ -83,9 +102,13 @@
 #define GLEXT_blend_func_separate SF_GLAD_GL_OES_blend_func_separate
 #define GLEXT_glBlendFuncSeparate glBlendFuncSeparateOES
 
+#define GLEXT_blend_func_separate_dependencies SF_GLAD_GL_OES_blend_func_separate, glBlendFuncSeparateOES
+
 // Core since 2.0 - OES_blend_equation_separate
 #define GLEXT_blend_equation_separate SF_GLAD_GL_OES_blend_equation_separate
 #define GLEXT_glBlendEquationSeparate glBlendEquationSeparateOES
+
+#define GLEXT_blend_equation_separate_dependencies SF_GLAD_GL_OES_blend_equation_separate, glBlendEquationSeparateOES
 
 // Core since 2.0 - OES_texture_npot
 #define GLEXT_texture_non_power_of_two false
@@ -113,6 +136,11 @@
 #define GLEXT_GL_FRAMEBUFFER_BINDING           GL_FRAMEBUFFER_BINDING_OES
 #define GLEXT_GL_INVALID_FRAMEBUFFER_OPERATION GL_INVALID_FRAMEBUFFER_OPERATION_OES
 #define GLEXT_GL_STENCIL_ATTACHMENT            GL_STENCIL_ATTACHMENT_OES
+
+#define GLEXT_framebuffer_object_dependencies                                                                  \
+    SF_GLAD_GL_OES_framebuffer_object, glBindRenderbufferOES, glDeleteRenderbuffersOES, glGenRenderbuffersOES, \
+        glRenderbufferStorageOES, glBindFramebufferOES, glDeleteFramebuffersOES, glGenFramebuffersOES,         \
+        glCheckFramebufferStatusOES, glFramebufferTexture2DOES, glFramebufferRenderbufferOES, glGenerateMipmapOES
 
 // Core since 3.0
 #define GLEXT_packed_depth_stencil SF_GLAD_GL_OES_packed_depth_stencil
@@ -146,8 +174,11 @@
 
 // Core since 3.0 - EXT_blend_minmax
 #define GLEXT_blend_minmax SF_GLAD_GL_EXT_blend_minmax
-#define GLEXT_GL_MIN       GL_MIN_EXT
-#define GLEXT_GL_MAX       GL_MAX_EXT
+// glBlendEquation is provided by OES_blend_subtract, see above
+#define GLEXT_GL_MIN GL_MIN_EXT
+#define GLEXT_GL_MAX GL_MAX_EXT
+
+#define GLEXT_EXT_blend_minmax_dependencies SF_GLAD_GL_EXT_blend_minmax, glBlendEquationEXT
 
 #else
 
@@ -156,8 +187,8 @@
 // and has to be checked for prior to use
 
 // Core since 1.1
-#define GLEXT_GL_DEPTH_COMPONENT                  GL_DEPTH_COMPONENT
-#define GLEXT_GL_CLAMP                            GL_CLAMP
+#define GLEXT_GL_DEPTH_COMPONENT GL_DEPTH_COMPONENT
+#define GLEXT_GL_CLAMP           GL_CLAMP
 
 // The following extensions are listed chronologically
 // Extension macro first, followed by tokens then
@@ -166,83 +197,100 @@
 // The following extensions are optional.
 
 // Core since 1.2 - SGIS_texture_edge_clamp / EXT_texture_edge_clamp
-#define GLEXT_texture_edge_clamp                  SF_GLAD_GL_SGIS_texture_edge_clamp
-#define GLEXT_GL_CLAMP_TO_EDGE                    GL_CLAMP_TO_EDGE_SGIS
+#define GLEXT_texture_edge_clamp SF_GLAD_GL_SGIS_texture_edge_clamp
+#define GLEXT_GL_CLAMP_TO_EDGE   GL_CLAMP_TO_EDGE_SGIS
 
 // Core since 1.2 - EXT_blend_minmax
-#define GLEXT_blend_minmax                        SF_GLAD_GL_EXT_blend_minmax
-#define GLEXT_glBlendEquation                     glBlendEquationEXT
-#define GLEXT_GL_FUNC_ADD                         GL_FUNC_ADD_EXT
-#define GLEXT_GL_MIN                              GL_MIN_EXT
-#define GLEXT_GL_MAX                              GL_MAX_EXT
+#define GLEXT_blend_minmax       SF_GLAD_GL_EXT_blend_minmax
+#define GLEXT_glBlendEquation    glBlendEquationEXT
+#define GLEXT_GL_FUNC_ADD        GL_FUNC_ADD_EXT
+#define GLEXT_GL_MIN             GL_MIN_EXT
+#define GLEXT_GL_MAX             GL_MAX_EXT
+
+#define GLEXT_blend_minmax_dependencies SF_GLAD_GL_EXT_blend_minmax, glBlendEquationEXT
 
 // Core since 1.2 - EXT_blend_subtract
-#define GLEXT_blend_subtract                      SF_GLAD_GL_EXT_blend_subtract
-#define GLEXT_GL_FUNC_SUBTRACT                    GL_FUNC_SUBTRACT_EXT
-#define GLEXT_GL_FUNC_REVERSE_SUBTRACT            GL_FUNC_REVERSE_SUBTRACT_EXT
+#define GLEXT_blend_subtract            SF_GLAD_GL_EXT_blend_subtract
+#define GLEXT_GL_FUNC_SUBTRACT          GL_FUNC_SUBTRACT_EXT
+#define GLEXT_GL_FUNC_REVERSE_SUBTRACT  GL_FUNC_REVERSE_SUBTRACT_EXT
 
 // Core since 1.3 - ARB_multitexture
-#define GLEXT_multitexture                        SF_GLAD_GL_ARB_multitexture
-#define GLEXT_glClientActiveTexture               glClientActiveTextureARB
-#define GLEXT_glActiveTexture                     glActiveTextureARB
-#define GLEXT_GL_TEXTURE0                         GL_TEXTURE0_ARB
+#define GLEXT_multitexture              SF_GLAD_GL_ARB_multitexture
+#define GLEXT_glClientActiveTexture     glClientActiveTextureARB
+#define GLEXT_glActiveTexture           glActiveTextureARB
+#define GLEXT_GL_TEXTURE0               GL_TEXTURE0_ARB
+
+#define GLEXT_multitexture_dependencies SF_GLAD_GL_ARB_multitexture, glClientActiveTextureARB, glActiveTextureARB
 
 // Core since 1.4 - EXT_blend_func_separate
-#define GLEXT_blend_func_separate                 SF_GLAD_GL_EXT_blend_func_separate
-#define GLEXT_glBlendFuncSeparate                 glBlendFuncSeparateEXT
+#define GLEXT_blend_func_separate       SF_GLAD_GL_EXT_blend_func_separate
+#define GLEXT_glBlendFuncSeparate       glBlendFuncSeparateEXT
+
+#define GLEXT_blend_func_separate_dependencies SF_GLAD_GL_EXT_blend_func_separate, glBlendFuncSeparateEXT
 
 // Core since 1.5 - ARB_vertex_buffer_object
-#define GLEXT_vertex_buffer_object                SF_GLAD_GL_ARB_vertex_buffer_object
-#define GLEXT_GL_ARRAY_BUFFER                     GL_ARRAY_BUFFER_ARB
-#define GLEXT_GL_DYNAMIC_DRAW                     GL_DYNAMIC_DRAW_ARB
-#define GLEXT_GL_READ_ONLY                        GL_READ_ONLY_ARB
-#define GLEXT_GL_STATIC_DRAW                      GL_STATIC_DRAW_ARB
-#define GLEXT_GL_STREAM_DRAW                      GL_STREAM_DRAW_ARB
-#define GLEXT_GL_WRITE_ONLY                       GL_WRITE_ONLY_ARB
-#define GLEXT_glBindBuffer                        glBindBufferARB
-#define GLEXT_glBufferData                        glBufferDataARB
-#define GLEXT_glBufferSubData                     glBufferSubDataARB
-#define GLEXT_glDeleteBuffers                     glDeleteBuffersARB
-#define GLEXT_glGenBuffers                        glGenBuffersARB
-#define GLEXT_glMapBuffer                         glMapBufferARB
-#define GLEXT_glUnmapBuffer                       glUnmapBufferARB
+#define GLEXT_vertex_buffer_object             SF_GLAD_GL_ARB_vertex_buffer_object
+#define GLEXT_GL_ARRAY_BUFFER                  GL_ARRAY_BUFFER_ARB
+#define GLEXT_GL_DYNAMIC_DRAW                  GL_DYNAMIC_DRAW_ARB
+#define GLEXT_GL_READ_ONLY                     GL_READ_ONLY_ARB
+#define GLEXT_GL_STATIC_DRAW                   GL_STATIC_DRAW_ARB
+#define GLEXT_GL_STREAM_DRAW                   GL_STREAM_DRAW_ARB
+#define GLEXT_GL_WRITE_ONLY                    GL_WRITE_ONLY_ARB
+#define GLEXT_glBindBuffer                     glBindBufferARB
+#define GLEXT_glBufferData                     glBufferDataARB
+#define GLEXT_glBufferSubData                  glBufferSubDataARB
+#define GLEXT_glDeleteBuffers                  glDeleteBuffersARB
+#define GLEXT_glGenBuffers                     glGenBuffersARB
+#define GLEXT_glMapBuffer                      glMapBufferARB
+#define GLEXT_glUnmapBuffer                    glUnmapBufferARB
+
+#define GLEXT_vertex_buffer_object_dependencies                                                                    \
+    SF_GLAD_GL_ARB_vertex_buffer_object, glBindBufferARB, glBufferDataARB, glBufferSubDataARB, glDeleteBuffersARB, \
+        glGenBuffersARB, glMapBufferARB, glUnmapBufferARB
 
 // Core since 2.0 - ARB_shading_language_100
-#define GLEXT_shading_language_100                SF_GLAD_GL_ARB_shading_language_100
+#define GLEXT_shading_language_100     SF_GLAD_GL_ARB_shading_language_100
 
 // Core since 2.0 - ARB_shader_objects
-#define GLEXT_shader_objects                      SF_GLAD_GL_ARB_shader_objects
-#define GLEXT_glDeleteObject                      glDeleteObjectARB
-#define GLEXT_glGetHandle                         glGetHandleARB
-#define GLEXT_glCreateShaderObject                glCreateShaderObjectARB
-#define GLEXT_glShaderSource                      glShaderSourceARB
-#define GLEXT_glCompileShader                     glCompileShaderARB
-#define GLEXT_glCreateProgramObject               glCreateProgramObjectARB
-#define GLEXT_glAttachObject                      glAttachObjectARB
-#define GLEXT_glLinkProgram                       glLinkProgramARB
-#define GLEXT_glUseProgramObject                  glUseProgramObjectARB
-#define GLEXT_glUniform1f                         glUniform1fARB
-#define GLEXT_glUniform2f                         glUniform2fARB
-#define GLEXT_glUniform3f                         glUniform3fARB
-#define GLEXT_glUniform4f                         glUniform4fARB
-#define GLEXT_glUniform1i                         glUniform1iARB
-#define GLEXT_glUniform2i                         glUniform2iARB
-#define GLEXT_glUniform3i                         glUniform3iARB
-#define GLEXT_glUniform4i                         glUniform4iARB
-#define GLEXT_glUniform1fv                        glUniform1fvARB
-#define GLEXT_glUniform2fv                        glUniform2fvARB
-#define GLEXT_glUniform2iv                        glUniform2ivARB
-#define GLEXT_glUniform3fv                        glUniform3fvARB
-#define GLEXT_glUniform4fv                        glUniform4fvARB
-#define GLEXT_glUniformMatrix3fv                  glUniformMatrix3fvARB
-#define GLEXT_glUniformMatrix4fv                  glUniformMatrix4fvARB
-#define GLEXT_glGetObjectParameteriv              glGetObjectParameterivARB
-#define GLEXT_glGetInfoLog                        glGetInfoLogARB
-#define GLEXT_glGetUniformLocation                glGetUniformLocationARB
-#define GLEXT_GL_PROGRAM_OBJECT                   GL_PROGRAM_OBJECT_ARB
-#define GLEXT_GL_OBJECT_COMPILE_STATUS            GL_OBJECT_COMPILE_STATUS_ARB
-#define GLEXT_GL_OBJECT_LINK_STATUS               GL_OBJECT_LINK_STATUS_ARB
-#define GLEXT_GLhandle                            GLhandleARB
+#define GLEXT_shader_objects           SF_GLAD_GL_ARB_shader_objects
+#define GLEXT_glDeleteObject           glDeleteObjectARB
+#define GLEXT_glGetHandle              glGetHandleARB
+#define GLEXT_glCreateShaderObject     glCreateShaderObjectARB
+#define GLEXT_glShaderSource           glShaderSourceARB
+#define GLEXT_glCompileShader          glCompileShaderARB
+#define GLEXT_glCreateProgramObject    glCreateProgramObjectARB
+#define GLEXT_glAttachObject           glAttachObjectARB
+#define GLEXT_glLinkProgram            glLinkProgramARB
+#define GLEXT_glUseProgramObject       glUseProgramObjectARB
+#define GLEXT_glUniform1f              glUniform1fARB
+#define GLEXT_glUniform2f              glUniform2fARB
+#define GLEXT_glUniform3f              glUniform3fARB
+#define GLEXT_glUniform4f              glUniform4fARB
+#define GLEXT_glUniform1i              glUniform1iARB
+#define GLEXT_glUniform2i              glUniform2iARB
+#define GLEXT_glUniform3i              glUniform3iARB
+#define GLEXT_glUniform4i              glUniform4iARB
+#define GLEXT_glUniform1fv             glUniform1fvARB
+#define GLEXT_glUniform2fv             glUniform2fvARB
+#define GLEXT_glUniform2iv             glUniform2ivARB
+#define GLEXT_glUniform3fv             glUniform3fvARB
+#define GLEXT_glUniform4fv             glUniform4fvARB
+#define GLEXT_glUniformMatrix3fv       glUniformMatrix3fvARB
+#define GLEXT_glUniformMatrix4fv       glUniformMatrix4fvARB
+#define GLEXT_glGetObjectParameteriv   glGetObjectParameterivARB
+#define GLEXT_glGetInfoLog             glGetInfoLogARB
+#define GLEXT_glGetUniformLocation     glGetUniformLocationARB
+#define GLEXT_GL_PROGRAM_OBJECT        GL_PROGRAM_OBJECT_ARB
+#define GLEXT_GL_OBJECT_COMPILE_STATUS GL_OBJECT_COMPILE_STATUS_ARB
+#define GLEXT_GL_OBJECT_LINK_STATUS    GL_OBJECT_LINK_STATUS_ARB
+#define GLEXT_GLhandle                 GLhandleARB
+
+#define GLEXT_shader_objects_dependencies                                                                               \
+    SF_GLAD_GL_ARB_shader_objects, glDeleteObjectARB, glGetHandleARB, glCreateShaderObjectARB, glShaderSourceARB,       \
+        glCompileShaderARB, glCreateProgramObjectARB, glAttachObjectARB, glLinkProgramARB, glUseProgramObjectARB,       \
+        glUniform1fARB, glUniform2fARB, glUniform3fARB, glUniform4fARB, glUniform1iARB, glUniform2iARB, glUniform3iARB, \
+        glUniform4iARB, glUniform1fvARB, glUniform2fvARB, glUniform2ivARB, glUniform3fvARB, glUniform4fvARB,            \
+        glUniformMatrix3fvARB, glUniformMatrix4fvARB, glGetObjectParameterivARB, glGetInfoLogARB, glGetUniformLocationARB
 
 // Core since 2.0 - ARB_vertex_shader
 #define GLEXT_vertex_shader                       SF_GLAD_GL_ARB_vertex_shader
@@ -260,59 +308,73 @@
 #define GLEXT_blend_equation_separate             SF_GLAD_GL_EXT_blend_equation_separate
 #define GLEXT_glBlendEquationSeparate             glBlendEquationSeparateEXT
 
+#define GLEXT_blend_equation_separate_dependencies SF_GLAD_GL_EXT_blend_equation_separate, glBlendEquationSeparateEXT
+
 // Core since 2.1 - EXT_texture_sRGB
-#define GLEXT_texture_sRGB                        SF_GLAD_GL_EXT_texture_sRGB
-#define GLEXT_GL_SRGB8_ALPHA8                     GL_SRGB8_ALPHA8_EXT
+#define GLEXT_texture_sRGB                         SF_GLAD_GL_EXT_texture_sRGB
+#define GLEXT_GL_SRGB8_ALPHA8                      GL_SRGB8_ALPHA8_EXT
 
 // Core since 3.0 - EXT_framebuffer_object
-#define GLEXT_framebuffer_object                  SF_GLAD_GL_EXT_framebuffer_object
-#define GLEXT_glBindRenderbuffer                  glBindRenderbufferEXT
-#define GLEXT_glDeleteRenderbuffers               glDeleteRenderbuffersEXT
-#define GLEXT_glGenRenderbuffers                  glGenRenderbuffersEXT
-#define GLEXT_glRenderbufferStorage               glRenderbufferStorageEXT
-#define GLEXT_glBindFramebuffer                   glBindFramebufferEXT
-#define GLEXT_glDeleteFramebuffers                glDeleteFramebuffersEXT
-#define GLEXT_glGenFramebuffers                   glGenFramebuffersEXT
-#define GLEXT_glCheckFramebufferStatus            glCheckFramebufferStatusEXT
-#define GLEXT_glFramebufferTexture2D              glFramebufferTexture2DEXT
-#define GLEXT_glFramebufferRenderbuffer           glFramebufferRenderbufferEXT
-#define GLEXT_glGenerateMipmap                    glGenerateMipmapEXT
-#define GLEXT_GL_FRAMEBUFFER                      GL_FRAMEBUFFER_EXT
-#define GLEXT_GL_RENDERBUFFER                     GL_RENDERBUFFER_EXT
-#define GLEXT_GL_STENCIL_INDEX8                   GL_STENCIL_INDEX8_EXT
-#define GLEXT_GL_COLOR_ATTACHMENT0                GL_COLOR_ATTACHMENT0_EXT
-#define GLEXT_GL_DEPTH_ATTACHMENT                 GL_DEPTH_ATTACHMENT_EXT
-#define GLEXT_GL_FRAMEBUFFER_COMPLETE             GL_FRAMEBUFFER_COMPLETE_EXT
-#define GLEXT_GL_FRAMEBUFFER_BINDING              GL_FRAMEBUFFER_BINDING_EXT
-#define GLEXT_GL_INVALID_FRAMEBUFFER_OPERATION    GL_INVALID_FRAMEBUFFER_OPERATION_EXT
-#define GLEXT_GL_STENCIL_ATTACHMENT               GL_STENCIL_ATTACHMENT_EXT
+#define GLEXT_framebuffer_object                   SF_GLAD_GL_EXT_framebuffer_object
+#define GLEXT_glBindRenderbuffer                   glBindRenderbufferEXT
+#define GLEXT_glDeleteRenderbuffers                glDeleteRenderbuffersEXT
+#define GLEXT_glGenRenderbuffers                   glGenRenderbuffersEXT
+#define GLEXT_glRenderbufferStorage                glRenderbufferStorageEXT
+#define GLEXT_glBindFramebuffer                    glBindFramebufferEXT
+#define GLEXT_glDeleteFramebuffers                 glDeleteFramebuffersEXT
+#define GLEXT_glGenFramebuffers                    glGenFramebuffersEXT
+#define GLEXT_glCheckFramebufferStatus             glCheckFramebufferStatusEXT
+#define GLEXT_glFramebufferTexture2D               glFramebufferTexture2DEXT
+#define GLEXT_glFramebufferRenderbuffer            glFramebufferRenderbufferEXT
+#define GLEXT_glGenerateMipmap                     glGenerateMipmapEXT
+#define GLEXT_GL_FRAMEBUFFER                       GL_FRAMEBUFFER_EXT
+#define GLEXT_GL_RENDERBUFFER                      GL_RENDERBUFFER_EXT
+#define GLEXT_GL_STENCIL_INDEX8                    GL_STENCIL_INDEX8_EXT
+#define GLEXT_GL_COLOR_ATTACHMENT0                 GL_COLOR_ATTACHMENT0_EXT
+#define GLEXT_GL_DEPTH_ATTACHMENT                  GL_DEPTH_ATTACHMENT_EXT
+#define GLEXT_GL_FRAMEBUFFER_COMPLETE              GL_FRAMEBUFFER_COMPLETE_EXT
+#define GLEXT_GL_FRAMEBUFFER_BINDING               GL_FRAMEBUFFER_BINDING_EXT
+#define GLEXT_GL_INVALID_FRAMEBUFFER_OPERATION     GL_INVALID_FRAMEBUFFER_OPERATION_EXT
+#define GLEXT_GL_STENCIL_ATTACHMENT                GL_STENCIL_ATTACHMENT_EXT
+
+#define GLEXT_framebuffer_object_dependencies                                                                  \
+    SF_GLAD_GL_EXT_framebuffer_object, glBindRenderbufferEXT, glDeleteRenderbuffersEXT, glGenRenderbuffersEXT, \
+        glRenderbufferStorageEXT, glBindFramebufferEXT, glDeleteFramebuffersEXT, glGenFramebuffersEXT,         \
+        glCheckFramebufferStatusEXT, glFramebufferTexture2DEXT, glFramebufferRenderbufferEXT, glGenerateMipmapEXT
 
 // Core since 3.0 - EXT_packed_depth_stencil
-#define GLEXT_packed_depth_stencil                SF_GLAD_GL_EXT_packed_depth_stencil
-#define GLEXT_GL_DEPTH24_STENCIL8                 GL_DEPTH24_STENCIL8_EXT
+#define GLEXT_packed_depth_stencil        SF_GLAD_GL_EXT_packed_depth_stencil
+#define GLEXT_GL_DEPTH24_STENCIL8         GL_DEPTH24_STENCIL8_EXT
 
 // Core since 3.0 - EXT_framebuffer_blit
-#define GLEXT_framebuffer_blit                    SF_GLAD_GL_EXT_framebuffer_blit
-#define GLEXT_glBlitFramebuffer                   glBlitFramebufferEXT
-#define GLEXT_GL_READ_FRAMEBUFFER                 GL_READ_FRAMEBUFFER_EXT
-#define GLEXT_GL_DRAW_FRAMEBUFFER                 GL_DRAW_FRAMEBUFFER_EXT
-#define GLEXT_GL_DRAW_FRAMEBUFFER_BINDING         GL_DRAW_FRAMEBUFFER_BINDING_EXT
-#define GLEXT_GL_READ_FRAMEBUFFER_BINDING         GL_READ_FRAMEBUFFER_BINDING_EXT
+#define GLEXT_framebuffer_blit            SF_GLAD_GL_EXT_framebuffer_blit
+#define GLEXT_glBlitFramebuffer           glBlitFramebufferEXT
+#define GLEXT_GL_READ_FRAMEBUFFER         GL_READ_FRAMEBUFFER_EXT
+#define GLEXT_GL_DRAW_FRAMEBUFFER         GL_DRAW_FRAMEBUFFER_EXT
+#define GLEXT_GL_DRAW_FRAMEBUFFER_BINDING GL_DRAW_FRAMEBUFFER_BINDING_EXT
+#define GLEXT_GL_READ_FRAMEBUFFER_BINDING GL_READ_FRAMEBUFFER_BINDING_EXT
+
+#define GLEXT_framebuffer_blit_dependencies    SF_GLAD_GL_EXT_framebuffer_blit, glBlitFramebufferEXT
 
 // Core since 3.0 - EXT_framebuffer_multisample
-#define GLEXT_framebuffer_multisample             SF_GLAD_GL_EXT_framebuffer_multisample
-#define GLEXT_glRenderbufferStorageMultisample    glRenderbufferStorageMultisampleEXT
-#define GLEXT_GL_MAX_SAMPLES                      GL_MAX_SAMPLES_EXT
+#define GLEXT_framebuffer_multisample          SF_GLAD_GL_EXT_framebuffer_multisample
+#define GLEXT_glRenderbufferStorageMultisample glRenderbufferStorageMultisampleEXT
+#define GLEXT_GL_MAX_SAMPLES                   GL_MAX_SAMPLES_EXT
+
+#define GLEXT_framebuffer_multisample_dependencies \
+    SF_GLAD_GL_EXT_framebuffer_multisample, glRenderbufferStorageMultisampleEXT
 
 // Core since 3.1 - ARB_copy_buffer
-#define GLEXT_copy_buffer                         SF_GLAD_GL_ARB_copy_buffer
-#define GLEXT_GL_COPY_READ_BUFFER                 GL_COPY_READ_BUFFER
-#define GLEXT_GL_COPY_WRITE_BUFFER                GL_COPY_WRITE_BUFFER
-#define GLEXT_glCopyBufferSubData                 glCopyBufferSubData
+#define GLEXT_copy_buffer          SF_GLAD_GL_ARB_copy_buffer
+#define GLEXT_GL_COPY_READ_BUFFER  GL_COPY_READ_BUFFER
+#define GLEXT_GL_COPY_WRITE_BUFFER GL_COPY_WRITE_BUFFER
+#define GLEXT_glCopyBufferSubData  glCopyBufferSubData
+
+#define GLEXT_copy_buffer_dependencies SF_GLAD_GL_ARB_copy_buffer, glCopyBufferSubData
 
 // Core since 3.2 - ARB_geometry_shader4
-#define GLEXT_geometry_shader4                    SF_GLAD_GL_ARB_geometry_shader4
-#define GLEXT_GL_GEOMETRY_SHADER                  GL_GEOMETRY_SHADER_ARB
+#define GLEXT_geometry_shader4         SF_GLAD_GL_ARB_geometry_shader4
+#define GLEXT_GL_GEOMETRY_SHADER       GL_GEOMETRY_SHADER_ARB
 
 #endif
 


### PR DESCRIPTION
Title.

We've seen in #2814 and #2462 that some OpenGL (ES) implementations don't behave as expected and misreport extensions as being available  when they don't even provide the corresponding entry points. This change protects us from such implementations by making sure the required entry points are available in order to be able to assume that an extension is supported.

When the issue was originally reported, I had a hard time reproducing the issue, but recently I grabbed the ANGLE .dlls from a Google Chrome installation, dumped them into the binaries folder and ran the examples built using OpenGL ES, and it crashed in the same way as described in aforementioned issue. If you want to test these changes, the easiest way would be to do the same.

Closes #2814
Closes #2462

@Zombieschannel can you test this change to see if it really fixes the issue?