### PR TITLE
Fixed cache state not correctly being ignored when switching between RenderTargets within a single context

### DIFF
--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -662,7 +662,7 @@ void RenderTarget::applyCurrentView()
     // Set the scissor rectangle and enable/disable scissor testing
     if (m_view.getScissor() == FloatRect({0, 0}, {1, 1}))
     {
-        if (m_cache.scissorEnabled)
+        if (!m_cache.enable || m_cache.scissorEnabled)
         {
             glCheck(glDisable(GL_SCISSOR_TEST));
             m_cache.scissorEnabled = false;
@@ -674,7 +674,7 @@ void RenderTarget::applyCurrentView()
         const int     scissorTop   = static_cast<int>(getSize().y) - (pixelScissor.position.y + pixelScissor.size.y);
         glCheck(glScissor(pixelScissor.position.x, scissorTop, pixelScissor.size.x, pixelScissor.size.y));
 
-        if (!m_cache.scissorEnabled)
+        if (!m_cache.enable || !m_cache.scissorEnabled)
         {
             glCheck(glEnable(GL_SCISSOR_TEST));
             m_cache.scissorEnabled = true;
@@ -754,7 +754,7 @@ void RenderTarget::applyStencilMode(const StencilMode& mode)
     // Fast path if we have a default (disabled) stencil mode
     if (mode == StencilMode())
     {
-        if (m_cache.stencilEnabled)
+        if (!m_cache.enable || m_cache.stencilEnabled)
         {
             glCheck(glDisable(GL_STENCIL_TEST));
             glCheck(glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE));
@@ -765,7 +765,7 @@ void RenderTarget::applyStencilMode(const StencilMode& mode)
     else
     {
         // Apply the stencil mode
-        if (!m_cache.stencilEnabled)
+        if (!m_cache.enable || !m_cache.stencilEnabled)
             glCheck(glEnable(GL_STENCIL_TEST));
 
         glCheck(glStencilOp(GL_KEEP,


### PR DESCRIPTION
Title.

Due to historic reasons, each `RenderTarget` has a state cache it uses to attempt to reduce unnecessary OpenGL function calls. This worked out in the days when each `RenderTarget` lived in its own separate context. Due to the high overhead of context switching, changes were made so that `RenderTarget`s could share a single context in order to save on the context switching. The original per-`RenderTarget` caching strategy was retained.

In order to fix cache synchronization issues, when we detect that we have switched from one `RenderTarget` to another within the same context, the cache is disabled for the first draw call via `m_cache.enabled = false`. This will ensure that all relevant states are set and their cache state synchronized. At the end of the draw call, the cache for the current `RenderTarget` is re-enabled via `m_cache.enabled = true` so that we don't have to go through setting all states again in subsequent draw calls _as long as we don't switch `RenderTarget`s_.

When adding scissor and stencil functionality, this synchronization mechanism was overlooked.

This fix just adds `!m_cache.enable` checks to the scissor and stencil apply functions in order to be able to force the cache state to be synchronized for them as well.

Fixes #3107

@danieljpetersen can test to verify this fixes the issue.