### PR TITLE
Added getAscent and getDescent functions to Font

### DIFF
--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -296,6 +296,30 @@ public:
     [[nodiscard]] float getKerning(char32_t first, char32_t second, unsigned int characterSize, bool bold = false) const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get the font's ascent
+    ///
+    /// The ascent is the distance between the top of the font and the baseline.
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return Font's ascent, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    float getAscent(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the font's descent
+    ///
+    /// The descent is the distance between the baseline and the bottom of the font.
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return Font's descent, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    float getDescent(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Get the line spacing
     ///
     /// Line spacing is the vertical offset to apply between two

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -310,7 +310,8 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the font's descent
     ///
-    /// The descent is the distance between the baseline and the bottom of the font.
+    /// The descent is the offset from the baseline to the bottom of the font.
+    /// This is a negative value.
     ///
     /// \param characterSize Reference character size
     ///

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -319,12 +319,11 @@ float Font::getAscent(unsigned int characterSize) const
         if (!FT_IS_SCALABLE(face))
             return std::ceil(static_cast<float>(face->size->metrics.ascender) / static_cast<float>(1 << 6));
 
-        return std::ceil(static_cast<float>(FT_MulFix(face->ascender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6));
+        return std::ceil(
+            static_cast<float>(FT_MulFix(face->ascender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6));
     }
-    else
-    {
-        return 0.f;
-    }
+
+    return 0.f;
 }
 
 ////////////////////////////////////////////////////////////
@@ -339,12 +338,11 @@ float Font::getDescent(unsigned int characterSize) const
         if (!FT_IS_SCALABLE(face))
             return std::floor(static_cast<float>(face->size->metrics.descender) / static_cast<float>(1 << 6));
 
-        return std::floor(static_cast<float>(FT_MulFix(face->descender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6));
+        return std::floor(
+            static_cast<float>(FT_MulFix(face->descender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6));
     }
-    else
-    {
-        return 0.f;
-    }
+
+    return 0.f;
 }
 
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -308,6 +308,48 @@ float Font::getKerning(char32_t first, char32_t second, unsigned int characterSi
 
 
 ////////////////////////////////////////////////////////////
+float Font::getAscent(unsigned int characterSize) const
+{
+    assert(m_fontHandles);
+
+    FT_Face face = m_fontHandles->face;
+
+    if (setCurrentSize(characterSize))
+    {
+        if (!FT_IS_SCALABLE(face))
+            return static_cast<float>(face->size->metrics.ascender) / static_cast<float>(1 << 6);
+
+        return static_cast<float>(FT_MulFix(face->ascender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6);
+    }
+    else
+    {
+        return 0.f;
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+float Font::getDescent(unsigned int characterSize) const
+{
+    assert(m_fontHandles);
+
+    FT_Face face = m_fontHandles->face;
+
+    if (setCurrentSize(characterSize))
+    {
+        if (!FT_IS_SCALABLE(face))
+            return static_cast<float>(-face->size->metrics.descender) / static_cast<float>(1 << 6);
+
+        return static_cast<float>(FT_MulFix(-face->descender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6);
+    }
+    else
+    {
+        return 0.f;
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 float Font::getLineSpacing(unsigned int characterSize) const
 {
     FT_Face face = m_fontHandles ? m_fontHandles->face : nullptr;

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -317,16 +317,15 @@ float Font::getAscent(unsigned int characterSize) const
     if (setCurrentSize(characterSize))
     {
         if (!FT_IS_SCALABLE(face))
-            return static_cast<float>(face->size->metrics.ascender) / static_cast<float>(1 << 6);
+            return std::ceil(static_cast<float>(face->size->metrics.ascender) / static_cast<float>(1 << 6));
 
-        return static_cast<float>(FT_MulFix(face->ascender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6);
+        return std::ceil(static_cast<float>(FT_MulFix(face->ascender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6));
     }
     else
     {
         return 0.f;
     }
 }
-
 
 ////////////////////////////////////////////////////////////
 float Font::getDescent(unsigned int characterSize) const
@@ -338,9 +337,9 @@ float Font::getDescent(unsigned int characterSize) const
     if (setCurrentSize(characterSize))
     {
         if (!FT_IS_SCALABLE(face))
-            return static_cast<float>(-face->size->metrics.descender) / static_cast<float>(1 << 6);
+            return std::floor(static_cast<float>(face->size->metrics.descender) / static_cast<float>(1 << 6));
 
-        return static_cast<float>(FT_MulFix(-face->descender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6);
+        return std::floor(static_cast<float>(FT_MulFix(face->descender, face->size->metrics.y_scale)) / static_cast<float>(1 << 6));
     }
     else
     {


### PR DESCRIPTION
## Description

This PR adds functions to the Font class to retrieve the ascent and descent of the font.

I marked the PR as a draft because there are some implementation details that still need to be discussed.

![image](https://github.com/SFML/SFML/assets/1461034/7de35e8e-0a1c-4bf9-aa89-29771a8cbd95)

## Motive

SFML doesn't really provide good way to vertically position text. These functions will help with that.

If two text objects using the same font and character size are given the same Y position, then their baselines do end up at the same vertical position as intended (irrelevant of which characters each text contains). We also know the location of the baseline, as the Text class places it at [y = character size](https://github.com/SFML/SFML/blob/31503844cd08558cf9acc8d24a0e9d4a9caed190/src/SFML/Graphics/Text.cpp#L399).

There are however two issues:

1)
We don't really know the full line height. If I render the letter `x`, it's bottom location will be at `m_characterSize`, and it's top position will be some offset that can be found with `text.getLocalBounds().getPosition().y`. However if I render the letter `g`, it extends below the baseline. I need to know the maximum amount that any text is going to go below the baseline to e.g. position text inside an edit box without the text being placed too low and be rendered outside the rectangle. Just knowing the position of the baseline isn't enough, I also need the font's descent, which is what the new `getDescent()` function will provide.

You could estimate the descent by subtracting the character size from the line spacing, but this could be off by a few pixels (and completely wrong for some broken fonts). The alternative that I used was to just get the information from the `g` glyph, but that only works if the font contains that character, and I learned today that `_` is sometimes placed even lower than a `g`.

2)
If you render text with Y position at 0 then there is a gap at the top. This is normal because you need to keep space for larger characters, it's normal for `x` to have a larger gap than `B` at the top. The problem is that the gap is *too large*. When using DejaVuSans with font size 16, the highest possible characters (e.g. `Ê`) are only 15 pixels tall). No matter what string you render, the top pixel will always be empty. Because the empty pixel (or more pixels for larger font sizes) is considered part of your line height, trying to vertically center text will always cause the text to be visually rendered too low. This is where the new `getAscent()` function comes in, it will return the real maximum character height (15 in this example) so that we don't have to wrongly assume that it equals the character size.

**Discussion question 1**: should sf::Text render the text higher? Instead of placing the baseline at `getCharacterSize()`, should it be located at `getAscent()` so that there is no empty space above the "Ê" character?

## Example

In the following example a text is drawn with character size 160 (an intentionally large number to make the issues more visible).
A yellow background is rendered to show where the left, top, right and bottom of the text object are located.

![SFMLFontAscentDescent](https://github.com/SFML/SFML/assets/1461034/522dc1f5-ee55-41cf-b3c5-c8417e6edd71)

As you can see in the image, the baseline is located at top 160 (= character size). The tallest character however is only 149 pixels, the top 11 pixels are always blank no matter which string you use. Without the `getDescent()` function, it would also be hard to figure out that the text can extend at most 38 pixels below the baseline and thus 198 pixels from the Y position of the text.

With both the ascent and descent we know the maximum space occupied by any string (149 + 38 = 187), which can be used to better position the text vertically.

Here is the example code:
```c++
#include <SFML/Graphics.hpp>
#include <iostream>

int main()
{
    sf::RenderWindow window{sf::VideoMode{{800, 600}}, "SFML font test"};

    sf::Font font("DejaVuSans.ttf");
    std::cerr << "Ascent: " << font.getAscent(160) << std::endl;
    std::cerr << "Descent: " << font.getDescent(160) << std::endl;

    sf::Text text(font);
    text.setCharacterSize(160);
    text.setFillColor(sf::Color::Black);
    text.setPosition({100, 100});
    text.setString(L"\\Êg_");

    sf::RectangleShape rect;
    rect.setPosition({100, 100});
    rect.setFillColor(sf::Color::Yellow);
    rect.setPosition(sf::Vector2f{100, 100});
    rect.setSize(text.getLocalBounds().position + text.getLocalBounds().size);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        window.clear({240, 240, 240});
        window.draw(rect);
        window.draw(text);
        window.display();
    }
}
```

The code has the following output:
```
Ascent: 148.516
Descent: 37.7344
```

**Discussion question 2**: should the values returned by getAscent and getDescent be rounded up to match what will be drawn instead of being the exact number returned by freetype?

**Discussion question 3**: FreeType and SDL_ttf return the descent as a negative value. The getDescent function currently returns a positive number. Which behavior should we use?

~~**Note on testing:** I did not test the `if (!FT_IS_SCALABLE(face))` branches, I don't know what kind of font I would need for that.~~
Edit: I managed to test the non-scalable branch with a bitmap font from https://github.com/olikraus/u8g2/tree/master/tools/font/bdf