### PR TITLE
Add clang-tidy `readability-redundant-member-init` check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,7 +71,6 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-redundant-casting,
-  -readability-redundant-member-init,
   -readability-uppercase-literal-suffix,
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase,           value: CamelCase }

--- a/include/SFML/Graphics/Vertex.hpp
+++ b/include/SFML/Graphics/Vertex.hpp
@@ -45,9 +45,9 @@ struct Vertex
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Vector2f position{};          //!< 2D position of the vertex
+    Vector2f position;            //!< 2D position of the vertex
     Color    color{Color::White}; //!< Color of the vertex
-    Vector2f texCoords{};         //!< Coordinates of the texture's pixel to map to the vertex
+    Vector2f texCoords{}; //!< Coordinates of the texture's pixel to map to the vertex NOLINT(readability-redundant-member-init)
 };
 
 } // namespace sf

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -217,7 +217,7 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
     std::uint64_t             samplesProcessed{};        //!< Number of samples processed since beginning of the stream
     unsigned int              channelCount{};            //!< Number of channels (1 = mono, 2 = stereo, ...)
     unsigned int              sampleRate{};              //!< Frequency (samples / second)
-    std::vector<SoundChannel> channelMap{};              //!< The map of position in sample frame to sound channel
+    std::vector<SoundChannel> channelMap;                //!< The map of position in sample frame to sound channel
     bool                      loop{};                    //!< Loop flag (true to loop, false to play once)
     bool                      streaming{true};           //!< True if we are still streaming samples from the source
 };


### PR DESCRIPTION
## Description

This has to be silenced for `sf::Vertex` because in some places within SFML we initialize only a subset of this aggregate type. If we remove the `{}` from `texCoords` then we get a compiler warning from Clang. It feels like these two clang-based tools are somewhat contradictory.
    
```
    error: missing field 'texCoords' initializer [-Werror,-Wmissing-field-initializers]
                m_points.append({{x, y}, {r, g, b}});
```