### PR TITLE
Update LLVM on Windows manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,18 @@ jobs:
         echo "Using $(which ccache)"
         ccache --version
 
+    - name: Cache LLVM
+      if: matrix.platform.name == 'Windows'
+      id: llvm-cache
+      uses: actions/cache@v4
+      with:
+        path: "C:\\Program Files\\LLVM"
+        key: llvm-17.0.6
+        
+    - name: Update LLVM on Windows
+      if: runner.os == 'Windows' && steps.llvm-cache.outputs.cache-hit != 'true'
+      run: choco upgrade llvm --version=17.0.6
+
     - name: Configure CMake
       run: cmake --preset dev -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
 
@@ -364,6 +376,18 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         curl.exe -o run-clang-tidy https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-15.0.7/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+
+    - name: Cache LLVM
+      if: matrix.platform.name == 'Windows'
+      id: llvm-cache
+      uses: actions/cache@v4
+      with:
+        path: "C:\\Program Files\\LLVM"
+        key: llvm-17.0.6
+        
+    - name: Update LLVM on Windows
+      if: runner.os == 'Windows' && steps.llvm-cache.outputs.cache-hit != 'true'
+      run: choco upgrade llvm --version=17.0.6
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -31,6 +31,12 @@ function(sfml_set_stdlib target)
             if(SFML_USE_STATIC_STD_LIBS)
                 set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
             endif()
+
+            # Workaround for runtime issue on Windows: https://github.com/actions/runner-images/issues/10004
+            target_compile_definitions(${target} PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+        elseif(SFML_COMPILER_CLANG AND NOT MINGW)
+            # Workaround for runtime issue on Windows: https://github.com/actions/runner-images/issues/10004
+            target_compile_definitions(${target} PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
         endif()
     endif()
 endfunction()


### PR DESCRIPTION
## Description

Fixes:

- LLVM version mismatch in the GitHub Windows image: https://github.com/actions/runner-images/issues/10001
- Disable the mutex flag that causes runtime issues: https://github.com/actions/runner-images/issues/10004

## How to test this PR?

CI's Windows LLVM & Windows Release tasks should pass