### PR TITLE
Pass `sf::RenderStates` by mutable reference

### DIFF
--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -62,7 +62,7 @@ private:
         m_shader.setUniform("pixel_threshold", (x + y) / 30);
     }
 
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         states.shader = &m_shader;
         target.draw(sf::Sprite{m_texture}, states);
@@ -95,7 +95,7 @@ public:
         m_shader.setUniform("blur_radius", (x + y) * 0.008f);
     }
 
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         states.shader = &m_shader;
         target.draw(m_text, states);
@@ -158,7 +158,7 @@ public:
         m_shader.setUniform("blink_alpha", 0.5f + std::cos(time * 3) * 0.25f);
     }
 
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         states.shader = &m_shader;
         target.draw(m_points, states);
@@ -259,7 +259,7 @@ public:
         m_surface.display();
     }
 
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         states.shader = &m_shader;
         target.draw(sf::Sprite{m_surface.getTexture()}, states);
@@ -333,7 +333,7 @@ public:
         m_shader.setUniform("size", sf::Vector2f{size, size});
     }
 
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         // Prepare the render state
         states.shader    = &m_shader;

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -53,7 +53,7 @@ public:
         onUpdate(time, x, y);
     }
 
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         onDraw(target, states);
     }
@@ -86,10 +86,10 @@ protected:
 
 private:
     // Virtual functions to be implemented in derived effects
-    virtual void onUpdate(float time, float x, float y)                          = 0;
-    virtual void onDraw(sf::RenderTarget& target, sf::RenderStates states) const = 0;
-    virtual void onStart()                                                       = 0;
-    virtual void onStop()                                                        = 0;
+    virtual void onUpdate(float time, float x, float y)                           = 0;
+    virtual void onDraw(sf::RenderTarget& target, sf::RenderStates& states) const = 0;
+    virtual void onStart()                                                        = 0;
+    virtual void onStop()                                                         = 0;
 
     virtual void onKey(sf::Keyboard::Key)
     {
@@ -130,14 +130,14 @@ public:
         m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void onDraw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
-        auto statesCopy(states);
-        statesCopy.transform = sf::Transform::Identity;
-        statesCopy.transform.translate(m_position);
-
         target.draw(m_listener, states);
-        target.draw(m_soundShape, statesCopy);
+
+        states.transform = sf::Transform::Identity;
+        states.transform.translate(m_position);
+
+        target.draw(m_soundShape, states);
     }
 
     void onStart() override
@@ -204,7 +204,7 @@ public:
         m_volumeText.setString("Volume: " + std::to_string(m_volume));
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void onDraw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         target.draw(m_pitchText, states);
         target.draw(m_volumeText, states);
@@ -307,7 +307,7 @@ public:
         m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void onDraw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         auto statesCopy(states);
 
@@ -377,7 +377,7 @@ public:
         m_currentFrequency.setString("Frequency: " + std::to_string(m_frequency) + " Hz");
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void onDraw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         target.draw(m_instruction, states);
         target.draw(m_currentType, states);
@@ -549,7 +549,7 @@ public:
         setDopplerFactor(m_factor);
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void onDraw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         auto statesCopy(states);
         statesCopy.transform = sf::Transform::Identity;
@@ -629,7 +629,7 @@ public:
         m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void onDraw(sf::RenderTarget& target, sf::RenderStates& states) const override
     {
         auto statesCopy(states);
         statesCopy.transform = sf::Transform::Identity;

--- a/include/SFML/Graphics/Drawable.hpp
+++ b/include/SFML/Graphics/Drawable.hpp
@@ -63,7 +63,7 @@ protected:
     /// \param states Current render states
     ///
     ////////////////////////////////////////////////////////////
-    virtual void draw(RenderTarget& target, RenderStates states) const = 0;
+    virtual void draw(RenderTarget& target, RenderStates& states) const = 0;
 };
 
 } // namespace sf
@@ -94,7 +94,7 @@ protected:
 ///
 /// private:
 ///
-///     void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+///     void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
 ///     {
 ///         // You can draw other high-level objects
 ///         target.draw(m_sprite, states);

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -299,13 +299,21 @@ public:
     Vector2i mapCoordsToPixel(const Vector2f& point, const View& view) const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Draw a drawable object to the render target with default render states
+    ///
+    /// \param drawable Object to draw
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(const Drawable& drawable);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Draw a drawable object to the render target
     ///
     /// \param drawable Object to draw
     /// \param states   Render states to use for drawing
     ///
     ////////////////////////////////////////////////////////////
-    void draw(const Drawable& drawable, const RenderStates& states = RenderStates::Default);
+    void draw(const Drawable& drawable, RenderStates states);
 
     ////////////////////////////////////////////////////////////
     /// \brief Draw primitives defined by an array of vertices

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -281,7 +281,7 @@ private:
     /// \param states Current render states
     ///
     ////////////////////////////////////////////////////////////
-    void draw(RenderTarget& target, RenderStates states) const override;
+    void draw(RenderTarget& target, RenderStates& states) const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the fill vertices' color

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -208,7 +208,7 @@ private:
     /// \param states Current render states
     ///
     ////////////////////////////////////////////////////////////
-    void draw(RenderTarget& target, RenderStates states) const override;
+    void draw(RenderTarget& target, RenderStates& states) const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the vertices' positions

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -398,7 +398,7 @@ private:
     /// \param states Current render states
     ///
     ////////////////////////////////////////////////////////////
-    void draw(RenderTarget& target, RenderStates states) const override;
+    void draw(RenderTarget& target, RenderStates& states) const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Make sure the text's geometry is updated

--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -288,7 +288,7 @@ private:
 /// \code
 /// class MyEntity : public sf::Transformable, public sf::Drawable
 /// {
-///     void draw(sf::RenderTarget& target, sf::RenderStates states) const override
+///     void draw(sf::RenderTarget& target, sf::RenderStates& states) const override
 ///     {
 ///         states.transform *= getTransform();
 ///         target.draw(..., states);

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -183,7 +183,7 @@ private:
     /// \param states Current render states
     ///
     ////////////////////////////////////////////////////////////
-    void draw(RenderTarget& target, RenderStates states) const override;
+    void draw(RenderTarget& target, RenderStates& states) const override;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -329,7 +329,7 @@ private:
     /// \param states Current render states
     ///
     ////////////////////////////////////////////////////////////
-    void draw(RenderTarget& target, RenderStates states) const override;
+    void draw(RenderTarget& target, RenderStates& states) const override;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -336,7 +336,14 @@ Vector2i RenderTarget::mapCoordsToPixel(const Vector2f& point, const View& view)
 
 
 ////////////////////////////////////////////////////////////
-void RenderTarget::draw(const Drawable& drawable, const RenderStates& states)
+void RenderTarget::draw(const Drawable& drawable)
+{
+    draw(drawable, RenderStates::Default);
+}
+
+
+////////////////////////////////////////////////////////////
+void RenderTarget::draw(const Drawable& drawable, RenderStates states)
 {
     drawable.draw(*this, states);
 }

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -234,7 +234,7 @@ void Shape::update()
 
 
 ////////////////////////////////////////////////////////////
-void Shape::draw(RenderTarget& target, RenderStates states) const
+void Shape::draw(RenderTarget& target, RenderStates& states) const
 {
     states.transform *= getTransform();
     states.coordinateType = CoordinateType::Pixels;

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -126,7 +126,7 @@ FloatRect Sprite::getGlobalBounds() const
 
 
 ////////////////////////////////////////////////////////////
-void Sprite::draw(RenderTarget& target, RenderStates states) const
+void Sprite::draw(RenderTarget& target, RenderStates& states) const
 {
     states.transform *= getTransform();
     states.texture        = m_texture;

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -339,7 +339,7 @@ FloatRect Text::getGlobalBounds() const
 
 
 ////////////////////////////////////////////////////////////
-void Text::draw(RenderTarget& target, RenderStates states) const
+void Text::draw(RenderTarget& target, RenderStates& states) const
 {
     ensureGeometryUpdate();
 

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -135,7 +135,7 @@ FloatRect VertexArray::getBounds() const
 
 
 ////////////////////////////////////////////////////////////
-void VertexArray::draw(RenderTarget& target, RenderStates states) const
+void VertexArray::draw(RenderTarget& target, RenderStates& states) const
 {
     if (!m_vertices.empty())
         target.draw(m_vertices.data(), m_vertices.size(), m_primitiveType, states);

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -348,7 +348,7 @@ bool VertexBuffer::isAvailable()
 
 
 ////////////////////////////////////////////////////////////
-void VertexBuffer::draw(RenderTarget& target, RenderStates states) const
+void VertexBuffer::draw(RenderTarget& target, RenderStates& states) const
 {
     if (m_buffer && m_size)
         target.draw(*this, 0, m_size, states);

--- a/test/Graphics/Drawable.test.cpp
+++ b/test/Graphics/Drawable.test.cpp
@@ -16,7 +16,7 @@ public:
     }
 
 private:
-    void draw(sf::RenderTarget&, sf::RenderStates) const override
+    void draw(sf::RenderTarget&, sf::RenderStates&) const override
     {
         ++m_callCount;
     }


### PR DESCRIPTION
See #3073 for context.

Basically, `sf::RenderTarget::draw` creates the first `sf::RenderStates`, then that same object is passed down the chain by mutable reference.

This prevents the unnecessary copies, allows mutability, and keeps the syntax simple for the end user.

As far as I understand, passing by reference here is the desired behavior -- if I have a `sf::Drawable` that internally stores some child drawable objects, I would expect those children to "inherit" the same render states as the parent.