### PR TITLE
Disallow construction from `const T&&`

### DIFF
--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -59,7 +59,7 @@ public:
     /// \brief Disallow construction from a temporary sound buffer
     ///
     ////////////////////////////////////////////////////////////
-    explicit Sound(SoundBuffer&& buffer) = delete;
+    explicit Sound(const SoundBuffer&& buffer) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
@@ -130,7 +130,7 @@ public:
     /// \brief Disallow setting from a temporary sound buffer
     ///
     ////////////////////////////////////////////////////////////
-    void setBuffer(SoundBuffer&& buffer) = delete;
+    void setBuffer(const SoundBuffer&& buffer) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set whether or not the sound should loop after reaching the end

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -493,7 +493,7 @@ public:
     /// \brief Disallow setting from a temporary texture
     ///
     ////////////////////////////////////////////////////////////
-    void setUniform(const std::string& name, Texture&& texture) = delete;
+    void setUniform(const std::string& name, const Texture&& texture) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Specify current texture as \p sampler2D uniform

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -64,7 +64,7 @@ public:
     /// \brief Disallow construction from a temporary texture
     ///
     ////////////////////////////////////////////////////////////
-    explicit Sprite(Texture&& texture) = delete;
+    explicit Sprite(const Texture&& texture) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the sprite from a sub-rectangle of a source texture
@@ -81,7 +81,7 @@ public:
     /// \brief Disallow construction from a temporary texture
     ///
     ////////////////////////////////////////////////////////////
-    Sprite(Texture&& texture, const IntRect& rectangle) = delete;
+    Sprite(const Texture&& texture, const IntRect& rectangle) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the source texture of the sprite
@@ -108,7 +108,7 @@ public:
     /// \brief Disallow setting from a temporary texture
     ///
     ////////////////////////////////////////////////////////////
-    void setTexture(Texture&& texture, bool resetRect = false) = delete;
+    void setTexture(const Texture&& texture, bool resetRect = false) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the sub-rectangle of the texture that the sprite will display

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -90,7 +90,7 @@ public:
     /// \brief Disallow construction from a temporary font
     ///
     ////////////////////////////////////////////////////////////
-    Text(Font&& font, String string = "", unsigned int characterSize = 30) = delete;
+    Text(const Font&& font, String string = "", unsigned int characterSize = 30) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the text's string
@@ -134,7 +134,7 @@ public:
     /// \brief Disallow setting from a temporary font
     ///
     ////////////////////////////////////////////////////////////
-    void setFont(Font&& font) = delete;
+    void setFont(const Font&& font) = delete;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the character size

--- a/test/Audio/Sound.test.cpp
+++ b/test/Audio/Sound.test.cpp
@@ -16,6 +16,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
     SECTION("Type traits")
     {
         STATIC_CHECK(!std::is_constructible_v<sf::Sound, sf::SoundBuffer&&>);
+        STATIC_CHECK(!std::is_constructible_v<sf::Sound, const sf::SoundBuffer&&>);
         STATIC_CHECK(std::is_copy_constructible_v<sf::Sound>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Sound>);
         STATIC_CHECK(std::is_move_constructible_v<sf::Sound>);

--- a/test/Graphics/Sprite.test.cpp
+++ b/test/Graphics/Sprite.test.cpp
@@ -13,6 +13,9 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
     SECTION("Type traits")
     {
         STATIC_CHECK(!std::is_constructible_v<sf::Sprite, sf::Texture&&>);
+        STATIC_CHECK(!std::is_constructible_v<sf::Sprite, const sf::Texture&&>);
+        STATIC_CHECK(!std::is_constructible_v<sf::Sprite, sf::Texture&&, const sf::IntRect&>);
+        STATIC_CHECK(!std::is_constructible_v<sf::Sprite, const sf::Texture&&, const sf::IntRect&>);
         STATIC_CHECK(std::is_copy_constructible_v<sf::Sprite>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Sprite>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Sprite>);

--- a/test/Graphics/Text.test.cpp
+++ b/test/Graphics/Text.test.cpp
@@ -14,6 +14,7 @@ TEST_CASE("[Graphics] sf::Text", runDisplayTests())
     SECTION("Type traits")
     {
         STATIC_CHECK(!std::is_constructible_v<sf::Text, sf::Font&&, sf::String, unsigned int>);
+        STATIC_CHECK(!std::is_constructible_v<sf::Text, const sf::Font&&, sf::String, unsigned int>);
         STATIC_CHECK(std::is_copy_constructible_v<sf::Text>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Text>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Text>);


### PR DESCRIPTION
## Description

Closes #3125. This was a pretty simple fix thanks to our type trait tests. I confirmed that the next tests I added fail if I don't add `const` to the signature of these deleted functions. 