### PR TITLE
Remove unnecessary round trip conversion

### DIFF
--- a/src/SFML/Window/Android/SensorImpl.cpp
+++ b/src/SFML/Window/Android/SensorImpl.cpp
@@ -99,11 +99,8 @@ bool SensorImpl::open(Sensor::Type sensor)
     if (!m_sensor)
         return false;
 
-    // Get the minimum delay allowed between events
-    const Time minimumDelay = microseconds(ASensor_getMinDelay(m_sensor));
-
     // Set the event rate (not to consume too much battery)
-    ASensorEventQueue_setEventRate(sensorEventQueue, m_sensor, static_cast<std::int32_t>(minimumDelay.asMicroseconds()));
+    ASensorEventQueue_setEventRate(sensorEventQueue, m_sensor, ASensor_getMinDelay(m_sensor));
 
     // Save the type of the sensor
     m_type = sensor;


### PR DESCRIPTION
## Description

There's no need to carefully construct an `sf::Time` just to then extract the same value out of it and cast it to another type. We can compose calls to Android APIs. This lets avoid doing a little bit of unnecessary work. 