### PR TITLE
Enable standard library assertions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         - platform: { name: Windows MinGW, os: windows-2022 }
           config: { name: Static Standard Libraries, flags: -GNinja -DSFML_USE_MESA3D=TRUE -DCMAKE_CXX_COMPILER=g++ -DSFML_USE_STATIC_STD_LIBS=TRUE }
         - platform: { name: Windows MinGW, os: windows-2022 }
-          config: { name: Static with PCH (GCC), flags: -GNinja -DSFML_USE_MESA3D=TRUE -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=FALSE -DSFML_ENABLE_PCH=1 }
+          config: { name: Static with PCH (GCC), flags: -GNinja -DSFML_USE_MESA3D=TRUE -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=FALSE -DSFML_ENABLE_PCH=1 -DSFML_ENABLE_STDLIB_ASSERTIONS=FALSE } # disabling stdlib assertions due to false positive
         - platform: { name: macOS, os: macos-12 }
           config: { name: Frameworks, flags: -GNinja -DSFML_BUILD_FRAMEWORKS=TRUE -DBUILD_SHARED_LIBS=TRUE }
         - platform: { name: macOS , os: macos-12 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,13 @@ if(SFML_ENABLE_SANITIZERS)
     string(APPEND CMAKE_CXX_FLAGS " -fno-omit-frame-pointer -fno-sanitize-recover=all -fsanitize=undefined")
 endif()
 
+option(SFML_ENABLE_STDLIB_ASSERTIONS "Enable standard library assertions" OFF)
+if(SFML_ENABLE_STDLIB_ASSERTIONS)
+    # intentionally using `add_definitions` here to propagate defines to subdirectories
+    add_definitions(-D_GLIBCXX_ASSERTIONS=1)                                   # see https://gcc.gnu.org/wiki/LibstdcxxDebugMode
+    add_definitions(-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE) # see https://libcxx.llvm.org/Hardening.html
+endif()
+
 # set the output directory for SFML DLLs and executables
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,6 +10,7 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "SFML_BUILD_EXAMPLES": "ON",
         "SFML_BUILD_TEST_SUITE": "ON",
+        "SFML_ENABLE_STDLIB_ASSERTIONS": "ON",
         "SFML_WARNINGS_AS_ERRORS": "ON"
       }
     }


### PR DESCRIPTION
Addresses #3098. I've chosen flags that enable unexpensive assertions (e.g. assert when dereferencing a smart pointer or `std::optional`).