### PR TITLE
Revert "Simplify `sf::Clock` usage"

### DIFF
--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -187,7 +187,8 @@ void Window::display()
     // Limit the framerate if needed
     if (m_frameTimeLimit != Time::Zero)
     {
-        sleep(m_frameTimeLimit - m_clock.restart());
+        sleep(m_frameTimeLimit - m_clock.getElapsedTime());
+        m_clock.restart();
     }
 }
 

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -258,7 +258,8 @@ void EaglContext::display()
     if (m_vsyncEnabled)
     {
         constexpr Time frameDuration = seconds(1.f / 60.f);
-        sleep(frameDuration - m_clock.restart());
+        sleep(frameDuration - m_clock.getElapsedTime());
+        m_clock.restart();
     }
 }
 


### PR DESCRIPTION
## Description

#3063 was a mistake and broke frame rate limiting. The responsible parties have been identified and will be sacked.