### PR TITLE
Improve/simplify `SoundEffects.cpp` example

### DIFF
--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -6,6 +6,7 @@
 #include <SFML/Audio.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -30,7 +31,6 @@ std::filesystem::path resourcesDir()
     return "resources";
 #endif
 }
-} // namespace
 
 
 ////////////////////////////////////////////////////////////
@@ -39,67 +39,29 @@ std::filesystem::path resourcesDir()
 class Effect : public sf::Drawable
 {
 public:
-    static void setFont(const sf::Font& font)
-    {
-        s_font = &font;
-    }
-
     const std::string& getName() const
     {
         return m_name;
     }
 
-    void update(float time, float x, float y)
-    {
-        onUpdate(time, x, y);
-    }
+    virtual void update(float time, float x, float y) = 0;
 
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
-    {
-        onDraw(target, states);
-    }
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override = 0;
 
-    void start()
-    {
-        onStart();
-    }
+    virtual void start() = 0;
+    virtual void stop()  = 0;
 
-    void stop()
+    virtual void handleKey([[maybe_unused]] sf::Keyboard::Key key)
     {
-        onStop();
-    }
-
-    void handleKey(sf::Keyboard::Key key)
-    {
-        onKey(key);
     }
 
 protected:
-    Effect(std::string name) : m_name(std::move(name))
+    explicit Effect(std::string name) : m_name(std::move(name))
     {
-    }
-
-    static const sf::Font& getFont()
-    {
-        assert(s_font != nullptr && "Cannot get font until setFont() is called");
-        return *s_font;
     }
 
 private:
-    // Virtual functions to be implemented in derived effects
-    virtual void onUpdate(float time, float x, float y)                          = 0;
-    virtual void onDraw(sf::RenderTarget& target, sf::RenderStates states) const = 0;
-    virtual void onStart()                                                       = 0;
-    virtual void onStop()                                                        = 0;
-
-    virtual void onKey(sf::Keyboard::Key)
-    {
-    }
-
     std::string m_name;
-
-    // NOLINTNEXTLINE(readability-identifier-naming)
-    static inline const sf::Font* s_font{nullptr};
 };
 
 
@@ -109,59 +71,52 @@ private:
 class Surround : public Effect
 {
 public:
-    Surround() : Effect("Surround / Attenuation")
+    explicit Surround(sf::Music&& music) : Effect("Surround / Attenuation"), m_music(std::move(music))
     {
         m_listener.setPosition({(windowWidth - 20.f) / 2.f, (windowHeight - 20.f) / 2.f});
         m_listener.setFillColor(sf::Color::Red);
 
-        // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
-        {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
-            std::abort();
-        }
-
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // Set attenuation to a nice value
-        m_music->setAttenuation(0.04f);
+        m_music.setAttenuation(0.04f);
     }
 
-    void onUpdate(float /*time*/, float x, float y) override
+    void update(float /*time*/, float x, float y) override
     {
         m_position = {windowWidth * x - 10.f, windowHeight * y - 10.f};
-        m_music->setPosition({m_position.x, m_position.y, 0.f});
+        m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
     {
-        auto statesCopy(states);
-        statesCopy.transform = sf::Transform::Identity;
-        statesCopy.transform.translate(m_position);
-
         target.draw(m_listener, states);
-        target.draw(m_soundShape, statesCopy);
+
+        states.transform = sf::Transform::Identity;
+        states.transform.translate(m_position);
+
+        target.draw(m_soundShape, states);
     }
 
-    void onStart() override
+    void start() override
     {
         // Synchronize listener audio position with graphical position
         sf::Listener::setPosition({m_listener.getPosition().x, m_listener.getPosition().y, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
-    void onStop() override
+    void stop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 private:
-    sf::CircleShape          m_listener{20.f};
-    sf::CircleShape          m_soundShape{20.f};
-    sf::Vector2f             m_position;
-    std::optional<sf::Music> m_music;
+    sf::CircleShape m_listener{20.f};
+    sf::CircleShape m_soundShape{20.f};
+    sf::Vector2f    m_position;
+    sf::Music       m_music;
 };
 
 
@@ -171,72 +126,66 @@ private:
 class PitchVolume : public Effect
 {
 public:
-    PitchVolume() :
+    explicit PitchVolume(const sf::Font& font, sf::Music&& music) :
     Effect("Pitch / Volume"),
-    m_pitchText(getFont(), "Pitch: " + std::to_string(m_pitch)),
-    m_volumeText(getFont(), "Volume: " + std::to_string(m_volume))
+    m_pitchText(font, "Pitch: " + std::to_string(m_pitch)),
+    m_volumeText(font, "Volume: " + std::to_string(m_volume)),
+    m_music(std::move(music))
     {
-        // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
-        {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
-            std::abort();
-        }
-
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // We don't care about attenuation in this effect
-        m_music->setAttenuation(0.f);
+        m_music.setAttenuation(0.f);
 
         // Set initial pitch
-        m_music->setPitch(m_pitch);
+        m_music.setPitch(m_pitch);
 
         // Set initial volume
-        m_music->setVolume(m_volume);
+        m_music.setVolume(m_volume);
 
         m_pitchText.setPosition({windowWidth / 2.f - 120.f, windowHeight / 2.f - 80.f});
         m_volumeText.setPosition({windowWidth / 2.f - 120.f, windowHeight / 2.f - 30.f});
     }
 
-    void onUpdate(float /*time*/, float x, float y) override
+    void update(float /*time*/, float x, float y) override
     {
         m_pitch  = std::clamp(2.f * x, 0.f, 2.f);
         m_volume = std::clamp(100.f * (1.f - y), 0.f, 100.f);
 
-        m_music->setPitch(m_pitch);
-        m_music->setVolume(m_volume);
+        m_music.setPitch(m_pitch);
+        m_music.setVolume(m_volume);
 
         m_pitchText.setString("Pitch: " + std::to_string(m_pitch));
         m_volumeText.setString("Volume: " + std::to_string(m_volume));
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
     {
         target.draw(m_pitchText, states);
         target.draw(m_volumeText, states);
     }
 
-    void onStart() override
+    void start() override
     {
         // We set the listener position back to the default
         // so that the music is right on top of the listener
         sf::Listener::setPosition({0.f, 0.f, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
-    void onStop() override
+    void stop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 private:
-    float                    m_pitch{1.f};
-    float                    m_volume{100.f};
-    sf::Text                 m_pitchText;
-    sf::Text                 m_volumeText;
-    std::optional<sf::Music> m_music;
+    float     m_pitch{1.f};
+    float     m_volume{100.f};
+    sf::Text  m_pitchText;
+    sf::Text  m_volumeText;
+    sf::Music m_music;
 };
 
 
@@ -246,7 +195,14 @@ private:
 class Attenuation : public Effect
 {
 public:
-    Attenuation() : Effect("Attenuation"), m_text(getFont())
+    explicit Attenuation(const sf::Font& font, sf::Music&& music) :
+    Effect("Attenuation"),
+    m_text(font,
+           "Attenuation factor dampens full volume of sound while within inner cone based on distance to "
+           "listener.\nCone outer gain determines volume of sound while outside outer cone.\nWhen within outer cone, "
+           "volume is linearly interpolated between inner and outer volumes.",
+           18),
+    m_music(std::move(music))
     {
         m_listener.setPosition({(windowWidth - 20.f) / 2.f, (windowHeight - 20.f) / 2.f + 100.f});
         m_listener.setFillColor(sf::Color::Red);
@@ -259,7 +215,7 @@ public:
         static constexpr auto innerConeAngle = sf::degrees(30.f);
 
         // Set common properties of both cones
-        for (auto* cone : {&m_soundConeOuter, &m_soundConeInner})
+        for (sf::ConvexShape* cone : {&m_soundConeOuter, &m_soundConeInner})
         {
             cone->setPointCount(3);
             cone->setPoint(0, {0.f, 0.f});
@@ -282,42 +238,28 @@ public:
         makeCone(m_soundConeOuter, outerConeAngle);
         makeCone(m_soundConeInner, innerConeAngle);
 
-        // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
-        {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
-            std::abort();
-        }
-
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // Set attenuation factor
-        m_music->setAttenuation(m_attenuation);
+        m_music.setAttenuation(m_attenuation);
 
         // Set direction to face "downwards"
-        m_music->setDirection({0.f, 1.f, 0.f});
+        m_music.setDirection({0.f, 1.f, 0.f});
 
         // Set cone
-        m_music->setCone({innerConeAngle, outerConeAngle, 0.f});
+        m_music.setCone({innerConeAngle, outerConeAngle, 0.f});
 
-        m_text.setString(
-            "Attenuation factor dampens full volume of sound while within inner cone based on distance to "
-            "listener.\nCone outer gain determines "
-            "volume of sound while outside outer cone.\nWhen within outer cone, volume is linearly interpolated "
-            "between "
-            "inner and outer volumes.");
-        m_text.setCharacterSize(18);
         m_text.setPosition({20.f, 20.f});
     }
 
-    void onUpdate(float /*time*/, float x, float y) override
+    void update(float /*time*/, float x, float y) override
     {
         m_position = {windowWidth * x - 10.f, windowHeight * y - 10.f};
-        m_music->setPosition({m_position.x, m_position.y, 0.f});
+        m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
     {
         auto statesCopy(states);
 
@@ -331,27 +273,27 @@ public:
         target.draw(m_text, states);
     }
 
-    void onStart() override
+    void start() override
     {
         // Synchronize listener audio position with graphical position
         sf::Listener::setPosition({m_listener.getPosition().x, m_listener.getPosition().y, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
-    void onStop() override
+    void stop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 private:
-    sf::CircleShape          m_listener{20.f};
-    sf::CircleShape          m_soundShape{20.f};
-    sf::ConvexShape          m_soundConeOuter;
-    sf::ConvexShape          m_soundConeInner;
-    sf::Text                 m_text;
-    sf::Vector2f             m_position;
-    std::optional<sf::Music> m_music;
+    sf::CircleShape m_listener{20.f};
+    sf::CircleShape m_soundShape{20.f};
+    sf::ConvexShape m_soundConeOuter;
+    sf::ConvexShape m_soundConeInner;
+    sf::Text        m_text;
+    sf::Vector2f    m_position;
+    sf::Music       m_music;
 
     float m_attenuation{0.01f};
 };
@@ -363,12 +305,12 @@ private:
 class Tone : public sf::SoundStream, public Effect
 {
 public:
-    Tone() :
+    explicit Tone(const sf::Font& font) :
     Effect("Tone Generator"),
-    m_instruction(getFont(), "Press up and down arrows to change the current wave type"),
-    m_currentType(getFont(), "Wave Type: Triangle"),
-    m_currentAmplitude(getFont(), "Amplitude: 0.05"),
-    m_currentFrequency(getFont(), "Frequency: 200 Hz")
+    m_instruction(font, "Press up and down arrows to change the current wave type"),
+    m_currentType(font, "Wave Type: Triangle"),
+    m_currentAmplitude(font, "Amplitude: 0.05"),
+    m_currentFrequency(font, "Frequency: 200 Hz")
     {
         m_instruction.setPosition({windowWidth / 2.f - 370.f, windowHeight / 2.f - 200.f});
         m_currentType.setPosition({windowWidth / 2.f - 150.f, windowHeight / 2.f - 100.f});
@@ -378,7 +320,7 @@ public:
         sf::SoundStream::initialize(1, sampleRate, {sf::SoundChannel::Mono});
     }
 
-    void onUpdate(float /*time*/, float x, float y) override
+    void update(float /*time*/, float x, float y) override
     {
         m_amplitude = std::clamp(0.2f * (1.f - y), 0.f, 0.2f);
         m_frequency = std::clamp(500.f * x, 0.f, 500.f);
@@ -387,7 +329,7 @@ public:
         m_currentFrequency.setString("Frequency: " + std::to_string(m_frequency) + " Hz");
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
     {
         target.draw(m_instruction, states);
         target.draw(m_currentType, states);
@@ -395,7 +337,7 @@ public:
         target.draw(m_currentFrequency, states);
     }
 
-    void onStart() override
+    void start() override
     {
         // We set the listener position back to the default
         // so that the tone is right on top of the listener
@@ -404,12 +346,12 @@ public:
         play();
     }
 
-    void onStop() override
+    void stop() override
     {
         SoundStream::stop();
     }
 
-    void onKey(sf::Keyboard::Key key) override
+    void handleKey(sf::Keyboard::Key key) override
     {
         auto ticks = 0;
 
@@ -525,10 +467,10 @@ private:
 class Doppler : public sf::SoundStream, public Effect
 {
 public:
-    Doppler() :
+    explicit Doppler(const sf::Font& font) :
     Effect("Doppler Shift"),
-    m_currentVelocity(getFont(), "Velocity: " + std::to_string(m_velocity)),
-    m_currentFactor(getFont(), "Doppler Factor: " + std::to_string(m_factor))
+    m_currentVelocity(font, "Velocity: " + std::to_string(m_velocity)),
+    m_currentFactor(font, "Doppler Factor: " + std::to_string(m_factor))
     {
         m_listener.setPosition({(windowWidth - 20.f) / 2.f, (windowHeight - 20.f) / 2.f});
         m_listener.setFillColor(sf::Color::Red);
@@ -544,7 +486,7 @@ public:
         sf::SoundStream::initialize(1, sampleRate, {sf::SoundChannel::Mono});
     }
 
-    void onUpdate(float time, float x, float y) override
+    void update(float time, float x, float y) override
     {
         m_velocity = std::clamp(150.f * (1.f - y), 0.f, 150.f);
         m_factor   = std::clamp(x, 0.f, 1.f);
@@ -559,7 +501,7 @@ public:
         setDopplerFactor(m_factor);
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
     {
         auto statesCopy(states);
         statesCopy.transform = sf::Transform::Identity;
@@ -571,7 +513,7 @@ public:
         target.draw(m_currentFactor, states);
     }
 
-    void onStart() override
+    void start() override
     {
         // Synchronize listener audio position with graphical position
         sf::Listener::setPosition({m_listener.getPosition().x, m_listener.getPosition().y, 0.f});
@@ -579,7 +521,7 @@ public:
         play();
     }
 
-    void onStop() override
+    void stop() override
     {
         SoundStream::stop();
     }
@@ -633,42 +575,43 @@ private:
 class Processing : public Effect
 {
 public:
-    void onUpdate([[maybe_unused]] float time, float x, float y) override
+    void update([[maybe_unused]] float time, float x, float y) override
     {
         m_position = {windowWidth * x - 10.f, windowHeight * y - 10.f};
-        m_music->setPosition({m_position.x, m_position.y, 0.f});
+        m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
-    void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override
     {
-        auto statesCopy(states);
-        statesCopy.transform = sf::Transform::Identity;
-        statesCopy.transform.translate(m_position);
-
         target.draw(m_listener, states);
-        target.draw(m_soundShape, statesCopy);
+
+        states.transform = sf::Transform::Identity;
+        states.transform.translate(m_position);
+
+        target.draw(m_soundShape, states);
         target.draw(m_enabledText);
         target.draw(m_instructions);
     }
 
-    void onStart() override
+    void start() override
     {
         // Synchronize listener audio position with graphical position
         sf::Listener::setPosition({m_listener.getPosition().x, m_listener.getPosition().y, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
-    void onStop() override
+    void stop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 protected:
-    Processing(std::string name) :
+    explicit Processing(const sf::Font& font, sf::Music&& music, std::string name) :
     Effect(std::move(name)),
-    m_enabledText(getFont(), "Processing: Enabled"),
-    m_instructions(getFont(), "Press Space to enable/disable processing")
+    m_music(std::move(music)),
+    m_enabledText(font, "Processing: Enabled"),
+    m_instructions(font, "Press Space to enable/disable processing")
     {
         m_listener.setPosition({(windowWidth - 20.f) / 2.f, (windowHeight - 20.f) / 2.f});
         m_listener.setFillColor(sf::Color::Red);
@@ -676,23 +619,11 @@ protected:
         m_enabledText.setPosition({windowWidth / 2.f - 120.f, windowHeight * 3.f / 4.f - 50.f});
         m_instructions.setPosition({windowWidth / 2.f - 250.f, windowHeight * 3.f / 4.f});
 
-        // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
-        {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
-            std::abort();
-        }
-
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // Set attenuation to a nice value
-        m_music->setAttenuation(0.0f);
-    }
-
-    sf::Music& getMusic()
-    {
-        return *m_music;
+        m_music.setAttenuation(0.0f);
     }
 
     const std::shared_ptr<bool>& getEnabled() const
@@ -700,8 +631,10 @@ protected:
         return m_enabled;
     }
 
+    sf::Music m_music;
+
 private:
-    void onKey(sf::Keyboard::Key key) override
+    void handleKey(sf::Keyboard::Key key) override
     {
         if (key == sf::Keyboard::Key::Space)
             *m_enabled = !*m_enabled;
@@ -709,13 +642,12 @@ private:
         m_enabledText.setString(*m_enabled ? "Processing: Enabled" : "Processing: Disabled");
     }
 
-    sf::CircleShape          m_listener{20.f};
-    sf::CircleShape          m_soundShape{20.f};
-    sf::Vector2f             m_position;
-    std::optional<sf::Music> m_music;
-    std::shared_ptr<bool>    m_enabled{std::make_shared<bool>(true)};
-    sf::Text                 m_enabledText;
-    sf::Text                 m_instructions;
+    sf::CircleShape       m_listener{20.f};
+    sf::CircleShape       m_soundShape{20.f};
+    sf::Vector2f          m_position;
+    std::shared_ptr<bool> m_enabled{std::make_shared<bool>(true)};
+    sf::Text              m_enabledText;
+    sf::Text              m_instructions;
 };
 
 
@@ -740,8 +672,6 @@ protected:
 
     void setCoefficients(const Coefficients& coefficients)
     {
-        auto& music = getMusic();
-
         struct State
         {
             float xnz1{};
@@ -755,14 +685,14 @@ protected:
         // While the Music object exists, it is possible that the audio engine will try to call
         // this lambda hence we need to always have usable coefficients and state until the Music and the
         // associated lambda are destroyed
-        music.setEffectProcessor(
+        m_music.setEffectProcessor(
             [coefficients,
              enabled = getEnabled(),
-             state   = std::vector<State>(music.getChannelCount())](const float*  inputFrames,
-                                                                  unsigned int& inputFrameCount,
-                                                                  float*        outputFrames,
-                                                                  unsigned int& outputFrameCount,
-                                                                  unsigned int  frameChannelCount) mutable
+             state   = std::vector<State>(m_music.getChannelCount())](const float*  inputFrames,
+                                                                    unsigned int& inputFrameCount,
+                                                                    float*        outputFrames,
+                                                                    unsigned int& outputFrameCount,
+                                                                    unsigned int  frameChannelCount) mutable
             {
                 for (auto frame = 0u; frame < outputFrameCount; ++frame)
                 {
@@ -799,11 +729,12 @@ protected:
 ////////////////////////////////////////////////////////////
 struct HighPassFilter : BiquadFilter
 {
-    HighPassFilter() : BiquadFilter("High-pass Filter")
+    explicit HighPassFilter(const sf::Font& font, sf::Music&& music) :
+    BiquadFilter(font, std::move(music), "High-pass Filter")
     {
         static constexpr auto cutoffFrequency = 2000.f;
 
-        const auto c = std::tan(pi * cutoffFrequency / static_cast<float>(getMusic().getSampleRate()));
+        const auto c = std::tan(pi * cutoffFrequency / static_cast<float>(m_music.getSampleRate()));
 
         Coefficients coefficients;
 
@@ -823,11 +754,12 @@ struct HighPassFilter : BiquadFilter
 ////////////////////////////////////////////////////////////
 struct LowPassFilter : BiquadFilter
 {
-    LowPassFilter() : BiquadFilter("Low-pass Filter")
+    explicit LowPassFilter(const sf::Font& font, sf::Music&& music) :
+    BiquadFilter(font, std::move(music), "Low-pass Filter")
     {
         static constexpr auto cutoffFrequency = 500.f;
 
-        const auto c = 1.f / std::tan(pi * cutoffFrequency / static_cast<float>(getMusic().getSampleRate()));
+        const auto c = 1.f / std::tan(pi * cutoffFrequency / static_cast<float>(m_music.getSampleRate()));
 
         Coefficients coefficients;
 
@@ -847,17 +779,15 @@ struct LowPassFilter : BiquadFilter
 ////////////////////////////////////////////////////////////
 struct Echo : Processing
 {
-    Echo() : Processing("Echo")
+    explicit Echo(const sf::Font& font, sf::Music&& music) : Processing(font, std::move(music), "Echo")
     {
-        auto& music = getMusic();
-
         static constexpr auto delay = 0.2f;
         static constexpr auto decay = 0.75f;
         static constexpr auto wet   = 0.8f;
         static constexpr auto dry   = 1.f;
 
-        const auto channelCount  = music.getChannelCount();
-        const auto sampleRate    = music.getSampleRate();
+        const auto channelCount  = m_music.getChannelCount();
+        const auto sampleRate    = m_music.getSampleRate();
         const auto delayInFrames = static_cast<unsigned int>(static_cast<float>(sampleRate) * delay);
 
         // We use a mutable lambda to tie the lifetime of the state to the lambda itself
@@ -865,7 +795,7 @@ struct Echo : Processing
         // While the Music object exists, it is possible that the audio engine will try to call
         // this lambda hence we need to always have a usable state until the Music and the
         // associated lambda are destroyed
-        music.setEffectProcessor(
+        m_music.setEffectProcessor(
             [delayInFrames,
              enabled = getEnabled(),
              buffer  = std::vector<float>(delayInFrames * channelCount, 0.f),
@@ -904,14 +834,12 @@ struct Echo : Processing
 class Reverb : public Processing
 {
 public:
-    Reverb() : Processing("Reverb")
+    explicit Reverb(const sf::Font& font, sf::Music&& music) : Processing(font, std::move(music), "Reverb")
     {
-        auto& music = getMusic();
-
         static constexpr auto sustain = 0.7f; // [0.f; 1.f]
 
-        const auto channelCount = music.getChannelCount();
-        const auto sampleRate   = music.getSampleRate();
+        const auto channelCount = m_music.getChannelCount();
+        const auto sampleRate   = m_music.getSampleRate();
 
         std::vector<ReverbFilter<float>> filters;
         filters.reserve(channelCount);
@@ -924,7 +852,7 @@ public:
         // While the Music object exists, it is possible that the audio engine will try to call
         // this lambda hence we need to always have a usable state until the Music and the
         // associated lambda are destroyed
-        music.setEffectProcessor(
+        m_music.setEffectProcessor(
             [filters, enabled = getEnabled()](const float*  inputFrames,
                                               unsigned int& inputFrameCount,
                                               float*        outputFrames,
@@ -972,12 +900,11 @@ private:
         const float    m_gain{};
     };
 
-
     template <typename T>
     class FIRFilter
     {
     public:
-        FIRFilter(std::vector<float> taps) : m_taps(std::move(taps))
+        explicit FIRFilter(std::vector<float> taps) : m_taps(std::move(taps))
         {
         }
 
@@ -1048,6 +975,8 @@ private:
     };
 };
 
+} // namespace
+
 
 ////////////////////////////////////////////////////////////
 /// Entry point of application
@@ -1065,18 +994,28 @@ int main()
 
     // Load the application font and pass it to the Effect class
     const auto font = sf::Font::loadFromFile(resourcesDir() / "tuffy.ttf").value();
-    Effect::setFont(font);
+
+    // Exit early if music file not found
+    const auto musicPath = resourcesDir() / "doodle_pop.ogg";
+    if (!std::filesystem::exists(musicPath))
+    {
+        std::cerr << "Music file '" << musicPath << "' not found, aborting" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Helper function to open a new instance of the music file
+    const auto openMusic = [&] { return sf::Music::openFromFile(musicPath).value(); };
 
     // Create the effects
-    Surround       surroundEffect;
-    PitchVolume    pitchVolumeEffect;
-    Attenuation    attenuationEffect;
-    Tone           toneEffect;
-    Doppler        dopplerEffect;
-    HighPassFilter highPassFilterEffect;
-    LowPassFilter  lowPassFilterEffect;
-    Echo           echoEffect;
-    Reverb         reverbEffect;
+    Surround       surroundEffect(openMusic());
+    PitchVolume    pitchVolumeEffect(font, openMusic());
+    Attenuation    attenuationEffect(font, openMusic());
+    Tone           toneEffect(font);
+    Doppler        dopplerEffect(font);
+    HighPassFilter highPassFilterEffect(font, openMusic());
+    LowPassFilter  lowPassFilterEffect(font, openMusic());
+    Echo           echoEffect(font, openMusic());
+    Reverb         reverbEffect(font, openMusic());
 
     const std::array<Effect*, 9> effects{&surroundEffect,
                                          &pitchVolumeEffect,
@@ -1128,7 +1067,10 @@ int main()
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())
+            {
                 window.close();
+                break;
+            }
 
             if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
             {
@@ -1136,30 +1078,42 @@ int main()
                 {
                     // Escape key: exit
                     case sf::Keyboard::Key::Escape:
+                    {
                         window.close();
                         break;
+                    }
 
                     // Left arrow key: previous effect
                     case sf::Keyboard::Key::Left:
+                    {
                         effects[current]->stop();
+
                         if (current == 0)
                             current = effects.size() - 1;
                         else
                             --current;
+
                         effects[current]->start();
+
                         description.setString("Current effect: " + effects[current]->getName());
                         break;
+                    }
 
                     // Right arrow key: next effect
                     case sf::Keyboard::Key::Right:
+                    {
                         effects[current]->stop();
+
                         if (current == effects.size() - 1)
                             current = 0;
                         else
                             ++current;
+
                         effects[current]->start();
+
                         description.setString("Current effect: " + effects[current]->getName());
                         break;
+                    }
 
                     // F1 key: change playback device
                     case sf::Keyboard::Key::F1:
@@ -1193,8 +1147,10 @@ int main()
                     }
 
                     default:
+                    {
                         effects[current]->handleKey(keyPressed->code);
                         break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Same principle as #3062 and #3071, basically:

- Remove unnecessary layers of abstraction 
- Pass dependencies of effects explicitly rather than relying on global state or initialization in constructors
- Avoid unnecessary usage of `std::optional` for music resources
- Minor readability improvements

Note that I still get segfaults in this example, with or without this PR. See #3079 for context.