### PR TITLE
Protect against drawing a sprite when the underlying texture has been moved from

### DIFF
--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Graphics/Sprite.hpp>
 #include <SFML/Graphics/Texture.hpp>
 
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 
@@ -128,6 +129,8 @@ FloatRect Sprite::getGlobalBounds() const
 ////////////////////////////////////////////////////////////
 void Sprite::draw(RenderTarget& target, RenderStates states) const
 {
+    assert(m_texture->getNativeHandle() != 0 && "Sprite::draw() Cannot draw sprite when texture is not initialized");
+
     states.transform *= getTransform();
     states.texture        = m_texture;
     states.coordinateType = CoordinateType::Pixels;


### PR DESCRIPTION
## Description

Inspired by #3062. If you construct a texture and a sprite then move the sprite, the sprite is left pointing at an address where there is no longer a usable texture. The texture's lifetime has not yet ended, however the texture is in a moved-from state and thus it's not suitable to draw the sprite. Doing so will result in unintended and undesirable effects.