### PR TITLE
Fix optional comparison to integer value

### DIFF
--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -66,7 +66,7 @@ bool FileInputStream::open(const std::filesystem::path& filename)
     if (priv::getActivityStatesPtr() != nullptr)
     {
         m_androidFile = std::make_unique<priv::ResourceStream>(filename);
-        return m_androidFile->tell() != -1;
+        return m_androidFile->tell().has_value();
     }
 #endif
 #ifdef SFML_SYSTEM_WINDOWS


### PR DESCRIPTION
## Description

Oversight from #2964. This code attempts to compare `-1` to a `std::optional<std::size_t>` which is not a comparison we meant to make. Checking against `-1` is checking against the old sentinel value.