### PR TITLE
Use `[[nodiscard]]` in more places

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,7 +54,6 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -modernize-avoid-c-arrays,
   -modernize-macro-to-enum,
-  -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -performance-avoid-endl,
   -performance-enum-size,

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -44,7 +44,7 @@ public:
         s_font = &font;
     }
 
-    const std::string& getName() const
+    [[nodiscard]] const std::string& getName() const
     {
         return m_name;
     }

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -103,7 +103,7 @@ public:
     /// \return Number of samples
     ///
     ////////////////////////////////////////////////////////////
-    std::uint64_t getSampleCount() const;
+    [[nodiscard]] std::uint64_t getSampleCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of channels used by the sound
@@ -111,7 +111,7 @@ public:
     /// \return Number of channels (1 = mono, 2 = stereo)
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getChannelCount() const;
+    [[nodiscard]] unsigned int getChannelCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the sample rate of the sound
@@ -119,7 +119,7 @@ public:
     /// \return Sample rate, in samples per second
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getSampleRate() const;
+    [[nodiscard]] unsigned int getSampleRate() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the map of position in sample frame to sound channel
@@ -132,7 +132,7 @@ public:
     /// \see getSampleRate, getChannelCount, getDuration
     ///
     ////////////////////////////////////////////////////////////
-    const std::vector<SoundChannel>& getChannelMap() const;
+    [[nodiscard]] const std::vector<SoundChannel>& getChannelMap() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total duration of the sound file
@@ -143,7 +143,7 @@ public:
     /// \return Duration of the sound file
     ///
     ////////////////////////////////////////////////////////////
-    Time getDuration() const;
+    [[nodiscard]] Time getDuration() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the read offset of the file in time
@@ -151,7 +151,7 @@ public:
     /// \return Time position
     ///
     ////////////////////////////////////////////////////////////
-    Time getTimeOffset() const;
+    [[nodiscard]] Time getTimeOffset() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the read offset of the file in samples
@@ -159,7 +159,7 @@ public:
     /// \return Sample position
     ///
     ////////////////////////////////////////////////////////////
-    std::uint64_t getSampleOffset() const;
+    [[nodiscard]] std::uint64_t getSampleOffset() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current read position to the given sample offset

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -155,7 +155,7 @@ public:
     /// \return Music duration
     ///
     ////////////////////////////////////////////////////////////
-    Time getDuration() const;
+    [[nodiscard]] Time getDuration() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the positions of the of the sound's looping sequence
@@ -172,7 +172,7 @@ public:
     /// \see setLoopPoints
     ///
     ////////////////////////////////////////////////////////////
-    TimeSpan getLoopPoints() const;
+    [[nodiscard]] TimeSpan getLoopPoints() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Sets the beginning and duration of the sound's looping sequence using sf::Time
@@ -252,7 +252,7 @@ private:
     /// \return The number of samples elapsed at the given time
     ///
     ////////////////////////////////////////////////////////////
-    std::uint64_t timeToSamples(Time position) const;
+    [[nodiscard]] std::uint64_t timeToSamples(Time position) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Helper to convert a sample position to an sf::Time
@@ -262,7 +262,7 @@ private:
     /// \return The Time position of the given sample
     ///
     ////////////////////////////////////////////////////////////
-    Time samplesToTime(std::uint64_t samples) const;
+    [[nodiscard]] Time samplesToTime(std::uint64_t samples) const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -179,7 +179,7 @@ public:
     /// \return Sound buffer attached to the sound
     ///
     ////////////////////////////////////////////////////////////
-    const SoundBuffer& getBuffer() const;
+    [[nodiscard]] const SoundBuffer& getBuffer() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether or not the sound is in loop mode
@@ -189,7 +189,7 @@ public:
     /// \see setLoop
     ///
     ////////////////////////////////////////////////////////////
-    bool getLoop() const;
+    [[nodiscard]] bool getLoop() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current playing position of the sound
@@ -199,7 +199,7 @@ public:
     /// \see setPlayingOffset
     ///
     ////////////////////////////////////////////////////////////
-    Time getPlayingOffset() const;
+    [[nodiscard]] Time getPlayingOffset() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current status of the sound (stopped, paused, playing)
@@ -207,7 +207,7 @@ public:
     /// \return Current status of the sound
     ///
     ////////////////////////////////////////////////////////////
-    Status getStatus() const override;
+    [[nodiscard]] Status getStatus() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
@@ -237,7 +237,7 @@ private:
     /// \return The sound object
     ///
     ////////////////////////////////////////////////////////////
-    void* getSound() const override;
+    [[nodiscard]] void* getSound() const override;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Audio/SoundRecorder.hpp
+++ b/include/SFML/Audio/SoundRecorder.hpp
@@ -96,7 +96,7 @@ public:
     /// \return Sample rate, in samples per second
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getSampleRate() const;
+    [[nodiscard]] unsigned int getSampleRate() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a list of the names of all available audio capture devices
@@ -144,7 +144,7 @@ public:
     /// \return The name of the current audio capture device
     ///
     ////////////////////////////////////////////////////////////
-    const std::string& getDevice() const;
+    [[nodiscard]] const std::string& getDevice() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the channel count of the audio capture device
@@ -172,7 +172,7 @@ public:
     /// \see setChannelCount
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getChannelCount() const;
+    [[nodiscard]] unsigned int getChannelCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the map of position in sample frame to sound channel
@@ -183,7 +183,7 @@ public:
     /// \return Map of position in sample frame to sound channel
     ///
     ////////////////////////////////////////////////////////////
-    const std::vector<SoundChannel>& getChannelMap() const;
+    [[nodiscard]] const std::vector<SoundChannel>& getChannelMap() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if the system supports audio capture

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -440,7 +440,7 @@ public:
     /// \see setPitch
     ///
     ////////////////////////////////////////////////////////////
-    float getPitch() const;
+    [[nodiscard]] float getPitch() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the pan of the sound
@@ -450,7 +450,7 @@ public:
     /// \see setPan
     ///
     ////////////////////////////////////////////////////////////
-    float getPan() const;
+    [[nodiscard]] float getPan() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the volume of the sound
@@ -460,7 +460,7 @@ public:
     /// \see setVolume
     ///
     ////////////////////////////////////////////////////////////
-    float getVolume() const;
+    [[nodiscard]] float getVolume() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether spatialization of the sound is enabled
@@ -470,7 +470,7 @@ public:
     /// \see setSpatializationEnabled
     ///
     ////////////////////////////////////////////////////////////
-    bool isSpatializationEnabled() const;
+    [[nodiscard]] bool isSpatializationEnabled() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the 3D position of the sound in the audio scene
@@ -480,7 +480,7 @@ public:
     /// \see setPosition
     ///
     ////////////////////////////////////////////////////////////
-    Vector3f getPosition() const;
+    [[nodiscard]] Vector3f getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the 3D direction of the sound in the audio scene
@@ -490,7 +490,7 @@ public:
     /// \see setDirection
     ///
     ////////////////////////////////////////////////////////////
-    Vector3f getDirection() const;
+    [[nodiscard]] Vector3f getDirection() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the cone properties of the sound in the audio scene
@@ -500,7 +500,7 @@ public:
     /// \see setCone
     ///
     ////////////////////////////////////////////////////////////
-    Cone getCone() const;
+    [[nodiscard]] Cone getCone() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the 3D velocity of the sound in the audio scene
@@ -510,7 +510,7 @@ public:
     /// \see setVelocity
     ///
     ////////////////////////////////////////////////////////////
-    Vector3f getVelocity() const;
+    [[nodiscard]] Vector3f getVelocity() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the doppler factor of the sound
@@ -520,7 +520,7 @@ public:
     /// \see setDopplerFactor
     ///
     ////////////////////////////////////////////////////////////
-    float getDopplerFactor() const;
+    [[nodiscard]] float getDopplerFactor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the directional attenuation factor of the sound
@@ -530,7 +530,7 @@ public:
     /// \see setDirectionalAttenuationFactor
     ///
     ////////////////////////////////////////////////////////////
-    float getDirectionalAttenuationFactor() const;
+    [[nodiscard]] float getDirectionalAttenuationFactor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether the sound's position is relative to the
@@ -541,7 +541,7 @@ public:
     /// \see setRelativeToListener
     ///
     ////////////////////////////////////////////////////////////
-    bool isRelativeToListener() const;
+    [[nodiscard]] bool isRelativeToListener() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the minimum distance of the sound
@@ -551,7 +551,7 @@ public:
     /// \see setMinDistance, getAttenuation
     ///
     ////////////////////////////////////////////////////////////
-    float getMinDistance() const;
+    [[nodiscard]] float getMinDistance() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the maximum distance of the sound
@@ -561,7 +561,7 @@ public:
     /// \see setMaxDistance, getAttenuation
     ///
     ////////////////////////////////////////////////////////////
-    float getMaxDistance() const;
+    [[nodiscard]] float getMaxDistance() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the minimum gain of the sound
@@ -571,7 +571,7 @@ public:
     /// \see setMinGain, getAttenuation
     ///
     ////////////////////////////////////////////////////////////
-    float getMinGain() const;
+    [[nodiscard]] float getMinGain() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the maximum gain of the sound
@@ -581,7 +581,7 @@ public:
     /// \see setMaxGain, getAttenuation
     ///
     ////////////////////////////////////////////////////////////
-    float getMaxGain() const;
+    [[nodiscard]] float getMaxGain() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the attenuation factor of the sound
@@ -591,7 +591,7 @@ public:
     /// \see setAttenuation, getMinDistance
     ///
     ////////////////////////////////////////////////////////////
-    float getAttenuation() const;
+    [[nodiscard]] float getAttenuation() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
@@ -644,7 +644,7 @@ public:
     /// \return Current status of the sound
     ///
     ////////////////////////////////////////////////////////////
-    virtual Status getStatus() const = 0;
+    [[nodiscard]] virtual Status getStatus() const = 0;
 
 protected:
     ////////////////////////////////////////////////////////////
@@ -662,7 +662,7 @@ private:
     /// \return The sound object
     ///
     ////////////////////////////////////////////////////////////
-    virtual void* getSound() const = 0;
+    [[nodiscard]] virtual void* getSound() const = 0;
 };
 
 // NOLINTEND(readability-make-member-function-const)

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -124,7 +124,7 @@ public:
     /// \return Number of channels
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getChannelCount() const;
+    [[nodiscard]] unsigned int getChannelCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the stream sample rate of the stream
@@ -135,7 +135,7 @@ public:
     /// \return Sample rate, in number of samples per second
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getSampleRate() const;
+    [[nodiscard]] unsigned int getSampleRate() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the map of position in sample frame to sound channel
@@ -146,7 +146,7 @@ public:
     /// \return Map of position in sample frame to sound channel
     ///
     ////////////////////////////////////////////////////////////
-    std::vector<SoundChannel> getChannelMap() const;
+    [[nodiscard]] std::vector<SoundChannel> getChannelMap() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current status of the stream (stopped, paused, playing)
@@ -154,7 +154,7 @@ public:
     /// \return Current status
     ///
     ////////////////////////////////////////////////////////////
-    Status getStatus() const override;
+    [[nodiscard]] Status getStatus() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current playing position of the stream
@@ -179,7 +179,7 @@ public:
     /// \see setPlayingOffset
     ///
     ////////////////////////////////////////////////////////////
-    Time getPlayingOffset() const;
+    [[nodiscard]] Time getPlayingOffset() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set whether or not the stream should loop after reaching the end
@@ -204,7 +204,7 @@ public:
     /// \see setLoop
     ///
     ////////////////////////////////////////////////////////////
-    bool getLoop() const;
+    [[nodiscard]] bool getLoop() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the effect processor to be applied to the sound
@@ -292,7 +292,7 @@ private:
     /// \return The sound object
     ///
     ////////////////////////////////////////////////////////////
-    void* getSound() const override;
+    [[nodiscard]] void* getSound() const override;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Graphics/Color.hpp
+++ b/include/SFML/Graphics/Color.hpp
@@ -75,7 +75,7 @@ public:
     /// \return Color represented as a 32-bit unsigned integer
     ///
     ////////////////////////////////////////////////////////////
-    constexpr std::uint32_t toInteger() const;
+    [[nodiscard]] constexpr std::uint32_t toInteger() const;
 
     ////////////////////////////////////////////////////////////
     // Static member data

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -170,7 +170,7 @@ public:
     /// \return Size of the image, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const;
+    [[nodiscard]] Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a transparency mask from a specified color-key
@@ -248,7 +248,7 @@ public:
     /// \see setPixel
     ///
     ////////////////////////////////////////////////////////////
-    Color getPixel(const Vector2u& coords) const;
+    [[nodiscard]] Color getPixel(const Vector2u& coords) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only pointer to the array of pixels
@@ -263,7 +263,7 @@ public:
     /// \return Read-only pointer to the array of pixels
     ///
     ////////////////////////////////////////////////////////////
-    const std::uint8_t* getPixelsPtr() const;
+    [[nodiscard]] const std::uint8_t* getPixelsPtr() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Flip the image horizontally (left <-> right)

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -90,7 +90,7 @@ public:
     /// \see findIntersection
     ///
     ////////////////////////////////////////////////////////////
-    constexpr bool contains(const Vector2<T>& point) const;
+    [[nodiscard]] constexpr bool contains(const Vector2<T>& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check the intersection between two rectangles
@@ -102,7 +102,7 @@ public:
     /// \see contains
     ///
     ////////////////////////////////////////////////////////////
-    constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
+    [[nodiscard]] constexpr std::optional<Rect<T>> findIntersection(const Rect<T>& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the center of the rectangle
@@ -110,7 +110,7 @@ public:
     /// \return Center of rectangle
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2<T> getCenter() const;
+    [[nodiscard]] constexpr Vector2<T> getCenter() const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -588,7 +588,7 @@ public:
     /// \return OpenGL handle of the shader or 0 if not yet loaded
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getNativeHandle() const;
+    [[nodiscard]] unsigned int getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind a shader for rendering

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -86,7 +86,7 @@ public:
     /// \return Pointer to a 4x4 matrix
     ///
     ////////////////////////////////////////////////////////////
-    constexpr const float* getMatrix() const;
+    [[nodiscard]] constexpr const float* getMatrix() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the inverse of the transform
@@ -97,7 +97,7 @@ public:
     /// \return A new transform which is the inverse of self
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Transform getInverse() const;
+    [[nodiscard]] constexpr Transform getInverse() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Transform a 2D point
@@ -113,7 +113,7 @@ public:
     /// \return Transformed point
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2f transformPoint(const Vector2f& point) const;
+    [[nodiscard]] constexpr Vector2f transformPoint(const Vector2f& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Transform a rectangle
@@ -129,7 +129,7 @@ public:
     /// \return Transformed rectangle
     ///
     ////////////////////////////////////////////////////////////
-    constexpr FloatRect transformRect(const FloatRect& rectangle) const;
+    [[nodiscard]] constexpr FloatRect transformRect(const FloatRect& rectangle) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with another one

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -74,7 +74,7 @@ public:
     /// \return Number of vertices in the array
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getVertexCount() const;
+    [[nodiscard]] std::size_t getVertexCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-write access to a vertex by its index
@@ -162,7 +162,7 @@ public:
     /// \return Primitive type
     ///
     ////////////////////////////////////////////////////////////
-    PrimitiveType getPrimitiveType() const;
+    [[nodiscard]] PrimitiveType getPrimitiveType() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Compute the bounding rectangle of the vertex array
@@ -173,7 +173,7 @@ public:
     /// \return Bounding rectangle of the vertex array
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getBounds() const;
+    [[nodiscard]] FloatRect getBounds() const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -145,7 +145,7 @@ public:
     /// \return Number of vertices in the vertex buffer
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getVertexCount() const;
+    [[nodiscard]] std::size_t getVertexCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the whole buffer from an array of vertices
@@ -238,7 +238,7 @@ public:
     /// \return OpenGL handle of the vertex buffer or 0 if not yet created
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getNativeHandle() const;
+    [[nodiscard]] unsigned int getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the type of primitives to draw
@@ -259,7 +259,7 @@ public:
     /// \return Primitive type
     ///
     ////////////////////////////////////////////////////////////
-    PrimitiveType getPrimitiveType() const;
+    [[nodiscard]] PrimitiveType getPrimitiveType() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the usage specifier of this vertex buffer
@@ -284,7 +284,7 @@ public:
     /// \return Usage specifier
     ///
     ////////////////////////////////////////////////////////////
-    Usage getUsage() const;
+    [[nodiscard]] Usage getUsage() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind a vertex buffer for rendering

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -154,7 +154,7 @@ public:
         /// \return True if the status is a success, false if it is a failure
         ///
         ////////////////////////////////////////////////////////////
-        bool isOk() const;
+        [[nodiscard]] bool isOk() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the status code of the response
@@ -162,7 +162,7 @@ public:
         /// \return Status code
         ///
         ////////////////////////////////////////////////////////////
-        Status getStatus() const;
+        [[nodiscard]] Status getStatus() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the full message contained in the response
@@ -170,7 +170,7 @@ public:
         /// \return The response message
         ///
         ////////////////////////////////////////////////////////////
-        const std::string& getMessage() const;
+        [[nodiscard]] const std::string& getMessage() const;
 
     private:
         ////////////////////////////////////////////////////////////
@@ -201,7 +201,7 @@ public:
         /// \return Directory name
         ///
         ////////////////////////////////////////////////////////////
-        const std::filesystem::path& getDirectory() const;
+        [[nodiscard]] const std::filesystem::path& getDirectory() const;
 
     private:
         ////////////////////////////////////////////////////////////
@@ -233,7 +233,7 @@ public:
         /// \return Array containing the requested listing
         ///
         ////////////////////////////////////////////////////////////
-        const std::vector<std::string>& getListing() const;
+        [[nodiscard]] const std::vector<std::string>& getListing() const;
 
     private:
         ////////////////////////////////////////////////////////////

--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -168,7 +168,7 @@ public:
         /// \return True if the field exists, false otherwise
         ///
         ////////////////////////////////////////////////////////////
-        bool hasField(const std::string& field) const;
+        [[nodiscard]] bool hasField(const std::string& field) const;
 
         ////////////////////////////////////////////////////////////
         // Types
@@ -245,7 +245,7 @@ public:
         /// \return Value of the field, or empty string if not found
         ///
         ////////////////////////////////////////////////////////////
-        const std::string& getField(const std::string& field) const;
+        [[nodiscard]] const std::string& getField(const std::string& field) const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the response status code
@@ -258,7 +258,7 @@ public:
         /// \return Status code of the response
         ///
         ////////////////////////////////////////////////////////////
-        Status getStatus() const;
+        [[nodiscard]] Status getStatus() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the major HTTP version number of the response
@@ -268,7 +268,7 @@ public:
         /// \see getMinorHttpVersion
         ///
         ////////////////////////////////////////////////////////////
-        unsigned int getMajorHttpVersion() const;
+        [[nodiscard]] unsigned int getMajorHttpVersion() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the minor HTTP version number of the response
@@ -278,7 +278,7 @@ public:
         /// \see getMajorHttpVersion
         ///
         ////////////////////////////////////////////////////////////
-        unsigned int getMinorHttpVersion() const;
+        [[nodiscard]] unsigned int getMinorHttpVersion() const;
 
         ////////////////////////////////////////////////////////////
         /// \brief Get the body of the response
@@ -292,7 +292,7 @@ public:
         /// \return The response body
         ///
         ////////////////////////////////////////////////////////////
-        const std::string& getBody() const;
+        [[nodiscard]] const std::string& getBody() const;
 
     private:
         friend class Http;

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -103,7 +103,7 @@ public:
     /// \see toInteger
     ///
     ////////////////////////////////////////////////////////////
-    std::string toString() const;
+    [[nodiscard]] std::string toString() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get an integer representation of the address
@@ -119,7 +119,7 @@ public:
     /// \see toString
     ///
     ////////////////////////////////////////////////////////////
-    std::uint32_t toInteger() const;
+    [[nodiscard]] std::uint32_t toInteger() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the computer's local address

--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -108,7 +108,7 @@ public:
     /// \see append
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getReadPosition() const;
+    [[nodiscard]] std::size_t getReadPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear the packet
@@ -133,7 +133,7 @@ public:
     /// \see getDataSize
     ///
     ////////////////////////////////////////////////////////////
-    const void* getData() const;
+    [[nodiscard]] const void* getData() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the data contained in the packet
@@ -146,7 +146,7 @@ public:
     /// \see getData
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getDataSize() const;
+    [[nodiscard]] std::size_t getDataSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell if the reading position has reached the
@@ -160,7 +160,7 @@ public:
     /// \see operator bool
     ///
     ////////////////////////////////////////////////////////////
-    bool endOfPacket() const;
+    [[nodiscard]] bool endOfPacket() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Test the validity of the packet, for reading

--- a/include/SFML/Network/Socket.hpp
+++ b/include/SFML/Network/Socket.hpp
@@ -118,7 +118,7 @@ public:
     /// \see setBlocking
     ///
     ////////////////////////////////////////////////////////////
-    bool isBlocking() const;
+    [[nodiscard]] bool isBlocking() const;
 
 protected:
     ////////////////////////////////////////////////////////////
@@ -151,7 +151,7 @@ protected:
     /// \return The internal (OS-specific) handle of the socket
     ///
     ////////////////////////////////////////////////////////////
-    SocketHandle getNativeHandle() const;
+    [[nodiscard]] SocketHandle getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the internal representation of the socket

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -61,7 +61,7 @@ public:
     /// \see listen
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getLocalPort() const;
+    [[nodiscard]] unsigned short getLocalPort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Start listening for incoming connection attempts

--- a/include/SFML/Network/TcpSocket.hpp
+++ b/include/SFML/Network/TcpSocket.hpp
@@ -69,7 +69,7 @@ public:
     /// \see connect, getRemotePort
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getLocalPort() const;
+    [[nodiscard]] unsigned short getLocalPort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the address of the connected peer
@@ -82,7 +82,7 @@ public:
     /// \see getRemotePort
     ///
     ////////////////////////////////////////////////////////////
-    std::optional<IpAddress> getRemoteAddress() const;
+    [[nodiscard]] std::optional<IpAddress> getRemoteAddress() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the port of the connected peer to which
@@ -95,7 +95,7 @@ public:
     /// \see getRemoteAddress
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getRemotePort() const;
+    [[nodiscard]] unsigned short getRemotePort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Connect the socket to a remote peer

--- a/include/SFML/Network/UdpSocket.hpp
+++ b/include/SFML/Network/UdpSocket.hpp
@@ -72,7 +72,7 @@ public:
     /// \see bind
     ///
     ////////////////////////////////////////////////////////////
-    unsigned short getLocalPort() const;
+    [[nodiscard]] unsigned short getLocalPort() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind the socket to a specific port

--- a/include/SFML/System/Clock.hpp
+++ b/include/SFML/System/Clock.hpp
@@ -101,7 +101,7 @@ public:
     /// \return Time elapsed
     ///
     ////////////////////////////////////////////////////////////
-    Time getElapsedTime() const;
+    [[nodiscard]] Time getElapsedTime() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the clock is running
@@ -109,7 +109,7 @@ public:
     /// \return True if the clock is running, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool isRunning() const;
+    [[nodiscard]] bool isRunning() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Start the clock

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -310,7 +310,7 @@ public:
     /// \see toUtf16, toUtf32
     ///
     ////////////////////////////////////////////////////////////
-    sf::U8String toUtf8() const;
+    [[nodiscard]] sf::U8String toUtf8() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-16 string
@@ -320,7 +320,7 @@ public:
     /// \see toUtf8, toUtf32
     ///
     ////////////////////////////////////////////////////////////
-    std::u16string toUtf16() const;
+    [[nodiscard]] std::u16string toUtf16() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-32 string
@@ -333,7 +333,7 @@ public:
     /// \see toUtf8, toUtf16
     ///
     ////////////////////////////////////////////////////////////
-    std::u32string toUtf32() const;
+    [[nodiscard]] std::u32string toUtf32() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of += operator to append an UTF-32 string
@@ -389,7 +389,7 @@ public:
     /// \see isEmpty
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getSize() const;
+    [[nodiscard]] std::size_t getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the string is empty or not
@@ -399,7 +399,7 @@ public:
     /// \see clear, getSize
     ///
     ////////////////////////////////////////////////////////////
-    bool isEmpty() const;
+    [[nodiscard]] bool isEmpty() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Erase one or more characters from the string
@@ -493,7 +493,7 @@ public:
     /// \return Read-only pointer to the array of characters
     ///
     ////////////////////////////////////////////////////////////
-    const char32_t* getData() const;
+    [[nodiscard]] const char32_t* getData() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return an iterator to the beginning of the string
@@ -513,7 +513,7 @@ public:
     /// \see end
     ///
     ////////////////////////////////////////////////////////////
-    ConstIterator begin() const;
+    [[nodiscard]] ConstIterator begin() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return an iterator to the end of the string
@@ -541,7 +541,7 @@ public:
     /// \see begin
     ///
     ////////////////////////////////////////////////////////////
-    ConstIterator end() const;
+    [[nodiscard]] ConstIterator end() const;
 
 private:
     friend SFML_SYSTEM_API bool operator==(const String& left, const String& right);

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -66,7 +66,7 @@ public:
     /// \see asMilliseconds, asMicroseconds
     ///
     ////////////////////////////////////////////////////////////
-    constexpr float asSeconds() const;
+    [[nodiscard]] constexpr float asSeconds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the time value as a number of milliseconds
@@ -76,7 +76,7 @@ public:
     /// \see asSeconds, asMicroseconds
     ///
     ////////////////////////////////////////////////////////////
-    constexpr std::int32_t asMilliseconds() const;
+    [[nodiscard]] constexpr std::int32_t asMilliseconds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the time value as a number of microseconds
@@ -86,7 +86,7 @@ public:
     /// \see asSeconds, asMilliseconds
     ///
     ////////////////////////////////////////////////////////////
-    constexpr std::int64_t asMicroseconds() const;
+    [[nodiscard]] constexpr std::int64_t asMicroseconds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the time value as a std::chorono::duration
@@ -94,7 +94,7 @@ public:
     /// \return Time in microseconds
     ///
     ////////////////////////////////////////////////////////////
-    constexpr std::chrono::microseconds toDuration() const;
+    [[nodiscard]] constexpr std::chrono::microseconds toDuration() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Implicit conversion to std::chrono::duration

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -93,7 +93,7 @@ public:
     /// If you are not interested in the actual length, but only in comparisons, consider using lengthSq().
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API T length() const;
+    [[nodiscard]] SFML_SYSTEM_API T length() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Square of vector's length.
@@ -101,7 +101,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T lengthSq() const;
+    [[nodiscard]] constexpr T lengthSq() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -120,7 +120,7 @@ public:
     /// \pre Neither \c *this nor \c rhs is a zero vector.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API Angle angleTo(const Vector2& rhs) const;
+    [[nodiscard]] SFML_SYSTEM_API Angle angleTo(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Signed angle from +X or (1,0) vector <i><b>(floating-point)</b></i>.
@@ -131,7 +131,7 @@ public:
     /// \pre This vector is no zero vector.
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API Angle angle() const;
+    [[nodiscard]] SFML_SYSTEM_API Angle angle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Rotate by angle \c phi <i><b>(floating-point)</b></i>.
@@ -163,13 +163,13 @@ public:
     /// this amounts to a clockwise rotation.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2 perpendicular() const;
+    [[nodiscard]] constexpr Vector2 perpendicular() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Dot product of two 2D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T dot(const Vector2& rhs) const;
+    [[nodiscard]] constexpr T dot(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Z component of the cross product of two 2D vectors.
@@ -178,7 +178,7 @@ public:
     /// and returns the result's Z component (X and Y components are always zero).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T cross(const Vector2& rhs) const;
+    [[nodiscard]] constexpr T cross(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise multiplication of \c *this and \c rhs.
@@ -189,7 +189,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2 cwiseMul(const Vector2& rhs) const;
+    [[nodiscard]] constexpr Vector2 cwiseMul(const Vector2& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -201,7 +201,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
+    [[nodiscard]] constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
 
 
     ////////////////////////////////////////////////////////////

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -76,7 +76,7 @@ public:
     /// If you are not interested in the actual length, but only in comparisons, consider using lengthSq().
     ///
     ////////////////////////////////////////////////////////////
-    SFML_SYSTEM_API T length() const;
+    [[nodiscard]] SFML_SYSTEM_API T length() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Square of vector's length.
@@ -84,7 +84,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T lengthSq() const;
+    [[nodiscard]] constexpr T lengthSq() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -98,13 +98,13 @@ public:
     /// \brief Dot product of two 3D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr T dot(const Vector3& rhs) const;
+    [[nodiscard]] constexpr T dot(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Cross product of two 3D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3 cross(const Vector3& rhs) const;
+    [[nodiscard]] constexpr Vector3 cross(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise multiplication of \c *this and \c rhs.
@@ -115,7 +115,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3 cwiseMul(const Vector3& rhs) const;
+    [[nodiscard]] constexpr Vector3 cwiseMul(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -127,7 +127,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3 cwiseDiv(const Vector3& rhs) const;
+    [[nodiscard]] constexpr Vector3 cwiseDiv(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -117,7 +117,7 @@ public:
     /// \return Structure containing the settings
     ///
     ////////////////////////////////////////////////////////////
-    const ContextSettings& getSettings() const;
+    [[nodiscard]] const ContextSettings& getSettings() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check whether a given OpenGL extension is available

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -210,7 +210,7 @@ private:
     /// \return a reference to the OS-specific implementation
     ///
     ////////////////////////////////////////////////////////////
-    const priv::CursorImpl& getImpl() const;
+    [[nodiscard]] const priv::CursorImpl& getImpl() const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -94,7 +94,7 @@ public:
     /// \return True if the video mode is valid for fullscreen mode
     ///
     ////////////////////////////////////////////////////////////
-    bool isValid() const;
+    [[nodiscard]] bool isValid() const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -221,7 +221,7 @@ public:
     /// \return Structure containing the OpenGL context settings
     ///
     ////////////////////////////////////////////////////////////
-    const ContextSettings& getSettings() const;
+    [[nodiscard]] const ContextSettings& getSettings() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable vertical synchronization

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -175,7 +175,7 @@ public:
     /// \return True if the window is open, false if it has been closed
     ///
     ////////////////////////////////////////////////////////////
-    bool isOpen() const;
+    [[nodiscard]] bool isOpen() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Pop the next event from the front of the FIFO event queue, if any, and return it
@@ -233,7 +233,7 @@ public:
     /// \see setPosition
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const;
+    [[nodiscard]] Vector2i getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -260,7 +260,7 @@ public:
     /// \see setSize
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const;
+    [[nodiscard]] Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -426,7 +426,7 @@ public:
     /// \see requestFocus
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const;
+    [[nodiscard]] bool hasFocus() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the OS-specific handle of the window
@@ -440,7 +440,7 @@ public:
     /// \return System handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getNativeHandle() const;
+    [[nodiscard]] WindowHandle getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a Vulkan rendering surface

--- a/src/SFML/Audio/AudioDevice.hpp
+++ b/src/SFML/Audio/AudioDevice.hpp
@@ -331,7 +331,7 @@ private:
     /// \return The device ID of the currently selected device or `std::nullopt` if none could be found
     ///
     ////////////////////////////////////////////////////////////
-    std::optional<ma_device_id> getSelectedDeviceId() const;
+    [[nodiscard]] std::optional<ma_device_id> getSelectedDeviceId() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Initialize the audio device and engine

--- a/src/SFML/Graphics/RenderTextureImpl.hpp
+++ b/src/SFML/Graphics/RenderTextureImpl.hpp
@@ -99,7 +99,7 @@ public:
     /// \return True if the render-texture use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool isSrgb() const = 0;
+    [[nodiscard]] virtual bool isSrgb() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -103,7 +103,7 @@ private:
     /// \return True if the render-texture use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool isSrgb() const override;
+    [[nodiscard]] bool isSrgb() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -128,7 +128,7 @@ private:
     /// \return True if the render-texture use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool isSrgb() const override;
+    [[nodiscard]] bool isSrgb() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the pixels of the target texture

--- a/src/SFML/Window/Android/JoystickImpl.hpp
+++ b/src/SFML/Window/Android/JoystickImpl.hpp
@@ -78,7 +78,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -86,7 +86,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -77,7 +77,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getNativeHandle() const override;
+    [[nodiscard]] WindowHandle getNativeHandle() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -85,7 +85,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const override;
+    [[nodiscard]] Vector2i getPosition() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -101,7 +101,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -201,7 +201,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const override;
+    [[nodiscard]] bool hasFocus() const override;
 
     static void               forwardEvent(const Event& event);
     static WindowImplAndroid* singleInstance;

--- a/src/SFML/Window/DRM/WindowImplDRM.hpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.hpp
@@ -71,7 +71,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getNativeHandle() const override;
+    [[nodiscard]] WindowHandle getNativeHandle() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -79,7 +79,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const override;
+    [[nodiscard]] Vector2i getPosition() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -95,7 +95,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -195,7 +195,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const override;
+    [[nodiscard]] bool hasFocus() const override;
 
 protected:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -197,7 +197,7 @@ public:
     /// \return Structure containing the settings
     ///
     ////////////////////////////////////////////////////////////
-    const ContextSettings& getSettings() const;
+    [[nodiscard]] const ContextSettings& getSettings() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the context as the current target for rendering

--- a/src/SFML/Window/JoystickManager.hpp
+++ b/src/SFML/Window/JoystickManager.hpp
@@ -70,7 +70,7 @@ public:
     /// \return Capabilities of the joystick
     ///
     ////////////////////////////////////////////////////////////
-    const JoystickCaps& getCapabilities(unsigned int joystick) const;
+    [[nodiscard]] const JoystickCaps& getCapabilities(unsigned int joystick) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current state of an open joystick
@@ -80,7 +80,7 @@ public:
     /// \return Current state of the joystick
     ///
     ////////////////////////////////////////////////////////////
-    const JoystickState& getState(unsigned int joystick) const;
+    [[nodiscard]] const JoystickState& getState(unsigned int joystick) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the identification for an open joystick
@@ -90,7 +90,7 @@ public:
     /// \return Identification for the joystick
     ///
     ////////////////////////////////////////////////////////////
-    const Joystick::Identification& getIdentification(unsigned int joystick) const;
+    [[nodiscard]] const Joystick::Identification& getIdentification(unsigned int joystick) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the state of all the joysticks

--- a/src/SFML/Window/SensorManager.hpp
+++ b/src/SFML/Window/SensorManager.hpp
@@ -89,7 +89,7 @@ public:
     /// \return True if the sensor is enabled, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool isEnabled(Sensor::Type sensor) const;
+    [[nodiscard]] bool isEnabled(Sensor::Type sensor) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current value of a sensor
@@ -99,7 +99,7 @@ public:
     /// \return Current value of the sensor
     ///
     ////////////////////////////////////////////////////////////
-    Vector3f getValue(Sensor::Type sensor) const;
+    [[nodiscard]] Vector3f getValue(Sensor::Type sensor) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the state of all the sensors

--- a/src/SFML/Window/Unix/JoystickImpl.hpp
+++ b/src/SFML/Window/Unix/JoystickImpl.hpp
@@ -83,7 +83,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -91,7 +91,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -79,7 +79,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getNativeHandle() const override;
+    [[nodiscard]] WindowHandle getNativeHandle() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -87,7 +87,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const override;
+    [[nodiscard]] Vector2i getPosition() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -103,7 +103,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -203,7 +203,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const override;
+    [[nodiscard]] bool hasFocus() const override;
 
 protected:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -101,7 +101,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -109,7 +109,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state
@@ -169,7 +169,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilitiesDInput() const;
+    [[nodiscard]] JoystickCaps getCapabilitiesDInput() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state (DInput, Buffered)

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -83,7 +83,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getNativeHandle() const override;
+    [[nodiscard]] WindowHandle getNativeHandle() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -91,7 +91,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const override;
+    [[nodiscard]] Vector2i getPosition() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -107,7 +107,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -187,7 +187,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const override;
+    [[nodiscard]] bool hasFocus() const override;
 
 protected:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -151,7 +151,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    virtual WindowHandle getNativeHandle() const = 0;
+    [[nodiscard]] virtual WindowHandle getNativeHandle() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -159,7 +159,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2i getPosition() const = 0;
+    [[nodiscard]] virtual Vector2i getPosition() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the minimum window rendering region size
@@ -167,7 +167,7 @@ public:
     /// \return Minimum size
     ///
     ////////////////////////////////////////////////////////////
-    std::optional<Vector2u> getMinimumSize() const;
+    [[nodiscard]] std::optional<Vector2u> getMinimumSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the maximum window rendering region size
@@ -175,7 +175,7 @@ public:
     /// \return Maximum size
     ///
     ////////////////////////////////////////////////////////////
-    std::optional<Vector2u> getMaximumSize() const;
+    [[nodiscard]] std::optional<Vector2u> getMaximumSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -191,7 +191,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2u getSize() const = 0;
+    [[nodiscard]] virtual Vector2u getSize() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -291,7 +291,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool hasFocus() const = 0;
+    [[nodiscard]] virtual bool hasFocus() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a Vulkan rendering surface

--- a/src/SFML/Window/iOS/JoystickImpl.hpp
+++ b/src/SFML/Window/iOS/JoystickImpl.hpp
@@ -78,7 +78,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -86,7 +86,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -72,7 +72,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getNativeHandle() const override;
+    [[nodiscard]] WindowHandle getNativeHandle() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -80,7 +80,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const override;
+    [[nodiscard]] Vector2i getPosition() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -96,7 +96,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -196,7 +196,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const override;
+    [[nodiscard]] bool hasFocus() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Notify an event
@@ -212,7 +212,7 @@ public:
     /// \return Pointer to the window's view
     ///
     ////////////////////////////////////////////////////////////
-    SFView* getGlView() const;
+    [[nodiscard]] SFView* getGlView() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the virtual keyboard

--- a/src/SFML/Window/macOS/JoystickImpl.hpp
+++ b/src/SFML/Window/macOS/JoystickImpl.hpp
@@ -88,7 +88,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -96,7 +96,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state

--- a/src/SFML/Window/macOS/WindowImplCocoa.hpp
+++ b/src/SFML/Window/macOS/WindowImplCocoa.hpp
@@ -243,7 +243,7 @@ public:
     /// \return Handle of the window
     ///
     ////////////////////////////////////////////////////////////
-    WindowHandle getNativeHandle() const override;
+    [[nodiscard]] WindowHandle getNativeHandle() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window
@@ -251,7 +251,7 @@ public:
     /// \return Position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i getPosition() const override;
+    [[nodiscard]] Vector2i getPosition() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the position of the window on screen
@@ -267,7 +267,7 @@ public:
     /// \return Size of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the size of the rendering region of the window
@@ -367,7 +367,7 @@ public:
     /// \return True if window has focus, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool hasFocus() const override;
+    [[nodiscard]] bool hasFocus() const override;
 
 protected:
     ////////////////////////////////////////////////////////////

--- a/test/Audio/SoundSource.test.cpp
+++ b/test/Audio/SoundSource.test.cpp
@@ -22,13 +22,13 @@ class SoundSource : public sf::SoundSource
     {
     }
 
-    void* getSound() const override
+    [[nodiscard]] void* getSound() const override
     {
         return {};
     }
 
 public:
-    Status getStatus() const override
+    [[nodiscard]] Status getStatus() const override
     {
         return {};
     }

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -50,7 +50,7 @@ public:
     TemporaryFile& operator=(const TemporaryFile&) = delete;
 
     // Return the randomly generated path.
-    const std::filesystem::path& getPath() const
+    [[nodiscard]] const std::filesystem::path& getPath() const
     {
         return m_path;
     }


### PR DESCRIPTION
## Description

This PR does two things. Primarily it adds `[[nodiscard]]` to many APIs (both public and private) where it would be unambiguously incorrect to ignore the return value. This makes it more difficult to write programs that misuse the API. GCC and Clang will warn about this by default so it's safe to assume once we add this all SFML 3 users will start potentially receiving these warnings. Whether or not those warnings are converted into errors is a matter of user preference. There are likely more APIs where `[[nodiscard]]` would be appropriate so we may add it in more places after this PR once a precedent has been established.

The second thing this PR does is use clang-tidy's [`modernize-use-nodiscard`](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nodiscard.html) check to automatically flag APIs that ought to be marked with `[[nodiscard]]` but are not. This only applies to class member functions so this check will not touch free functions. We will have to manually audit the codebase to find free functions that need the `[[nodiscard]]` attribute. This is doable albeit rather labor intensive.