### PR TITLE
Added assert that a texture is valid when attempting to bind it.

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -107,6 +107,13 @@ Texture::~Texture()
         const GLuint texture = m_texture;
         glCheck(glDeleteTextures(1, &texture));
     }
+
+#ifndef NDEBUG
+    // Set m_texture and m_cacheId to an invalid value to help the assert and glIsTexture in bind detect trying
+    // to bind this texture in cases where it has already been destroyed but its memory not yet deallocated
+    m_texture = 0xFFFFFFFFu;
+    m_cacheId = 0xFFFFFFFFFFFFFFFFull;
+#endif
 }
 
 ////////////////////////////////////////////////////////////
@@ -854,6 +861,10 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
 
     if (texture && texture->m_texture)
     {
+        // When debugging, ensure that the texture name is valid
+        assert((glIsTexture(texture->m_texture) == GL_TRUE) &&
+               "Texture to be bound is invalid, check if the texture is still being used after it has been destroyed");
+
         // Bind the texture
         glCheck(glBindTexture(GL_TEXTURE_2D, texture->m_texture));
 


### PR DESCRIPTION
Title.

Perhaps the simplest solution to make the "white square problem" at least detectable when running a debug build.

Normally, debug memory allocators fill freed memory with patterns such as `0xDDDDDDDD` in order to make detecting use-after-frees easier. In our case however, because textures can be (and more recently are probably) stored in `std::optional`s, we can't assume that the memory will be freed by the allocator even after the texture is destroyed. The OpenGL texture name will be deleted, but the actual memory contents of the still allocated `sf::Texture` memory block will remain identical after its destructor has completed.

In order to detect bind-after-frees even in such cases, (in debug builds) we assign `m_texture` with a value that is very unlikely to be generated as an OpenGL texture name. After the destructor runs but before the memory block is deallocated, this value will sit in `m_texture` and any attempt to bind the texture will read this value and fail the assert because `glIsTexture` will return `GL_FALSE`.

In the case the memory was actually deallocated, either the operating system throws a SEGFAULT/Access Violation or `0xDDDDDDDD` (or whatever pattern your allocator uses) is read from `m_texture` when attempting to bind it. `0xDDDDDDDD` is also very unlikely to be a texture name OpenGL generates, so the assertion should fail in this case as well.

Test with any code that causes the "white square problem" to manifest itself, e.g.:
```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({200, 200}), "Test");

    auto texture = sf::Texture::loadFromImage(sf::Image({100, 100}, sf::Color::Red));
    sf::Sprite sprite(*texture);
    texture.reset();

    while (window.isOpen())
    {
        while (const auto event = window.pollEvent())
        {
            if (event.is<sf::Event::Closed>())
                return 0;
        }

        window.clear();
        window.draw(sprite);
        window.display();
    }
}
```