### PR TITLE
`sf::Sprite` as temporary view over geometry + texture

### DIFF
--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -20,9 +20,11 @@
 ///     // Create the main window
 ///     sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
-///     // Load a sprite to display
+///     // Load a texture to display
 ///     const auto texture = sf::Texture::loadFromFile("cute_image.jpg").value();
-///     sf::Sprite sprite(texture);
+///
+///     // Create geometry for the sprite that will display the texture
+///     sf::SpriteGeometry geometry(texture.getRect());
 ///
 ///     // Create a graphical text to display
 ///     const auto font = sf::Font::loadFromFile("arial.ttf").value();
@@ -50,8 +52,8 @@
 ///         // Clear screen
 ///         window.clear();
 ///
-///         // Draw the sprite
-///         window.draw(sprite);
+///         // Create and draw the sprite
+///         window.draw(sf::Sprite(geometry, texture));
 ///
 ///         // Draw the string
 ///         window.draw(text);

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -58,8 +58,8 @@ int main()
         window.setMaximumSize(sf::Vector2u(1200, 900));
 
         // Create a sprite for the background
-        const auto       backgroundTexture = sf::Texture::loadFromFile(resourcesDir() / "background.jpg", sRgb).value();
-        const sf::Sprite background(backgroundTexture);
+        const auto backgroundTexture = sf::Texture::loadFromFile(resourcesDir() / "background.jpg", sRgb).value();
+        const sf::SpriteGeometry backgroundGeometry(backgroundTexture.getRect());
 
         // Create some text to draw on top of our OpenGL object
         const auto font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf").value();
@@ -282,7 +282,7 @@ int main()
 
             // Draw the background
             window.pushGLStates();
-            window.draw(background);
+            window.draw(sf::Sprite(backgroundGeometry, backgroundTexture));
             window.popGLStates();
 
             // Make the window the active window for OpenGL calls

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -1081,9 +1081,9 @@ int main()
 
     // Create the messages background
     const auto textBackgroundTexture = sf::Texture::loadFromFile(resourcesDir() / "text-background.png").value();
-    sf::Sprite textBackground(textBackgroundTexture);
-    textBackground.setPosition({0.f, 520.f});
-    textBackground.setColor(sf::Color(255, 255, 255, 200));
+    sf::SpriteGeometry textBackgroundGeometry(textBackgroundTexture.getRect());
+    textBackgroundGeometry.setPosition({0.f, 520.f});
+    textBackgroundGeometry.setColor(sf::Color(255, 255, 255, 200));
 
     // Create the description text
     sf::Text description(font, "Current effect: " + effects[current]->getName(), 20);
@@ -1197,7 +1197,7 @@ int main()
         window.draw(*effects[current]);
 
         // Draw the text
-        window.draw(textBackground);
+        window.draw(sf::Sprite(textBackgroundGeometry, textBackgroundTexture));
         window.draw(instructions);
         window.draw(description);
         window.draw(playbackDevice);

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -54,8 +54,8 @@ int main()
 
     // Create the SFML logo texture:
     const auto sfmlLogoTexture = sf::Texture::loadFromFile(resourcesDir() / "sfml_logo.png").value();
-    sf::Sprite sfmlLogo(sfmlLogoTexture);
-    sfmlLogo.setPosition({170.f, 50.f});
+    sf::SpriteGeometry sfmlLogoGeometry(sfmlLogoTexture.getRect());
+    sfmlLogoGeometry.setPosition({170.f, 50.f});
 
     // Create the left paddle
     sf::RectangleShape leftPaddle;
@@ -275,7 +275,7 @@ int main()
         {
             // Draw the pause message
             window.draw(pauseMessage);
-            window.draw(sfmlLogo);
+            window.draw(sf::Sprite(sfmlLogoGeometry, sfmlLogoTexture));
         }
 
         // Display things on screen

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -53,7 +53,7 @@ int main()
     sf::Sound  ballSound(ballSoundBuffer);
 
     // Create the SFML logo texture:
-    const auto sfmlLogoTexture = sf::Texture::loadFromFile(resourcesDir() / "sfml_logo.png").value();
+    const auto         sfmlLogoTexture = sf::Texture::loadFromFile(resourcesDir() / "sfml_logo.png").value();
     sf::SpriteGeometry sfmlLogoGeometry(sfmlLogoTexture.getRect());
     sfmlLogoGeometry.setPosition({170.f, 50.f});
 

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -111,8 +111,8 @@ int main()
     sf::RenderWindow sfmlView2(view2);
 
     // Load some textures to display
-    const auto texture1 = sf::Texture::loadFromFile("resources/image1.jpg").value();
-    const auto texture2 = sf::Texture::loadFromFile("resources/image2.jpg").value();
+    const auto         texture1 = sf::Texture::loadFromFile("resources/image1.jpg").value();
+    const auto         texture2 = sf::Texture::loadFromFile("resources/image2.jpg").value();
     sf::SpriteGeometry geometry1(texture1.getRect());
     sf::SpriteGeometry geometry2(texture2.getRect());
     geometry1.setOrigin(sf::Vector2f(texture1.getSize()) / 2.f);

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -113,10 +113,10 @@ int main()
     // Load some textures to display
     const auto texture1 = sf::Texture::loadFromFile("resources/image1.jpg").value();
     const auto texture2 = sf::Texture::loadFromFile("resources/image2.jpg").value();
-    sf::Sprite sprite1(texture1);
-    sf::Sprite sprite2(texture2);
-    sprite1.setOrigin(sf::Vector2f(texture1.getSize()) / 2.f);
-    sprite1.setPosition(sprite1.getOrigin());
+    sf::SpriteGeometry geometry1(texture1.getRect());
+    sf::SpriteGeometry geometry2(texture2.getRect());
+    geometry1.setOrigin(sf::Vector2f(texture1.getSize()) / 2.f);
+    geometry1.setPosition(geometry1.getOrigin());
 
     // Create a clock for measuring elapsed time
     const sf::Clock clock;
@@ -141,12 +141,12 @@ int main()
             sfmlView2.clear();
 
             // Draw sprite 1 on view 1
-            sprite1.setRotation(sf::degrees(time * 100));
-            sfmlView1.draw(sprite1);
+            geometry1.setRotation(sf::degrees(time * 100));
+            sfmlView1.draw(sf::Sprite(geometry1, texture1));
 
             // Draw sprite 2 on view 2
-            sprite2.setPosition({std::cos(time) * 100.f, 0.f});
-            sfmlView2.draw(sprite2);
+            geometry2.setPosition({std::cos(time) * 100.f, 0.f});
+            sfmlView2.draw(sf::Sprite(geometry2, texture2));
 
             // Display each view on screen
             sfmlView1.display();

--- a/include/SFML/Graphics.hpp
+++ b/include/SFML/Graphics.hpp
@@ -46,6 +46,7 @@
 #include <SFML/Graphics/Shader.hpp>
 #include <SFML/Graphics/Shape.hpp>
 #include <SFML/Graphics/Sprite.hpp>
+#include <SFML/Graphics/SpriteGeometry.hpp>
 #include <SFML/Graphics/StencilMode.hpp>
 #include <SFML/Graphics/Text.hpp>
 #include <SFML/Graphics/Texture.hpp>

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -54,6 +54,7 @@ class Shader;
 class Texture;
 class Transform;
 class VertexBuffer;
+class Sprite;
 
 ////////////////////////////////////////////////////////////
 /// \brief Base class for all render targets (window, texture, ...)
@@ -343,6 +344,30 @@ public:
               std::size_t         firstVertex,
               std::size_t         vertexCount,
               const RenderStates& states = RenderStates::Default);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Prevent drawing a const non-temporary sprite to avoid lifetime issues
+    ///
+    /// If you are really sure about the lifetime of your sprite dependencies, you can draw
+    /// your sprite by casting it to an rvalue via `std::move`.
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(const Sprite& sprite, const RenderStates& states = RenderStates::Default) = delete;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Prevent drawing a non-const non-temporary sprite to avoid lifetime issues
+    ///
+    /// If you are really sure about the lifetime of your sprite dependencies, you can draw
+    /// your sprite by casting it to an rvalue via `std::move`.
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(Sprite& sprite, const RenderStates& states = RenderStates::Default) = delete;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw a temporary sprite
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(Sprite&& sprite, const RenderStates& states = RenderStates::Default);
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the rendering region of the target

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -302,8 +302,8 @@ private:
 ///    window.clear();
 ///
 ///    // Draw the texture
-///    sf::Sprite sprite(texture.getTexture());
-///    window.draw(sprite);
+///    sf::SpriteGeometry geometry(texture.getTexture().getRect());
+///    window.draw(sf::Sprite(geometry, texture));
 ///
 ///    // End the current frame and display its contents on screen
 ///    window.display();

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -265,10 +265,14 @@ private:
 /// // Create the render window
 /// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML OpenGL");
 ///
-/// // Create a sprite and a text to display
+/// // Load required resources for the sprite and the text
 /// const auto texture = sf::Texture::loadFromFile("circle.png").value();
-/// sf::Sprite sprite(texture);
 /// const auto font = sf::Font::loadFromFile("arial.ttf").value();
+///
+/// // Create geometry for the sprite that will display the texture
+/// sf::SpriteGeometry geometry(texture.getRect());
+///
+/// // Create text object
 /// sf::Text text(font);
 /// ...
 ///
@@ -282,9 +286,9 @@ private:
 ///     // Process events
 ///     ...
 ///
-///     // Draw a background sprite
+///     // Create and draw a background sprite
 ///     window.pushGLStates();
-///     window.draw(sprite);
+///     window.draw(sf::Sprite(geometry, texture));
 ///     window.popGLStates();
 ///
 ///     // Draw a 3D object using OpenGL

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -30,16 +30,12 @@
 #include <SFML/Graphics/Export.hpp>
 
 #include <SFML/Graphics/Drawable.hpp>
-#include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/RenderStates.hpp>
-#include <SFML/Graphics/Transformable.hpp>
-#include <SFML/Graphics/Vertex.hpp>
-
-#include <array>
 
 
 namespace sf
 {
+class SpriteGeometry;
 class Texture;
 
 ////////////////////////////////////////////////////////////
@@ -47,7 +43,7 @@ class Texture;
 ///        own transformations, color, etc.
 ///
 ////////////////////////////////////////////////////////////
-class SFML_GRAPHICS_API Sprite : public Drawable, public Transformable
+class SFML_GRAPHICS_API Sprite : public Drawable
 {
 public:
     ////////////////////////////////////////////////////////////
@@ -58,147 +54,31 @@ public:
     /// \see setTexture
     ///
     ////////////////////////////////////////////////////////////
-    explicit Sprite(const Texture& texture);
+    explicit Sprite(const SpriteGeometry& geometry, const Texture& texture);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Disallow construction from a temporary texture
+    /// \brief Deleted copy constructor
     ///
     ////////////////////////////////////////////////////////////
-    explicit Sprite(Texture&& texture) = delete;
+    Sprite(const Sprite&) = delete;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Construct the sprite from a sub-rectangle of a source texture
-    ///
-    /// \param texture   Source texture
-    /// \param rectangle Sub-rectangle of the texture to assign to the sprite
-    ///
-    /// \see setTexture, setTextureRect
+    /// \brief Deleted copy assignment
     ///
     ////////////////////////////////////////////////////////////
-    Sprite(const Texture& texture, const IntRect& rectangle);
+    Sprite& operator=(const Sprite&) = delete;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Disallow construction from a temporary texture
+    /// \brief Deleted move constructor
     ///
     ////////////////////////////////////////////////////////////
-    Sprite(Texture&& texture, const IntRect& rectangle) = delete;
+    Sprite(Sprite&&) noexcept = delete;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Change the source texture of the sprite
-    ///
-    /// The \a texture argument refers to a texture that must
-    /// exist as long as the sprite uses it. Indeed, the sprite
-    /// doesn't store its own copy of the texture, but rather keeps
-    /// a pointer to the one that you passed to this function.
-    /// If the source texture is destroyed and the sprite tries to
-    /// use it, the behavior is undefined.
-    /// If \a resetRect is true, the TextureRect property of
-    /// the sprite is automatically adjusted to the size of the new
-    /// texture. If it is false, the texture rect is left unchanged.
-    ///
-    /// \param texture   New texture
-    /// \param resetRect Should the texture rect be reset to the size of the new texture?
-    ///
-    /// \see getTexture, setTextureRect
+    /// \brief Deleted move assignment
     ///
     ////////////////////////////////////////////////////////////
-    void setTexture(const Texture& texture, bool resetRect = false);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Disallow setting from a temporary texture
-    ///
-    ////////////////////////////////////////////////////////////
-    void setTexture(Texture&& texture, bool resetRect = false) = delete;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the sub-rectangle of the texture that the sprite will display
-    ///
-    /// The texture rect is useful when you don't want to display
-    /// the whole texture, but rather a part of it.
-    /// By default, the texture rect covers the entire texture.
-    ///
-    /// \param rectangle Rectangle defining the region of the texture to display
-    ///
-    /// \see getTextureRect, setTexture
-    ///
-    ////////////////////////////////////////////////////////////
-    void setTextureRect(const IntRect& rectangle);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Set the global color of the sprite
-    ///
-    /// This color is modulated (multiplied) with the sprite's
-    /// texture. It can be used to colorize the sprite, or change
-    /// its global opacity.
-    /// By default, the sprite's color is opaque white.
-    ///
-    /// \param color New color of the sprite
-    ///
-    /// \see getColor
-    ///
-    ////////////////////////////////////////////////////////////
-    void setColor(const Color& color);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the source texture of the sprite
-    ///
-    /// The returned reference is const, which means that you can't
-    /// modify the texture when you retrieve it with this function.
-    ///
-    /// \return Reference to the sprite's texture
-    ///
-    /// \see setTexture
-    ///
-    ////////////////////////////////////////////////////////////
-    const Texture& getTexture() const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the sub-rectangle of the texture displayed by the sprite
-    ///
-    /// \return Texture rectangle of the sprite
-    ///
-    /// \see setTextureRect
-    ///
-    ////////////////////////////////////////////////////////////
-    const IntRect& getTextureRect() const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the global color of the sprite
-    ///
-    /// \return Global color of the sprite
-    ///
-    /// \see setColor
-    ///
-    ////////////////////////////////////////////////////////////
-    const Color& getColor() const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the local bounding rectangle of the entity
-    ///
-    /// The returned rectangle is in local coordinates, which means
-    /// that it ignores the transformations (translation, rotation,
-    /// scale, ...) that are applied to the entity.
-    /// In other words, this function returns the bounds of the
-    /// entity in the entity's coordinate system.
-    ///
-    /// \return Local bounding rectangle of the entity
-    ///
-    ////////////////////////////////////////////////////////////
-    FloatRect getLocalBounds() const;
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Get the global bounding rectangle of the entity
-    ///
-    /// The returned rectangle is in global coordinates, which means
-    /// that it takes into account the transformations (translation,
-    /// rotation, scale, ...) that are applied to the entity.
-    /// In other words, this function returns the bounds of the
-    /// sprite in the global 2D world's coordinate system.
-    ///
-    /// \return Global bounding rectangle of the entity
-    ///
-    ////////////////////////////////////////////////////////////
-    FloatRect getGlobalBounds() const;
+    Sprite& operator=(Sprite&&) noexcept = delete;
 
 private:
     ////////////////////////////////////////////////////////////
@@ -211,17 +91,10 @@ private:
     void draw(RenderTarget& target, RenderStates states) const override;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Update the vertices' positions and texture coordinates
-    ///
-    ////////////////////////////////////////////////////////////
-    void updateVertices();
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::array<Vertex, 4> m_vertices;    //!< Vertices defining the sprite's geometry
-    const Texture*        m_texture;     //!< Texture of the sprite
-    IntRect               m_textureRect; //!< Rectangle defining the area of the source texture to display
+    const SpriteGeometry& m_geometry; //!< Geometry of the sprite
+    const Texture&        m_texture;  //!< Texture of the sprite
 };
 
 } // namespace sf
@@ -263,16 +136,16 @@ private:
 /// // Load a texture
 /// const auto texture = sf::Texture::loadFromFile("texture.png").value();
 ///
-/// // Create a sprite
-/// sf::Sprite sprite(texture);
-/// sprite.setTextureRect(sf::IntRect({10, 10}, {50, 30}));
-/// sprite.setColor(sf::Color(255, 255, 255, 200));
-/// sprite.setPosition(100, 25);
+/// // Create the sprite geometry
+/// sf::SpriteGeometry geometry(texture.getRect());
+/// geometry.setTextureRect(sf::IntRect({10, 10}, {50, 30}));
+/// geometry.setColor(sf::Color(255, 255, 255, 200));
+/// geometry.setPosition(100, 25);
 ///
-/// // Draw it
-/// window.draw(sprite);
+/// // Create and draw the sprite
+/// window.draw(sf::Sprite(geometry, texture));
 /// \endcode
 ///
-/// \see sf::Texture, sf::Transformable
+/// \see sf::SpriteGeometry, sf::Texture, sf::Transformable, sf::Drawable
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/SpriteGeometry.hpp
+++ b/include/SFML/Graphics/SpriteGeometry.hpp
@@ -1,0 +1,205 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2024 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+
+#include <SFML/Graphics/Color.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/Transformable.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+
+#include <array>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Transformable geometry for a textured quad
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API SpriteGeometry : public Transformable
+{
+public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sprite geometry from a sub-rectangle of an eventual source texture
+    ///
+    /// \param rectangle Sub-rectangle of the eventual texture (specified during sprite drawing)
+    ///
+    /// \see setTextureRect
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit SpriteGeometry(const IntRect& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the sub-rectangle of the texture that the sprite geometry will display
+    ///
+    /// The texture rect is useful when you don't want to display
+    /// the whole texture, but rather a part of it.
+    ///
+    /// \param rectangle Rectangle defining the region of the texture to display
+    ///
+    /// \see getTextureRect, setTexture
+    ///
+    ////////////////////////////////////////////////////////////
+    void setTextureRect(const IntRect& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the global color of the sprite geometry
+    ///
+    /// This color is modulated (multiplied) with the sprite's
+    /// texture. It can be used to colorize the sprite, or change
+    /// its global opacity.
+    /// By default, the sprite's color is opaque white.
+    ///
+    /// \param color New color of the sprite geometry
+    ///
+    /// \see getColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the sub-rectangle of the texture displayed by the sprite
+    ///
+    /// \return Texture rectangle of the sprite geometry
+    ///
+    /// \see setTextureRect
+    ///
+    ////////////////////////////////////////////////////////////
+    IntRect getTextureRect() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the global color of the sprite geometry
+    ///
+    /// \return Global color of the sprite geometry
+    ///
+    /// \see setColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the local bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in local coordinates, which means
+    /// that it ignores the transformations (translation, rotation,
+    /// scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// entity in the entity's coordinate system.
+    ///
+    /// \return Local bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getLocalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the global bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in global coordinates, which means
+    /// that it takes into account the transformations (translation,
+    /// rotation, scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// sprite in the global 2D world's coordinate system.
+    ///
+    /// \return Global bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getGlobalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the vertices of the sprite geometry
+    ///
+    ////////////////////////////////////////////////////////////
+    const std::array<Vertex, 4>& getVertices() const;
+
+private:
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the vertices' positions and texture coordinates
+    ///
+    ////////////////////////////////////////////////////////////
+    void updateVertices(const IntRect& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::array<Vertex, 4> m_vertices;    //!< Vertices defining the sprite's geometry
+};
+
+} // namespace sf
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Sprite
+/// \ingroup graphics
+///
+/// sf::Sprite is a drawable class that allows to easily display
+/// a texture (or a part of it) on a render target.
+///
+/// It inherits all the functions from sf::Transformable:
+/// position, rotation, scale, origin. It also adds sprite-specific
+/// properties such as the texture to use, the part of it to display,
+/// and some convenience functions to change the overall color of the
+/// sprite, or to get its bounding rectangle.
+///
+/// sf::Sprite works in combination with the sf::Texture class, which
+/// loads and provides the pixel data of a given texture.
+///
+/// The separation of sf::Sprite and sf::Texture allows more flexibility
+/// and better performances: indeed a sf::Texture is a heavy resource,
+/// and any operation on it is slow (often too slow for real-time
+/// applications). On the other side, a sf::Sprite is a lightweight
+/// object which can use the pixel data of a sf::Texture and draw
+/// it with its own transformation/color/blending attributes.
+///
+/// It is important to note that the sf::Sprite instance doesn't
+/// copy the texture that it uses, it only keeps a reference to it.
+/// Thus, a sf::Texture must not be destroyed while it is
+/// used by a sf::Sprite (i.e. never write a function that
+/// uses a local sf::Texture instance for creating a sprite).
+///
+/// See also the note on coordinates and undistorted rendering in sf::Transformable.
+///
+/// Usage example:
+/// \code
+/// // Load a texture
+/// const auto texture = sf::Texture::loadFromFile("texture.png").value();
+///
+/// // Create the sprite geometry
+/// sf::SpriteGeometry geometry(texture.getRect);
+/// geometry.setTextureRect({{10, 10}, {50, 30}});
+/// geometry.setColor({255, 255, 255, 200});
+/// geometry.setPosition(100, 25);
+///
+/// // Create and draw the sprite
+/// window.draw(sf::Sprite(geometry, texture));
+/// \endcode
+///
+/// \see sf::Sprite, sf::Texture, sf::Transformable
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/SpriteGeometry.hpp
+++ b/include/SFML/Graphics/SpriteGeometry.hpp
@@ -148,7 +148,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::array<Vertex, 4> m_vertices;    //!< Vertices defining the sprite's geometry
+    std::array<Vertex, 4> m_vertices; //!< Vertices defining the sprite's geometry
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -496,6 +496,16 @@ public:
     unsigned int getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get a rectangle covering the entire texture
+    ///
+    /// This function is useful to conveniently initialize `sf::SpriteGeometry`
+    /// objects that are intended to be used with this texture.
+    ///
+    /// \return Rectangle covering the entire texture, from {0, 0} to {width, height}
+    ////////////////////////////////////////////////////////////
+    IntRect getRect() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Bind a texture for rendering
     ///
     /// This function is not part of the graphics API, it mustn't be
@@ -664,11 +674,11 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// // Load a texture from a file
 /// const auto texture = sf::Texture::loadFromFile("texture.png").value();
 ///
-/// // Assign it to a sprite
-/// sf::Sprite sprite(texture);
+/// // Create geometry for the sprite that will display the texture
+/// sf::SpriteGeometry geometry(texture.getRect());
 ///
-/// // Draw the textured sprite
-/// window.draw(sprite);
+/// // Create and draw the textured sprite
+/// window.draw(sf::Sprite(geometry, texture));
 /// \endcode
 ///
 /// \code
@@ -678,8 +688,8 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// // Create an empty texture
 /// auto texture = sf::Texture::create({640, 480}).value();
 ///
-/// // Create a sprite that will display the texture
-/// sf::Sprite sprite(texture);
+/// // Create geometry for the sprite that will display the texture
+/// sf::SpriteGeometry geometry(texture.getRect());
 ///
 /// while (...) // the main loop
 /// {
@@ -689,8 +699,8 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 ///     std::uint8_t* pixels = ...; // get a fresh chunk of pixels (the next frame of a movie, for example)
 ///     texture.update(pixels);
 ///
-///     // draw it
-///     window.draw(sprite);
+///     // create and draw a sprite
+///     window.draw(sf::Sprite(geometry, texture));
 ///
 ///     ...
 /// }
@@ -706,6 +716,6 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// sf::Texture::bind(nullptr);
 /// \endcode
 ///
-/// \see sf::Sprite, sf::Image, sf::RenderTexture
+/// \see sf::Sprite, sf::SpriteGeometry, sf::Image, sf::RenderTexture
 ///
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -64,6 +64,8 @@ set(DRAWABLES_SRC
     ${INCROOT}/ConvexShape.hpp
     ${SRCROOT}/Sprite.cpp
     ${INCROOT}/Sprite.hpp
+    ${SRCROOT}/SpriteGeometry.cpp
+    ${INCROOT}/SpriteGeometry.hpp
     ${SRCROOT}/Text.cpp
     ${INCROOT}/Text.hpp
     ${SRCROOT}/VertexArray.cpp

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Graphics/GLExtensions.hpp>
 #include <SFML/Graphics/RenderTarget.hpp>
 #include <SFML/Graphics/Shader.hpp>
+#include <SFML/Graphics/Sprite.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/VertexBuffer.hpp>
 
@@ -465,6 +466,12 @@ void RenderTarget::draw(const VertexBuffer& vertexBuffer, std::size_t firstVerte
         m_cache.useVertexCache        = false;
         m_cache.texCoordsArrayEnabled = true;
     }
+}
+
+////////////////////////////////////////////////////////////
+void RenderTarget::draw(Sprite&& sprite, const RenderStates& states)
+{
+    draw(static_cast<Drawable&>(sprite), states);
 }
 
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -471,7 +471,7 @@ void RenderTarget::draw(const VertexBuffer& vertexBuffer, std::size_t firstVerte
 ////////////////////////////////////////////////////////////
 void RenderTarget::draw(Sprite&& sprite, const RenderStates& states)
 {
-    draw(static_cast<Drawable&>(sprite), states);
+    draw(static_cast<const Drawable&>(sprite), states);
 }
 
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -27,131 +27,25 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/RenderTarget.hpp>
 #include <SFML/Graphics/Sprite.hpp>
-#include <SFML/Graphics/Texture.hpp>
-
-#include <cmath>
-#include <cstdlib>
+#include <SFML/Graphics/SpriteGeometry.hpp>
 
 
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Sprite::Sprite(const Texture& texture) : Sprite(texture, IntRect({0, 0}, Vector2i(texture.getSize())))
+Sprite::Sprite(const SpriteGeometry& geometry, const Texture& texture) : m_geometry(geometry), m_texture(texture)
 {
-}
-
-
-////////////////////////////////////////////////////////////
-Sprite::Sprite(const Texture& texture, const IntRect& rectangle) : m_texture(&texture), m_textureRect(rectangle)
-{
-    updateVertices();
-}
-
-
-////////////////////////////////////////////////////////////
-void Sprite::setTexture(const Texture& texture, bool resetRect)
-{
-    // Recompute the texture area if requested
-    if (resetRect)
-    {
-        setTextureRect(IntRect({0, 0}, Vector2i(texture.getSize())));
-    }
-
-    // Assign the new texture
-    m_texture = &texture;
-}
-
-
-////////////////////////////////////////////////////////////
-void Sprite::setTextureRect(const IntRect& rectangle)
-{
-    if (rectangle != m_textureRect)
-    {
-        m_textureRect = rectangle;
-        updateVertices();
-    }
-}
-
-
-////////////////////////////////////////////////////////////
-void Sprite::setColor(const Color& color)
-{
-    for (Vertex& vertex : m_vertices)
-        vertex.color = color;
-}
-
-
-////////////////////////////////////////////////////////////
-const Texture& Sprite::getTexture() const
-{
-    return *m_texture;
-}
-
-
-////////////////////////////////////////////////////////////
-const IntRect& Sprite::getTextureRect() const
-{
-    return m_textureRect;
-}
-
-
-////////////////////////////////////////////////////////////
-const Color& Sprite::getColor() const
-{
-    return m_vertices[0].color;
-}
-
-
-////////////////////////////////////////////////////////////
-FloatRect Sprite::getLocalBounds() const
-{
-    const auto width  = static_cast<float>(std::abs(m_textureRect.width));
-    const auto height = static_cast<float>(std::abs(m_textureRect.height));
-
-    return {{0.f, 0.f}, {width, height}};
-}
-
-
-////////////////////////////////////////////////////////////
-FloatRect Sprite::getGlobalBounds() const
-{
-    return getTransform().transformRect(getLocalBounds());
 }
 
 
 ////////////////////////////////////////////////////////////
 void Sprite::draw(RenderTarget& target, RenderStates states) const
 {
-    states.transform *= getTransform();
-    states.texture        = m_texture;
+    states.transform *= m_geometry.getTransform();
+    states.texture        = &m_texture;
     states.coordinateType = CoordinateType::Pixels;
-    target.draw(m_vertices.data(), m_vertices.size(), PrimitiveType::TriangleStrip, states);
-}
 
-
-////////////////////////////////////////////////////////////
-void Sprite::updateVertices()
-{
-    // Update positions
-    const FloatRect bounds = getLocalBounds();
-
-    m_vertices[0].position = Vector2f(0, 0);
-    m_vertices[1].position = Vector2f(0, bounds.height);
-    m_vertices[2].position = Vector2f(bounds.width, 0);
-    m_vertices[3].position = Vector2f(bounds.width, bounds.height);
-
-    // Update texture coordinates
-    const FloatRect convertedTextureRect(m_textureRect);
-
-    const float left   = convertedTextureRect.left;
-    const float right  = left + convertedTextureRect.width;
-    const float top    = convertedTextureRect.top;
-    const float bottom = top + convertedTextureRect.height;
-
-    m_vertices[0].texCoords = Vector2f(left, top);
-    m_vertices[1].texCoords = Vector2f(left, bottom);
-    m_vertices[2].texCoords = Vector2f(right, top);
-    m_vertices[3].texCoords = Vector2f(right, bottom);
+    target.draw(m_geometry.getVertices().data(), m_geometry.getVertices().size(), PrimitiveType::TriangleStrip, states);
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -45,7 +45,7 @@ void Sprite::draw(RenderTarget& target, RenderStates states) const
     states.texture        = &m_texture;
     states.coordinateType = CoordinateType::Pixels;
 
-    target.draw(m_geometry.getVertices().data(), m_geometry.getVertices().size(), PrimitiveType::TriangleStrip, states);
+    target.draw(m_geometry.getVertices().data(), 4, PrimitiveType::TriangleStrip, states);
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/SpriteGeometry.cpp
+++ b/src/SFML/Graphics/SpriteGeometry.cpp
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2024 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/SpriteGeometry.hpp>
+
+#include <cmath>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+SpriteGeometry::SpriteGeometry(const IntRect& rectangle)
+{
+    updateVertices(rectangle);
+}
+
+
+////////////////////////////////////////////////////////////
+void SpriteGeometry::setTextureRect(const IntRect& rectangle)
+{
+    updateVertices(rectangle);
+}
+
+
+////////////////////////////////////////////////////////////
+void SpriteGeometry::setColor(const Color& color)
+{
+    for (Vertex& vertex : m_vertices)
+        vertex.color = color;
+}
+
+
+////////////////////////////////////////////////////////////
+IntRect SpriteGeometry::getTextureRect() const
+{
+    return IntRect{Vector2i(m_vertices[0].texCoords), Vector2i(m_vertices[3].texCoords - m_vertices[0].texCoords)};
+}
+
+
+////////////////////////////////////////////////////////////
+const Color& SpriteGeometry::getColor() const
+{
+    return m_vertices[0].color;
+}
+
+
+////////////////////////////////////////////////////////////
+FloatRect SpriteGeometry::getLocalBounds() const
+{
+    const auto width  = static_cast<float>(std::abs(getTextureRect().width));
+    const auto height = static_cast<float>(std::abs(getTextureRect().height));
+
+    return {{0.f, 0.f}, {width, height}};
+}
+
+
+////////////////////////////////////////////////////////////
+FloatRect SpriteGeometry::getGlobalBounds() const
+{
+    return getTransform().transformRect(getLocalBounds());
+}
+
+////////////////////////////////////////////////////////////
+const std::array<Vertex, 4>& SpriteGeometry::getVertices() const
+{
+    return m_vertices;
+}
+
+////////////////////////////////////////////////////////////
+void SpriteGeometry::updateVertices(const IntRect& rectangle)
+{
+    // Update positions
+    const FloatRect bounds = getLocalBounds();
+
+    m_vertices[0].position = Vector2f(0, 0);
+    m_vertices[1].position = Vector2f(0, bounds.height);
+    m_vertices[2].position = Vector2f(bounds.width, 0);
+    m_vertices[3].position = Vector2f(bounds.width, bounds.height);
+
+    // Update texture coordinates
+    const FloatRect convertedTextureRect(rectangle);
+
+    const float left   = convertedTextureRect.left;
+    const float right  = left + convertedTextureRect.width;
+    const float top    = convertedTextureRect.top;
+    const float bottom = top + convertedTextureRect.height;
+
+    m_vertices[0].texCoords = Vector2f(left, top);
+    m_vertices[1].texCoords = Vector2f(left, bottom);
+    m_vertices[2].texCoords = Vector2f(right, top);
+    m_vertices[3].texCoords = Vector2f(right, bottom);
+}
+
+} // namespace sf

--- a/src/SFML/Graphics/SpriteGeometry.cpp
+++ b/src/SFML/Graphics/SpriteGeometry.cpp
@@ -71,8 +71,10 @@ const Color& SpriteGeometry::getColor() const
 ////////////////////////////////////////////////////////////
 FloatRect SpriteGeometry::getLocalBounds() const
 {
-    const auto width  = static_cast<float>(std::abs(getTextureRect().width));
-    const auto height = static_cast<float>(std::abs(getTextureRect().height));
+    const Vector2f size = m_vertices[3].texCoords - m_vertices[0].texCoords;
+
+    const auto width  = static_cast<float>(std::abs(size.x));
+    const auto height = static_cast<float>(std::abs(size.y));
 
     return {{0.f, 0.f}, {width, height}};
 }
@@ -94,12 +96,10 @@ const std::array<Vertex, 4>& SpriteGeometry::getVertices() const
 void SpriteGeometry::updateVertices(const IntRect& rectangle)
 {
     // Update positions
-    const FloatRect bounds = getLocalBounds();
-
     m_vertices[0].position = Vector2f(0, 0);
-    m_vertices[1].position = Vector2f(0, bounds.height);
-    m_vertices[2].position = Vector2f(bounds.width, 0);
-    m_vertices[3].position = Vector2f(bounds.width, bounds.height);
+    m_vertices[1].position = Vector2f(0, static_cast<float>(rectangle.height));
+    m_vertices[2].position = Vector2f(static_cast<float>(rectangle.width), 0);
+    m_vertices[3].position = Vector2f(static_cast<float>(rectangle.width), static_cast<float>(rectangle.height));
 
     // Update texture coordinates
     const FloatRect convertedTextureRect(rectangle);

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -961,6 +961,13 @@ unsigned int Texture::getNativeHandle() const
 
 
 ////////////////////////////////////////////////////////////
+IntRect Texture::getRect() const
+{
+    return {{0, 0}, Vector2i(getSize())};
+}
+
+
+////////////////////////////////////////////////////////////
 unsigned int Texture::getValidSize(unsigned int size)
 {
     if (GLEXT_texture_non_power_of_two)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,7 @@ set(GRAPHICS_SRC
     Graphics/Shader.test.cpp
     Graphics/Shape.test.cpp
     Graphics/Sprite.test.cpp
+    Graphics/SpriteGeometry.test.cpp
     Graphics/StencilMode.test.cpp
     Graphics/Text.test.cpp
     Graphics/Texture.test.cpp

--- a/test/Graphics/Sprite.test.cpp
+++ b/test/Graphics/Sprite.test.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Graphics/Sprite.hpp>
 
 // Other 1st party headers
+#include <SFML/Graphics/SpriteGeometry.hpp>
 #include <SFML/Graphics/Texture.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -12,57 +13,20 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(!std::is_constructible_v<sf::Sprite, sf::Texture&&>);
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Sprite>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Sprite>);
-        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Sprite>);
-        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Sprite>);
+        STATIC_CHECK(std::is_constructible_v<sf::Sprite, const sf::SpriteGeometry&, const sf::Texture&>);
+        STATIC_CHECK(!std::is_copy_constructible_v<sf::Sprite>);
+        STATIC_CHECK(!std::is_copy_assignable_v<sf::Sprite>);
+        STATIC_CHECK(!std::is_nothrow_move_constructible_v<sf::Sprite>);
+        STATIC_CHECK(!std::is_nothrow_move_assignable_v<sf::Sprite>);
     }
 
     const auto texture = sf::Texture::create({64, 64}).value();
 
     SECTION("Construction")
     {
-        SECTION("Texture constructor")
+        SECTION("Geometry and texture constructor")
         {
-            const sf::Sprite sprite(texture);
-            CHECK(&sprite.getTexture() == &texture);
-            CHECK(sprite.getTextureRect() == sf::IntRect({}, {64, 64}));
-            CHECK(sprite.getColor() == sf::Color::White);
-            CHECK(sprite.getLocalBounds() == sf::FloatRect({}, {64, 64}));
-            CHECK(sprite.getGlobalBounds() == sf::FloatRect({}, {64, 64}));
+            const sf::Sprite sprite(sf::SpriteGeometry({{0, 0}, {40, 60}}), texture);
         }
-
-        SECTION("Texture and rectangle constructor")
-        {
-            const sf::Sprite sprite(texture, {{0, 0}, {40, 60}});
-            CHECK(&sprite.getTexture() == &texture);
-            CHECK(sprite.getTextureRect() == sf::IntRect({0, 0}, {40, 60}));
-            CHECK(sprite.getColor() == sf::Color::White);
-            CHECK(sprite.getLocalBounds() == sf::FloatRect({0, 0}, {40, 60}));
-            CHECK(sprite.getGlobalBounds() == sf::FloatRect({0, 0}, {40, 60}));
-        }
-    }
-
-    SECTION("Set/get texture")
-    {
-        sf::Sprite        sprite(texture);
-        const sf::Texture otherTexture = sf::Texture::create({64, 64}).value();
-        sprite.setTexture(otherTexture);
-        CHECK(&sprite.getTexture() == &otherTexture);
-    }
-
-    SECTION("Set/get texture rect")
-    {
-        sf::Sprite sprite(texture);
-        sprite.setTextureRect({{1, 2}, {3, 4}});
-        CHECK(sprite.getTextureRect() == sf::IntRect({1, 2}, {3, 4}));
-    }
-
-    SECTION("Set/get color")
-    {
-        sf::Sprite sprite(texture);
-        sprite.setColor(sf::Color::Red);
-        CHECK(sprite.getColor() == sf::Color::Red);
     }
 }

--- a/test/Graphics/SpriteGeometry.test.cpp
+++ b/test/Graphics/SpriteGeometry.test.cpp
@@ -1,0 +1,44 @@
+#include <SFML/Graphics/SpriteGeometry.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <WindowUtil.hpp>
+#include <type_traits>
+
+TEST_CASE("[Graphics] sf::SpriteGeometry", runDisplayTests())
+{
+    SECTION("Type traits")
+    {
+        STATIC_CHECK(std::is_constructible_v<sf::SpriteGeometry, const sf::IntRect&>);
+        STATIC_CHECK(std::is_copy_constructible_v<sf::SpriteGeometry>);
+        STATIC_CHECK(std::is_copy_assignable_v<sf::SpriteGeometry>);
+        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::SpriteGeometry>);
+        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::SpriteGeometry>);
+    }
+
+    SECTION("Construction")
+    {
+        SECTION("Rectangle constructor")
+        {
+            const sf::SpriteGeometry geometry({{0, 0}, {40, 60}});
+            CHECK(geometry.getTextureRect() == sf::IntRect({0, 0}, {40, 60}));
+            CHECK(geometry.getColor() == sf::Color::White);
+            CHECK(geometry.getLocalBounds() == sf::FloatRect({0, 0}, {40, 60}));
+            CHECK(geometry.getGlobalBounds() == sf::FloatRect({0, 0}, {40, 60}));
+        }
+    }
+
+    SECTION("Set/get texture rect")
+    {
+        sf::SpriteGeometry geometry({});
+        geometry.setTextureRect({{1, 2}, {3, 4}});
+        CHECK(geometry.getTextureRect() == sf::IntRect({1, 2}, {3, 4}));
+    }
+
+    SECTION("Set/get color")
+    {
+        sf::SpriteGeometry geometry({});
+        geometry.setColor(sf::Color::Red);
+        CHECK(geometry.getColor() == sf::Color::Red);
+    }
+}

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -29,9 +29,11 @@ int main()
     const auto icon = sf::Image::loadFromFile(resourcePath() / "icon.png").value();
     window.setIcon(icon);
 
-    // Load a sprite to display
+    // Load a texture to display
     const auto texture = sf::Texture::loadFromFile(resourcePath() / "background.jpg").value();
-    sf::Sprite sprite(texture);
+
+    // Create geometry for the sprite that will display the texture
+    sf::SpriteGeometry geometry(texture.getRect());
 
     // Create a graphical text to display
     const auto font = sf::Font::loadFromFile(resourcePath() / "tuffy.ttf").value();
@@ -71,8 +73,8 @@ int main()
         // Clear screen
         window.clear();
 
-        // Draw the sprite
-        window.draw(sprite);
+        // Create and draw the sprite
+        window.draw(sf::Sprite(geometry, texture));
 
         // Draw the string
         window.draw(text);

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -27,9 +27,11 @@ int main()
     const auto icon = sf::Image::loadFromFile("icon.png").value();
     window.setIcon(icon);
 
-    // Load a sprite to display
+    // Load a texture to display
     const auto texture = sf::Texture::loadFromFile("background.jpg").value();
-    sf::Sprite sprite(texture);
+
+    // Create geometry for the sprite that will display the texture
+    sf::SpriteGeometry geometry(texture.getRect());
 
     // Create a graphical text to display
     const auto font = sf::Font::loadFromFile("tuffy.ttf").value();
@@ -69,8 +71,8 @@ int main()
         // Clear screen
         window.clear();
 
-        // Draw the sprite
-        window.draw(sprite);
+        // Create and draw the sprite
+        window.draw(sf::Sprite(geometry, texture));
 
         // Draw the string
         window.draw(text);


### PR DESCRIPTION
(Based on #3067.)

Alternative design to #3072 that:
- Solves the same lifetime issues
- Still greatly simplifies the API and implementation of sprites
- Retains SFML's OOP nature, keeping `sf::Sprite` as a "drawable texture"

The new design is as follows:
- A new transformable but not drawable class, `sf::SpriteGeometry` has been extracted from `sf::Sprite`
- `sf::SpriteGeometry` calculates and owns the vertices required to draw a textured quad
- `sf::Sprite` is now a lightweight view over the combination of a `sf::SpriteGeometry` and a `sf::Texture`
- `sf::Sprite` is still drawable, but not transformable
- Only temporary instances of `sf::Sprite` can be drawn on a `sf::RenderTarget`, preventing lifetime bugs

Here is the simplest example of using this new API:

```cpp
// Load a texture from a file
const auto texture = sf::Texture::loadFromFile("texture.png").value();

// Create geometry for the sprite that will display the texture
sf::SpriteGeometry geometry(texture.getRect());

// Create and draw the textured sprite
window.draw(sf::Sprite(geometry, texture));
```

`sf::SpriteGeometry` is safe to be precalculated, stored in classes, copied, and moved around. This cleanly solves the lifetime issues encountered in #3062, in fact this PR restores part of the original design where the sprite geometry is a data member of the shader effects.

---

If you feel like the new syntax is too verbose, there is a lot of room to add "convenience" functions, e.g.,

```cpp
// POSSIBLE MORE CONCISE API #1
sf::SpriteGeometry geometry(texture); // IDEA: no need for `.getRect()` call
window.draw(sf::Sprite(geometry, texture));

// POSSIBLE MORE CONCISE API #2
window.draw(sf::Sprite(texture)); // IDEA: shorthand notation for `sf::Sprite(sf::SpriteGeometry(texture), texture)`

// POSSIBLE MORE CONCISE API #3
window.draw(geometry, texture); // IDEA: shorthand notation for `sf::Sprite(geometry, texture)`
```

---

This API is also very suitable for a future batching extension:

```cpp
std::vector<sf::SpriteGeometry> geometries;
// ...fill `geometries`...

window.draw(geometries.data(), geometries.size(), texture); // single draw call for many sprites
```