### PR TITLE
Added throwing constructor analogs of load/open factory functions.

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -53,6 +53,51 @@ class SFML_AUDIO_API InputSoundFile
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Construct a sound file from the disk for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC, MP3.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// Because of minimp3_ex limitation, for MP3 files with big (>16kb) APEv2 tag,
+    /// it may not be properly removed, tag data will be treated as MP3 data
+    /// and there is a low chance of garbage decoded at the end of file.
+    /// See also: https://github.com/lieff/minimp3
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \throws std::runtime_error if opening the file was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a sound file in memory for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if opening the file was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a sound file from a custom stream for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if opening the file was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open a sound file from the disk for reading
     ///
     /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC, MP3.

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -67,6 +67,71 @@ public:
     using TimeSpan = Span<Time>;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct a music from an audio file
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the file must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param filename Path of the music file to open
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromMemory, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Music(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a music from an audio file in memory
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather streamed
+    /// continuously, the \a data buffer must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed. That is,
+    /// you can't deallocate the buffer right after calling this function.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromFile, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Music(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a music from an audio file in a custom stream
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the \a stream must remain accessible
+    /// until the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromFile, openFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    Music(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -50,6 +50,24 @@ class SFML_AUDIO_API OutputSoundFile
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound file from the disk for writing
+    ///
+    /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.
+    ///
+    /// \param filename     Path of the sound file to write
+    /// \param sampleRate   Sample rate of the sound
+    /// \param channelCount Number of channels in the sound
+    /// \param channelMap   Map of position in sample frame to sound channel
+    ///
+    /// \throws std::runtime_error if the file could not be opened successfully
+    ///
+    ////////////////////////////////////////////////////////////
+    OutputSoundFile(const std::filesystem::path&     filename,
+                    unsigned int                     sampleRate,
+                    unsigned int                     channelCount,
+                    const std::vector<SoundChannel>& channelMap);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the sound file from the disk for writing
     ///
     /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -56,6 +56,74 @@ class SFML_AUDIO_API SoundBuffer
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from a file
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from a file in memory
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream, loadFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from a custom stream
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from an array of audio samples
+    ///
+    /// The assumed format of the audio samples is 16 bits signed integer.
+    ///
+    /// \param samples      Pointer to the array of samples in memory
+    /// \param sampleCount  Number of samples in the array
+    /// \param channelCount Number of channels (1 = mono, 2 = stereo, ...)
+    /// \param sampleRate   Sample rate (number of samples to play per second)
+    /// \param channelMap   Map of position in sample frame to sound channel
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(const std::int16_t*              samples,
+                std::uint64_t                    sampleCount,
+                unsigned int                     channelCount,
+                unsigned int                     sampleRate,
+                const std::vector<SoundChannel>& channelMap);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
     ///
     /// \param copy Instance to copy
@@ -254,10 +322,22 @@ private:
     ///
     /// \param file Sound file providing access to the new loaded sound
     ///
-    /// \return True on successful initialization, false on failure
+    /// \return Sound buffer on successful initialization, `std::nullopt` if it failed
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static std::optional<SoundBuffer> initialize(InputSoundFile& file);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Initialize the internal state after loading a new sound
+    ///
+    /// \param file Sound file providing access to the new loaded sound
+    ///
+    /// \return True on success, false initialization was unsuccessful
+    ///
+    /// \throws std::runtime_error if initialization was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool initialize(InputSoundFile& file, int);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the internal buffer with the cached audio samples

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -74,6 +74,71 @@ public:
     };
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the font from a file
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Note that this function knows nothing about the standard
+    /// fonts installed on the user's system, thus you can't
+    /// load them directly.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the file has to remain accessible until
+    /// the sf::Font object loads a new font or is destroyed.
+    ///
+    /// \param filename Path of the font file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Font(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the font from a file in memory
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the buffer pointed by \a data has to remain
+    /// valid until the sf::Font object loads a new font or
+    /// is destroyed.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Font(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the font from a custom stream
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Warning: SFML cannot preload all the font data in this
+    /// function, so the contents of \a stream have to remain
+    /// valid as long as the font is used.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the stream has to remain accessible until
+    /// the sf::Font object loads a new font or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    Font(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the font from a file
     ///
     /// The supported font formats are: TrueType, Type 1, CFF,

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -55,6 +55,58 @@ class SFML_GRAPHICS_API Image
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the image from a file on disk
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param filename Path of the image file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Image(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the image from a file in memory
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Image(const void* data, std::size_t size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the image from a custom stream
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Image(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Construct the image and fill it with a unique color
     ///
     /// \param size  Width and height of the image

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -55,6 +55,25 @@ class SFML_GRAPHICS_API RenderTexture : public RenderTarget
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Construct a render-texture
+    ///
+    /// The last parameter, \a settings, is useful if you want to enable
+    /// multi-sampling or use the render-texture for OpenGL rendering that
+    /// requires a depth or stencil buffer. Otherwise it is unnecessary, and
+    /// you should leave this parameter at its default value.
+    ///
+    /// After creation, the contents of the render-texture are undefined.
+    /// Call `RenderTexture::clear` first to ensure a single color fill.
+    ///
+    /// \param size     Width and height of the render-texture
+    /// \param settings Additional settings for the underlying OpenGL texture and context
+    ///
+    /// \throws std::runtime_error if creation was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderTexture(const Vector2u& size, const ContextSettings& settings = {});
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -86,6 +86,198 @@ public:
     static inline CurrentTextureType CurrentTexture;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a file
+    ///
+    /// This function loads a single shader, vertex, geometry or
+    /// fragment, identified by the second argument.
+    /// The source must be a text file containing a valid
+    /// shader in GLSL language. GLSL is a C-like language
+    /// dedicated to OpenGL shaders; you'll probably need to
+    /// read a good documentation for it before writing your
+    /// own shaders.
+    ///
+    /// \param filename Path of the vertex, geometry or fragment shader file to load
+    /// \param type     Type of shader (vertex, geometry or fragment)
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(const std::filesystem::path& filename, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from files
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(const std::filesystem::path& vertexShaderFilename, const std::filesystem::path& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from files
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param geometryShaderFilename Path of the geometry shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(const std::filesystem::path& vertexShaderFilename,
+           const std::filesystem::path& geometryShaderFilename,
+           const std::filesystem::path& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a source code in memory
+    ///
+    /// This function loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param shader String containing the source code of the shader
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(std::string_view shader, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from source codes in memory
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(std::string_view vertexShader, std::string_view fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from source codes in memory
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param geometryShader String containing the source code of the geometry shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(std::string_view vertexShader, std::string_view geometryShader, std::string_view fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a custom stream
+    ///
+    /// This function loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for it
+    /// before writing your own shaders.
+    ///
+    /// \param stream Source stream to read from
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(InputStream& stream, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from custom streams
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(InputStream& vertexShaderStream, InputStream& fragmentShaderStream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from custom streams
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param geometryShaderStream Source stream to read the geometry shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(InputStream& vertexShaderStream, InputStream& geometryShaderStream, InputStream& fragmentShaderStream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -114,7 +306,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     Shader& operator=(Shader&& right) noexcept;
-
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry or fragment shader from a file
@@ -661,12 +852,12 @@ private:
     /// \param geometryShaderCode Source code of the geometry shader
     /// \param fragmentShaderCode Source code of the fragment shader
     ///
-    /// \return Shader on success, `std::nullopt` if any error happened
+    /// \return shader program object on success, `std::nullopt` if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> compile(std::string_view vertexShaderCode,
-                                                       std::string_view geometryShaderCode,
-                                                       std::string_view fragmentShaderCode);
+    [[nodiscard]] static std::optional<unsigned int> compile(std::string_view vertexShaderCode,
+                                                             std::string_view geometryShaderCode,
+                                                             std::string_view fragmentShaderCode);
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind all the textures used by the shader

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -57,6 +57,174 @@ class SFML_GRAPHICS_API Texture : GlResource
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a file on disk
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param filename Path of the image file to load
+    /// \param sRgb     True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(const std::filesystem::path& filename, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of a file on disk
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param filename Path of the image file to load
+    /// \param sRgb     True to enable sRGB conversion, false to disable it
+    /// \param area     Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const std::filesystem::path& filename, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a file in memory
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const void* data, std::size_t size, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of a file in memory
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    /// \param area Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const void* data, std::size_t size, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a custom stream
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param stream Source stream to read from
+    /// \param sRgb   True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(InputStream& stream, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of a custom stream
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param stream Source stream to read from
+    /// \param sRgb   True to enable sRGB conversion, false to disable it
+    /// \param area   Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(InputStream& stream, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from an image
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param image Image to load into the texture
+    /// \param sRgb  True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(const Image& image, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of an image
+    ///
+    /// The \a area argument is used to load only a sub-rectangle
+    /// of the whole image.
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param image Image to load into the texture
+    /// \param sRgb  True to enable sRGB conversion, false to disable it
+    /// \param area  Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const Image& image, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture with a given size
+    ///
+    /// \param size Width and height of the texture
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if construction was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(const Vector2u& size, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -91,8 +259,6 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Create the texture
     ///
-    /// If this function fails, the texture is left unchanged.
-    ///
     /// \param size Width and height of the texture
     /// \param sRgb True to enable sRGB conversion, false to disable it
     ///
@@ -112,8 +278,6 @@ public:
     ///
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
-    ///
-    /// If this function fails, the texture is left unchanged.
     ///
     /// \param filename Path of the image file to load
     /// \param sRgb     True to enable sRGB conversion, false to disable it
@@ -139,8 +303,6 @@ public:
     ///
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
-    ///
-    /// If this function fails, the texture is left unchanged.
     ///
     /// \param data Pointer to the file data in memory
     /// \param size Size of the data to load, in bytes
@@ -170,8 +332,6 @@ public:
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
     ///
-    /// If this function fails, the texture is left unchanged.
-    ///
     /// \param stream Source stream to read from
     /// \param sRgb   True to enable sRGB conversion, false to disable it
     /// \param area   Area of the image to load
@@ -194,8 +354,6 @@ public:
     ///
     /// The maximum size for a texture depends on the graphics
     /// driver and can be retrieved with the getMaximumSize function.
-    ///
-    /// If this function fails, the texture is left unchanged.
     ///
     /// \param image Image to load into the texture
     /// \param sRgb   True to enable sRGB conversion, false to disable it

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -57,6 +57,16 @@ class SFML_SYSTEM_API FileInputStream : public InputStream
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the stream from a file path
+    ///
+    /// \param filename Name of the file to open
+    ///
+    /// \throws std::runtime_error on error
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit FileInputStream(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Default destructor
     ///
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -112,6 +112,55 @@ public:
     };
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct a cursor with the provided image
+    ///
+    /// \a pixels must be an array of \a width by \a height pixels
+    /// in 32-bit RGBA format. If not, this will cause undefined behavior.
+    ///
+    /// If \a pixels is null or either \a width or \a height are 0,
+    /// the current cursor is left unchanged and the function will
+    /// return false.
+    ///
+    /// In addition to specifying the pixel data, you can also
+    /// specify the location of the hotspot of the cursor. The
+    /// hotspot is the pixel coordinate within the cursor image
+    /// which will be located exactly where the mouse pointer
+    /// position is. Any mouse actions that are performed will
+    /// return the window/screen location of the hotspot.
+    ///
+    /// \warning On Unix platforms which do not support colored
+    ///          cursors, the pixels are mapped into a monochrome
+    ///          bitmap: pixels with an alpha channel to 0 are
+    ///          transparent, black if the RGB channel are close
+    ///          to zero, and white otherwise.
+    ///
+    /// \param pixels  Array of pixels of the image
+    /// \param size    Width and height of the image
+    /// \param hotspot (x,y) location of the hotspot
+    ///
+    /// \throws std::runtime_error if the cursor could not be constructed
+    ///
+    ////////////////////////////////////////////////////////////
+    Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a native system cursor
+    ///
+    /// Refer to the list of cursor available on each system
+    /// (see sf::Cursor::Type) to know whether a given cursor is
+    /// expected to load successfully or is not supported by
+    /// the operating system.
+    ///
+    /// \param type Native system cursor type
+    ///
+    /// \throws std::runtime_error if the corresponding cursor
+    ///         is not natively supported by the operating
+    ///         system
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Cursor(Type type);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     /// This destructor releases the system resources

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -60,6 +60,24 @@ struct Music::Impl
 
 
 ////////////////////////////////////////////////////////////
+Music::Music(const std::filesystem::path& filename) : Music(InputSoundFile(filename))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+Music::Music(const void* data, std::size_t sizeInBytes) : Music(InputSoundFile(data, sizeInBytes))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+Music::Music(InputStream& stream) : Music(InputSoundFile(stream))
+{
+}
+
+
+////////////////////////////////////////////////////////////
 Music::~Music()
 {
     // We must stop before destroying the file

--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -37,6 +37,28 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
+OutputSoundFile::OutputSoundFile(const std::filesystem::path&     filename,
+                                 unsigned int                     sampleRate,
+                                 unsigned int                     channelCount,
+                                 const std::vector<SoundChannel>& channelMap) :
+m_writer(SoundFileFactory::createWriterFromFilename(filename)) // Find a suitable writer for the file type
+{
+    if (!m_writer)
+    {
+        // Error message generated in called function.
+        throw std::runtime_error("Failed to open file");
+    }
+
+    // Pass the stream to the reader
+    if (!m_writer->open(filename, sampleRate, channelCount, channelMap))
+    {
+        err() << "Failed to open output sound file from file (writer open failure)" << std::endl;
+        throw std::runtime_error("Failed to open output sound file from file (writer open failure)");
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 std::optional<OutputSoundFile> OutputSoundFile::openFromFile(
     const std::filesystem::path&     filename,
     unsigned int                     sampleRate,

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -225,6 +225,257 @@ struct Shader::UniformBinder
 
 
 ////////////////////////////////////////////////////////////
+Shader::Shader(const std::filesystem::path& filename, Type type)
+{
+    // Read the file
+    std::vector<char> shader;
+    if (!getFileContents(filename, shader))
+    {
+        err() << "Failed to open shader file\n" << formatDebugPathInfo(filename) << std::endl;
+        throw std::runtime_error("Failed to open shader file");
+    }
+
+    std::optional<unsigned int> program;
+
+    // Compile the shader program
+    if (type == Type::Vertex)
+        program = compile(shader.data(), {}, {});
+    else if (type == Type::Geometry)
+        program = compile({}, shader.data(), {});
+    else
+        program = compile({}, {}, shader.data());
+
+    if (program)
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(const std::filesystem::path& vertexShaderFilename, const std::filesystem::path& fragmentShaderFilename)
+{
+    // Read the vertex shader file
+    std::vector<char> vertexShader;
+    if (!getFileContents(vertexShaderFilename, vertexShader))
+    {
+        err() << "Failed to open vertex shader file\n" << formatDebugPathInfo(vertexShaderFilename) << std::endl;
+        throw std::runtime_error("Failed to open vertex shader file");
+    }
+
+    // Read the fragment shader file
+    std::vector<char> fragmentShader;
+    if (!getFileContents(fragmentShaderFilename, fragmentShader))
+    {
+        err() << "Failed to open fragment shader file\n" << formatDebugPathInfo(fragmentShaderFilename) << std::endl;
+        throw std::runtime_error("Failed to open fragment shader file");
+    }
+
+    // Compile the shader program
+    if (const auto program = compile(vertexShader.data(), {}, fragmentShader.data()))
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(const std::filesystem::path& vertexShaderFilename,
+               const std::filesystem::path& geometryShaderFilename,
+               const std::filesystem::path& fragmentShaderFilename)
+{
+    // Read the vertex shader file
+    std::vector<char> vertexShader;
+    if (!getFileContents(vertexShaderFilename, vertexShader))
+    {
+        err() << "Failed to open vertex shader file\n" << formatDebugPathInfo(vertexShaderFilename) << std::endl;
+        throw std::runtime_error("Failed to open vertex shader file");
+    }
+
+    // Read the geometry shader file
+    std::vector<char> geometryShader;
+    if (!getFileContents(geometryShaderFilename, geometryShader))
+    {
+        err() << "Failed to open geometry shader file\n" << formatDebugPathInfo(geometryShaderFilename) << std::endl;
+        throw std::runtime_error("Failed to open geometry shader file");
+    }
+
+    // Read the fragment shader file
+    std::vector<char> fragmentShader;
+    if (!getFileContents(fragmentShaderFilename, fragmentShader))
+    {
+        err() << "Failed to open fragment shader file\n" << formatDebugPathInfo(fragmentShaderFilename) << std::endl;
+        throw std::runtime_error("Failed to open fragment shader file");
+    }
+
+    // Compile the shader program
+    if (const auto program = compile(vertexShader.data(), geometryShader.data(), fragmentShader.data()))
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(std::string_view shader, Type type)
+{
+    std::optional<unsigned int> program;
+
+    // Compile the shader program
+    if (type == Type::Vertex)
+        program = compile(shader, {}, {});
+    else if (type == Type::Geometry)
+        program = compile({}, shader, {});
+    else
+        program = compile({}, {}, shader);
+
+    if (program)
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(std::string_view vertexShader, std::string_view fragmentShader)
+{
+    // Compile the shader program
+    if (const auto program = compile(vertexShader, {}, fragmentShader))
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(std::string_view vertexShader, std::string_view geometryShader, std::string_view fragmentShader)
+{
+    // Compile the shader program
+    if (const auto program = compile(vertexShader, geometryShader, fragmentShader))
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(InputStream& stream, Type type)
+{
+    // Read the shader code from the stream
+    std::vector<char> shader;
+    if (!getStreamContents(stream, shader))
+    {
+        err() << "Failed to read shader from stream" << std::endl;
+        throw std::runtime_error("Failed to read shader from stream");
+    }
+
+    std::optional<unsigned int> program;
+
+    // Compile the shader program
+    if (type == Type::Vertex)
+        program = compile(shader.data(), {}, {});
+    else if (type == Type::Geometry)
+        program = compile({}, shader.data(), {});
+    else
+        program = compile({}, {}, shader.data());
+
+    if (program)
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(InputStream& vertexShaderStream, InputStream& fragmentShaderStream)
+{
+    // Read the vertex shader code from the stream
+    std::vector<char> vertexShader;
+    if (!getStreamContents(vertexShaderStream, vertexShader))
+    {
+        err() << "Failed to read vertex shader from stream" << std::endl;
+        throw std::runtime_error("Failed to read vertex shader from stream");
+    }
+
+    // Read the fragment shader code from the stream
+    std::vector<char> fragmentShader;
+    if (!getStreamContents(fragmentShaderStream, fragmentShader))
+    {
+        err() << "Failed to read fragment shader from stream" << std::endl;
+        throw std::runtime_error("Failed to read fragment shader from stream");
+    }
+
+    // Compile the shader program
+    if (const auto program = compile(vertexShader.data(), {}, fragmentShader.data()))
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(InputStream& vertexShaderStream, InputStream& geometryShaderStream, InputStream& fragmentShaderStream)
+{
+    // Read the vertex shader code from the stream
+    std::vector<char> vertexShader;
+    if (!getStreamContents(vertexShaderStream, vertexShader))
+    {
+        err() << "Failed to read vertex shader from stream" << std::endl;
+        throw std::runtime_error("Failed to read vertex shader from stream");
+    }
+
+    // Read the geometry shader code from the stream
+    std::vector<char> geometryShader;
+    if (!getStreamContents(geometryShaderStream, geometryShader))
+    {
+        err() << "Failed to read geometry shader from stream" << std::endl;
+        throw std::runtime_error("Failed to read geometry shader from stream");
+    }
+
+    // Read the fragment shader code from the stream
+    std::vector<char> fragmentShader;
+    if (!getStreamContents(fragmentShaderStream, fragmentShader))
+    {
+        err() << "Failed to read fragment shader from stream" << std::endl;
+        throw std::runtime_error("Failed to read fragment shader from stream");
+    }
+
+    // Compile the shader program
+    if (const auto program = compile(vertexShader.data(), geometryShader.data(), fragmentShader.data()))
+    {
+        m_shaderProgram = *program;
+        return;
+    }
+
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
 Shader::~Shader()
 {
     const TransientContextLock lock;
@@ -234,6 +485,7 @@ Shader::~Shader()
         glCheck(GLEXT_glDeleteObject(castToGlHandle(m_shaderProgram)));
 }
 
+
 ////////////////////////////////////////////////////////////
 Shader::Shader(Shader&& source) noexcept :
 m_shaderProgram(std::exchange(source.m_shaderProgram, 0U)),
@@ -242,6 +494,7 @@ m_textures(std::move(source.m_textures)),
 m_uniforms(std::move(source.m_uniforms))
 {
 }
+
 
 ////////////////////////////////////////////////////////////
 Shader& Shader::operator=(Shader&& right) noexcept
@@ -267,6 +520,7 @@ Shader& Shader::operator=(Shader&& right) noexcept
     return *this;
 }
 
+
 ////////////////////////////////////////////////////////////
 std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& filename, Type type)
 {
@@ -278,14 +532,20 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& filename
         return std::nullopt;
     }
 
+    std::optional<unsigned int> program;
+
     // Compile the shader program
     if (type == Type::Vertex)
-        return compile(shader.data(), {}, {});
+        program = compile(shader.data(), {}, {});
+    else if (type == Type::Geometry)
+        program = compile({}, shader.data(), {});
+    else
+        program = compile({}, {}, shader.data());
 
-    if (type == Type::Geometry)
-        return compile({}, shader.data(), {});
+    if (program)
+        return Shader(*program);
 
-    return compile({}, {}, shader.data());
+    return std::nullopt;
 }
 
 
@@ -310,7 +570,10 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexSh
     }
 
     // Compile the shader program
-    return compile(vertexShader.data(), {}, fragmentShader.data());
+    if (const auto program = compile(vertexShader.data(), {}, fragmentShader.data()))
+        return Shader(*program);
+
+    return std::nullopt;
 }
 
 
@@ -344,21 +607,30 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexSh
     }
 
     // Compile the shader program
-    return compile(vertexShader.data(), geometryShader.data(), fragmentShader.data());
+    if (const auto program = compile(vertexShader.data(), geometryShader.data(), fragmentShader.data()))
+        return Shader(*program);
+
+    return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
 std::optional<Shader> Shader::loadFromMemory(std::string_view shader, Type type)
 {
+    std::optional<unsigned int> program;
+
     // Compile the shader program
     if (type == Type::Vertex)
-        return compile(shader, {}, {});
+        program = compile(shader, {}, {});
+    else if (type == Type::Geometry)
+        program = compile({}, shader, {});
+    else
+        program = compile({}, {}, shader);
 
-    if (type == Type::Geometry)
-        return compile({}, shader, {});
+    if (program)
+        return Shader(*program);
 
-    return compile({}, {}, shader);
+    return std::nullopt;
 }
 
 
@@ -366,7 +638,10 @@ std::optional<Shader> Shader::loadFromMemory(std::string_view shader, Type type)
 std::optional<Shader> Shader::loadFromMemory(std::string_view vertexShader, std::string_view fragmentShader)
 {
     // Compile the shader program
-    return compile(vertexShader, {}, fragmentShader);
+    if (const auto program = compile(vertexShader, {}, fragmentShader))
+        return Shader(*program);
+
+    return std::nullopt;
 }
 
 
@@ -376,7 +651,10 @@ std::optional<Shader> Shader::loadFromMemory(std::string_view vertexShader,
                                              std::string_view fragmentShader)
 {
     // Compile the shader program
-    return compile(vertexShader, geometryShader, fragmentShader);
+    if (const auto program = compile(vertexShader, geometryShader, fragmentShader))
+        return Shader(*program);
+
+    return std::nullopt;
 }
 
 
@@ -391,14 +669,20 @@ std::optional<Shader> Shader::loadFromStream(InputStream& stream, Type type)
         return std::nullopt;
     }
 
+    std::optional<unsigned int> program;
+
     // Compile the shader program
     if (type == Type::Vertex)
-        return compile(shader.data(), {}, {});
+        program = compile(shader.data(), {}, {});
+    else if (type == Type::Geometry)
+        program = compile({}, shader.data(), {});
+    else
+        program = compile({}, {}, shader.data());
 
-    if (type == Type::Geometry)
-        return compile({}, shader.data(), {});
+    if (program)
+        return Shader(*program);
 
-    return compile({}, {}, shader.data());
+    return std::nullopt;
 }
 
 
@@ -422,7 +706,10 @@ std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream, In
     }
 
     // Compile the shader program
-    return compile(vertexShader.data(), {}, fragmentShader.data());
+    if (const auto program = compile(vertexShader.data(), {}, fragmentShader.data()))
+        return Shader(*program);
+
+    return std::nullopt;
 }
 
 
@@ -456,7 +743,10 @@ std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream,
     }
 
     // Compile the shader program
-    return compile(vertexShader.data(), geometryShader.data(), fragmentShader.data());
+    if (const auto program = compile(vertexShader.data(), geometryShader.data(), fragmentShader.data()))
+        return Shader(*program);
+
+    return std::nullopt;
 }
 
 
@@ -778,9 +1068,9 @@ Shader::Shader(unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
-                                      std::string_view geometryShaderCode,
-                                      std::string_view fragmentShaderCode)
+std::optional<unsigned int> Shader::compile(std::string_view vertexShaderCode,
+                                            std::string_view geometryShaderCode,
+                                            std::string_view fragmentShaderCode)
 {
     const TransientContextLock lock;
 
@@ -909,7 +1199,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
     // in all contexts immediately (solves problems in multi-threaded apps)
     glCheck(glFlush());
 
-    return Shader(castFromGlHandle(shaderProgram));
+    return castFromGlHandle(shaderProgram);
 }
 
 
@@ -959,6 +1249,74 @@ int Shader::getUniformLocation(const std::string& name)
 
 namespace sf
 {
+////////////////////////////////////////////////////////////
+Shader::Shader(const std::filesystem::path& /* filename */, Type /* type */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(const std::filesystem::path& /* vertexShaderFilename */,
+               const std::filesystem::path& /* fragmentShaderFilename */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(const std::filesystem::path& /* vertexShaderFilename */,
+               const std::filesystem::path& /* geometryShaderFilename */,
+               const std::filesystem::path& /* fragmentShaderFilename */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(std::string_view /* shader */, Type /* type */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(std::string_view /* vertexShader */, std::string_view /* fragmentShader */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(std::string_view /* vertexShader */, std::string_view /* geometryShader */, std::string_view /* fragmentShader */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(InputStream& /* stream */, Type /* type */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(InputStream& /* vertexShaderStream */, InputStream& /* fragmentShaderStream */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
+////////////////////////////////////////////////////////////
+Shader::Shader(InputStream& /* vertexShaderStream */,
+               InputStream& /* geometryShaderStream */,
+               InputStream& /* fragmentShaderStream */)
+{
+    throw std::runtime_error("Failed to load shader");
+}
+
+
 ////////////////////////////////////////////////////////////
 Shader::~Shader() = default;
 
@@ -1207,9 +1565,9 @@ Shader::Shader(unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::compile(std::string_view /* vertexShaderCode */,
-                                      std::string_view /* geometryShaderCode */,
-                                      std::string_view /* fragmentShaderCode */)
+std::optional<unsigned int> Shader::compile(std::string_view /* vertexShaderCode */,
+                                            std::string_view /* geometryShaderCode */,
+                                            std::string_view /* fragmentShaderCode */)
 {
     return std::nullopt;
 }

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -45,6 +45,28 @@ void FileInputStream::FileCloser::operator()(std::FILE* file)
 
 
 ////////////////////////////////////////////////////////////
+FileInputStream::FileInputStream(const std::filesystem::path& filename)
+{
+#ifdef SFML_SYSTEM_ANDROID
+    if (priv::getActivityStatesPtr() != nullptr)
+    {
+        m_androidFile = std::make_unique<priv::ResourceStream>(filename);
+        if (!m_androidFile->tell().has_value())
+            throw std::runtime_error("Failed to open file");
+        return;
+    }
+#endif
+#ifdef SFML_SYSTEM_WINDOWS
+    if ((m_file = std::unique_ptr<std::FILE, FileCloser>(_wfopen(filename.c_str(), L"rb"))))
+#else
+    if ((m_file = std::unique_ptr<std::FILE, FileCloser>(std::fopen(filename.c_str(), "rb"))))
+#endif
+        return;
+    throw std::runtime_error("Failed to open file");
+}
+
+
+////////////////////////////////////////////////////////////
 FileInputStream::~FileInputStream() = default;
 
 

--- a/src/SFML/Window/Cursor.cpp
+++ b/src/SFML/Window/Cursor.cpp
@@ -44,6 +44,35 @@ Cursor::Cursor() : m_impl(std::make_unique<priv::CursorImpl>())
 
 
 ////////////////////////////////////////////////////////////
+Cursor::Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot) :
+m_impl(std::make_unique<priv::CursorImpl>())
+{
+    if ((pixels == nullptr) || (size.x == 0) || (size.y == 0))
+    {
+        err() << "Failed to load cursor from pixels (invalid arguments)" << std::endl;
+        throw std::runtime_error("Failed to load cursor from pixels (invalid arguments)");
+    }
+
+    if (!m_impl->loadFromPixels(pixels, size, hotspot))
+    {
+        // Error message generated in called function.
+        throw std::runtime_error("Failed to load cursor from pixels");
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+Cursor::Cursor(Type type) : m_impl(std::make_unique<priv::CursorImpl>())
+{
+    if (!m_impl->loadFromSystem(type))
+    {
+        // Error message generated in called function.
+        throw std::runtime_error("Failed to load cursor from pixels");
+    }
+}
+
+
+////////////////////////////////////////////////////////////
 Cursor::~Cursor() = default;
 
 

--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -22,6 +22,124 @@ TEST_CASE("[Audio] sf::InputSoundFile")
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::InputSoundFile>);
     }
 
+    SECTION("Constructor")
+    {
+        SECTION("Invalid file")
+        {
+            CHECK_THROWS_AS(sf::InputSoundFile("does/not/exist.wav"), std::runtime_error);
+        }
+
+        SECTION("Valid file")
+        {
+            SECTION("flac")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/ding.flac");
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("mp3")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/ding.mp3");
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("ogg")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/doodle_pop.ogg");
+                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
+                CHECK(inputSoundFile.getChannelCount() == 2);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("wav")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/killdeer.wav");
+                CHECK(inputSoundFile.getSampleCount() == 112'941);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 22'050);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+        }
+
+        SECTION("Memory")
+        {
+            const auto               memory = loadIntoMemory("Audio/killdeer.wav");
+            const sf::InputSoundFile inputSoundFile(memory.data(), memory.size());
+            CHECK(inputSoundFile.getSampleCount() == 112'941);
+            CHECK(inputSoundFile.getChannelCount() == 1);
+            CHECK(inputSoundFile.getSampleRate() == 22'050);
+            CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+            CHECK(inputSoundFile.getSampleOffset() == 0);
+        }
+
+        SECTION("Stream")
+        {
+            SECTION("flac")
+            {
+                sf::FileInputStream      stream("Audio/ding.flac");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("mp3")
+            {
+                sf::FileInputStream      stream("Audio/ding.mp3");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("ogg")
+            {
+                sf::FileInputStream      stream("Audio/doodle_pop.ogg");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
+                CHECK(inputSoundFile.getChannelCount() == 2);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("wav")
+            {
+                sf::FileInputStream      stream("Audio/killdeer.wav");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 112'941);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 22'050);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+        }
+    }
+
     SECTION("openFromFile()")
     {
         SECTION("Invalid file")

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -32,6 +32,72 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         CHECK(timeSpan.length == sf::Time::Zero);
     }
 
+    SECTION("Constructor")
+    {
+        SECTION("File")
+        {
+            SECTION("Invalid file")
+            {
+                CHECK_THROWS_AS(sf::Music("does/not/exist.wav"), std::runtime_error);
+            }
+
+            SECTION("Valid file")
+            {
+                const sf::Music music("Audio/ding.mp3");
+                CHECK(music.getDuration() == sf::microseconds(1990884));
+                const auto [offset, length] = music.getLoopPoints();
+                CHECK(offset == sf::Time::Zero);
+                CHECK(length == sf::microseconds(1990884));
+                CHECK(music.getChannelCount() == 1);
+                CHECK(music.getSampleRate() == 44100);
+                CHECK(music.getStatus() == sf::Music::Status::Stopped);
+                CHECK(music.getPlayingOffset() == sf::Time::Zero);
+                CHECK(!music.getLoop());
+            }
+        }
+
+        SECTION("Memory")
+        {
+            std::vector<std::byte> memory(10, std::byte{0xCA});
+
+            SECTION("Invalid buffer")
+            {
+                CHECK_THROWS_AS(sf::Music(memory.data(), memory.size()), std::runtime_error);
+            }
+
+            SECTION("Valid buffer")
+            {
+                memory = loadIntoMemory("Audio/ding.flac");
+
+                const sf::Music music(memory.data(), memory.size());
+                CHECK(music.getDuration() == sf::microseconds(1990884));
+                const auto [offset, length] = music.getLoopPoints();
+                CHECK(offset == sf::Time::Zero);
+                CHECK(length == sf::microseconds(1990884));
+                CHECK(music.getChannelCount() == 1);
+                CHECK(music.getSampleRate() == 44100);
+                CHECK(music.getStatus() == sf::Music::Status::Stopped);
+                CHECK(music.getPlayingOffset() == sf::Time::Zero);
+                CHECK(!music.getLoop());
+            }
+        }
+
+        SECTION("Stream")
+        {
+            sf::FileInputStream stream("Audio/doodle_pop.ogg");
+            const sf::Music     music(stream);
+            CHECK(music.getDuration() == sf::microseconds(24002176));
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::microseconds(24002176));
+            CHECK(music.getChannelCount() == 2);
+            CHECK(music.getSampleRate() == 44100);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
+        }
+    }
+
     SECTION("openFromFile()")
     {
         SECTION("Invalid file")

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -23,6 +23,58 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
         STATIC_CHECK(!std::is_nothrow_move_assignable_v<sf::SoundBuffer>);
     }
 
+    SECTION("Constructor")
+    {
+        SECTION("File")
+        {
+            SECTION("Invalid filename")
+            {
+                CHECK_THROWS_AS(sf::SoundBuffer("does/not/exist.wav"), std::runtime_error);
+            }
+
+            SECTION("Valid file")
+            {
+                const sf::SoundBuffer soundBuffer("Audio/ding.flac");
+                CHECK(soundBuffer.getSamples() != nullptr);
+                CHECK(soundBuffer.getSampleCount() == 87798);
+                CHECK(soundBuffer.getSampleRate() == 44100);
+                CHECK(soundBuffer.getChannelCount() == 1);
+                CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
+            }
+        }
+
+        SECTION("Memory")
+        {
+            SECTION("Invalid memory")
+            {
+                constexpr std::array<std::byte, 5> memory{};
+                CHECK_THROWS_AS(sf::SoundBuffer(memory.data(), memory.size()), std::runtime_error);
+            }
+
+            SECTION("Valid memory")
+            {
+                const auto            memory = loadIntoMemory("Audio/ding.flac");
+                const sf::SoundBuffer soundBuffer(memory.data(), memory.size());
+                CHECK(soundBuffer.getSamples() != nullptr);
+                CHECK(soundBuffer.getSampleCount() == 87798);
+                CHECK(soundBuffer.getSampleRate() == 44100);
+                CHECK(soundBuffer.getChannelCount() == 1);
+                CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
+            }
+        }
+
+        SECTION("Stream")
+        {
+            sf::FileInputStream   stream("Audio/ding.flac");
+            const sf::SoundBuffer soundBuffer(stream);
+            CHECK(soundBuffer.getSamples() != nullptr);
+            CHECK(soundBuffer.getSampleCount() == 87798);
+            CHECK(soundBuffer.getSampleRate() == 44100);
+            CHECK(soundBuffer.getChannelCount() == 1);
+            CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
+        }
+    }
+
     SECTION("Copy semantics")
     {
         const auto soundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();

--- a/test/Graphics/Font.test.cpp
+++ b/test/Graphics/Font.test.cpp
@@ -22,6 +22,107 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
         STATIC_CHECK(std::is_move_assignable_v<sf::Font>);
     }
 
+    SECTION("Constructor")
+    {
+        SECTION("File")
+        {
+            SECTION("Invalid filename")
+            {
+                CHECK_THROWS_AS(sf::Font("does/not/exist.ttf"), std::runtime_error);
+            }
+
+            SECTION("Successful load")
+            {
+                const sf::Font font("Graphics/tuffy.ttf");
+                CHECK(font.getInfo().family == "Tuffy");
+                const auto& glyph = font.getGlyph(0x45, 16, false);
+                CHECK(glyph.advance == 9);
+                CHECK(glyph.lsbDelta == 9);
+                CHECK(glyph.rsbDelta == 16);
+                CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
+                CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
+                CHECK(font.hasGlyph(0x41));
+                CHECK(font.hasGlyph(0xC0));
+                CHECK(font.getKerning(0x41, 0x42, 12) == -1);
+                CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
+                CHECK(font.getLineSpacing(24) == 30);
+                CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
+                CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
+                const auto& texture = font.getTexture(10);
+                CHECK(texture.getSize() == sf::Vector2u(128, 128));
+                CHECK(texture.isSmooth());
+                CHECK(!texture.isSrgb());
+                CHECK(!texture.isRepeated());
+                CHECK(texture.getNativeHandle() != 0);
+                CHECK(font.isSmooth());
+            }
+        }
+
+        SECTION("Memory")
+        {
+            SECTION("Invalid data and size")
+            {
+                CHECK_THROWS_AS(sf::Font(nullptr, 1), std::runtime_error);
+                const std::byte testByte{0xCD};
+                CHECK_THROWS_AS(sf::Font(&testByte, 0), std::runtime_error);
+            }
+
+            SECTION("Successful load")
+            {
+                const auto     memory = loadIntoMemory("Graphics/tuffy.ttf");
+                const sf::Font font(memory.data(), memory.size());
+                CHECK(font.getInfo().family == "Tuffy");
+                const auto& glyph = font.getGlyph(0x45, 16, false);
+                CHECK(glyph.advance == 9);
+                CHECK(glyph.lsbDelta == 9);
+                CHECK(glyph.rsbDelta == 16);
+                CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
+                CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
+                CHECK(font.hasGlyph(0x41));
+                CHECK(font.hasGlyph(0xC0));
+                CHECK(font.getKerning(0x41, 0x42, 12) == -1);
+                CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
+                CHECK(font.getLineSpacing(24) == 30);
+                CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
+                CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
+                const auto& texture = font.getTexture(10);
+                CHECK(texture.getSize() == sf::Vector2u(128, 128));
+                CHECK(texture.isSmooth());
+                CHECK(!texture.isSrgb());
+                CHECK(!texture.isRepeated());
+                CHECK(texture.getNativeHandle() != 0);
+                CHECK(font.isSmooth());
+            }
+        }
+
+        SECTION("Stream")
+        {
+            sf::FileInputStream stream("Graphics/tuffy.ttf");
+            const sf::Font      font(stream);
+            CHECK(font.getInfo().family == "Tuffy");
+            const auto& glyph = font.getGlyph(0x45, 16, false);
+            CHECK(glyph.advance == 9);
+            CHECK(glyph.lsbDelta == 9);
+            CHECK(glyph.rsbDelta == 16);
+            CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
+            CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
+            CHECK(font.hasGlyph(0x41));
+            CHECK(font.hasGlyph(0xC0));
+            CHECK(font.getKerning(0x41, 0x42, 12) == -1);
+            CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
+            CHECK(font.getLineSpacing(24) == 30);
+            CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
+            CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
+            const auto& texture = font.getTexture(10);
+            CHECK(texture.getSize() == sf::Vector2u(128, 128));
+            CHECK(texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() != 0);
+            CHECK(font.isSmooth());
+        }
+    }
+
     SECTION("openFromFile()")
     {
         SECTION("Invalid filename")

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -22,6 +22,114 @@ TEST_CASE("[Graphics] sf::Image")
 
     SECTION("Construction")
     {
+        SECTION("File constructor")
+        {
+            SECTION("Invalid file")
+            {
+                CHECK_THROWS_AS(sf::Image("."), std::runtime_error);
+                CHECK_THROWS_AS(sf::Image("this/does/not/exist.jpg"), std::runtime_error);
+            }
+
+            SECTION("Successful load")
+            {
+                SECTION("bmp")
+                {
+                    const sf::Image image("Graphics/sfml-logo-big.bmp");
+                    CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                    CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+                    CHECK(image.getSize() == sf::Vector2u(1001, 304));
+                    CHECK(image.getPixelsPtr() != nullptr);
+                }
+
+                SECTION("png")
+                {
+                    const sf::Image image("Graphics/sfml-logo-big.png");
+                    CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
+                    CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+                    CHECK(image.getSize() == sf::Vector2u(1001, 304));
+                    CHECK(image.getPixelsPtr() != nullptr);
+                }
+
+                SECTION("jpg")
+                {
+                    const sf::Image image("Graphics/sfml-logo-big.jpg");
+                    CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                    CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+                    CHECK(image.getSize() == sf::Vector2u(1001, 304));
+                    CHECK(image.getPixelsPtr() != nullptr);
+                }
+
+                SECTION("gif")
+                {
+                    const sf::Image image("Graphics/sfml-logo-big.gif");
+                    CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                    CHECK(image.getPixel({200, 150}) == sf::Color(146, 210, 62));
+                    CHECK(image.getSize() == sf::Vector2u(1001, 304));
+                    CHECK(image.getPixelsPtr() != nullptr);
+                }
+
+                SECTION("psd")
+                {
+                    const sf::Image image("Graphics/sfml-logo-big.psd");
+                    CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                    CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+                    CHECK(image.getSize() == sf::Vector2u(1001, 304));
+                    CHECK(image.getPixelsPtr() != nullptr);
+                }
+            }
+        }
+
+        SECTION("Memory constructor")
+        {
+            SECTION("Invalid pointer")
+            {
+                CHECK_THROWS_AS(sf::Image(nullptr, 1), std::runtime_error);
+            }
+
+            SECTION("Invalid size")
+            {
+                const std::byte testByte{0xAB};
+                CHECK_THROWS_AS(sf::Image(&testByte, 0), std::runtime_error);
+            }
+
+            SECTION("Failed load")
+            {
+                std::vector<std::uint8_t> memory;
+
+                SECTION("Empty")
+                {
+                    memory.clear();
+                }
+
+                SECTION("Junk data")
+                {
+                    memory = {1, 2, 3, 4};
+                }
+
+                CHECK_THROWS_AS(sf::Image(memory.data(), memory.size()), std::runtime_error);
+            }
+
+            SECTION("Successful load")
+            {
+                const auto      memory = sf::Image({24, 24}, sf::Color::Green).saveToMemory("png").value();
+                const sf::Image image(memory.data(), memory.size());
+                CHECK(image.getSize() == sf::Vector2u(24, 24));
+                CHECK(image.getPixelsPtr() != nullptr);
+                CHECK(image.getPixel({0, 0}) == sf::Color::Green);
+                CHECK(image.getPixel({23, 23}) == sf::Color::Green);
+            }
+        }
+
+        SECTION("Stream constructor")
+        {
+            sf::FileInputStream stream("Graphics/sfml-logo-big.png");
+            const sf::Image     image(stream);
+            CHECK(image.getSize() == sf::Vector2u(1001, 304));
+            CHECK(image.getPixelsPtr() != nullptr);
+            CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
+            CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+        }
+
         SECTION("Vector2 constructor")
         {
             const sf::Image image(sf::Vector2u(10, 10));

--- a/test/Graphics/RenderTexture.test.cpp
+++ b/test/Graphics/RenderTexture.test.cpp
@@ -16,6 +16,27 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::RenderTexture>);
     }
 
+    SECTION("Constructor")
+    {
+        CHECK_THROWS_AS(sf::RenderTexture({1'000'000, 1'000'000}), std::runtime_error);
+
+        CHECK_NOTHROW(sf::RenderTexture({100, 100}, sf::ContextSettings{8 /* depthBits */, 0 /* stencilBits */}));
+        CHECK_NOTHROW(sf::RenderTexture({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */}));
+
+        const sf::RenderTexture renderTexture({360, 480});
+        CHECK(renderTexture.getSize() == sf::Vector2u(360, 480));
+        CHECK(!renderTexture.isSmooth());
+        CHECK(!renderTexture.isRepeated());
+        CHECK(!renderTexture.isSrgb());
+
+        const auto& texture = renderTexture.getTexture();
+        CHECK(texture.getSize() == sf::Vector2u(360, 480));
+        CHECK(!texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() != 0);
+    }
+
     SECTION("create()")
     {
         CHECK(!sf::RenderTexture::create({1'000'000, 1'000'000}));

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -76,6 +76,17 @@ TEST_CASE("[System] sf::FileInputStream")
     const TemporaryFile temporaryFile("Hello world");
     char                buffer[32];
 
+    SECTION("Constructor")
+    {
+        sf::FileInputStream fileInputStream(temporaryFile.getPath());
+        CHECK(fileInputStream.read(buffer, 5) == 5);
+        CHECK(fileInputStream.tell() == 5);
+        CHECK(fileInputStream.getSize() == 11);
+        CHECK(std::string_view(buffer, 5) == "Hello"sv);
+        CHECK(fileInputStream.seek(6) == 6);
+        CHECK(fileInputStream.tell() == 6);
+    }
+
     SECTION("Move semantics")
     {
         SECTION("Move constructor")

--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -17,6 +17,37 @@ TEST_CASE("[Window] sf::Cursor", runDisplayTests())
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Cursor>);
     }
 
+    SECTION("Constructor")
+    {
+        SECTION("Pixels")
+        {
+            static constexpr std::array<std::uint8_t, 4> pixels{};
+
+            CHECK_THROWS_AS(sf::Cursor(nullptr, {}, {}), std::runtime_error);
+            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {0, 1}, {}), std::runtime_error);
+            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {1, 0}, {}), std::runtime_error);
+            CHECK_NOTHROW(sf::Cursor(pixels.data(), {1, 1}, {}));
+        }
+
+        SECTION("System")
+        {
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::Hand));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeHorizontal));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeVertical));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeLeft));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeRight));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeTop));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeBottom));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeTopLeft));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeTopRight));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeBottomLeft));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeBottomRight));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::Cross));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::Help));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::NotAllowed));
+        }
+    }
+
     SECTION("loadFromPixels()")
     {
         static constexpr std::array<std::uint8_t, 4> pixels{};


### PR DESCRIPTION
Title.

Enables better integration with the STL without having to constantly unwrap `optional`s.

Also due to the fact that object memory is only allocated once and resources don't have to be moved back and forth (not only for the object itself but also within the constructor implementations), the throwing constructor variants might provide better runtime performance and cause less memory fragmentation.

```cpp
std::make_unique<sf::Texture>(...);
std::vector<sf::Texture>::emplace_back(...);
std::unordered_map<std::string, sf::Texture>::try_emplace(key, ...);
...
```

Also allows concise and better support for programmatic handling of errors, without having to rely on `err()` or other debug-only output.

```cpp
try
{
    texture = std::make_unique<sf::Texture>(...);
    imageMap.try_emplace("someKey", ...);
    ...
}
catch (const std::runtime_error& ex)
{
    std::cout << "Something went wrong during loading: " << ex.what() << std::endl;
}
```

If we add support for our own differentiated exceptions, the user will have finer grained control over how they might want to handle them.

Slightly related to #3120.
@danieljpetersen might be interested in this.