### PR TITLE
Use `std::` namespace

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -508,7 +508,7 @@ bool AudioDevice::initialize()
     // Update the current device string from the the device we just initialized
     {
         std::array<char, MA_MAX_DEVICE_NAME_LENGTH + 1> deviceName{};
-        size_t                                          deviceNameLength{};
+        std::size_t                                     deviceNameLength{};
 
         if (const auto result = ma_device_get_name(&*m_playbackDevice,
                                                    ma_device_type_playback,

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -52,8 +52,8 @@
 
 #if defined(SFML_SYSTEM_MACOS) || defined(SFML_SYSTEM_IOS)
 
-#define castToGlHandle(x)   reinterpret_cast<GLEXT_GLhandle>(static_cast<ptrdiff_t>(x))
-#define castFromGlHandle(x) static_cast<unsigned int>(reinterpret_cast<ptrdiff_t>(x))
+#define castToGlHandle(x)   reinterpret_cast<GLEXT_GLhandle>(static_cast<std::ptrdiff_t>(x))
+#define castFromGlHandle(x) static_cast<unsigned int>(reinterpret_cast<std::ptrdiff_t>(x))
 
 #else
 

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -214,7 +214,7 @@ GlFunctionPointer WglContext::getFunction(const char* name)
         if (address)
         {
             // Test whether the returned value is a valid error code
-            auto errorCode = reinterpret_cast<ptrdiff_t>(address);
+            auto errorCode = reinterpret_cast<std::ptrdiff_t>(address);
 
             if ((errorCode != -1) && (errorCode != 1) && (errorCode != 2) && (errorCode != 3))
                 return address;


### PR DESCRIPTION
## Description

Same idea as https://github.com/SFML/SFML/pull/2184, https://github.com/SFML/SFML/pull/2500, https://github.com/SFML/SFML/pull/2867, and https://github.com/SFML/SFML/pull/2880.

We still use `size_t` without the `std::` namespace for some callbacks passed to C library. I can't imagine using `std::size_t` would ever cause problems but I left those as-is since it seemed like a reasonable use of the C version of that type.