### PR TITLE
Fixed SoundEffects example allocating effect processor resources based on source channel count instead of engine channel count

### DIFF
--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -108,6 +108,14 @@ public:
     /// count or write more frames than the output frame count
     /// will result in undefined behaviour.
     ///
+    /// It is important to note that the channel count of the
+    /// audio engine currently sourcing data from this sound
+    /// will always be provided in frameChannelCount. This can
+    /// be different from the channel count of the sound source
+    /// so make sure to size necessary processing buffers
+    /// according to the engine channel count and not the sound
+    /// source channel count.
+    ///
     /// When done processing the frames, the input and output
     /// frame counts must be updated to reflect the actual
     /// number of frames that were read from the input and


### PR DESCRIPTION
Title.

When creating miniaudio `ma_sound` objects their output bus channel count is set to the channel count of the engine they are attached to. The engine derives its channel count from the audio device. When the audio source has a lower channel count the node will automatically convert it to the engine channel count for internal processing.

This change makes sure that the effect processor buffers in the SoundEffects example are sized based on the engine channel count, which is provided via parameter, instead of the channel count of the audio source.

Without this change, if the audio device has more channels than the audio source, the code would have tried to access out-of-bounds buffers since it will use the audio source channel count to construct the buffers and the engine channel count to iterate them.

Test by running the SoundEffects example using an audio device with more than 2 output channels. On Windows this can be done without hardware using something like [VB-Audio Virtual Audio Device](https://vb-audio.com/Cable/) and setting the device channel configuration to 7.1.

Fixes #3079