### PR TITLE
Create a new font page in Font::loadPage only when needed

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -464,9 +464,12 @@ bool Font::isSmooth() const
 ////////////////////////////////////////////////////////////
 Font::Page& Font::loadPage(unsigned int characterSize) const
 {
+    if (const auto it = m_pages.find(characterSize); it != m_pages.end())
+        return it->second;
+
     auto page = Page::make(m_isSmooth);
     assert(page && "Font::loadPage() Failed to load page");
-    return m_pages.try_emplace(characterSize, std::move(*page)).first->second;
+    return m_pages.emplace(characterSize, std::move(*page)).first->second;
 }
 
 


### PR DESCRIPTION
While updating [SFML-Input](https://github.com/eXpl0it3r/SFML-Input) to work with latest in-development SFML version, I noticed performance was suddenly very bad.
It turns out `Font::loadPage` was creating a `Font::Page` instance and its corresponding `Texture` instance for nothing most of the time.
This commit solves the performance problem.
For reference, the bug was introduced in #3027.