### PR TITLE
Work around errors with code coverage upload job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
 
     env:
       CMAKE_CXX_COMPILER_LAUNCHER: ccache # Use ccache to cache C++ compiler output
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1" # Work around Homebrew errors within coverallsapp/github-action@v2
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Code coverage uploads starting failing on certain macOS jobs. This seems to fix that problem but I'm not entirely sure what other implications it has. 