### PR TITLE
Simplify `sf::Sprite` implementation and reduce branches

### DIFF
--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -211,22 +211,16 @@ private:
     void draw(RenderTarget& target, RenderStates states) const override;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Update the vertices' positions
+    /// \brief Update the vertices' positions and texture coordinates
     ///
     ////////////////////////////////////////////////////////////
-    void updatePositions();
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Update the vertices' texture coordinates
-    ///
-    ////////////////////////////////////////////////////////////
-    void updateTexCoords();
+    void updateVertices();
 
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     std::array<Vertex, 4> m_vertices;    //!< Vertices defining the sprite's geometry
-    const Texture*        m_texture{};   //!< Texture of the sprite
+    const Texture*        m_texture;     //!< Texture of the sprite
     IntRect               m_textureRect; //!< Rectangle defining the area of the source texture to display
 };
 
@@ -271,9 +265,9 @@ private:
 ///
 /// // Create a sprite
 /// sf::Sprite sprite(texture);
-/// sprite.setTextureRect(sf::IntRect({10, 10}, {50, 30}));
-/// sprite.setColor(sf::Color(255, 255, 255, 200));
-/// sprite.setPosition({100, 25});
+/// sprite.setTextureRect({{10, 10}, {50, 30}});
+/// sprite.setColor({255, 255, 255, 200});
+/// sprite.setPosition({100.f, 25.f});
 ///
 /// // Draw it
 /// window.draw(sprite);

--- a/test/Graphics/Sprite.test.cpp
+++ b/test/Graphics/Sprite.test.cpp
@@ -42,6 +42,16 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
             CHECK(sprite.getLocalBounds() == sf::FloatRect({0, 0}, {40, 60}));
             CHECK(sprite.getGlobalBounds() == sf::FloatRect({0, 0}, {40, 60}));
         }
+
+        SECTION("Negative-size texture rectangle")
+        {
+            const sf::Sprite sprite(texture, {{0, 0}, {-40, -60}});
+            CHECK(&sprite.getTexture() == &texture);
+            CHECK(sprite.getTextureRect() == sf::IntRect({0, 0}, {-40, -60}));
+            CHECK(sprite.getColor() == sf::Color::White);
+            CHECK(sprite.getLocalBounds() == sf::FloatRect({0, 0}, {40, 60}));
+            CHECK(sprite.getGlobalBounds() == sf::FloatRect({0, 0}, {40, 60}));
+        }
     }
 
     SECTION("Set/get texture")


### PR DESCRIPTION
Few various improvements:
- Initialize data members on construction, rather than default-constructing them and then assigning
- Remove unnecessary branches during construction
- Define simpler constructor via delegation
- Merge `updatePositions` and `updateTexCoords` in the same function, as they're always called together
- Remove unnecessary use of `auto`
- Remove redundant comment
