### PR TITLE
Testable debug run-time lifetime tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         - { name: Shared, flags: -DBUILD_SHARED_LIBS=TRUE }
         - { name: Static, flags: -DBUILD_SHARED_LIBS=FALSE }
         type:
-        - { name: Release }
+        - { name: Release, flags: -DSFML_ENABLE_LIFETIME_TRACKING=TRUE }
         - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=TRUE }
 
         include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ if(SFML_OS_ANDROID)
     set(BUILD_SHARED_LIBS TRUE)
 endif()
 
+# add an option to enable lifetime tracking
+sfml_set_option(SFML_ENABLE_LIFETIME_TRACKING $<CONFIG:Debug> BOOL "TRUE to enable lifetime tracking, FALSE to disable it")
+if(SFML_ENABLE_LIFETIME_TRACKING)
+    add_definitions(-DSFML_ENABLE_LIFETIME_TRACKING)
+endif()
+
 # add options to select which modules to build
 sfml_set_option(SFML_BUILD_WINDOW TRUE BOOL "TRUE to build SFML's Window module. This setting is ignored, if the graphics module is built.")
 sfml_set_option(SFML_BUILD_GRAPHICS TRUE BOOL "TRUE to build SFML's Graphics module.")

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -31,6 +31,8 @@
 
 #include <SFML/Audio/SoundSource.hpp>
 
+#include <SFML/System/LifetimeTracking.hpp>
+
 #include <memory>
 
 #include <cstdlib>
@@ -244,6 +246,11 @@ private:
     ////////////////////////////////////////////////////////////
     struct Impl;
     const std::unique_ptr<Impl> m_impl; //!< Implementation details
+
+    ////////////////////////////////////////////////////////////
+    // Lifetime tracking
+    ////////////////////////////////////////////////////////////
+    SFML_DEFINE_LIFETIME_DEPENDANT(SoundBuffer);
 };
 
 } // namespace sf

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -31,6 +31,7 @@
 
 #include <SFML/Audio/SoundChannel.hpp>
 
+#include <SFML/System/LifetimeTracking.hpp>
 #include <SFML/System/Time.hpp>
 
 #include <filesystem>
@@ -300,6 +301,11 @@ private:
     std::vector<SoundChannel> m_channelMap{SoundChannel::Mono}; //!< The map of position in sample frame to sound channel
     Time                      m_duration;                       //!< Sound duration
     mutable SoundList         m_sounds;                         //!< List of sounds that are using this buffer
+
+    ////////////////////////////////////////////////////////////
+    // Lifetime tracking
+    ////////////////////////////////////////////////////////////
+    SFML_DEFINE_LIFETIME_DEPENDEE(SoundBuffer, Sound);
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -33,6 +33,7 @@
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/Texture.hpp>
 
+#include <SFML/System/LifetimeTracking.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <filesystem>
@@ -56,6 +57,7 @@ class ResourceStream;
 namespace sf
 {
 class InputStream;
+class Text;
 
 ////////////////////////////////////////////////////////////
 /// \brief Class for loading and manipulating character fonts
@@ -391,6 +393,11 @@ private:
 #ifdef SFML_SYSTEM_ANDROID
     std::shared_ptr<priv::ResourceStream> m_stream; //!< Asset file streamer (if loaded from file)
 #endif
+
+    ////////////////////////////////////////////////////////////
+    // Lifetime tracking
+    ////////////////////////////////////////////////////////////
+    SFML_DEFINE_LIFETIME_DEPENDEE(Font, Text);
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -37,6 +37,7 @@
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
 
+#include <SFML/System/LifetimeTracking.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <cstddef>
@@ -319,6 +320,11 @@ private:
     VertexArray    m_outlineVertices{PrimitiveType::TriangleStrip}; //!< Vertex array containing the outline geometry
     FloatRect      m_insideBounds;                                  //!< Bounding rectangle of the inside (fill)
     FloatRect      m_bounds; //!< Bounding rectangle of the whole shape (outline + fill)
+
+    ////////////////////////////////////////////////////////////
+    // Lifetime tracking
+    ////////////////////////////////////////////////////////////
+    SFML_DEFINE_LIFETIME_DEPENDANT(Texture);
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -35,6 +35,8 @@
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/Vertex.hpp>
 
+#include <SFML/System/LifetimeTracking.hpp>
+
 #include <array>
 
 
@@ -222,6 +224,11 @@ private:
     std::array<Vertex, 4> m_vertices;    //!< Vertices defining the sprite's geometry
     const Texture*        m_texture;     //!< Texture of the sprite
     IntRect               m_textureRect; //!< Rectangle defining the area of the source texture to display
+
+    ////////////////////////////////////////////////////////////
+    // Lifetime tracking
+    ////////////////////////////////////////////////////////////
+    SFML_DEFINE_LIFETIME_DEPENDANT(Texture);
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -37,6 +37,7 @@
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/VertexArray.hpp>
 
+#include <SFML/System/LifetimeTracking.hpp>
 #include <SFML/System/String.hpp>
 #include <SFML/System/Vector2.hpp>
 
@@ -426,6 +427,11 @@ private:
     mutable FloatRect     m_bounds;               //!< Bounding rectangle of the text (in local coordinates)
     mutable bool          m_geometryNeedUpdate{}; //!< Does the geometry need to be recomputed?
     mutable std::uint64_t m_fontTextureId{};      //!< The font texture id
+
+    ////////////////////////////////////////////////////////////
+    // Lifetime tracking
+    ////////////////////////////////////////////////////////////
+    SFML_DEFINE_LIFETIME_DEPENDANT(Font);
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -34,6 +34,7 @@
 
 #include <SFML/Window/GlResource.hpp>
 
+#include <SFML/System/LifetimeTracking.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <filesystem>
@@ -48,6 +49,8 @@ namespace sf
 class InputStream;
 class Window;
 class Image;
+class Sprite;
+class Shape;
 
 ////////////////////////////////////////////////////////////
 /// \brief Image living on the graphics card that can be used for drawing
@@ -590,6 +593,12 @@ private:
     bool          m_fboAttachment{}; //!< Is this texture owned by a framebuffer object?
     bool          m_hasMipmap{};     //!< Has the mipmap been generated?
     std::uint64_t m_cacheId;         //!< Unique number that identifies the texture to the render target's cache
+
+    ////////////////////////////////////////////////////////////
+    // Lifetime tracking
+    ////////////////////////////////////////////////////////////
+    SFML_DEFINE_LIFETIME_DEPENDEE(Texture, Sprite);
+    SFML_DEFINE_LIFETIME_DEPENDEE(Texture, Shape);
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/System/LifetimeTracking.hpp
+++ b/include/SFML/System/LifetimeTracking.hpp
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2024 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifdef SFML_ENABLE_LIFETIME_TRACKING
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/System/Export.hpp>
+
+#include <atomic>
+
+
+namespace sf::priv
+{
+
+class SFML_SYSTEM_API LifetimeDependee
+{
+public:
+    struct SFML_SYSTEM_API TestingModeGuard
+    {
+        TestingModeGuard();
+        ~TestingModeGuard();
+
+        TestingModeGuard(const TestingModeGuard&) = delete;
+        TestingModeGuard(TestingModeGuard&&)      = delete;
+
+        TestingModeGuard& operator=(const TestingModeGuard&) = delete;
+        TestingModeGuard& operator=(TestingModeGuard&&)      = delete;
+
+        [[nodiscard]] static bool fatalErrorTriggered();
+    };
+
+    explicit LifetimeDependee(const char* dependeeName, const char* dependantName);
+    ~LifetimeDependee();
+
+    LifetimeDependee(const LifetimeDependee& rhs);
+    LifetimeDependee(LifetimeDependee&& rhs) noexcept;
+
+    LifetimeDependee& operator=(const LifetimeDependee& rhs);
+    LifetimeDependee& operator=(LifetimeDependee&& rhs) noexcept;
+
+    void addDependant();
+    void subDependant();
+
+private:
+    // NOLINTBEGIN(readability-identifier-naming)
+    static inline std::atomic<bool> s_testingMode{false};
+    static inline std::atomic<bool> s_fatalErrorTriggered{false};
+    // NOLINTEND(readability-identifier-naming)
+
+    const char*               m_dependeeName;   ///< Readable dependee type name
+    const char*               m_dependantName;  ///< Readable dependent type name
+    std::atomic<unsigned int> m_dependantCount; ///< Current alive dependant count
+};
+
+class SFML_SYSTEM_API LifetimeDependant
+{
+public:
+    explicit LifetimeDependant(LifetimeDependee* dependee = nullptr) noexcept;
+    ~LifetimeDependant();
+
+    LifetimeDependant(const LifetimeDependant& rhs) noexcept;
+    LifetimeDependant(LifetimeDependant&& rhs) noexcept;
+
+    LifetimeDependant& operator=(const LifetimeDependant& rhs) noexcept;
+    LifetimeDependant& operator=(LifetimeDependant&& rhs) noexcept;
+
+    void update(LifetimeDependee* dependee) noexcept;
+
+private:
+    void addSelfAsDependant();
+    void subSelfAsDependant();
+
+    LifetimeDependee* m_dependee;
+};
+
+} // namespace sf::priv
+
+// NOLINTBEGIN(bugprone-macro-parentheses)
+#define SFML_DEFINE_LIFETIME_DEPENDEE(dependeeType, dependantType)                                               \
+    friend dependantType;                                                                                        \
+    mutable ::sf::priv::LifetimeDependee m_sfPrivLifetimeDependee##dependantType{#dependeeType, #dependantType}; \
+    using sfPrivSwallowSemicolon##dependantType##dependeeType = void
+
+#define SFML_DEFINE_LIFETIME_DEPENDANT(dependantType)                               \
+    mutable ::sf::priv::LifetimeDependant m_sfPrivLifetimeDependant##dependantType; \
+    using sfPrivSwallowSemicolon##dependantType = void
+
+#define SFML_UPDATE_LIFETIME_DEPENDANT(dependantType, dependeeType, dependantMemberPtr) \
+    m_sfPrivLifetimeDependant##dependantType.update(                                    \
+        dependantMemberPtr == nullptr ? nullptr : &dependantMemberPtr->m_sfPrivLifetimeDependee##dependeeType)
+// NOLINTEND(bugprone-macro-parentheses)
+
+#else // SFML_ENABLE_LIFETIME_TRACKING
+
+#define SFML_DEFINE_LIFETIME_DEPENDEE(dependantType, dependeeType) \
+    using sfPrivSwallowSemicolon##dependantType##dependeeType = void
+
+#define SFML_DEFINE_LIFETIME_DEPENDANT(dependantType) using sfPrivSwallowSemicolon##dependantType = void
+
+#define SFML_UPDATE_LIFETIME_DEPENDANT(...) (void)0
+
+#endif // SFML_ENABLE_LIFETIME_TRACKING

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -189,6 +189,8 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
 Sound::Sound(const SoundBuffer& buffer) : m_impl(std::make_unique<Impl>())
 {
     setBuffer(buffer);
+
+    SFML_UPDATE_LIFETIME_DEPENDANT(SoundBuffer, Sound, m_impl->buffer);
 }
 
 
@@ -201,6 +203,8 @@ Sound::Sound(const Sound& copy) : SoundSource(copy), m_impl(std::make_unique<Imp
     if (copy.m_impl->buffer)
         setBuffer(*copy.m_impl->buffer);
     setLoop(copy.getLoop());
+
+    SFML_UPDATE_LIFETIME_DEPENDANT(SoundBuffer, Sound, m_impl->buffer);
 }
 
 
@@ -279,6 +283,8 @@ void Sound::setBuffer(const SoundBuffer& buffer)
 
     m_impl->deinitialize();
     m_impl->initialize();
+
+    SFML_UPDATE_LIFETIME_DEPENDANT(SoundBuffer, Sound, m_impl->buffer);
 }
 
 

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -62,6 +62,8 @@ void Shape::setTexture(const Texture* texture, bool resetRect)
 
     // Assign the new texture
     m_texture = texture;
+
+    SFML_UPDATE_LIFETIME_DEPENDANT(Texture, Shape, m_texture);
 }
 
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -44,6 +44,8 @@ Sprite::Sprite(const Texture& texture) : Sprite(texture, IntRect({0, 0}, Vector2
 Sprite::Sprite(const Texture& texture, const IntRect& rectangle) : m_texture(&texture), m_textureRect(rectangle)
 {
     updateVertices();
+
+    SFML_UPDATE_LIFETIME_DEPENDANT(Texture, Sprite, m_texture);
 }
 
 
@@ -56,6 +58,8 @@ void Sprite::setTexture(const Texture& texture, bool resetRect)
 
     // Assign the new texture
     m_texture = &texture;
+
+    SFML_UPDATE_LIFETIME_DEPENDANT(Texture, Sprite, m_texture);
 }
 
 

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -93,6 +93,7 @@ m_string(std::move(string)),
 m_font(&font),
 m_characterSize(characterSize)
 {
+    SFML_UPDATE_LIFETIME_DEPENDANT(Font, Text, m_font);
 }
 
 

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -35,6 +35,8 @@ set(SRC
     ${SRCROOT}/MemoryInputStream.cpp
     ${INCROOT}/MemoryInputStream.hpp
     ${INCROOT}/SuspendAwareClock.hpp
+    ${SRCROOT}/LifetimeTracking.cpp
+    ${INCROOT}/LifetimeTracking.hpp
 )
 source_group("" FILES ${SRC})
 

--- a/src/SFML/System/LifetimeTracking.cpp
+++ b/src/SFML/System/LifetimeTracking.cpp
@@ -1,0 +1,294 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2024 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#include <SFML/Config.hpp>
+
+#ifdef SFML_ENABLE_LIFETIME_TRACKING
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/System/Export.hpp>
+
+#include <SFML/System/Err.hpp>
+#include <SFML/System/LifetimeTracking.hpp>
+
+#include <exception>
+#include <ostream>
+#include <string>
+
+#include <cassert>
+#include <cctype>
+
+
+namespace sf::priv
+{
+////////////////////////////////////////////////////////////
+LifetimeDependee::TestingModeGuard::TestingModeGuard()
+{
+    LifetimeDependee::s_testingMode.store(true, std::memory_order_seq_cst);
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependee::TestingModeGuard::~TestingModeGuard()
+{
+    LifetimeDependee::s_testingMode.store(false, std::memory_order_seq_cst);
+    LifetimeDependee::s_fatalErrorTriggered.store(false, std::memory_order_seq_cst);
+}
+
+
+////////////////////////////////////////////////////////////
+bool LifetimeDependee::TestingModeGuard::fatalErrorTriggered()
+{
+    return LifetimeDependee::s_fatalErrorTriggered.load(std::memory_order_seq_cst);
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependee::LifetimeDependee(const char* dependeeName, const char* dependantName) :
+m_dependeeName(dependeeName),
+m_dependantName(dependantName),
+m_dependantCount(0u)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+// A deep copy of a resource implies that lifetime tracking must being from scratch for that new copy.
+LifetimeDependee::LifetimeDependee(const LifetimeDependee& rhs) :
+LifetimeDependee(rhs.m_dependeeName, rhs.m_dependantName)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependee::LifetimeDependee(LifetimeDependee&& rhs) noexcept :
+m_dependeeName(rhs.m_dependeeName),
+m_dependantName(rhs.m_dependantName),
+m_dependantCount(rhs.m_dependantCount.load(std::memory_order_relaxed))
+{
+    // Intentionally not resetting `rhs.m_dependantCount` here, as we want to get a fatal error
+    // if it wasn't `0u` when the move occurred.
+
+    // We delay the check until the destructor to give a chance to the user to adjust the pointers
+    // after the move if they so desire.
+}
+
+
+////////////////////////////////////////////////////////////
+// A deep copy of a resource implies that lifetime tracking must being from scratch for that new copy.
+LifetimeDependee& LifetimeDependee::operator=(const LifetimeDependee& rhs)
+{
+    if (&rhs == this)
+        return *this;
+
+    m_dependeeName  = rhs.m_dependeeName;
+    m_dependantName = rhs.m_dependantName;
+    m_dependantCount.store(0u, std::memory_order_relaxed);
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependee& LifetimeDependee::operator=(LifetimeDependee&& rhs) noexcept
+{
+    if (&rhs == this)
+        return *this;
+
+    m_dependeeName  = rhs.m_dependeeName;
+    m_dependantName = rhs.m_dependantName;
+    m_dependantCount.store(rhs.m_dependantCount.load(std::memory_order_relaxed), std::memory_order_relaxed);
+
+    // See rationale in move constructor for not resetting `rhs.m_dependantCount`.
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependee::~LifetimeDependee()
+{
+    if (m_dependantCount.load(std::memory_order_relaxed) == 0u)
+        return;
+
+    if (s_testingMode)
+    {
+        s_fatalErrorTriggered = true;
+        return;
+    }
+
+    const auto toLowerStr = [](std::string s)
+    {
+        for (char& c : s)
+            c = static_cast<char>(std::tolower(c));
+
+        return s;
+    };
+
+    const auto toTildes = [](std::string s)
+    {
+        for (char& c : s)
+            c = '~';
+
+        s[s.size() - 1] = '\0';
+        return s;
+    };
+
+    const auto dependeeNameLower  = toLowerStr(m_dependeeName);
+    const auto dependantNameLower = toLowerStr(m_dependantName);
+
+    err() << "FATAL ERROR: a " << dependeeNameLower << " object was destroyed while existing " << dependantNameLower
+          << " objects depended on it.\n\n";
+
+    err() << "Please ensure that every " << dependeeNameLower << " object outlives all of the " << dependantNameLower
+          << " objects associated with it, otherwise those " << dependantNameLower
+          << "s will try to access the memory of the destroyed " << dependeeNameLower
+          << ", causing undefined behavior (e.g., crashes, segfaults, or unexpected run-time behavior).\n\n";
+
+    err() << "One of the ways this issue can occur is when a " << dependeeNameLower
+          << " object is created as a local variable in a function and passed to a " << dependantNameLower
+          << " object. When the function has finished executing, the local " << dependeeNameLower
+          << " object will be destroyed, and the " << dependantNameLower
+          << " object associated with it will now be referring to invalid memory. Example:\n\n";
+
+    // clang-format off
+    err() << "    sf::" << m_dependantName << " create" << m_dependantName << "()\n"
+          << "    {\n"
+          << "        " << "sf::" << m_dependeeName << " " << dependeeNameLower << "(/* ... */);\n"
+          << "        " << "sf::" << m_dependantName << " " << dependantNameLower << "(" << dependeeNameLower << ", /* ... */);\n"
+          << "        " << "\n"
+          << "        " << "return " << dependantNameLower << ";\n"
+          << "        " << "//     ^" << toTildes(dependantNameLower) << "\n"
+          << "        " << "// ERROR: `" << dependeeNameLower << "` will be destroyed right after\n"
+          << "        " << "//        `" << dependantNameLower << "` is returned from the function!\n"
+          << "    }\n\n";
+    // clang-format on
+
+    err() << "Another possible cause of this error is storing both a " << dependeeNameLower << " and a "
+          << dependantNameLower
+          << " together in a data structure (e.g., `class`, `struct`, container, pair, etc...), and then moving that "
+             "data structure (i.e., returning it from a function, or using `std::move`) -- the internal references "
+             "between the "
+          << dependeeNameLower << " and " << dependantNameLower
+          << " will not be updated, resulting in the same lifetime issue.\n\n";
+
+    err() << "In general, make sure that all your " << dependeeNameLower << " objects are destroyed *after* all the "
+          << dependantNameLower << " objects depending on them to avoid these sort of issues." << std::endl;
+
+    std::terminate();
+}
+
+
+////////////////////////////////////////////////////////////
+void LifetimeDependee::addDependant()
+{
+    m_dependantCount.fetch_add(1u, std::memory_order_relaxed);
+}
+
+
+////////////////////////////////////////////////////////////
+void LifetimeDependee::subDependant()
+{
+    assert(m_dependantCount.load(std::memory_order_relaxed) > 0u);
+    m_dependantCount.fetch_sub(1u, std::memory_order_relaxed);
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependant::LifetimeDependant(LifetimeDependee* dependee) noexcept : m_dependee(dependee)
+{
+    addSelfAsDependant();
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependant::~LifetimeDependant()
+{
+    subSelfAsDependant();
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependant::LifetimeDependant(const LifetimeDependant& rhs) noexcept : LifetimeDependant(rhs.m_dependee)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependant::LifetimeDependant(LifetimeDependant&& rhs) noexcept : LifetimeDependant(rhs.m_dependee)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependant& LifetimeDependant::operator=(const LifetimeDependant& rhs) noexcept
+{
+    if (&rhs == this)
+        return *this;
+
+    m_dependee = rhs.m_dependee;
+    addSelfAsDependant();
+
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+LifetimeDependant& LifetimeDependant::operator=(LifetimeDependant&& rhs) noexcept
+{
+    return (*this = rhs);
+}
+
+
+////////////////////////////////////////////////////////////
+void LifetimeDependant::update(LifetimeDependee* dependee) noexcept
+{
+    subSelfAsDependant();
+    m_dependee = dependee;
+    addSelfAsDependant();
+}
+
+
+////////////////////////////////////////////////////////////
+void LifetimeDependant::addSelfAsDependant()
+{
+    if (m_dependee != nullptr && !LifetimeDependee::TestingModeGuard::fatalErrorTriggered())
+        m_dependee->addDependant();
+}
+
+
+////////////////////////////////////////////////////////////
+void LifetimeDependant::subSelfAsDependant()
+{
+    if (m_dependee != nullptr && !LifetimeDependee::TestingModeGuard::fatalErrorTriggered())
+        m_dependee->subDependant();
+}
+
+
+} // namespace sf::priv
+
+#endif // SFML_ENABLE_LIFETIME_TRACKING

--- a/test/Audio/Sound.test.cpp
+++ b/test/Audio/Sound.test.cpp
@@ -9,6 +9,7 @@
 
 #include <AudioUtil.hpp>
 #include <SystemUtil.hpp>
+#include <optional>
 #include <type_traits>
 
 TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
@@ -82,4 +83,47 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
         sound.setPlayingOffset(sf::seconds(10));
         CHECK(sound.getPlayingOffset() == sf::seconds(10));
     }
+
+#ifdef SFML_ENABLE_LIFETIME_TRACKING
+    SECTION("Lifetime tracking")
+    {
+        SECTION("Return local from function")
+        {
+            const auto badFunction = []
+            {
+                const auto localSoundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();
+                return sf::Sound(localSoundBuffer);
+            };
+
+            const sf::priv::LifetimeDependee::TestingModeGuard guard;
+            CHECK(!guard.fatalErrorTriggered());
+
+            badFunction();
+
+            CHECK(guard.fatalErrorTriggered());
+        }
+
+        SECTION("Move struct holding both dependee and dependant")
+        {
+            struct BadStruct
+            {
+                sf::SoundBuffer memberSoundBuffer{sf::SoundBuffer::loadFromFile("Audio/ding.flac").value()};
+                sf::Sound       membeSound{memberSoundBuffer};
+            };
+
+            const sf::priv::LifetimeDependee::TestingModeGuard guard;
+            CHECK(!guard.fatalErrorTriggered());
+
+            std::optional<BadStruct> badStruct0;
+            badStruct0.emplace();
+            CHECK(!guard.fatalErrorTriggered());
+
+            const BadStruct badStruct1 = std::move(badStruct0.value());
+            CHECK(!guard.fatalErrorTriggered());
+
+            badStruct0.reset();
+            CHECK(guard.fatalErrorTriggered());
+        }
+    }
+#endif
 }


### PR DESCRIPTION
Add a new `SFML/System/LifetimeTracking.hpp` header that provides testable run-time lifetime tracking. 

---

The tracking is enabled only when `SFML_ENABLE_LIFETIME_TRACKING` is defined. That macro is controlled by a CMake option of the same name, enabled by default when building in debug mode.

The tracking is also enabled for our CI test suite, regardless of the build mode.

---

The tracking catches common lifetime mistakes between dependee types (e.g. `Texture`) and dependant types (e.g. `Sprite`) at run-time, providing the user with a readable error message:

> ```
> FATAL ERROR: a texture object was destroyed while existing sprite objects depended on it.
> 
> Please ensure that every texture object outlives all of the sprite objects associated with it,
> otherwise those sprites will try to access the memory of the destroyed texture, 
> causing undefined behavior (e.g., crashes, segfaults, or unexpected run-time behavior).
>  
> One of the ways this issue can occur is when a texture object is created as a local variable 
> in a function and passed to a sprite object. When the function has finished executing, the 
> local texture object will be destroyed, and the sprite object associated with it will now be
> referring to invalid memory. Example:
> 
>     sf::Sprite createSprite()
>     {
>         sf::Texture texture(/* ... */);
>         sf::Sprite sprite(texture, /* ... */);
> 
>         return sprite;
>         //     ^~~~~~
>         // ERROR: `texture` will be destroyed right after
>         //        `sprite` is returned from the function!
>     }
> 
> Another possible cause of this error is storing both a texture and a sprite together in a
> data structure (e.g., `class`, `struct`, container, pair, etc...), and then moving that 
> data structure (i.e., returning it from a function, or using `std::move`) -- the internal 
> references between the texture and sprite will not be updated, resulting in the same 
> lifetime issue.
> 
> In general, make sure that all your texture objects are destroyed *after* all the 
> sprite objects depending on them to avoid these sort of issues.
> ```

Note that the error message generation dynamically changes depending on the object types, it's not hardcoded for sprites and textures specifically.

---

Adding lifetime tracking to SFML types is trivial and requires minimum changes, as shown by the diff. It consists in a few simple steps:

- In the dependee type (e.g. `Texture`):
    1. Forward-declare the dependent type (e.g. `Sprite`);
    2. Add the following code at the end of the dependee type's `private` section:
    
    ```cpp
    SFML_DEFINE_LIFETIME_DEPENDEE(Texture, Sprite);
    ```
    
- In the dependant type (e.g. `Sprite`):
    1. Add the following code at the end of the dependant type's `private` section:

    ```cpp
    SFML_DEFINE_LIFETIME_DEPENDANT(Texture);
    ```
    
    2. Add the following code in any function that changes the dependant type's pointer-to-dependee:
    
    ```cpp
    SFML_UPDATE_LIFETIME_DEPENDANT(Texture, Sprite, m_texture);
    ```
    
That's it!

---

For testing, use the provided `sf::priv::LifetimeDependee::TestingModeGuard`:

```cpp
SECTION("Return local from function")
{
    const auto badFunction = []
    {
        const auto texture = sf::Texture::create({64, 64}).value();
        return sf::Sprite(texture);
    };

    const sf::priv::LifetimeDependee::TestingModeGuard guard;
    CHECK(!guard.fatalErrorTriggered());

    badFunction();

    CHECK(guard.fatalErrorTriggered());
}
```

---

Drawbacks:

- Some valid constructs might need to be slightly rearranged to please the lifetime tracker. E.g.:

    ```cpp
    // Techincally valid, but triggers a fatal error
    {
        sf::Sprite sprite(texture);
        const sf::Texture otherTexture = sf::Texture::create({64, 64}).value();
        sprite.setTexture(otherTexture);
    }

    // Valid, and pleases the lifetime tracker
    {
        const sf::Texture otherTexture = sf::Texture::create({64, 64}).value();
    
        sf::Sprite sprite(texture);
        sprite.setTexture(otherTexture);
    }
    ```
    
    However, this is more of a design problem with `sf::Sprite` itself than with the lifetime tracker, as `sf::Sprite` only needs a reference to the texture during its draw call, but SFML artificially extends the relationship between `sf::Sprite` and `sf::Texture` way beyond that. See #3072 and #3080 for an ample discussion on that.
    
---
    
FAQ:

- > Is this useful for newbies?

  - Yes. Newbies might not be familiar with the concepts of lifetime and ownership in C++, and might inadvertedly get into a situation where a dependee is destroyed before a dependant. This PR ensures that they will be alerted of the issue as soon as possible, saving them minutes or hours of frustration, debugging, saving us from having to help them out on Discord, and prompting them to learn more about lifetimes and ownership in C++.

- > Is this useful for power users?
 
  - Yes. While powerusers are familiar with lifetimes and don’t typically struggle with them, they can still make mistakes. This PR aims to alert powerusers to subtle lifetime issues that might arise from complex interactions, refactoring, or occasional human errors. It's not about teaching lifetimes but providing a safety net for those rare mistakes.
  
- > Is there any overhead if lifetime tracking is disabled?

  - Nope. Disabled lifetime tracking incurs no memory or run-time overhead at all.
