### PR TITLE
Refactor `sf::Text` geometry update code

### DIFF
--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -31,14 +31,15 @@
 
 #include <SFML/Graphics/Color.hpp>
 #include <SFML/Graphics/Drawable.hpp>
-#include <SFML/Graphics/PrimitiveType.hpp>
 #include <SFML/Graphics/Rect.hpp>
 #include <SFML/Graphics/RenderStates.hpp>
 #include <SFML/Graphics/Transformable.hpp>
-#include <SFML/Graphics/VertexArray.hpp>
+#include <SFML/Graphics/Vertex.hpp>
 
 #include <SFML/System/String.hpp>
 #include <SFML/System/Vector2.hpp>
+
+#include <vector>
 
 #include <cstddef>
 #include <cstdint>
@@ -412,20 +413,20 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    String                m_string;                                    //!< String to display
-    const Font*           m_font{};                                    //!< Font used to display the string
-    unsigned int          m_characterSize{30};                         //!< Base size of characters, in pixels
-    float                 m_letterSpacingFactor{1.f};                  //!< Spacing factor between letters
-    float                 m_lineSpacingFactor{1.f};                    //!< Spacing factor between lines
-    std::uint32_t         m_style{Regular};                            //!< Text style (see Style enum)
-    Color                 m_fillColor{Color::White};                   //!< Text fill color
-    Color                 m_outlineColor{Color::Black};                //!< Text outline color
-    float                 m_outlineThickness{0.f};                     //!< Thickness of the text's outline
-    mutable VertexArray   m_vertices{PrimitiveType::Triangles};        //!< Vertex array containing the fill geometry
-    mutable VertexArray   m_outlineVertices{PrimitiveType::Triangles}; //!< Vertex array containing the outline geometry
-    mutable FloatRect     m_bounds;               //!< Bounding rectangle of the text (in local coordinates)
-    mutable bool          m_geometryNeedUpdate{}; //!< Does the geometry need to be recomputed?
-    mutable std::uint64_t m_fontTextureId{};      //!< The font texture id
+    String                      m_string;                     //!< String to display
+    const Font*                 m_font{};                     //!< Font used to display the string
+    unsigned int                m_characterSize{30};          //!< Base size of characters, in pixels
+    float                       m_letterSpacingFactor{1.f};   //!< Spacing factor between letters
+    float                       m_lineSpacingFactor{1.f};     //!< Spacing factor between lines
+    std::uint32_t               m_style{Regular};             //!< Text style (see Style enum)
+    Color                       m_fillColor{Color::White};    //!< Text fill color
+    Color                       m_outlineColor{Color::Black}; //!< Text outline color
+    float                       m_outlineThickness{0.f};      //!< Thickness of the text's outline
+    mutable std::vector<Vertex> m_vertices;                   //!< Vertex array containing the fill geometry
+    mutable std::vector<Vertex> m_outlineVertices;            //!< Vertex array containing the outline geometry
+    mutable FloatRect           m_bounds;                     //!< Bounding rectangle of the text (in local coordinates)
+    mutable bool                m_geometryNeedUpdate{};       //!< Does the geometry need to be recomputed?
+    mutable std::uint64_t       m_fontTextureId{};            //!< The font texture id
 };
 
 } // namespace sf


### PR DESCRIPTION
Pure refactoring change that does not change the behavior of `sf::Text` whatsoever. These are some improvements I made when researching the performance benefit of merging outline and fill vertices into a single vertex array (and single draw call). Those benefits still need to be measured, but I wanted to capture the refactoring work in a separate PR regardless of whether those rendering changes are going to be made.