### PR TITLE
Allow Sprite to share ownership of underlying Texture data.

### DIFF
--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -32,6 +32,7 @@
 #include <SFML/Graphics/Drawable.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/RenderStates.hpp>
+#include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/Transformable.hpp>
 #include <SFML/Graphics/Vertex.hpp>
 
@@ -40,8 +41,6 @@
 
 namespace sf
 {
-class Texture;
-
 ////////////////////////////////////////////////////////////
 /// \brief Drawable representation of a texture, with its
 ///        own transformations, color, etc.
@@ -220,7 +219,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     std::array<Vertex, 4> m_vertices;    //!< Vertices defining the sprite's geometry
-    const Texture*        m_texture;     //!< Texture of the sprite
+    Texture               m_texture;     //!< Texture of the sprite
     IntRect               m_textureRect; //!< Rectangle defining the area of the source texture to display
 };
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -799,7 +799,7 @@ void RenderTarget::applyTexture(const Texture* texture, CoordinateType coordinat
 {
     Texture::bind(texture, coordinateType);
 
-    m_cache.lastTextureId      = texture ? texture->m_cacheId : 0;
+    m_cache.lastTextureId      = texture ? texture->m_data->cacheId : 0;
     m_cache.lastCoordinateType = coordinateType;
 }
 
@@ -860,7 +860,7 @@ void RenderTarget::setupDraw(bool useVertexCache, const RenderStates& states)
         glCheck(glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE));
 
     // Apply the texture
-    if (!m_cache.enable || (states.texture && states.texture->m_fboAttachment))
+    if (!m_cache.enable || (states.texture && states.texture->m_data->fboAttachment))
     {
         // If the texture is an FBO attachment, always rebind it
         // in order to inform the OpenGL driver that we want changes
@@ -872,7 +872,7 @@ void RenderTarget::setupDraw(bool useVertexCache, const RenderStates& states)
     }
     else
     {
-        const std::uint64_t textureId = states.texture ? states.texture->m_cacheId : 0;
+        const std::uint64_t textureId = states.texture ? states.texture->m_data->cacheId : 0;
         if (textureId != m_cache.lastTextureId || states.coordinateType != m_cache.lastCoordinateType)
             applyTexture(states.texture, states.coordinateType);
     }
@@ -904,7 +904,7 @@ void RenderTarget::cleanupDraw(const RenderStates& states)
 
     // If the texture we used to draw belonged to a RenderTexture, then forcibly unbind that texture.
     // This prevents a bug where some drivers do not clear RenderTextures properly.
-    if (states.texture && states.texture->m_fboAttachment)
+    if (states.texture && states.texture->m_data->fboAttachment)
         applyTexture(nullptr);
 
     // Mask the color buffer back on if necessary

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -72,7 +72,7 @@ std::optional<RenderTexture> RenderTexture::create(const Vector2u& size, const C
         renderTexture.m_impl = std::make_unique<priv::RenderTextureImplFBO>();
 
         // Mark the texture as being a framebuffer object attachment
-        renderTexture.m_texture.m_fboAttachment = true;
+        renderTexture.m_texture.m_data->fboAttachment = true;
     }
     else
     {
@@ -82,7 +82,7 @@ std::optional<RenderTexture> RenderTexture::create(const Vector2u& size, const C
 
     // Initialize the render texture
     // We pass the actual size of our texture since OpenGL ES requires that all attachments have identical sizes
-    if (!renderTexture.m_impl->create(renderTexture.m_texture.m_actualSize, renderTexture.m_texture.m_texture, settings))
+    if (!renderTexture.m_impl->create(renderTexture.m_texture.m_data->actualSize, renderTexture.m_texture.m_data->texture, settings))
         return std::nullopt;
 
     // We can now initialize the render target part
@@ -169,8 +169,8 @@ void RenderTexture::display()
     }
 
     // Update the target texture
-    m_impl->updateTexture(m_texture.m_texture);
-    m_texture.m_pixelsFlipped = true;
+    m_impl->updateTexture(m_texture.m_data->texture);
+    m_texture.m_data->pixelsFlipped = true;
     m_texture.invalidateMipmap();
 }
 

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -41,7 +41,7 @@ Sprite::Sprite(const Texture& texture) : Sprite(texture, IntRect({0, 0}, Vector2
 
 
 ////////////////////////////////////////////////////////////
-Sprite::Sprite(const Texture& texture, const IntRect& rectangle) : m_texture(&texture), m_textureRect(rectangle)
+Sprite::Sprite(const Texture& texture, const IntRect& rectangle) : m_texture(texture.m_data), m_textureRect(rectangle)
 {
     updateVertices();
 }
@@ -55,7 +55,7 @@ void Sprite::setTexture(const Texture& texture, bool resetRect)
         setTextureRect(IntRect({0, 0}, Vector2i(texture.getSize())));
 
     // Assign the new texture
-    m_texture = &texture;
+    m_texture = Texture(texture.m_data);
 }
 
 
@@ -81,7 +81,7 @@ void Sprite::setColor(const Color& color)
 ////////////////////////////////////////////////////////////
 const Texture& Sprite::getTexture() const
 {
-    return *m_texture;
+    return m_texture;
 }
 
 
@@ -118,7 +118,7 @@ FloatRect Sprite::getGlobalBounds() const
 void Sprite::draw(RenderTarget& target, RenderStates states) const
 {
     states.transform *= getTransform();
-    states.texture        = m_texture;
+    states.texture        = &m_texture;
     states.coordinateType = CoordinateType::Pixels;
 
     target.draw(m_vertices.data(), m_vertices.size(), PrimitiveType::TriangleStrip, states);

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -355,11 +355,11 @@ void Text::draw(RenderTarget& target, RenderStates states) const
 void Text::ensureGeometryUpdate() const
 {
     // Do nothing, if geometry has not changed and the font texture has not changed
-    if (!m_geometryNeedUpdate && m_font->getTexture(m_characterSize).m_cacheId == m_fontTextureId)
+    if (!m_geometryNeedUpdate && m_font->getTexture(m_characterSize).m_data->cacheId == m_fontTextureId)
         return;
 
     // Save the current fonts texture id
-    m_fontTextureId = m_font->getTexture(m_characterSize).m_cacheId;
+    m_fontTextureId = m_font->getTexture(m_characterSize).m_data->cacheId;
 
     // Mark geometry as updated
     m_geometryNeedUpdate = false;

--- a/test/Graphics/Sprite.test.cpp
+++ b/test/Graphics/Sprite.test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
         SECTION("Texture constructor")
         {
             const sf::Sprite sprite(texture);
-            CHECK(&sprite.getTexture() == &texture);
+            CHECK(sprite.getTexture().getNativeHandle() == texture.getNativeHandle());
             CHECK(sprite.getTextureRect() == sf::IntRect({}, {64, 64}));
             CHECK(sprite.getColor() == sf::Color::White);
             CHECK(sprite.getLocalBounds() == sf::FloatRect({}, {64, 64}));
@@ -36,7 +36,7 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
         SECTION("Texture and rectangle constructor")
         {
             const sf::Sprite sprite(texture, {{0, 0}, {40, 60}});
-            CHECK(&sprite.getTexture() == &texture);
+            CHECK(sprite.getTexture().getNativeHandle() == texture.getNativeHandle());
             CHECK(sprite.getTextureRect() == sf::IntRect({0, 0}, {40, 60}));
             CHECK(sprite.getColor() == sf::Color::White);
             CHECK(sprite.getLocalBounds() == sf::FloatRect({0, 0}, {40, 60}));
@@ -46,7 +46,7 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
         SECTION("Negative-size texture rectangle")
         {
             const sf::Sprite sprite(texture, {{0, 0}, {-40, -60}});
-            CHECK(&sprite.getTexture() == &texture);
+            CHECK(sprite.getTexture().getNativeHandle() == texture.getNativeHandle());
             CHECK(sprite.getTextureRect() == sf::IntRect({0, 0}, {-40, -60}));
             CHECK(sprite.getColor() == sf::Color::White);
             CHECK(sprite.getLocalBounds() == sf::FloatRect({0, 0}, {40, 60}));
@@ -59,7 +59,7 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
         sf::Sprite        sprite(texture);
         const sf::Texture otherTexture = sf::Texture::create({64, 64}).value();
         sprite.setTexture(otherTexture);
-        CHECK(&sprite.getTexture() == &otherTexture);
+        CHECK(sprite.getTexture().getNativeHandle() == otherTexture.getNativeHandle());
     }
 
     SECTION("Set/get texture rect")


### PR DESCRIPTION
Title.

This change allows the underlying `sf::Texture` data to be shared between the user `sf::Texture` object and the `sf::Sprite`s it is attached to. In the case the user relinquishes ownership of their `sf::Texture` object, the underlying data will still be available to any `sf::Sprite` objects that it is attached to, avoiding the infamous "white square problem" without any public API changes.

Test with any code that causes the "white square problem" to manifest itself, e.g.:
```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({200, 200}), "Test");

    auto texture = sf::Texture::loadFromImage(sf::Image({100, 100}, sf::Color::Red));
    sf::Sprite sprite(*texture);
    texture.reset();

    while (window.isOpen())
    {
        while (const auto event = window.pollEvent())
        {
            if (event.is<sf::Event::Closed>())
                return 0;
        }

        window.clear();
        window.draw(sprite);
        window.display();
    }
}
```