### PR TITLE
Optimize `std::optional` creation, enable more [N]RVO opportunities

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -31,6 +31,8 @@
 
 #include <SFML/Audio/SoundFileReader.hpp>
 
+#include <SFML/System/PassKey.hpp>
+
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -237,16 +239,21 @@ private:
         bool owned{true};
     };
 
+public:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Constructor from reader, stream, and attributes
     ///
     ////////////////////////////////////////////////////////////
-    InputSoundFile(std::unique_ptr<SoundFileReader>&&            reader,
+    InputSoundFile(priv::PassKey<InputSoundFile>&&,
+                   std::unique_ptr<SoundFileReader>&&            reader,
                    std::unique_ptr<InputStream, StreamDeleter>&& stream,
                    std::uint64_t                                 sampleCount,
                    unsigned int                                  sampleRate,
                    std::vector<SoundChannel>&&                   channelMap);
 
+private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -31,6 +31,8 @@
 
 #include <SFML/Audio/SoundStream.hpp>
 
+#include <SFML/System/PassKey.hpp>
+
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -238,12 +240,16 @@ private:
     [[nodiscard]] static std::optional<Music> tryOpenFromInputSoundFile(std::optional<InputSoundFile>&& optFile,
                                                                         const char*                     errorContext);
 
+public:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Initialize the internal state after loading a new music
     ///
     ////////////////////////////////////////////////////////////
-    explicit Music(InputSoundFile&& file);
+    explicit Music(priv::PassKey<Music>&&, InputSoundFile&& file);
 
+private:
     ////////////////////////////////////////////////////////////
     /// \brief Helper to convert an sf::Time to a sample position
     ///

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -32,6 +32,8 @@
 #include <SFML/Audio/SoundChannel.hpp>
 #include <SFML/Audio/SoundFileWriter.hpp>
 
+#include <SFML/System/PassKey.hpp>
+
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -83,13 +85,15 @@ public:
     ////////////////////////////////////////////////////////////
     void close();
 
-private:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Constructor from writer
     ///
     ////////////////////////////////////////////////////////////
-    explicit OutputSoundFile(std::unique_ptr<SoundFileWriter>&& writer);
+    explicit OutputSoundFile(priv::PassKey<OutputSoundFile>&&, std::unique_ptr<SoundFileWriter>&& writer);
 
+private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -31,6 +31,7 @@
 
 #include <SFML/Audio/SoundChannel.hpp>
 
+#include <SFML/System/PassKey.hpp>
 #include <SFML/System/Time.hpp>
 
 #include <filesystem>
@@ -243,11 +244,25 @@ public:
 private:
     friend class Sound;
 
+public:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Construct from vector of samples
     ///
     ////////////////////////////////////////////////////////////
-    explicit SoundBuffer(std::vector<std::int16_t>&& samples);
+    explicit SoundBuffer(priv::PassKey<SoundBuffer>&&, std::vector<std::int16_t>&& samples);
+
+private:
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the sound buffer taking ownership of a vector of audio samples
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<SoundBuffer> loadFromSamplesImpl(
+        std::vector<std::int16_t>&&      samples,
+        unsigned int                     channelCount,
+        unsigned int                     sampleRate,
+        const std::vector<SoundChannel>& channelMap);
 
     ////////////////////////////////////////////////////////////
     /// \brief Initialize the internal state after loading a new sound

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -33,6 +33,7 @@
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/Texture.hpp>
 
+#include <SFML/System/PassKey.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <filesystem>
@@ -374,12 +375,16 @@ private:
     struct FontHandles;
     using PageTable = std::unordered_map<unsigned int, Page>; //!< Table mapping a character size to its page (texture)
 
+public:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Create a font from font handles and a family name
     ///
     ////////////////////////////////////////////////////////////
-    Font(std::shared_ptr<FontHandles>&& fontHandles, std::string&& familyName);
+    Font(priv::PassKey<Font>&&, std::shared_ptr<FontHandles>&& fontHandles, std::string&& familyName);
 
+private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -32,6 +32,7 @@
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Rect.hpp>
 
+#include <SFML/System/PassKey.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <filesystem>
@@ -277,13 +278,15 @@ public:
     ////////////////////////////////////////////////////////////
     void flipVertically();
 
-private:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Directly initialize data members
     ///
     ////////////////////////////////////////////////////////////
-    Image(Vector2u size, std::vector<std::uint8_t>&& pixels);
+    Image(priv::PassKey<Image>&&, Vector2u size, std::vector<std::uint8_t>&& pixels);
 
+private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -101,7 +101,8 @@ constexpr std::optional<Rect<T>> Rect<T>::findIntersection(const Rect<T>& rectan
     // If the intersection is valid (positive non zero area), then there is an intersection
     if ((interLeft < interRight) && (interTop < interBottom))
     {
-        return Rect<T>({interLeft, interTop}, {interRight - interLeft, interBottom - interTop});
+        return std::make_optional<Rect<T>>(Vector2<T>{interLeft, interTop},
+                                           Vector2<T>{interRight - interLeft, interBottom - interTop});
     }
     else
     {

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -34,6 +34,7 @@
 
 #include <SFML/Window/ContextSettings.hpp>
 
+#include <SFML/System/PassKey.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <memory>
@@ -239,13 +240,15 @@ public:
     ////////////////////////////////////////////////////////////
     const Texture& getTexture() const;
 
-private:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Construct from texture
     ///
     ////////////////////////////////////////////////////////////
-    explicit RenderTexture(Texture&& texture);
+    explicit RenderTexture(priv::PassKey<RenderTexture>&&, Texture&& texture);
 
+private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -33,6 +33,8 @@
 
 #include <SFML/Window/GlResource.hpp>
 
+#include <SFML/System/PassKey.hpp>
+
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -114,7 +116,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     Shader& operator=(Shader&& right) noexcept;
-
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry or fragment shader from a file
@@ -644,13 +645,15 @@ public:
     ////////////////////////////////////////////////////////////
     static bool isGeometryAvailable();
 
-private:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Construct from shader program
     ///
     ////////////////////////////////////////////////////////////
-    explicit Shader(unsigned int shaderProgram);
+    explicit Shader(priv::PassKey<Shader>&&, unsigned int shaderProgram);
 
+private:
     ////////////////////////////////////////////////////////////
     /// \brief Compile the shader(s) and create the program
     ///

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -34,6 +34,7 @@
 
 #include <SFML/Window/GlResource.hpp>
 
+#include <SFML/System/PassKey.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <filesystem>
@@ -545,14 +546,18 @@ private:
     friend class RenderTexture;
     friend class RenderTarget;
 
+public:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Default constructor
     ///
     /// Creates an empty texture.
     ///
     ////////////////////////////////////////////////////////////
-    Texture(const Vector2u& size, const Vector2u& actualSize, unsigned int texture, bool sRgb);
+    Texture(priv::PassKey<Texture>&&, const Vector2u& size, const Vector2u& actualSize, unsigned int texture, bool sRgb);
 
+private:
     ////////////////////////////////////////////////////////////
     /// \brief Get a valid image size according to hardware support
     ///

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -32,11 +32,11 @@
 #include <SFML/System/Export.hpp>
 
 #include <SFML/System/InputStream.hpp>
+#include <SFML/System/PassKey.hpp>
 
 #include <filesystem>
 #include <memory>
 
-#include <cstdint>
 #include <cstdio>
 
 #ifdef SFML_SYSTEM_ANDROID
@@ -146,20 +146,26 @@ private:
         void operator()(std::FILE* file);
     };
 
+public:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Construct from file
     ///
     ////////////////////////////////////////////////////////////
-    explicit FileInputStream(std::unique_ptr<std::FILE, FileCloser>&& file);
+    explicit FileInputStream(priv::PassKey<FileInputStream>&&, std::unique_ptr<std::FILE, FileCloser>&& file);
 
 #ifdef SFML_SYSTEM_ANDROID
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Construct from resource stream
     ///
     ////////////////////////////////////////////////////////////
-    explicit FileInputStream(std::unique_ptr<priv::ResourceStream>&& androidFile);
+    explicit FileInputStream(priv::PassKey<FileInputStream>&&, std::unique_ptr<priv::ResourceStream>&& androidFile);
 #endif
 
+private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/System/PassKey.hpp
+++ b/include/SFML/System/PassKey.hpp
@@ -22,62 +22,42 @@
 //
 ////////////////////////////////////////////////////////////
 
+#pragma once
+
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Audio/AudioDevice.hpp>
-#include <SFML/Audio/PlaybackDevice.hpp>
-
-#include <algorithm>
+#include <SFML/System/Export.hpp>
 
 
-namespace sf::PlaybackDevice
+namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-std::vector<std::string> getAvailableDevices()
-{
-    const auto devices = priv::AudioDevice::getAvailableDevices();
-
-    std::vector<std::string> deviceNameList;
-    deviceNameList.reserve(devices.size());
-
-    for (const auto& device : devices)
-        deviceNameList.emplace_back(device.name);
-
-    return deviceNameList;
-}
-
-
+/// \private
+///
+/// \brief Generic implementation of the PassKey idiom
+///
 ////////////////////////////////////////////////////////////
-std::optional<std::string> getDefaultDevice()
+template <typename T>
+class PassKey
 {
-    for (const auto& device : priv::AudioDevice::getAvailableDevices())
+    friend T;
+
+private:
+    // NOLINTBEGIN(modernize-use-equals-delete)
+    // Intentionally not using `= default` here as it would make `PassKey` an aggregate
+    // and thus constructible from anyone
+    explicit PassKey() noexcept
     {
-        if (device.isDefault)
-            return std::make_optional(device.name);
     }
+    //NOLINTEND(modernize-use-equals-delete)
 
-    return std::nullopt;
-}
+public:
+    PassKey(const PassKey&) = delete;
+    PassKey(PassKey&&)      = delete;
 
+    PassKey& operator=(const PassKey&) = delete;
+    PassKey& operator=(PassKey&&)      = delete;
+};
 
-////////////////////////////////////////////////////////////
-bool setDevice(const std::string& name)
-{
-    // Perform a sanity check to make sure the user isn't passing us a non-existant device name
-    const auto devices = priv::AudioDevice::getAvailableDevices();
-    if (auto iter = std::find_if(devices.begin(), devices.end(), [&](const auto& device) { return device.name == name; });
-        iter == devices.end())
-        return false;
-
-    return priv::AudioDevice::setDevice(name);
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<std::string> getDevice()
-{
-    return priv::AudioDevice::getDevice();
-}
-
-} // namespace sf::PlaybackDevice
+} // namespace sf::priv

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Export.hpp>
 
+#include <SFML/System/PassKey.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <memory>
@@ -195,12 +196,16 @@ public:
 private:
     friend class WindowBase;
 
+public:
     ////////////////////////////////////////////////////////////
+    /// \private
+    ///
     /// \brief Default constructor
     ///
     ////////////////////////////////////////////////////////////
-    Cursor();
+    Cursor(priv::PassKey<Cursor>&&);
 
+private:
     ////////////////////////////////////////////////////////////
     /// \brief Get access to the underlying implementation
     ///

--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -216,6 +216,8 @@ std::vector<AudioDevice::DeviceEntry> AudioDevice::getAvailableDevices()
 {
     const auto getDevices = [](auto& context)
     {
+        std::vector<DeviceEntry> deviceList; // Use a single local variable for NRVO
+
         ma_device_info* deviceInfos{};
         ma_uint32       deviceCount{};
 
@@ -224,10 +226,9 @@ std::vector<AudioDevice::DeviceEntry> AudioDevice::getAvailableDevices()
             result != MA_SUCCESS)
         {
             err() << "Failed to get audio playback devices: " << ma_result_description(result) << std::endl;
-            return std::vector<DeviceEntry>{};
+            return deviceList; // Empty device list
         }
 
-        std::vector<DeviceEntry> deviceList;
         deviceList.reserve(deviceCount);
 
         // In order to report devices with identical names and still allow

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -100,7 +100,12 @@ std::optional<InputSoundFile> InputSoundFile::openFromFile(const std::filesystem
         return std::nullopt;
     }
 
-    return InputSoundFile(std::move(reader), std::move(file), info->sampleCount, info->sampleRate, std::move(info->channelMap));
+    return std::make_optional<InputSoundFile>(priv::PassKey<InputSoundFile>{},
+                                              std::move(reader),
+                                              std::move(file),
+                                              info->sampleCount,
+                                              info->sampleRate,
+                                              std::move(info->channelMap));
 }
 
 
@@ -126,7 +131,12 @@ std::optional<InputSoundFile> InputSoundFile::openFromMemory(const void* data, s
         return std::nullopt;
     }
 
-    return InputSoundFile(std::move(reader), std::move(memory), info->sampleCount, info->sampleRate, std::move(info->channelMap));
+    return std::make_optional<InputSoundFile>(priv::PassKey<InputSoundFile>{},
+                                              std::move(reader),
+                                              std::move(memory),
+                                              info->sampleCount,
+                                              info->sampleRate,
+                                              std::move(info->channelMap));
 }
 
 
@@ -156,7 +166,12 @@ std::optional<InputSoundFile> InputSoundFile::openFromStream(InputStream& stream
         return std::nullopt;
     }
 
-    return InputSoundFile(std::move(reader), {&stream, false}, info->sampleCount, info->sampleRate, std::move(info->channelMap));
+    return std::make_optional<InputSoundFile>(priv::PassKey<InputSoundFile>{},
+                                              std::move(reader),
+                                              std::unique_ptr<InputStream, StreamDeleter>{&stream, false},
+                                              info->sampleCount,
+                                              info->sampleRate,
+                                              std::move(info->channelMap));
 }
 
 
@@ -263,7 +278,8 @@ void InputSoundFile::close()
 
 
 ////////////////////////////////////////////////////////////
-InputSoundFile::InputSoundFile(std::unique_ptr<SoundFileReader>&&            reader,
+InputSoundFile::InputSoundFile(priv::PassKey<InputSoundFile>&&,
+                               std::unique_ptr<SoundFileReader>&&            reader,
                                std::unique_ptr<InputStream, StreamDeleter>&& stream,
                                std::uint64_t                                 sampleCount,
                                unsigned int                                  sampleRate,

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -87,8 +87,7 @@ std::optional<Music> Music::tryOpenFromInputSoundFile(std::optional<InputSoundFi
         return std::nullopt;
     }
 
-    // TODO: apply RVO here via passkey idiom
-    return Music(std::move(*optFile));
+    return std::make_optional<Music>(priv::PassKey<Music>{}, std::move(*optFile));
 }
 
 
@@ -248,7 +247,7 @@ std::optional<std::uint64_t> Music::onLoop()
 
 
 ////////////////////////////////////////////////////////////
-Music::Music(InputSoundFile&& file) : m_impl(std::make_unique<Impl>(std::move(file)))
+Music::Music(priv::PassKey<Music>&&, InputSoundFile&& file) : m_impl(std::make_unique<Impl>(std::move(file)))
 {
     // Initialize the stream
     SoundStream::initialize(m_impl->file.getChannelCount(), m_impl->file.getSampleRate(), m_impl->file.getChannelMap());

--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -58,7 +58,7 @@ std::optional<OutputSoundFile> OutputSoundFile::openFromFile(
         return std::nullopt;
     }
 
-    return OutputSoundFile(std::move(writer));
+    return std::make_optional<OutputSoundFile>(priv::PassKey<OutputSoundFile>{}, std::move(writer));
 }
 
 
@@ -81,7 +81,8 @@ void OutputSoundFile::close()
 
 
 ////////////////////////////////////////////////////////////
-OutputSoundFile::OutputSoundFile(std::unique_ptr<SoundFileWriter>&& writer) : m_writer(std::move(writer))
+OutputSoundFile::OutputSoundFile(priv::PassKey<OutputSoundFile>&&, std::unique_ptr<SoundFileWriter>&& writer) :
+m_writer(std::move(writer))
 {
 }
 

--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -324,7 +324,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderFlac::open(InputStream& stre
     }
 
     // Retrieve the sound properties
-    return m_clientData.info; // was filled in the "metadata" callback
+    return std::make_optional(m_clientData.info); // was filled in the "metadata" callback
 }
 
 

--- a/src/SFML/Audio/SoundFileReaderMp3.cpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.cpp
@@ -127,13 +127,15 @@ std::optional<SoundFileReader::Info> SoundFileReaderMp3::open(InputStream& strea
     m_io.read_data = &stream;
     m_io.seek_data = &stream;
 
+    std::optional<Info> result; // Use a single local variable for NRVO
+
     // Init mp3 decoder
     mp3dec_ex_open_cb(&m_decoder, &m_io, MP3D_SEEK_TO_SAMPLE);
     if (!m_decoder.samples)
-        return std::nullopt;
+        return result; // Empty optional
 
     // Retrieve the music attributes
-    Info info;
+    Info& info        = result.emplace();
     info.channelCount = static_cast<unsigned int>(m_decoder.info.channels);
     info.sampleRate   = static_cast<unsigned int>(m_decoder.info.hz);
     info.sampleCount  = m_decoder.samples;
@@ -157,7 +159,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderMp3::open(InputStream& strea
     }
 
     m_numSamples = info.sampleCount;
-    return info;
+    return result;
 }
 
 

--- a/src/SFML/Audio/SoundFileReaderOgg.cpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.cpp
@@ -100,17 +100,20 @@ SoundFileReaderOgg::~SoundFileReaderOgg()
 ////////////////////////////////////////////////////////////
 std::optional<SoundFileReader::Info> SoundFileReaderOgg::open(InputStream& stream)
 {
+    std::optional<Info> result; // Use a single local variable for NRVO
+
     // Open the Vorbis stream
     const int status = ov_open_callbacks(&stream, &m_vorbis, nullptr, 0, callbacks);
     if (status < 0)
     {
         err() << "Failed to open Vorbis file for reading" << std::endl;
-        return std::nullopt;
+        return result; // Empty optional
     }
 
     // Retrieve the music attributes
     vorbis_info* vorbisInfo = ov_info(&m_vorbis, -1);
-    Info         info;
+
+    Info& info        = result.emplace();
     info.channelCount = static_cast<unsigned int>(vorbisInfo->channels);
     info.sampleRate   = static_cast<unsigned int>(vorbisInfo->rate);
     info.sampleCount  = static_cast<std::size_t>(ov_pcm_total(&m_vorbis, -1) * vorbisInfo->channels);
@@ -176,7 +179,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderOgg::open(InputStream& strea
     // We must keep the channel count for the seek function
     m_channelCount = info.channelCount;
 
-    return info;
+    return result;
 }
 
 

--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -169,7 +169,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderWav::open(InputStream& strea
     for (auto i = 0u; i < m_channelCount; ++i)
         soundChannels.emplace_back(priv::MiniaudioUtils::miniaudioChannelToSoundChannel(channelMap[i]));
 
-    return Info{frameCount * m_channelCount, m_channelCount, sampleRate, std::move(soundChannels)};
+    return std::make_optional<Info>({frameCount * m_channelCount, m_channelCount, sampleRate, std::move(soundChannels)});
 }
 
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -122,7 +122,8 @@ struct Font::FontHandles
 
 
 ////////////////////////////////////////////////////////////
-Font::Font(std::shared_ptr<FontHandles>&& fontHandles, std::string&& familyName) : m_fontHandles(std::move(fontHandles))
+Font::Font(priv::PassKey<Font>&&, std::shared_ptr<FontHandles>&& fontHandles, std::string&& familyName) :
+m_fontHandles(std::move(fontHandles))
 {
     m_info.family = std::move(familyName);
 }
@@ -168,7 +169,9 @@ std::optional<Font> Font::loadFromFile(const std::filesystem::path& filename)
         return std::nullopt;
     }
 
-    return Font(std::move(fontHandles), std::string(face->family_name ? face->family_name : ""));
+    return std::make_optional<Font>(priv::PassKey<Font>{},
+                                    std::move(fontHandles),
+                                    std::string(face->family_name ? face->family_name : ""));
 
 #else
 
@@ -223,7 +226,9 @@ std::optional<Font> Font::loadFromMemory(const void* data, std::size_t sizeInByt
         return std::nullopt;
     }
 
-    return Font(std::move(fontHandles), std::string(face->family_name ? face->family_name : ""));
+    return std::make_optional<Font>(priv::PassKey<Font>{},
+                                    std::move(fontHandles),
+                                    std::string(face->family_name ? face->family_name : ""));
 }
 
 
@@ -285,7 +290,9 @@ std::optional<Font> Font::loadFromStream(InputStream& stream)
         return std::nullopt;
     }
 
-    return Font(std::move(fontHandles), std::string(face->family_name ? face->family_name : ""));
+    return std::make_optional<Font>(priv::PassKey<Font>{},
+                                    std::move(fontHandles),
+                                    std::string(face->family_name ? face->family_name : ""));
 }
 
 
@@ -657,6 +664,8 @@ IntRect Font::findGlyphRect(Page& page, const Vector2u& size) const
         bestRatio = ratio;
     }
 
+    IntRect rect{{0, 0}, {2, 2}}; // Use a single local variable for NRVO
+
     // If we didn't find a matching row, create a new one (10% taller than the glyph)
     if (!row)
     {
@@ -672,7 +681,7 @@ IntRect Font::findGlyphRect(Page& page, const Vector2u& size) const
                 if (!newTexture)
                 {
                     err() << "Failed to create new page texture" << std::endl;
-                    return {{0, 0}, {2, 2}};
+                    return rect;
                 }
 
                 newTexture->setSmooth(m_isSmooth);
@@ -684,7 +693,7 @@ IntRect Font::findGlyphRect(Page& page, const Vector2u& size) const
                 // Oops, we've reached the maximum texture size...
                 err() << "Failed to add a new character to the font: the maximum texture size has been reached"
                       << std::endl;
-                return {{0, 0}, {2, 2}};
+                return rect;
             }
         }
 
@@ -695,7 +704,10 @@ IntRect Font::findGlyphRect(Page& page, const Vector2u& size) const
     }
 
     // Find the glyph's rectangle on the selected row
-    IntRect rect(Rect<unsigned int>({row->width, row->top}, size));
+    rect.position.x = static_cast<int>(row->width);
+    rect.position.y = static_cast<int>(row->top);
+    rect.size.x     = static_cast<int>(size.x);
+    rect.size.y     = static_cast<int>(size.y);
 
     // Update the row information
     row->width += size.x;
@@ -765,7 +777,7 @@ std::optional<Font::Page> Font::Page::make(bool smooth)
     }
 
     texture->setSmooth(smooth);
-    return Page(std::move(*texture));
+    return std::make_optional<Page>(std::move(*texture));
 }
 
 

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -52,15 +52,17 @@ RenderTexture& RenderTexture::operator=(RenderTexture&&) noexcept = default;
 ////////////////////////////////////////////////////////////
 std::optional<RenderTexture> RenderTexture::create(const Vector2u& size, const ContextSettings& settings)
 {
+    std::optional<RenderTexture> result; // Use a single local variable for NRVO
+
     // Create the texture
     auto texture = sf::Texture::create(size, settings.sRgbCapable);
     if (!texture)
     {
         err() << "Impossible to create render texture (failed to create the target texture)" << std::endl;
-        return std::nullopt;
+        return result; // Empty optional
     }
 
-    RenderTexture renderTexture(std::move(*texture));
+    auto& renderTexture = result.emplace(priv::PassKey<RenderTexture>{}, std::move(*texture));
 
     // We disable smoothing by default for render textures
     renderTexture.setSmooth(false);
@@ -83,12 +85,15 @@ std::optional<RenderTexture> RenderTexture::create(const Vector2u& size, const C
     // Initialize the render texture
     // We pass the actual size of our texture since OpenGL ES requires that all attachments have identical sizes
     if (!renderTexture.m_impl->create(renderTexture.m_texture.m_actualSize, renderTexture.m_texture.m_texture, settings))
-        return std::nullopt;
+    {
+        result.reset();
+        return result; // Empty optional
+    }
 
     // We can now initialize the render target part
     renderTexture.initialize();
 
-    return renderTexture;
+    return result;
 }
 
 
@@ -197,7 +202,7 @@ const Texture& RenderTexture::getTexture() const
 
 
 ////////////////////////////////////////////////////////////
-RenderTexture::RenderTexture(Texture&& texture) : m_texture(std::move(texture))
+RenderTexture::RenderTexture(priv::PassKey<RenderTexture>&&, Texture&& texture) : m_texture(std::move(texture))
 {
 }
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -771,7 +771,7 @@ bool Shader::isGeometryAvailable()
 
 
 ////////////////////////////////////////////////////////////
-Shader::Shader(unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
+Shader::Shader(priv::PassKey<Shader>&&, unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
 {
 }
 
@@ -908,7 +908,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
     // in all contexts immediately (solves problems in multi-threaded apps)
     glCheck(glFlush());
 
-    return Shader(castFromGlHandle(shaderProgram));
+    return std::make_optional<Shader>(priv::PassKey<Shader>{}, castFromGlHandle(shaderProgram));
 }
 
 
@@ -1202,7 +1202,7 @@ bool Shader::isGeometryAvailable()
 
 
 ////////////////////////////////////////////////////////////
-Shader::Shader(unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
+Shader::Shader(priv::PassKey<Shader>&&, unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
 {
 }
 

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -60,15 +60,15 @@ std::optional<IpAddress> IpAddress::resolve(std::string_view address)
     {
         // The broadcast address needs to be handled explicitly,
         // because it is also the value returned by inet_addr on error
-        return Broadcast;
+        return std::make_optional(Broadcast);
     }
 
     if (address == "0.0.0.0"sv)
-        return Any;
+        return std::make_optional(Any);
 
     // Try to convert the address as a byte representation ("xxx.xxx.xxx.xxx")
     if (const std::uint32_t ip = inet_addr(address.data()); ip != INADDR_NONE)
-        return IpAddress(ntohl(ip));
+        return std::make_optional<IpAddress>(ntohl(ip));
 
     // Not a valid address, try to convert it as a host name
     addrinfo hints{}; // Zero-initialize
@@ -83,7 +83,7 @@ std::optional<IpAddress> IpAddress::resolve(std::string_view address)
         const std::uint32_t ip = sin.sin_addr.s_addr;
         freeaddrinfo(result);
 
-        return IpAddress(ntohl(ip));
+        return std::make_optional<IpAddress>(ntohl(ip));
     }
 
     // Not generating en error message here as resolution failure is a valid outcome.
@@ -160,7 +160,7 @@ std::optional<IpAddress> IpAddress::getLocalAddress()
     priv::SocketImpl::close(sock);
 
     // Finally build the IP address
-    return IpAddress(ntohl(address.sin_addr.s_addr));
+    return std::make_optional<IpAddress>(ntohl(address.sin_addr.s_addr));
 }
 
 

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRC
     ${SRCROOT}/MemoryInputStream.cpp
     ${INCROOT}/MemoryInputStream.hpp
     ${INCROOT}/SuspendAwareClock.hpp
+    ${INCROOT}/PassKey.hpp
 )
 source_group("" FILES ${SRC})
 

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -64,7 +64,7 @@ std::optional<FileInputStream> FileInputStream::open(const std::filesystem::path
     {
         auto androidFile = std::make_unique<priv::ResourceStream>(filename);
         if (androidFile->tell().has_value())
-            return FileInputStream(std::move(androidFile));
+            return std::make_optional<FileInputStream>(priv::PassKey<FileInputStream>{}, std::move(androidFile));
         return std::nullopt;
     }
 #endif
@@ -73,7 +73,7 @@ std::optional<FileInputStream> FileInputStream::open(const std::filesystem::path
 #else
     if (auto file = std::unique_ptr<std::FILE, FileCloser>(std::fopen(filename.c_str(), "rb")))
 #endif
-        return FileInputStream(std::move(file));
+        return std::make_optional<FileInputStream>(priv::PassKey<FileInputStream>{}, std::move(file));
     return std::nullopt;
 }
 
@@ -150,14 +150,15 @@ std::optional<std::size_t> FileInputStream::getSize()
 
 
 ////////////////////////////////////////////////////////////
-FileInputStream::FileInputStream(std::unique_ptr<std::FILE, FileCloser>&& file) : m_file(std::move(file))
+FileInputStream::FileInputStream(priv::PassKey<FileInputStream>&&, std::unique_ptr<std::FILE, FileCloser>&& file) :
+m_file(std::move(file))
 {
 }
 
 
 ////////////////////////////////////////////////////////////
 #ifdef SFML_SYSTEM_ANDROID
-FileInputStream::FileInputStream(std::unique_ptr<priv::ResourceStream>&& androidFile) :
+FileInputStream::FileInputStream(priv::PassKey<FileInputStream>&&, std::unique_ptr<priv::ResourceStream>&& androidFile) :
 m_androidFile(std::move(androidFile))
 {
 }

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -522,24 +522,24 @@ std::optional<sf::String> sfScanToConsumerKeyName(sf::Keyboard::Scancode code)
     // clang-format off
     switch (code)
     {
-        case sf::Keyboard::Scan::MediaNextTrack:     return "Next Track";
-        case sf::Keyboard::Scan::MediaPreviousTrack: return "Previous Track";
-        case sf::Keyboard::Scan::MediaStop:          return "Stop";
-        case sf::Keyboard::Scan::MediaPlayPause:     return "Play/Pause";
-        case sf::Keyboard::Scan::VolumeMute:         return "Mute";
-        case sf::Keyboard::Scan::VolumeUp:           return "Volume Increment";
-        case sf::Keyboard::Scan::VolumeDown:         return "Volume Decrement";
-        case sf::Keyboard::Scan::LaunchMediaSelect:  return "Consumer Control Configuration";
-        case sf::Keyboard::Scan::LaunchMail:         return "Email Reader";
-        case sf::Keyboard::Scan::LaunchApplication2: return "Calculator";
-        case sf::Keyboard::Scan::LaunchApplication1: return "Local Machine Browser";
-        case sf::Keyboard::Scan::Search:             return "Search";
-        case sf::Keyboard::Scan::HomePage:           return "Home";
-        case sf::Keyboard::Scan::Back:               return "Back";
-        case sf::Keyboard::Scan::Forward:            return "Forward";
-        case sf::Keyboard::Scan::Stop:               return "Stop";
-        case sf::Keyboard::Scan::Refresh:            return "Refresh";
-        case sf::Keyboard::Scan::Favorites:          return "Bookmarks";
+        case sf::Keyboard::Scan::MediaNextTrack:     return std::make_optional<sf::String>("Next Track");
+        case sf::Keyboard::Scan::MediaPreviousTrack: return std::make_optional<sf::String>("Previous Track");
+        case sf::Keyboard::Scan::MediaStop:          return std::make_optional<sf::String>("Stop");
+        case sf::Keyboard::Scan::MediaPlayPause:     return std::make_optional<sf::String>("Play/Pause");
+        case sf::Keyboard::Scan::VolumeMute:         return std::make_optional<sf::String>("Mute");
+        case sf::Keyboard::Scan::VolumeUp:           return std::make_optional<sf::String>("Volume Increment");
+        case sf::Keyboard::Scan::VolumeDown:         return std::make_optional<sf::String>("Volume Decrement");
+        case sf::Keyboard::Scan::LaunchMediaSelect:  return std::make_optional<sf::String>("Consumer Control Configuration");
+        case sf::Keyboard::Scan::LaunchMail:         return std::make_optional<sf::String>("Email Reader");
+        case sf::Keyboard::Scan::LaunchApplication2: return std::make_optional<sf::String>("Calculator");
+        case sf::Keyboard::Scan::LaunchApplication1: return std::make_optional<sf::String>("Local Machine Browser");
+        case sf::Keyboard::Scan::Search:             return std::make_optional<sf::String>("Search");
+        case sf::Keyboard::Scan::HomePage:           return std::make_optional<sf::String>("Home");
+        case sf::Keyboard::Scan::Back:               return std::make_optional<sf::String>("Back");
+        case sf::Keyboard::Scan::Forward:            return std::make_optional<sf::String>("Forward");
+        case sf::Keyboard::Scan::Stop:               return std::make_optional<sf::String>("Stop");
+        case sf::Keyboard::Scan::Refresh:            return std::make_optional<sf::String>("Refresh");
+        case sf::Keyboard::Scan::Favorites:          return std::make_optional<sf::String>("Bookmarks");
 
         // Not a consumer key
         default: return std::nullopt;

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -324,23 +324,41 @@ void JoystickImpl::close()
 ////////////////////////////////////////////////////////////
 JoystickCaps JoystickImpl::getCapabilities() const
 {
+    JoystickCaps caps; // Use a single local variable for NRVO
+
     if (directInput)
-        return getCapabilitiesDInput();
+    {
+        // Count how many buttons have valid offsets
+        caps.buttonCount = 0;
 
-    JoystickCaps caps;
+        for (const int button : m_buttons)
+        {
+            if (button != -1)
+                ++caps.buttonCount;
+        }
 
-    caps.buttonCount = m_caps.wNumButtons;
-    if (caps.buttonCount > Joystick::ButtonCount)
-        caps.buttonCount = Joystick::ButtonCount;
+        // Check which axes have valid offsets
+        for (unsigned int i = 0; i < Joystick::AxisCount; ++i)
+        {
+            const auto axis = static_cast<Joystick::Axis>(i);
+            caps.axes[axis] = (m_axes[axis] != -1);
+        }
+    }
+    else
+    {
+        caps.buttonCount = m_caps.wNumButtons;
+        if (caps.buttonCount > Joystick::ButtonCount)
+            caps.buttonCount = Joystick::ButtonCount;
 
-    caps.axes[Joystick::Axis::X]    = true;
-    caps.axes[Joystick::Axis::Y]    = true;
-    caps.axes[Joystick::Axis::Z]    = (m_caps.wCaps & JOYCAPS_HASZ) != 0;
-    caps.axes[Joystick::Axis::R]    = (m_caps.wCaps & JOYCAPS_HASR) != 0;
-    caps.axes[Joystick::Axis::U]    = (m_caps.wCaps & JOYCAPS_HASU) != 0;
-    caps.axes[Joystick::Axis::V]    = (m_caps.wCaps & JOYCAPS_HASV) != 0;
-    caps.axes[Joystick::Axis::PovX] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
-    caps.axes[Joystick::Axis::PovY] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
+        caps.axes[Joystick::Axis::X]    = true;
+        caps.axes[Joystick::Axis::Y]    = true;
+        caps.axes[Joystick::Axis::Z]    = (m_caps.wCaps & JOYCAPS_HASZ) != 0;
+        caps.axes[Joystick::Axis::R]    = (m_caps.wCaps & JOYCAPS_HASR) != 0;
+        caps.axes[Joystick::Axis::U]    = (m_caps.wCaps & JOYCAPS_HASU) != 0;
+        caps.axes[Joystick::Axis::V]    = (m_caps.wCaps & JOYCAPS_HASV) != 0;
+        caps.axes[Joystick::Axis::PovX] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
+        caps.axes[Joystick::Axis::PovY] = (m_caps.wCaps & JOYCAPS_HASPOV) != 0;
+    }
 
     return caps;
 }
@@ -860,31 +878,6 @@ void JoystickImpl::closeDInput()
         m_device->Release();
         m_device = nullptr;
     }
-}
-
-
-////////////////////////////////////////////////////////////
-JoystickCaps JoystickImpl::getCapabilitiesDInput() const
-{
-    JoystickCaps caps;
-
-    // Count how many buttons have valid offsets
-    caps.buttonCount = 0;
-
-    for (const int button : m_buttons)
-    {
-        if (button != -1)
-            ++caps.buttonCount;
-    }
-
-    // Check which axes have valid offsets
-    for (unsigned int i = 0; i < Joystick::AxisCount; ++i)
-    {
-        const auto axis = static_cast<Joystick::Axis>(i);
-        caps.axes[axis] = (m_axes[axis] != -1);
-    }
-
-    return caps;
 }
 
 

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -164,14 +164,6 @@ public:
     void closeDInput();
 
     ////////////////////////////////////////////////////////////
-    /// \brief Get the joystick capabilities (DInput)
-    ///
-    /// \return Joystick capabilities
-    ///
-    ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilitiesDInput() const;
-
-    ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state (DInput, Buffered)
     ///
     /// \return Joystick state


### PR DESCRIPTION
*(Supersedes #3068 and #3069, because they were getting stale, and some changes were conflicting between the two PRs.)*

The goal of this PR is to improve the performance of factory functions, primarily resource-loading ones based on `std::optional`, but also a few other ones of various nature.

---

To improve `std::optional` creation, I've changed our usual pattern. Basically, the pattern we frequently use...

```cpp
class Widget
{
private:
    explicit Widget(Dependency&&);

public:
    static std::optional<Widget> make(std::filesystem::path p)
    {
        std::optional<Dependency> d = loadDependencyFromPath(p);
        if (!d.has_value()) { return std::nullopt; }
        
        return Widget{std::move(*d)};
    }
};
```

...has a flaw -- it is not eligible for C++17 guaranteed copy elision (RVO) due to the fact that we're not returning a prvalue of type `std::optional<Widget>`, but a prvalue of type `Widget` instead, whose type does *not* match the function's return type.

That has a few practical drawbacks:

- Non-copyable/non-movable types cannot be returned in this way;
- Performance is worsened, as extra move/copy operations will be invoked;
- Code that previously relied on address stability might break after switching to this pattern due to the extra move/copy operations (see #3062).

The way of improving the pattern is to return a *prvalue* of `std::optional<Widget>` type, thus gaining eligibility for guaranteed copy elision. E.g.,

```cpp
static std::optional<Widget> make(std::filesystem::path p)
{
    std::optional<Dependency> d = loadDependencyFromPath(p);
    if (!d.has_value()) { return std::nullopt; }
    
    return std::make_optional<Widget>(std::move(*d));
}
```

This works, but only if the constructor of `Widget` is `public`, as internally `std::make_optional` tries to construct `Widget` outside of `Widget` itself's scope. The same issue applies to `std::optional<T>{std::in_place, ...}`.

Therefore, I added a new `sf::priv::PassKey<T>` helper class to give access to the `private` constructors to `std::optional`'s internals. It adds a bit of complexity, and requires us to mark those constructors `public:` and annotate them with `\private` for Doxygen, but I strongly believe it's worth doing as all the heavyweight types such as `Texture`, `Font`, et cetera, all have `private` constructors and use the inefficient factory pattern that does not support guaranteed copy elision. 

See also: https://stackoverflow.com/questions/78581072/stdoptional-factory-function-with-guaranteed-copy-elision-and-private-cons

---

To enable more NRVO opportunities, I was guided by the newly added `-Wnrvo` GCC warning, that produces diagnostics like these:

```
In file included from C:/OHWorkspace/SFML/build/src/SFML/Audio/CMakeFiles/sfml-audio.dir/Unity/unity_0_cxx.cxx:7:
C:/OHWorkspace/SFML/src/SFML/Audio/AudioDevice.cpp: In static member function 'static std::vector<sf::priv::AudioDevice::DeviceEntry> sf::priv::AudioDevice::getAvailableDevices()':
C:/OHWorkspace/SFML/src/SFML/Audio/AudioDevice.cpp:275:12: warning: not eliding copy on return in 'static std::vector<sf::priv::AudioDevice::DeviceEntry> sf::priv::AudioDevice::getAvailableDevices()' [-Wnrvo]
  275 |     return deviceList;
      |            ^~~~~~~~~~
```

Note that I did not address the one above, because it was not worth it and it would have complicated the control flow too much.

The new pattern is as follows:

```cpp
////////////////////////////////////////////////////////////
std::optional<SoundBuffer> SoundBuffer::loadFromSamplesImpl(
    std::vector<std::int16_t>&&      samples,
    unsigned int                     channelCount,
    unsigned int                     sampleRate,
    const std::vector<SoundChannel>& channelMap)
{
    std::optional<SoundBuffer> soundBuffer; // Use a single local variable for NRVO

    if (channelCount == 0 || sampleRate == 0 || channelMap.empty())
    {
        err() << "...";
        return soundBuffer; // Same as `std::nullopt`, but NRVO-friendly
    }

    // Take ownership of the audio samples
    soundBuffer.emplace(priv::PassKey<SoundBuffer>{}, std::move(samples));

    // ...

    return soundBuffer; // Eligible for NRVO
}