### PR TITLE
Decrease test precision to reduce flakey failures

### DIFF
--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -130,7 +130,7 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
             const auto event     = windowBase.waitEvent(timeout);
             const auto elapsed   = std::chrono::steady_clock::now() - startTime;
 
-            REQUIRE(elapsed < (timeout + sf::milliseconds(50)).toDuration());
+            REQUIRE(elapsed < (timeout + sf::milliseconds(100)).toDuration());
 
             if (elapsed <= timeout.toDuration())
                 CHECK(event);


### PR DESCRIPTION
## Description

Sometimes this test fails. Perhaps it needs to be resructured or removed if we can't figure out how to make it more reliable.

https://github.com/SFML/SFML/actions/runs/9569223439/job/26381302304?pr=3106#step:21:137