### PR TITLE
Fix SFML_USE_STATIC_STD_LIBS behaviour with newer cmake (2.6.x)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,10 +219,9 @@ if(SFML_OS_WINDOWS)
         foreach(flag
                 CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
                 CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if(${flag} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-            endif()
+            string(REGEX REPLACE "/MD|/MDd|/MT|/MTd" "" ${flag} "${${flag}}")
         endforeach()
+        add_compile_options(/MT$<$<CONFIG:Debug>:d>)
     endif()
 endif()
 


### PR DESCRIPTION
CMAKE_CXX_FLAGS does not always contain the `/MD` flags so using a string replace doesn't have any effect in that case.

Instead, remove the default flag if it's present, and always add the correct flag