### PR TITLE
Remove default empty state of `sf::FileInputStream`

### DIFF
--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -923,18 +923,17 @@ public:
 
         // Use the vertex shader SPIR-V code to create a vertex shader module
         {
-            sf::FileInputStream file;
-
-            if (!file.open("resources/shader.vert.spv"))
+            auto file = sf::FileInputStream::open("resources/shader.vert.spv");
+            if (!file)
             {
                 vulkanAvailable = false;
                 return;
             }
 
-            const auto                 fileSize = file.getSize().value();
+            const auto                 fileSize = file->getSize().value();
             std::vector<std::uint32_t> buffer(fileSize / sizeof(std::uint32_t));
 
-            if (file.read(buffer.data(), fileSize) != file.getSize())
+            if (file->read(buffer.data(), fileSize) != file->getSize())
             {
                 vulkanAvailable = false;
                 return;
@@ -952,18 +951,17 @@ public:
 
         // Use the fragment shader SPIR-V code to create a fragment shader module
         {
-            sf::FileInputStream file;
-
-            if (!file.open("resources/shader.frag.spv"))
+            auto file = sf::FileInputStream::open("resources/shader.frag.spv");
+            if (!file)
             {
                 vulkanAvailable = false;
                 return;
             }
 
-            const auto                 fileSize = file.getSize().value();
+            const auto                 fileSize = file->getSize().value();
             std::vector<std::uint32_t> buffer(fileSize / sizeof(std::uint32_t));
 
-            if (file.read(buffer.data(), fileSize) != file.getSize())
+            if (file->read(buffer.data(), fileSize) != file->getSize())
             {
                 vulkanAvailable = false;
                 return;

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -57,12 +57,6 @@ class SFML_SYSTEM_API FileInputStream : public InputStream
 {
 public:
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    ////////////////////////////////////////////////////////////
-    FileInputStream();
-
-    ////////////////////////////////////////////////////////////
     /// \brief Default destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -97,10 +91,10 @@ public:
     ///
     /// \param filename Name of the file to open
     ///
-    /// \return True on success, false on error
+    /// \return File input stream on success, `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool open(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<FileInputStream> open(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Read data from the stream
@@ -144,12 +138,6 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
-    // Member data
-    ////////////////////////////////////////////////////////////
-#ifdef SFML_SYSTEM_ANDROID
-    std::unique_ptr<priv::ResourceStream> m_androidFile;
-#endif
-    ////////////////////////////////////////////////////////////
     /// \brief Deleter for stdio file stream that closes the file stream
     ///
     ////////////////////////////////////////////////////////////
@@ -157,6 +145,27 @@ private:
     {
         void operator()(std::FILE* file);
     };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from file
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit FileInputStream(std::unique_ptr<std::FILE, FileCloser>&& file);
+
+#ifdef SFML_SYSTEM_ANDROID
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from resource stream
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit FileInputStream(std::unique_ptr<priv::ResourceStream>&& androidFile);
+#endif
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+#ifdef SFML_SYSTEM_ANDROID
+    std::unique_ptr<priv::ResourceStream> m_androidFile;
+#endif
 
     std::unique_ptr<std::FILE, FileCloser> m_file; //!< stdio file stream
 };
@@ -188,9 +197,9 @@ private:
 /// \code
 /// void process(InputStream& stream);
 ///
-/// FileInputStream stream;
-/// if (stream.open("some_file.dat"))
-///    process(stream);
+/// std::optional stream = sf::FileInputStream::open("some_file.dat");
+/// if (stream)
+///    process(*stream);
 /// \endcode
 ///
 /// InputStream, MemoryInputStream

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -77,17 +77,18 @@ std::optional<InputSoundFile> InputSoundFile::openFromFile(const std::filesystem
         return std::nullopt;
     }
 
-    // Wrap the file into a stream
-    auto file = std::make_unique<FileInputStream>();
-
-    // Open it
-    if (!file->open(filename))
+    // Open the file
+    auto fileInputStream = FileInputStream::open(filename);
+    if (!fileInputStream)
     {
         err() << "Failed to open input sound file from file (couldn't open file input stream)\n"
               << formatDebugPathInfo(filename) << std::endl;
 
         return std::nullopt;
     }
+
+    // Wrap the file into a stream
+    auto file = std::make_unique<FileInputStream>(std::move(*fileInputStream));
 
     // Pass the stream to the reader
     auto info = reader->open(*file);

--- a/src/SFML/Audio/SoundFileFactory.cpp
+++ b/src/SFML/Audio/SoundFileFactory.cpp
@@ -48,8 +48,8 @@ namespace sf
 std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromFilename(const std::filesystem::path& filename)
 {
     // Wrap the input file into a file stream
-    FileInputStream stream;
-    if (!stream.open(filename))
+    auto stream = FileInputStream::open(filename);
+    if (!stream)
     {
         err() << "Failed to open sound file (couldn't open stream)\n" << formatDebugPathInfo(filename) << std::endl;
         return nullptr;
@@ -58,13 +58,13 @@ std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromFilename(cons
     // Test the filename in all the registered factories
     for (const auto& [fpCreate, fpCheck] : getReaderFactoryMap())
     {
-        if (!stream.seek(0).has_value())
+        if (!stream->seek(0).has_value())
         {
             err() << "Failed to seek sound stream" << std::endl;
             return nullptr;
         }
 
-        if (fpCheck(stream))
+        if (fpCheck(*stream))
             return fpCreate();
     }
 

--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -91,62 +91,52 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("openFromStream()")
     {
-        sf::FileInputStream stream;
-
-        SECTION("Invalid stream")
+        SECTION("flac")
         {
-            CHECK(!sf::InputSoundFile::openFromStream(stream));
+            auto       stream         = sf::FileInputStream::open("Audio/ding.flac").value();
+            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            CHECK(inputSoundFile.getSampleCount() == 87'798);
+            CHECK(inputSoundFile.getChannelCount() == 1);
+            CHECK(inputSoundFile.getSampleRate() == 44'100);
+            CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+            CHECK(inputSoundFile.getSampleOffset() == 0);
         }
 
-        SECTION("Valid stream")
+        SECTION("mp3")
         {
-            SECTION("flac")
-            {
-                REQUIRE(stream.open("Audio/ding.flac"));
-                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
-                CHECK(inputSoundFile.getSampleCount() == 87'798);
-                CHECK(inputSoundFile.getChannelCount() == 1);
-                CHECK(inputSoundFile.getSampleRate() == 44'100);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
+            auto       stream         = sf::FileInputStream::open("Audio/ding.mp3").value();
+            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            CHECK(inputSoundFile.getSampleCount() == 87'798);
+            CHECK(inputSoundFile.getChannelCount() == 1);
+            CHECK(inputSoundFile.getSampleRate() == 44'100);
+            CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+            CHECK(inputSoundFile.getSampleOffset() == 0);
+        }
 
-            SECTION("mp3")
-            {
-                REQUIRE(stream.open("Audio/ding.mp3"));
-                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
-                CHECK(inputSoundFile.getSampleCount() == 87'798);
-                CHECK(inputSoundFile.getChannelCount() == 1);
-                CHECK(inputSoundFile.getSampleRate() == 44'100);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
+        SECTION("ogg")
+        {
+            auto       stream         = sf::FileInputStream::open("Audio/doodle_pop.ogg").value();
+            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            CHECK(inputSoundFile.getSampleCount() == 2'116'992);
+            CHECK(inputSoundFile.getChannelCount() == 2);
+            CHECK(inputSoundFile.getSampleRate() == 44'100);
+            CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
+            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+            CHECK(inputSoundFile.getSampleOffset() == 0);
+        }
 
-            SECTION("ogg")
-            {
-                REQUIRE(stream.open("Audio/doodle_pop.ogg"));
-                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
-                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
-                CHECK(inputSoundFile.getChannelCount() == 2);
-                CHECK(inputSoundFile.getSampleRate() == 44'100);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
-
-            SECTION("wav")
-            {
-                REQUIRE(stream.open("Audio/killdeer.wav"));
-                const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
-                CHECK(inputSoundFile.getSampleCount() == 112'941);
-                CHECK(inputSoundFile.getChannelCount() == 1);
-                CHECK(inputSoundFile.getSampleRate() == 22'050);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
+        SECTION("wav")
+        {
+            auto       stream         = sf::FileInputStream::open("Audio/killdeer.wav").value();
+            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            CHECK(inputSoundFile.getSampleCount() == 112'941);
+            CHECK(inputSoundFile.getChannelCount() == 1);
+            CHECK(inputSoundFile.getSampleRate() == 22'050);
+            CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+            CHECK(inputSoundFile.getSampleOffset() == 0);
         }
     }
 

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -82,28 +82,17 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
     SECTION("openFromStream()")
     {
-        sf::FileInputStream stream;
-
-        SECTION("Invalid stream")
-        {
-            CHECK(!sf::Music::openFromStream(stream));
-        }
-
-        SECTION("Valid stream")
-        {
-            REQUIRE(stream.open("Audio/doodle_pop.ogg"));
-
-            const auto music = sf::Music::openFromStream(stream).value();
-            CHECK(music.getDuration() == sf::microseconds(24002176));
-            const auto [offset, length] = music.getLoopPoints();
-            CHECK(offset == sf::Time::Zero);
-            CHECK(length == sf::microseconds(24002176));
-            CHECK(music.getChannelCount() == 2);
-            CHECK(music.getSampleRate() == 44100);
-            CHECK(music.getStatus() == sf::Music::Status::Stopped);
-            CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
-        }
+        auto       stream = sf::FileInputStream::open("Audio/doodle_pop.ogg").value();
+        const auto music  = sf::Music::openFromStream(stream).value();
+        CHECK(music.getDuration() == sf::microseconds(24002176));
+        const auto [offset, length] = music.getLoopPoints();
+        CHECK(offset == sf::Time::Zero);
+        CHECK(length == sf::microseconds(24002176));
+        CHECK(music.getChannelCount() == 2);
+        CHECK(music.getSampleRate() == 44100);
+        CHECK(music.getStatus() == sf::Music::Status::Stopped);
+        CHECK(music.getPlayingOffset() == sf::Time::Zero);
+        CHECK(!music.getLoop());
     }
 
     SECTION("play/pause/stop")

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -89,23 +89,13 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
 
     SECTION("loadFromStream()")
     {
-        sf::FileInputStream stream;
-
-        SECTION("Invalid stream")
-        {
-            CHECK(!sf::SoundBuffer::loadFromStream(stream));
-        }
-
-        SECTION("Valid stream")
-        {
-            REQUIRE(stream.open("Audio/ding.flac"));
-            const auto soundBuffer = sf::SoundBuffer::loadFromStream(stream).value();
-            CHECK(soundBuffer.getSamples() != nullptr);
-            CHECK(soundBuffer.getSampleCount() == 87798);
-            CHECK(soundBuffer.getSampleRate() == 44100);
-            CHECK(soundBuffer.getChannelCount() == 1);
-            CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
-        }
+        auto       stream      = sf::FileInputStream::open("Audio/ding.flac").value();
+        const auto soundBuffer = sf::SoundBuffer::loadFromStream(stream).value();
+        CHECK(soundBuffer.getSamples() != nullptr);
+        CHECK(soundBuffer.getSampleCount() == 87798);
+        CHECK(soundBuffer.getSampleRate() == 44100);
+        CHECK(soundBuffer.getChannelCount() == 1);
+        CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
     }
 
     SECTION("saveToFile()")

--- a/test/Audio/SoundFileFactory.test.cpp
+++ b/test/Audio/SoundFileFactory.test.cpp
@@ -110,37 +110,30 @@ TEST_CASE("[Audio] sf::SoundFileFactory")
 
     SECTION("createReaderFromStream()")
     {
-        sf::FileInputStream stream;
+        std::optional<sf::FileInputStream> stream;
 
-        SECTION("Invalid stream")
+        SECTION("flac")
         {
-            CHECK(!sf::SoundFileFactory::createReaderFromStream(stream));
+            stream = sf::FileInputStream::open("Audio/ding.flac");
         }
 
-        SECTION("Valid file")
+        SECTION("mp3")
         {
-            SECTION("flac")
-            {
-                REQUIRE(stream.open("Audio/ding.flac"));
-            }
-
-            SECTION("mp3")
-            {
-                REQUIRE(stream.open("Audio/ding.mp3"));
-            }
-
-            SECTION("ogg")
-            {
-                REQUIRE(stream.open("Audio/doodle_pop.ogg"));
-            }
-
-            SECTION("wav")
-            {
-                REQUIRE(stream.open("Audio/killdeer.wav"));
-            }
-
-            CHECK(sf::SoundFileFactory::createReaderFromStream(stream));
+            stream = sf::FileInputStream::open("Audio/ding.mp3");
         }
+
+        SECTION("ogg")
+        {
+            stream = sf::FileInputStream::open("Audio/doodle_pop.ogg");
+        }
+
+        SECTION("wav")
+        {
+            stream = sf::FileInputStream::open("Audio/killdeer.wav");
+        }
+
+        REQUIRE(stream);
+        CHECK(sf::SoundFileFactory::createReaderFromStream(*stream));
     }
 
     SECTION("createWriterFromFilename()")

--- a/test/Graphics/Font.test.cpp
+++ b/test/Graphics/Font.test.cpp
@@ -95,39 +95,29 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
 
     SECTION("loadFromStream()")
     {
-        sf::FileInputStream stream;
-
-        SECTION("Invalid stream")
-        {
-            CHECK(!sf::Font::loadFromStream(stream));
-        }
-
-        SECTION("Successful load")
-        {
-            REQUIRE(stream.open("Graphics/tuffy.ttf"));
-            const auto font = sf::Font::loadFromStream(stream).value();
-            CHECK(font.getInfo().family == "Tuffy");
-            const auto& glyph = font.getGlyph(0x45, 16, false);
-            CHECK(glyph.advance == 9);
-            CHECK(glyph.lsbDelta == 9);
-            CHECK(glyph.rsbDelta == 16);
-            CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
-            CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
-            CHECK(font.hasGlyph(0x41));
-            CHECK(font.hasGlyph(0xC0));
-            CHECK(font.getKerning(0x41, 0x42, 12) == -1);
-            CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
-            CHECK(font.getLineSpacing(24) == 30);
-            CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
-            CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
-            const auto& texture = font.getTexture(10);
-            CHECK(texture.getSize() == sf::Vector2u(128, 128));
-            CHECK(texture.isSmooth());
-            CHECK(!texture.isSrgb());
-            CHECK(!texture.isRepeated());
-            CHECK(texture.getNativeHandle() != 0);
-            CHECK(font.isSmooth());
-        }
+        auto       stream = sf::FileInputStream::open("Graphics/tuffy.ttf").value();
+        const auto font   = sf::Font::loadFromStream(stream).value();
+        CHECK(font.getInfo().family == "Tuffy");
+        const auto& glyph = font.getGlyph(0x45, 16, false);
+        CHECK(glyph.advance == 9);
+        CHECK(glyph.lsbDelta == 9);
+        CHECK(glyph.rsbDelta == 16);
+        CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
+        CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
+        CHECK(font.hasGlyph(0x41));
+        CHECK(font.hasGlyph(0xC0));
+        CHECK(font.getKerning(0x41, 0x42, 12) == -1);
+        CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
+        CHECK(font.getLineSpacing(24) == 30);
+        CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
+        CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
+        const auto& texture = font.getTexture(10);
+        CHECK(texture.getSize() == sf::Vector2u(128, 128));
+        CHECK(texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() != 0);
+        CHECK(font.isSmooth());
     }
 
     SECTION("Set/get smooth")

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -178,22 +178,12 @@ TEST_CASE("[Graphics] sf::Image")
 
     SECTION("loadFromStream()")
     {
-        sf::FileInputStream stream;
-
-        SECTION("Invalid stream")
-        {
-            CHECK(!sf::Image::loadFromStream(stream));
-        }
-
-        SECTION("Successful load")
-        {
-            CHECK(stream.open("Graphics/sfml-logo-big.png"));
-            const auto image = sf::Image::loadFromStream(stream).value();
-            CHECK(image.getSize() == sf::Vector2u(1001, 304));
-            CHECK(image.getPixelsPtr() != nullptr);
-            CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
-            CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
-        }
+        auto       stream = sf::FileInputStream::open("Graphics/sfml-logo-big.png").value();
+        const auto image  = sf::Image::loadFromStream(stream).value();
+        CHECK(image.getSize() == sf::Vector2u(1001, 304));
+        CHECK(image.getPixelsPtr() != nullptr);
+        CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
+        CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
     }
 
     SECTION("saveToFile()")

--- a/test/Graphics/Shader.test.cpp
+++ b/test/Graphics/Shader.test.cpp
@@ -243,16 +243,11 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
 
     SECTION("loadFromStream()")
     {
-        sf::FileInputStream vertexShaderStream;
-        REQUIRE(vertexShaderStream.open("Graphics/shader.vert"));
+        auto vertexShaderStream   = sf::FileInputStream::open("Graphics/shader.vert").value();
+        auto fragmentShaderStream = sf::FileInputStream::open("Graphics/shader.frag").value();
+        auto geometryShaderStream = sf::FileInputStream::open("Graphics/shader.geom").value();
 
-        sf::FileInputStream fragmentShaderStream;
-        REQUIRE(fragmentShaderStream.open("Graphics/shader.frag"));
-
-        sf::FileInputStream geometryShaderStream;
-        REQUIRE(geometryShaderStream.open("Graphics/shader.geom"));
-
-        sf::FileInputStream emptyStream;
+        auto emptyStream = sf::FileInputStream::open("Graphics/invalid_shader.vert").value();
 
         SECTION("One shader")
         {

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -95,8 +95,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 
     SECTION("loadFromStream()")
     {
-        sf::FileInputStream stream;
-        REQUIRE(stream.open("Graphics/sfml-logo-big.png"));
+        auto       stream  = sf::FileInputStream::open("Graphics/sfml-logo-big.png").value();
         const auto texture = sf::Texture::loadFromStream(stream).value();
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -66,19 +66,11 @@ TEST_CASE("[System] sf::FileInputStream")
 
     SECTION("Type traits")
     {
+        STATIC_CHECK(!std::is_default_constructible_v<sf::FileInputStream>);
         STATIC_CHECK(!std::is_copy_constructible_v<sf::FileInputStream>);
         STATIC_CHECK(!std::is_copy_assignable_v<sf::FileInputStream>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::FileInputStream>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::FileInputStream>);
-    }
-
-    SECTION("Default constructor")
-    {
-        sf::FileInputStream fileInputStream;
-        CHECK(fileInputStream.read(nullptr, 0) == std::nullopt);
-        CHECK(fileInputStream.seek(0) == std::nullopt);
-        CHECK(fileInputStream.tell() == std::nullopt);
-        CHECK(fileInputStream.getSize() == std::nullopt);
     }
 
     const TemporaryFile temporaryFile("Hello world");
@@ -88,10 +80,8 @@ TEST_CASE("[System] sf::FileInputStream")
     {
         SECTION("Move constructor")
         {
-            sf::FileInputStream movedFileInputStream;
-            REQUIRE(movedFileInputStream.open(temporaryFile.getPath()));
-
-            sf::FileInputStream fileInputStream = std::move(movedFileInputStream);
+            auto                movedFileInputStream = sf::FileInputStream::open(temporaryFile.getPath()).value();
+            sf::FileInputStream fileInputStream      = std::move(movedFileInputStream);
             CHECK(fileInputStream.read(buffer, 6) == 6);
             CHECK(fileInputStream.tell() == 6);
             CHECK(fileInputStream.getSize() == 11);
@@ -100,11 +90,10 @@ TEST_CASE("[System] sf::FileInputStream")
 
         SECTION("Move assignment")
         {
-            sf::FileInputStream movedFileInputStream;
-            REQUIRE(movedFileInputStream.open(temporaryFile.getPath()));
-
-            sf::FileInputStream fileInputStream;
-            fileInputStream = std::move(movedFileInputStream);
+            auto                movedFileInputStream = sf::FileInputStream::open(temporaryFile.getPath()).value();
+            const TemporaryFile temporaryFile2("Hello world the sequel");
+            auto                fileInputStream = sf::FileInputStream::open(temporaryFile2.getPath()).value();
+            fileInputStream                     = std::move(movedFileInputStream);
             CHECK(fileInputStream.read(buffer, 6) == 6);
             CHECK(fileInputStream.tell() == 6);
             CHECK(fileInputStream.getSize() == 11);
@@ -114,8 +103,7 @@ TEST_CASE("[System] sf::FileInputStream")
 
     SECTION("Temporary file stream")
     {
-        sf::FileInputStream fileInputStream;
-        REQUIRE(fileInputStream.open(temporaryFile.getPath()));
+        auto fileInputStream = sf::FileInputStream::open(temporaryFile.getPath()).value();
         CHECK(fileInputStream.read(buffer, 5) == 5);
         CHECK(fileInputStream.tell() == 5);
         CHECK(fileInputStream.getSize() == 11);

--- a/test/install/Install.cpp
+++ b/test/install/Install.cpp
@@ -24,10 +24,9 @@ int main()
     [[maybe_unused]] const sf::UdpSocket udpSocket;
 
     // System
-    [[maybe_unused]] const sf::Angle           angle;
-    [[maybe_unused]] const sf::FileInputStream fileInputStream;
-    [[maybe_unused]] const sf::String          string;
-    [[maybe_unused]] const sf::Time            time;
+    [[maybe_unused]] const sf::Angle  angle;
+    [[maybe_unused]] const sf::String string;
+    [[maybe_unused]] const sf::Time   time;
 
     // Window
     [[maybe_unused]] const sf::Context   context;


### PR DESCRIPTION
## Description

Continuing in the tradition of

- #2992 
- #3020 
- #3021 
- #3022
- #3025
- #3028
- #3030
- #3032
- #3027
- #3075
- #3085

Was it necessary that I list out all of these PRs? No. But I thought it would be fun to include a really long list of PRs that this one refers to. Look how satisfying all these matching PR titles are.