### PR TITLE
Reduce the scope of variables

### DIFF
--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -473,7 +473,6 @@ void ensureMapping()
     XkbGetNames(display.get(), XkbKeyNamesMask, descriptor);
 
     std::unordered_map<std::string, sf::Keyboard::Scancode> nameScancodeMap = getNameScancodeMap();
-    sf::Keyboard::Scancode                                  scancode        = sf::Keyboard::Scan::Unknown;
 
     for (int keycode = descriptor->min_key_code; keycode <= descriptor->max_key_code; ++keycode)
     {
@@ -486,7 +485,7 @@ void ensureMapping()
         name[XkbKeyNameLength] = '\0';
 
         const auto mappedScancode = nameScancodeMap.find(std::string(name));
-        scancode                  = sf::Keyboard::Scan::Unknown;
+        auto       scancode       = sf::Keyboard::Scan::Unknown;
 
         if (mappedScancode != nameScancodeMap.end())
             scancode = mappedScancode->second;
@@ -505,7 +504,7 @@ void ensureMapping()
     {
         if (keycodeToScancode[static_cast<KeyCode>(keycode)] == sf::Keyboard::Scan::Unknown)
         {
-            scancode = translateKeyCode(display.get(), static_cast<KeyCode>(keycode));
+            const auto scancode = translateKeyCode(display.get(), static_cast<KeyCode>(keycode));
 
             if (scancode != sf::Keyboard::Scan::Unknown && scancodeToKeycode[scancode] == nullKeyCode)
                 scancodeToKeycode[scancode] = static_cast<KeyCode>(keycode);

--- a/src/SFML/Window/Unix/VideoModeImpl.cpp
+++ b/src/SFML/Window/Unix/VideoModeImpl.cpp
@@ -57,8 +57,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     std::vector<VideoMode> modes;
 
     // Open a connection with the X server
-    const auto display = openDisplay();
-    if (display)
+    if (const auto display = openDisplay())
     {
         // Retrieve the default screen number
         const int screen = DefaultScreen(display.get());
@@ -135,8 +134,7 @@ VideoMode VideoModeImpl::getDesktopMode()
     VideoMode desktopMode;
 
     // Open a connection with the X server
-    const auto display = openDisplay();
-    if (display)
+    if (const auto display = openDisplay())
     {
         // Retrieve the default screen number
         const int screen = DefaultScreen(display.get());

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -110,7 +110,6 @@ struct ConnectionCache
     bool      connected{};
     sf::Clock timer;
 };
-const sf::Time connectionRefreshDelay = sf::milliseconds(500);
 
 ConnectionCache connectionCache[sf::Joystick::Count];
 
@@ -251,7 +250,8 @@ bool JoystickImpl::isConnected(unsigned int index)
     if (directInput)
         return isConnectedDInput(index);
 
-    ConnectionCache& cache = connectionCache[index];
+    ConnectionCache&   cache                  = connectionCache[index];
+    constexpr sf::Time connectionRefreshDelay = sf::milliseconds(500);
     if (!lazyUpdates && cache.timer.getElapsedTime() > connectionRefreshDelay)
     {
         JOYINFOEX joyInfo;


### PR DESCRIPTION
## Description

Reducing the scope of variables is something we've long since desired. Lots of older code puts variables in unnecessarily broad scopes which makes code harder to read and more prone to future errors.

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es6-declare-names-in-for-statement-initializers-and-conditions-to-limit-scope