### PR TITLE
Simplify `sf::Clock` usage

### DIFF
--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -187,8 +187,7 @@ void Window::display()
     // Limit the framerate if needed
     if (m_frameTimeLimit != Time::Zero)
     {
-        sleep(m_frameTimeLimit - m_clock.getElapsedTime());
-        m_clock.restart();
+        sleep(m_frameTimeLimit - m_clock.restart());
     }
 }
 

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -258,8 +258,7 @@ void EaglContext::display()
     if (m_vsyncEnabled)
     {
         constexpr Time frameDuration = seconds(1.f / 60.f);
-        sleep(frameDuration - m_clock.getElapsedTime());
-        m_clock.restart();
+        sleep(frameDuration - m_clock.restart());
     }
 }
 


### PR DESCRIPTION
## Description

`sf::Clock::restart` exists so we might as well use it internally. In addition to this being less code, it also results in marginally less work being performed.