### PR TITLE
Fix oversights from 735f2d9

### DIFF
--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -462,7 +462,7 @@ bool eventProcess(sf::Event& event)
                         touchFd     = fileDescriptor;
                         break;
                     case ABS_MT_TRACKING_ID:
-                        atSlot(currentSlot).id = inputEvent.value;
+                        atSlot(currentSlot).id = inputEvent.value >= 0 ? std::optional(inputEvent.value) : std::nullopt;
                         touchFd                = fileDescriptor;
                         break;
                     case ABS_MT_POSITION_X:
@@ -657,7 +657,7 @@ bool isTouchDown(unsigned int finger)
 {
     return std::any_of(touchSlots.cbegin(),
                        touchSlots.cend(),
-                       [finger](const TouchSlot& slot) { return slot.id == static_cast<int>(finger); });
+                       [finger](const TouchSlot& slot) { return slot.id == finger; });
 }
 
 
@@ -666,7 +666,7 @@ Vector2i getTouchPosition(unsigned int finger)
 {
     for (const auto& slot : touchSlots)
     {
-        if (slot.id == static_cast<int>(finger))
+        if (slot.id == finger)
             return slot.pos;
     }
 


### PR DESCRIPTION
## Description

Bug found by Kimci86 [here](https://github.com/SFML/SFML/pull/3106#issuecomment-2176926782).

I recently learned about MSVC's [C4365](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4365?view=msvc-170) warning which unlike `-Wconversion` or `-Wsign-conversion` in GCC and Clang can actually detect instances of assigning a signed integer to an unsigned integer optional. This won't help with DRM code which of course does compile with MSVC but may catch this same issue elsewhere in the codebase.