### PR TITLE
`break` event handling loop after `window.close()`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,10 @@ body:
                       while (const auto event = window.pollEvent())
                       {
                           if (event.is<sf::Event::Closed>())
+                          {
                               window.close();
+                              break;
+                          }
                       }
 
                       window.clear();

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -57,7 +57,10 @@ body:
                       while (const auto event = window.pollEvent())
                       {
                           if (event.is<sf::Event::Closed>())
+                          {
                               window.close();
+                              break;
+                          }
                       }
 
                       window.clear();

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,7 +42,10 @@ int main()
         while (const auto event = window.pollEvent())
         {
             if (event.is<sf::Event::Closed>())
+            {
                 window.close();
+                break;
+            }
         }
 
         window.clear();

--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -42,7 +42,10 @@
 ///         {
 ///             // Close window: exit
 ///             if (event.is<sf::Event::Closed>())
+///             {
 ///                 window.close();
+///                 break;
+///             }
 ///         }
 ///
 ///         // Clear screen

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -111,16 +111,14 @@ int main(int argc, char* argv[])
     {
         while (const auto event = active ? window.pollEvent() : window.waitEvent())
         {
-            if (event.is<sf::Event::Closed>())
+            if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&
+                                                  event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape))
             {
                 window.close();
+                break;
             }
-            else if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
-            {
-                if (keyPressed->code == sf::Keyboard::Key::Escape)
-                    window.close();
-            }
-            else if (const auto* resized = event.getIf<sf::Event::Resized>())
+
+            if (const auto* resized = event.getIf<sf::Event::Resized>())
             {
                 const auto size = sf::Vector2f(resized->size);
                 view.setSize(size);

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -165,7 +165,8 @@ int main()
                 window.close();
                 break;
             }
-            else if (const auto* joystickButtonPressed = event.getIf<sf::Event::JoystickButtonPressed>())
+
+            if (const auto* joystickButtonPressed = event.getIf<sf::Event::JoystickButtonPressed>())
             {
                 // Update displayed joystick values
                 updateValues(joystickButtonPressed->joystickId);

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -203,19 +203,14 @@ int main()
             // Process events
             while (const auto event = window.pollEvent())
             {
-                // Close window: exit
-                if (event.is<sf::Event::Closed>())
+                // Window closed or escape key pressed: exit
+                if (event.is<sf::Event::Closed>() ||
+                    (event.is<sf::Event::KeyPressed>() &&
+                     event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape))
                 {
                     exit = true;
                     window.close();
-                }
-
-                // Escape key: exit
-                if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>();
-                    keyPressed && keyPressed->code == sf::Keyboard::Key::Escape)
-                {
-                    exit = true;
-                    window.close();
+                    break;
                 }
 
                 // Return key: toggle mipmapping
@@ -241,6 +236,7 @@ int main()
                 {
                     sRgb = !sRgb;
                     window.close();
+                    break;
                 }
 
                 // Adjust the viewport when the window is resized

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -1128,7 +1128,10 @@ int main()
         {
             // Close window: exit
             if (event.is<sf::Event::Closed>())
+            {
                 window.close();
+                break;
+            }
 
             if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
             {

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -2546,14 +2546,14 @@ public:
             // Process events
             while (const auto event = window.pollEvent())
             {
-                // Close window: exit
-                if (event.is<sf::Event::Closed>())
+                // Window closed or escape key pressed: exit
+                if (event.is<sf::Event::Closed>() ||
+                    (event.is<sf::Event::KeyPressed>() &&
+                     event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape))
+                {
                     window.close();
-
-                // Escape key: exit
-                if (event.is<sf::Event::KeyPressed>() &&
-                    event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape)
-                    window.close();
+                    break;
+                }
 
                 // Re-create the swapchain when the window is resized
                 if (event.is<sf::Event::Resized>())

--- a/examples/window/Window.cpp
+++ b/examples/window/Window.cpp
@@ -143,14 +143,13 @@ int main()
         // Process events
         while (const auto event = window.pollEvent())
         {
-            // Close window: exit
-            if (event.is<sf::Event::Closed>())
+            // Window closed or escape key pressed: exit
+            if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&
+                                                  event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape))
+            {
                 window.close();
-
-            // Escape key: exit
-            if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
-                if (keyPressed->code == sf::Keyboard::Key::Escape)
-                    window.close();
+                break;
+            }
 
             // Resize event: adjust the viewport
             if (const auto* resized = event.getIf<sf::Event::Resized>())

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -241,7 +241,10 @@ private:
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())
+///        {
 ///            window.close();
+///            break;
+///        }
 ///    }
 ///
 ///    // Clear the whole window before rendering a new frame

--- a/include/SFML/Window/Clipboard.hpp
+++ b/include/SFML/Window/Clipboard.hpp
@@ -94,7 +94,11 @@ SFML_WINDOW_API void setString(const String& text);
 /// while (const auto event = window.pollEvent())
 /// {
 ///     if(event.is<sf::Event::Closed>())
+///     {
 ///         window.close();
+///         break;
+///     }
+///
 ///     if(const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
 ///     {
 ///         // Using Ctrl + V to paste a string into SFML

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -392,14 +392,14 @@ private:
 /// \code
 /// while (const auto event = window.pollEvent())
 /// {
-///     // Request for closing the window
-///     if (event.is<sf::Event::Closed>())
+///     // Window closed or escape key pressed: exit
+///     if (event.is<sf::Event::Closed>() ||
+///         (event.is<sf::Event::KeyPressed>() &&
+///          event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape))
+///     {
 ///         window.close();
-///
-///     // The escape key was pressed
-///     if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>())
-///         if (keyPressed->code == sf::Keyboard::Key::Escape)
-///             window.close();
+///         break;
+///     }
 ///
 ///     // The window was resized
 ///     if (const auto* resized = event.getIf<sf::Event::Resized>())

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -351,7 +351,10 @@ private:
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())
+///        {
 ///            window.close();
+///            break;
+///        }
 ///    }
 ///
 ///    // Activate the window for OpenGL rendering

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -565,7 +565,10 @@ private:
 ///    {
 ///        // Request for closing the window
 ///        if (event.is<sf::Event::Closed>())
+///        {
 ///            window.close();
+///            break;
+///        }
 ///    }
 ///
 ///    // Do things with the window here...

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -54,17 +54,12 @@ int main()
         // Process events
         while (const auto event = window.pollEvent())
         {
-            // Close window: exit
-            if (event.is<sf::Event::Closed>())
+            // Window closed or escape key pressed: exit
+            if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&
+                                                  event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape))
             {
                 window.close();
-            }
-
-            // Escape pressed: exit
-            if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>();
-                keyPressed && keyPressed->code == sf::Keyboard::Key::Escape)
-            {
-                window.close();
+                break;
             }
         }
 

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -52,17 +52,12 @@ int main()
         // Process events
         while (const auto event = window.pollEvent())
         {
-            // Close window: exit
-            if (event.is<sf::Event::Closed>())
+            // Window closed or escape key pressed: exit
+            if (event.is<sf::Event::Closed>() || (event.is<sf::Event::KeyPressed>() &&
+                                                  event.getIf<sf::Event::KeyPressed>()->code == sf::Keyboard::Key::Escape))
             {
                 window.close();
-            }
-
-            // Escape pressed: exit
-            if (const auto* keyPressed = event.getIf<sf::Event::KeyPressed>();
-                keyPressed && keyPressed->code == sf::Keyboard::Key::Escape)
-            {
-                window.close();
+                break;
             }
         }
 


### PR DESCRIPTION
Extracted from #2992. Adds a `break;` right after a `window.close()` call in event handling loops, as there's nothing useful that can be done since the window will be closed immediately.

Rationale:
- Technically a tiny run-time optimization.
- Promotes good practice of exiting from the event handling loop when the window is closed, as neither `pollEvent` nor `waitEvent` will produce any event if the window has been closed.