### PR TITLE
Fix sf::VideoMode usage example

### DIFF
--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -212,7 +212,7 @@ SFML_WINDOW_API bool operator>=(const VideoMode& left, const VideoMode& right);
 /// {
 ///     sf::VideoMode mode = modes[i];
 ///     std::cout << "Mode #" << i << ": "
-///               << mode.width << "x" << mode.height << " - "
+///               << mode.size.x << "x" << mode.size.y << " - "
 ///               << mode.bitsPerPixel << " bpp" << std::endl;
 /// }
 ///


### PR DESCRIPTION
A small inconsistency I noticed while looking at `.width` and `.height` occurrences during my work on `sf::Rect` type.
For reference, `width` and `height` were replaced by a `size` vector in #2055.