### PR TITLE
Optimize `std::optional<T>` factory function returns for `T` with public ctor

### DIFF
--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -109,7 +109,8 @@ constexpr std::optional<Rect<T>> Rect<T>::findIntersection(const Rect<T>& rectan
     // If the intersection is valid (positive non zero area), then there is an intersection
     if ((interLeft < interRight) && (interTop < interBottom))
     {
-        return Rect<T>({interLeft, interTop}, {interRight - interLeft, interBottom - interTop});
+        return std::make_optional<Rect<T>>(Vector2<T>{interLeft, interTop},
+                                           Vector2<T>{interRight - interLeft, interBottom - interTop});
     }
     else
     {

--- a/src/SFML/Audio/PlaybackDevice.cpp
+++ b/src/SFML/Audio/PlaybackDevice.cpp
@@ -54,7 +54,7 @@ std::optional<std::string> getDefaultDevice()
     for (const auto& device : priv::AudioDevice::getAvailableDevices())
     {
         if (device.isDefault)
-            return device.name;
+            return std::make_optional(device.name);
     }
 
     return std::nullopt;

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -113,7 +113,7 @@ std::optional<SoundBuffer> SoundBuffer::loadFromSamples(
         // Update the internal buffer with the new samples
         if (!soundBuffer.update(channelCount, sampleRate, channelMap))
             return std::nullopt;
-        return soundBuffer;
+        return std::make_optional(std::move(soundBuffer));
     }
     else
     {
@@ -224,7 +224,7 @@ std::optional<SoundBuffer> SoundBuffer::initialize(InputSoundFile& file)
         SoundBuffer soundBuffer(std::move(samples));
         if (!soundBuffer.update(file.getChannelCount(), file.getSampleRate(), file.getChannelMap()))
             return std::nullopt;
-        return soundBuffer;
+        return std::make_optional(std::move(soundBuffer));
     }
     else
     {

--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -325,7 +325,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderFlac::open(InputStream& stre
     }
 
     // Retrieve the sound properties
-    return m_clientData.info; // was filled in the "metadata" callback
+    return std::make_optional(m_clientData.info); // was filled in the "metadata" callback
 }
 
 

--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -133,7 +133,9 @@ std::optional<SoundFileReader::Info> SoundFileReaderMp3::open(InputStream& strea
         return std::nullopt;
 
     // Retrieve the music attributes
-    Info info;
+    auto result = std::make_optional<Info>();
+
+    Info& info        = *result;
     info.channelCount = static_cast<unsigned int>(m_decoder.info.channels);
     info.sampleRate   = static_cast<unsigned int>(m_decoder.info.hz);
     info.sampleCount  = m_decoder.samples;
@@ -157,7 +159,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderMp3::open(InputStream& strea
     }
 
     m_numSamples = info.sampleCount;
-    return info;
+    return result;
 }
 
 

--- a/src/SFML/Audio/SoundFileReaderOgg.cpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.cpp
@@ -107,7 +107,10 @@ std::optional<SoundFileReader::Info> SoundFileReaderOgg::open(InputStream& strea
 
     // Retrieve the music attributes
     vorbis_info* vorbisInfo = ov_info(&m_vorbis, -1);
-    Info         info;
+
+    auto result = std::make_optional<Info>();
+
+    Info& info        = *result;
     info.channelCount = static_cast<unsigned int>(vorbisInfo->channels);
     info.sampleRate   = static_cast<unsigned int>(vorbisInfo->rate);
     info.sampleCount  = static_cast<std::size_t>(ov_pcm_total(&m_vorbis, -1) * vorbisInfo->channels);
@@ -173,7 +176,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderOgg::open(InputStream& strea
     // We must keep the channel count for the seek function
     m_channelCount = info.channelCount;
 
-    return info;
+    return result;
 }
 
 

--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -171,7 +171,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderWav::open(InputStream& strea
     for (auto i = 0u; i < m_channelCount; ++i)
         soundChannels.emplace_back(priv::MiniaudioUtils::miniaudioChannelToSoundChannel(channelMap[i]));
 
-    return Info{frameCount * m_channelCount, m_channelCount, sampleRate, std::move(soundChannels)};
+    return std::make_optional<Info>({frameCount * m_channelCount, m_channelCount, sampleRate, std::move(soundChannels)});
 }
 
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -775,7 +775,7 @@ std::optional<Font::Page> Font::Page::make(bool smooth)
     }
 
     texture->setSmooth(smooth);
-    return Page(std::move(*texture));
+    return std::make_optional<Page>(std::move(*texture));
 }
 
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -77,6 +77,8 @@ void bufferFromCallback(void* context, void* data, int size)
 {
     const auto* source = static_cast<std::uint8_t*>(data);
     auto*       dest   = static_cast<std::vector<std::uint8_t>*>(context);
+
+    dest->reserve(static_cast<std::size_t>(size));
     std::copy(source, source + size, std::back_inserter(*dest));
 }
 
@@ -321,30 +323,30 @@ std::optional<std::vector<std::uint8_t>> Image::saveToMemory(std::string_view fo
         const std::string specified     = toLower(std::string(format));
         const Vector2i    convertedSize = Vector2i(m_size);
 
-        std::vector<std::uint8_t> buffer;
+        auto buffer = std::make_optional<std::vector<std::uint8_t>>();
 
         if (specified == "bmp")
         {
             // BMP format
-            if (stbi_write_bmp_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+            if (stbi_write_bmp_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
                 return buffer;
         }
         else if (specified == "tga")
         {
             // TGA format
-            if (stbi_write_tga_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+            if (stbi_write_tga_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
                 return buffer;
         }
         else if (specified == "png")
         {
             // PNG format
-            if (stbi_write_png_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
+            if (stbi_write_png_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
                 return buffer;
         }
         else if (specified == "jpg" || specified == "jpeg")
         {
             // JPG format
-            if (stbi_write_jpg_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
+            if (stbi_write_jpg_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
                 return buffer;
         }
     }

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -88,7 +88,7 @@ std::optional<RenderTexture> RenderTexture::create(const Vector2u& size, const C
     // We can now initialize the render target part
     renderTexture.initialize();
 
-    return renderTexture;
+    return std::make_optional(std::move(renderTexture));
 }
 
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -259,7 +259,7 @@ std::optional<Texture> Texture::create(const Vector2u& size, bool sRgb)
 
     texture.m_hasMipmap = false;
 
-    return texture;
+    return std::make_optional(std::move(texture));
 }
 
 

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -55,15 +55,15 @@ std::optional<IpAddress> IpAddress::resolve(std::string_view address)
     {
         // The broadcast address needs to be handled explicitly,
         // because it is also the value returned by inet_addr on error
-        return Broadcast;
+        return std::make_optional(Broadcast);
     }
 
     if (address == "0.0.0.0"sv)
-        return Any;
+        return std::make_optional(Any);
 
     // Try to convert the address as a byte representation ("xxx.xxx.xxx.xxx")
     if (const std::uint32_t ip = inet_addr(address.data()); ip != INADDR_NONE)
-        return IpAddress(ntohl(ip));
+        return std::make_optional<IpAddress>(ntohl(ip));
 
     // Not a valid address, try to convert it as a host name
     addrinfo hints{}; // Zero-initialize
@@ -78,7 +78,7 @@ std::optional<IpAddress> IpAddress::resolve(std::string_view address)
         const std::uint32_t ip = sin.sin_addr.s_addr;
         freeaddrinfo(result);
 
-        return IpAddress(ntohl(ip));
+        return std::make_optional<IpAddress>(ntohl(ip));
     }
 
     return std::nullopt;
@@ -147,7 +147,7 @@ std::optional<IpAddress> IpAddress::getLocalAddress()
     priv::SocketImpl::close(sock);
 
     // Finally build the IP address
-    return IpAddress(ntohl(address.sin_addr.s_addr));
+    return std::make_optional<IpAddress>(ntohl(address.sin_addr.s_addr));
 }
 
 

--- a/src/SFML/Window/Cursor.cpp
+++ b/src/SFML/Window/Cursor.cpp
@@ -63,7 +63,7 @@ std::optional<Cursor> Cursor::loadFromPixels(const std::uint8_t* pixels, Vector2
     if (!cursor.m_impl->loadFromPixels(pixels, size, hotspot))
         return std::nullopt;
 
-    return cursor;
+    return std::make_optional(std::move(cursor));
 }
 
 
@@ -74,7 +74,7 @@ std::optional<Cursor> Cursor::loadFromSystem(Type type)
     if (!cursor.m_impl->loadFromSystem(type))
         return std::nullopt;
 
-    return cursor;
+    return std::make_optional(std::move(cursor));
 }
 
 

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -522,24 +522,24 @@ std::optional<sf::String> sfScanToConsumerKeyName(sf::Keyboard::Scancode code)
     // clang-format off
     switch (code)
     {
-        case sf::Keyboard::Scan::MediaNextTrack:     return "Next Track";
-        case sf::Keyboard::Scan::MediaPreviousTrack: return "Previous Track";
-        case sf::Keyboard::Scan::MediaStop:          return "Stop";
-        case sf::Keyboard::Scan::MediaPlayPause:     return "Play/Pause";
-        case sf::Keyboard::Scan::VolumeMute:         return "Mute";
-        case sf::Keyboard::Scan::VolumeUp:           return "Volume Increment";
-        case sf::Keyboard::Scan::VolumeDown:         return "Volume Decrement";
-        case sf::Keyboard::Scan::LaunchMediaSelect:  return "Consumer Control Configuration";
-        case sf::Keyboard::Scan::LaunchMail:         return "Email Reader";
-        case sf::Keyboard::Scan::LaunchApplication2: return "Calculator";
-        case sf::Keyboard::Scan::LaunchApplication1: return "Local Machine Browser";
-        case sf::Keyboard::Scan::Search:             return "Search";
-        case sf::Keyboard::Scan::HomePage:           return "Home";
-        case sf::Keyboard::Scan::Back:               return "Back";
-        case sf::Keyboard::Scan::Forward:            return "Forward";
-        case sf::Keyboard::Scan::Stop:               return "Stop";
-        case sf::Keyboard::Scan::Refresh:            return "Refresh";
-        case sf::Keyboard::Scan::Favorites:          return "Bookmarks";
+        case sf::Keyboard::Scan::MediaNextTrack:     return std::make_optional<sf::String>("Next Track");
+        case sf::Keyboard::Scan::MediaPreviousTrack: return std::make_optional<sf::String>("Previous Track");
+        case sf::Keyboard::Scan::MediaStop:          return std::make_optional<sf::String>("Stop");
+        case sf::Keyboard::Scan::MediaPlayPause:     return std::make_optional<sf::String>("Play/Pause");
+        case sf::Keyboard::Scan::VolumeMute:         return std::make_optional<sf::String>("Mute");
+        case sf::Keyboard::Scan::VolumeUp:           return std::make_optional<sf::String>("Volume Increment");
+        case sf::Keyboard::Scan::VolumeDown:         return std::make_optional<sf::String>("Volume Decrement");
+        case sf::Keyboard::Scan::LaunchMediaSelect:  return std::make_optional<sf::String>("Consumer Control Configuration");
+        case sf::Keyboard::Scan::LaunchMail:         return std::make_optional<sf::String>("Email Reader");
+        case sf::Keyboard::Scan::LaunchApplication2: return std::make_optional<sf::String>("Calculator");
+        case sf::Keyboard::Scan::LaunchApplication1: return std::make_optional<sf::String>("Local Machine Browser");
+        case sf::Keyboard::Scan::Search:             return std::make_optional<sf::String>("Search");
+        case sf::Keyboard::Scan::HomePage:           return std::make_optional<sf::String>("Home");
+        case sf::Keyboard::Scan::Back:               return std::make_optional<sf::String>("Back");
+        case sf::Keyboard::Scan::Forward:            return std::make_optional<sf::String>("Forward");
+        case sf::Keyboard::Scan::Stop:               return std::make_optional<sf::String>("Stop");
+        case sf::Keyboard::Scan::Refresh:            return std::make_optional<sf::String>("Refresh");
+        case sf::Keyboard::Scan::Favorites:          return std::make_optional<sf::String>("Bookmarks");
 
         // Not a consumer key
         default: return std::nullopt;


### PR DESCRIPTION
Basically, this pattern we frequently use

```cpp
class Widget
{
private:
    explicit Widget(Dependency&&);

public:
    static std::optional<Widget> make(std::filesystem::path p)
    {
        std::optional<Dependency> d = loadDependencyFromPath(p);
        if (!d.has_value()) { return std::nullopt; }
        
        return Widget{std::move(*d)};
    }
};
```

has a flaw -- it is not eligible for C++17 guaranteed copy elision (RVO) due to the fact that we're not returning a prvalue of type `std::optional<Widget>`, but a prvalue of type `Widget` instead, whose type does *not* match the function's return type.

That has a few practical drawbacks:

- Non-copyable/non-movable types cannot be returned in this way;
- Performance is sligthly worse, as extra move/copy operations will be invoked;
- Code that previously relied on address stability might break after switching to this pattern due to the extra move/copy operations (see #3062).

The way of improving the pattern is to return a prvalue of `std::optional<Widget>` type, thus gaining eligibility for guaranteed copy elision. E.g.,

```cpp
static std::optional<Widget> make(std::filesystem::path p)
{
    std::optional<Dependency> d = loadDependencyFromPath(p);
    if (!d.has_value()) { return std::nullopt; }
    
    return std::make_optional<Widget>(std::move(*d));
}
```

This works, but only if the constructor of `Widget` is `public`, as internally `std::make_optional` tries to construct `Widget` outside of `Widget` itself's scope. The same issue applies to `std::optional<T>{std::in_place, ...}`.

This PR aims to improve our usage of the factory pattern *only* for types where the constructor is public and where the extra copies/moves are not trivial. 

For all the other types, we have two options AFAICS:

1. Make the constructors `public`, allowing users to call them directly;
2. Make the constructors `public`, but using the passkey idiom to prevent users from calling them.

Number (2) seems like the best choice, but it adds a bit of extra boilerplate and we'd have to use some sort of Doxygen annotations to suppress documentation generation for those constructors.

I think it's worth doing as all the heavyweight types such as `Texture`, `Font`, et cetera, all have `private` constructors and use the inefficient factory pattern that does not support guaranteed copy elision. But that's for another PR.

See also: https://stackoverflow.com/questions/78581072/stdoptional-factory-function-with-guaranteed-copy-elision-and-private-cons