### PR TITLE
Use more `[[nodiscard]]`

### DIFF
--- a/include/SFML/Audio/Listener.hpp
+++ b/include/SFML/Audio/Listener.hpp
@@ -80,7 +80,7 @@ SFML_AUDIO_API void setGlobalVolume(float volume);
 /// \see setGlobalVolume
 ///
 ////////////////////////////////////////////////////////////
-SFML_AUDIO_API float getGlobalVolume();
+[[nodiscard]] SFML_AUDIO_API float getGlobalVolume();
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the position of the listener in the scene
@@ -102,7 +102,7 @@ SFML_AUDIO_API void setPosition(const Vector3f& position);
 /// \see setPosition
 ///
 ////////////////////////////////////////////////////////////
-SFML_AUDIO_API Vector3f getPosition();
+[[nodiscard]] SFML_AUDIO_API Vector3f getPosition();
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the forward vector of the listener in the scene
@@ -129,7 +129,7 @@ SFML_AUDIO_API void setDirection(const Vector3f& direction);
 /// \see setDirection
 ///
 ////////////////////////////////////////////////////////////
-SFML_AUDIO_API Vector3f getDirection();
+[[nodiscard]] SFML_AUDIO_API Vector3f getDirection();
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the velocity of the listener in the scene
@@ -151,7 +151,7 @@ SFML_AUDIO_API void setVelocity(const Vector3f& velocity);
 /// \see setVelocity
 ///
 ////////////////////////////////////////////////////////////
-SFML_AUDIO_API Vector3f getVelocity();
+[[nodiscard]] SFML_AUDIO_API Vector3f getVelocity();
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the cone properties of the listener in the audio scene
@@ -174,7 +174,7 @@ SFML_AUDIO_API void setCone(const Listener::Cone& cone);
 /// \see setCone
 ///
 ////////////////////////////////////////////////////////////
-SFML_AUDIO_API Listener::Cone getCone();
+[[nodiscard]] SFML_AUDIO_API Listener::Cone getCone();
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the upward vector of the listener in the scene
@@ -201,7 +201,7 @@ SFML_AUDIO_API void setUpVector(const Vector3f& upVector);
 /// \see setUpVector
 ///
 ////////////////////////////////////////////////////////////
-SFML_AUDIO_API Vector3f getUpVector();
+[[nodiscard]] SFML_AUDIO_API Vector3f getUpVector();
 } // namespace sf::Listener
 
 

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -165,7 +165,7 @@ public:
     /// \see getSampleCount
     ///
     ////////////////////////////////////////////////////////////
-    const std::int16_t* getSamples() const;
+    [[nodiscard]] const std::int16_t* getSamples() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of samples stored in the buffer
@@ -178,7 +178,7 @@ public:
     /// \see getSamples
     ///
     ////////////////////////////////////////////////////////////
-    std::uint64_t getSampleCount() const;
+    [[nodiscard]] std::uint64_t getSampleCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the sample rate of the sound
@@ -192,7 +192,7 @@ public:
     /// \see getChannelCount, getChannelmap, getDuration
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getSampleRate() const;
+    [[nodiscard]] unsigned int getSampleRate() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of channels used by the sound
@@ -205,7 +205,7 @@ public:
     /// \see getSampleRate, getChannelmap, getDuration
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getChannelCount() const;
+    [[nodiscard]] unsigned int getChannelCount() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the map of position in sample frame to sound channel
@@ -218,7 +218,7 @@ public:
     /// \see getSampleRate, getChannelCount, getDuration
     ///
     ////////////////////////////////////////////////////////////
-    std::vector<SoundChannel> getChannelMap() const;
+    [[nodiscard]] std::vector<SoundChannel> getChannelMap() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total duration of the sound
@@ -228,7 +228,7 @@ public:
     /// \see getSampleRate, getChannelCount, getChannelmap
     ///
     ////////////////////////////////////////////////////////////
-    Time getDuration() const;
+    [[nodiscard]] Time getDuration() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator

--- a/include/SFML/Audio/SoundBufferRecorder.hpp
+++ b/include/SFML/Audio/SoundBufferRecorder.hpp
@@ -65,7 +65,7 @@ public:
     /// \return Read-only access to the sound buffer
     ///
     ////////////////////////////////////////////////////////////
-    const SoundBuffer& getBuffer() const;
+    [[nodiscard]] const SoundBuffer& getBuffer() const;
 
 protected:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Audio/SoundFileFactory.hpp
+++ b/include/SFML/Audio/SoundFileFactory.hpp
@@ -72,7 +72,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
-    static bool isReaderRegistered();
+    [[nodiscard]] static bool isReaderRegistered();
 
     ////////////////////////////////////////////////////////////
     /// \brief Register a new writer
@@ -97,7 +97,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
-    static bool isWriterRegistered();
+    [[nodiscard]] static bool isWriterRegistered();
 
     ////////////////////////////////////////////////////////////
     /// \brief Instantiate the right reader for the given file on disk
@@ -109,7 +109,7 @@ public:
     /// \see createReaderFromMemory, createReaderFromStream
     ///
     ////////////////////////////////////////////////////////////
-    static std::unique_ptr<SoundFileReader> createReaderFromFilename(const std::filesystem::path& filename);
+    [[nodiscard]] static std::unique_ptr<SoundFileReader> createReaderFromFilename(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Instantiate the right codec for the given file in memory
@@ -122,7 +122,7 @@ public:
     /// \see createReaderFromFilename, createReaderFromStream
     ///
     ////////////////////////////////////////////////////////////
-    static std::unique_ptr<SoundFileReader> createReaderFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] static std::unique_ptr<SoundFileReader> createReaderFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Instantiate the right codec for the given file in stream
@@ -134,7 +134,7 @@ public:
     /// \see createReaderFromFilename, createReaderFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    static std::unique_ptr<SoundFileReader> createReaderFromStream(InputStream& stream);
+    [[nodiscard]] static std::unique_ptr<SoundFileReader> createReaderFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Instantiate the right writer for the given file on disk
@@ -144,7 +144,7 @@ public:
     /// \return A new sound file writer that can write given file, or null if no writer can handle it
     ///
     ////////////////////////////////////////////////////////////
-    static std::unique_ptr<SoundFileWriter> createWriterFromFilename(const std::filesystem::path& filename);
+    [[nodiscard]] static std::unique_ptr<SoundFileWriter> createWriterFromFilename(const std::filesystem::path& filename);
 
 private:
     ////////////////////////////////////////////////////////////
@@ -162,8 +162,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Static member functions
     ////////////////////////////////////////////////////////////
-    static ReaderFactoryMap& getReaderFactoryMap();
-    static WriterFactoryMap& getWriterFactoryMap();
+    [[nodiscard]] static ReaderFactoryMap& getReaderFactoryMap();
+    [[nodiscard]] static WriterFactoryMap& getWriterFactoryMap();
 };
 
 } // namespace sf

--- a/include/SFML/Audio/SoundRecorder.hpp
+++ b/include/SFML/Audio/SoundRecorder.hpp
@@ -107,7 +107,7 @@ public:
     /// \return A vector of strings containing the names
     ///
     ////////////////////////////////////////////////////////////
-    static std::vector<std::string> getAvailableDevices();
+    [[nodiscard]] static std::vector<std::string> getAvailableDevices();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the name of the default audio capture device
@@ -119,7 +119,7 @@ public:
     /// \return The name of the default audio capture device
     ///
     ////////////////////////////////////////////////////////////
-    static std::string getDefaultDevice();
+    [[nodiscard]] static std::string getDefaultDevice();
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the audio capture device
@@ -196,7 +196,7 @@ public:
     /// \return True if audio capture is supported, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    static bool isAvailable();
+    [[nodiscard]] static bool isAvailable();
 
 protected:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/BlendMode.hpp
+++ b/include/SFML/Graphics/BlendMode.hpp
@@ -134,7 +134,7 @@ struct SFML_GRAPHICS_API BlendMode
 /// \return True if blending modes are equal, false if they are different
 ///
 ////////////////////////////////////////////////////////////
-SFML_GRAPHICS_API bool operator==(const BlendMode& left, const BlendMode& right);
+[[nodiscard]] SFML_GRAPHICS_API bool operator==(const BlendMode& left, const BlendMode& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates BlendMode
@@ -146,7 +146,7 @@ SFML_GRAPHICS_API bool operator==(const BlendMode& left, const BlendMode& right)
 /// \return True if blending modes are different, false if they are equal
 ///
 ////////////////////////////////////////////////////////////
-SFML_GRAPHICS_API bool operator!=(const BlendMode& left, const BlendMode& right);
+[[nodiscard]] SFML_GRAPHICS_API bool operator!=(const BlendMode& left, const BlendMode& right);
 
 ////////////////////////////////////////////////////////////
 // Commonly used blending modes

--- a/include/SFML/Graphics/CircleShape.hpp
+++ b/include/SFML/Graphics/CircleShape.hpp
@@ -72,7 +72,7 @@ public:
     /// \see setRadius
     ///
     ////////////////////////////////////////////////////////////
-    float getRadius() const;
+    [[nodiscard]] float getRadius() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the number of points of the circle
@@ -92,7 +92,7 @@ public:
     /// \see setPointCount
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getPointCount() const override;
+    [[nodiscard]] std::size_t getPointCount() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a point of the circle
@@ -107,7 +107,7 @@ public:
     /// \return index-th point of the shape
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f getPoint(std::size_t index) const override;
+    [[nodiscard]] Vector2f getPoint(std::size_t index) const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the geometric center of the circle
@@ -119,7 +119,7 @@ public:
     /// \return The geometric center of the shape
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f getGeometricCenter() const override;
+    [[nodiscard]] Vector2f getGeometricCenter() const override;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/ConvexShape.hpp
+++ b/include/SFML/Graphics/ConvexShape.hpp
@@ -74,7 +74,7 @@ public:
     /// \see setPointCount
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getPointCount() const override;
+    [[nodiscard]] std::size_t getPointCount() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the position of a point
@@ -111,7 +111,7 @@ public:
     /// \see setPoint
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f getPoint(std::size_t index) const override;
+    [[nodiscard]] Vector2f getPoint(std::size_t index) const override;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -140,7 +140,7 @@ public:
     /// \return A structure that holds the font information
     ///
     ////////////////////////////////////////////////////////////
-    const Info& getInfo() const;
+    [[nodiscard]] const Info& getInfo() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Retrieve a glyph of the font
@@ -164,7 +164,10 @@ public:
     /// \return The glyph corresponding to \a codePoint and \a characterSize
     ///
     ////////////////////////////////////////////////////////////
-    const Glyph& getGlyph(std::uint32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness = 0) const;
+    [[nodiscard]] const Glyph& getGlyph(std::uint32_t codePoint,
+                                        unsigned int  characterSize,
+                                        bool          bold,
+                                        float         outlineThickness = 0) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Determine if this font has a glyph representing the requested code point
@@ -182,7 +185,7 @@ public:
     /// \return True if the codepoint has a glyph representation, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool hasGlyph(std::uint32_t codePoint) const;
+    [[nodiscard]] bool hasGlyph(std::uint32_t codePoint) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the kerning offset of two glyphs
@@ -201,7 +204,7 @@ public:
     /// \return Kerning value for \a first and \a second, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    float getKerning(std::uint32_t first, std::uint32_t second, unsigned int characterSize, bool bold = false) const;
+    [[nodiscard]] float getKerning(std::uint32_t first, std::uint32_t second, unsigned int characterSize, bool bold = false) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the line spacing
@@ -214,7 +217,7 @@ public:
     /// \return Line spacing, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    float getLineSpacing(unsigned int characterSize) const;
+    [[nodiscard]] float getLineSpacing(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the underline
@@ -229,7 +232,7 @@ public:
     /// \see getUnderlineThickness
     ///
     ////////////////////////////////////////////////////////////
-    float getUnderlinePosition(unsigned int characterSize) const;
+    [[nodiscard]] float getUnderlinePosition(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the thickness of the underline
@@ -243,7 +246,7 @@ public:
     /// \see getUnderlinePosition
     ///
     ////////////////////////////////////////////////////////////
-    float getUnderlineThickness(unsigned int characterSize) const;
+    [[nodiscard]] float getUnderlineThickness(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Retrieve the texture containing the loaded glyphs of a certain size
@@ -257,7 +260,7 @@ public:
     /// \return Texture containing the glyphs of the requested size
     ///
     ////////////////////////////////////////////////////////////
-    const Texture& getTexture(unsigned int characterSize) const;
+    [[nodiscard]] const Texture& getTexture(unsigned int characterSize) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the smooth filter
@@ -283,7 +286,7 @@ public:
     /// \see setSmooth
     ///
     ////////////////////////////////////////////////////////////
-    bool isSmooth() const;
+    [[nodiscard]] bool isSmooth() const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/RectangleShape.hpp
+++ b/include/SFML/Graphics/RectangleShape.hpp
@@ -71,7 +71,7 @@ public:
     /// \see setSize
     ///
     ////////////////////////////////////////////////////////////
-    const Vector2f& getSize() const;
+    [[nodiscard]] const Vector2f& getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of points defining the shape
@@ -80,7 +80,7 @@ public:
     ///         shapes, this number is always 4.
     ///
     ////////////////////////////////////////////////////////////
-    std::size_t getPointCount() const override;
+    [[nodiscard]] std::size_t getPointCount() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a point of the rectangle
@@ -95,7 +95,7 @@ public:
     /// \return index-th point of the shape
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f getPoint(std::size_t index) const override;
+    [[nodiscard]] Vector2f getPoint(std::size_t index) const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the geometric center of the rectangle
@@ -107,7 +107,7 @@ public:
     /// \return The geometric center of the shape
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f getGeometricCenter() const override;
+    [[nodiscard]] Vector2f getGeometricCenter() const override;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -155,7 +155,7 @@ public:
     /// \see setView, getDefaultView
     ///
     ////////////////////////////////////////////////////////////
-    const View& getView() const;
+    [[nodiscard]] const View& getView() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the default view of the render target
@@ -168,7 +168,7 @@ public:
     /// \see setView, getView
     ///
     ////////////////////////////////////////////////////////////
-    const View& getDefaultView() const;
+    [[nodiscard]] const View& getDefaultView() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the viewport of a view, applied to this render target
@@ -183,7 +183,7 @@ public:
     /// \return Viewport rectangle, expressed in pixels
     ///
     ////////////////////////////////////////////////////////////
-    IntRect getViewport(const View& view) const;
+    [[nodiscard]] IntRect getViewport(const View& view) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the scissor rectangle of a view, applied to this render target
@@ -198,7 +198,7 @@ public:
     /// \return Scissor rectangle, expressed in pixels
     ///
     ////////////////////////////////////////////////////////////
-    IntRect getScissor(const View& view) const;
+    [[nodiscard]] IntRect getScissor(const View& view) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a point from target coordinates to world
@@ -218,7 +218,7 @@ public:
     /// \see mapCoordsToPixel
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f mapPixelToCoords(const Vector2i& point) const;
+    [[nodiscard]] Vector2f mapPixelToCoords(const Vector2i& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a point from target coordinates to world coordinates
@@ -249,7 +249,7 @@ public:
     /// \see mapCoordsToPixel
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f mapPixelToCoords(const Vector2i& point, const View& view) const;
+    [[nodiscard]] Vector2f mapPixelToCoords(const Vector2i& point, const View& view) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a point from world coordinates to target
@@ -269,7 +269,7 @@ public:
     /// \see mapPixelToCoords
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i mapCoordsToPixel(const Vector2f& point) const;
+    [[nodiscard]] Vector2i mapCoordsToPixel(const Vector2f& point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a point from world coordinates to target coordinates
@@ -296,7 +296,7 @@ public:
     /// \see mapPixelToCoords
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i mapCoordsToPixel(const Vector2f& point, const View& view) const;
+    [[nodiscard]] Vector2i mapCoordsToPixel(const Vector2f& point, const View& view) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Draw a drawable object to the render target
@@ -350,7 +350,7 @@ public:
     /// \return Size in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2u getSize() const = 0;
+    [[nodiscard]] virtual Vector2u getSize() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell if the render target will use sRGB encoding when drawing on it
@@ -358,7 +358,7 @@ public:
     /// \return True if the render target use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool isSrgb() const;
+    [[nodiscard]] virtual bool isSrgb() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render target for rendering

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -109,7 +109,7 @@ public:
     /// \return The maximum anti-aliasing level supported by the system
     ///
     ////////////////////////////////////////////////////////////
-    static unsigned int getMaximumAntialiasingLevel();
+    [[nodiscard]] static unsigned int getMaximumAntialiasingLevel();
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable texture smoothing
@@ -132,7 +132,7 @@ public:
     /// \see setSmooth
     ///
     ////////////////////////////////////////////////////////////
-    bool isSmooth() const;
+    [[nodiscard]] bool isSmooth() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable texture repeating
@@ -155,7 +155,7 @@ public:
     /// \see setRepeated
     ///
     ////////////////////////////////////////////////////////////
-    bool isRepeated() const;
+    [[nodiscard]] bool isRepeated() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Generate a mipmap using the current texture data
@@ -210,7 +210,7 @@ public:
     /// \return Size in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell if the render-texture will use sRGB encoding when drawing on it
@@ -221,7 +221,7 @@ public:
     /// \return True if the render-texture use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool isSrgb() const override;
+    [[nodiscard]] bool isSrgb() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only reference to the target texture
@@ -237,7 +237,7 @@ public:
     /// \return Const reference to the texture
     ///
     ////////////////////////////////////////////////////////////
-    const Texture& getTexture() const;
+    [[nodiscard]] const Texture& getTexture() const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -135,7 +135,7 @@ public:
     /// \return Size in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const override;
+    [[nodiscard]] Vector2u getSize() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the window's icon
@@ -158,7 +158,7 @@ public:
     /// \return True if the window use sRGB encoding, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool isSrgb() const override;
+    [[nodiscard]] bool isSrgb() const override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the window as the current target

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -623,7 +623,7 @@ public:
     /// \return True if shaders are supported, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    static bool isAvailable();
+    [[nodiscard]] static bool isAvailable();
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether or not the system supports geometry shaders
@@ -642,7 +642,7 @@ public:
     /// \return True if geometry shaders are supported, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    static bool isGeometryAvailable();
+    [[nodiscard]] static bool isGeometryAvailable();
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -146,7 +146,7 @@ public:
     /// \see setTexture
     ///
     ////////////////////////////////////////////////////////////
-    const Texture* getTexture() const;
+    [[nodiscard]] const Texture* getTexture() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the sub-rectangle of the texture displayed by the shape
@@ -156,7 +156,7 @@ public:
     /// \see setTextureRect
     ///
     ////////////////////////////////////////////////////////////
-    const IntRect& getTextureRect() const;
+    [[nodiscard]] const IntRect& getTextureRect() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the fill color of the shape
@@ -166,7 +166,7 @@ public:
     /// \see setFillColor
     ///
     ////////////////////////////////////////////////////////////
-    const Color& getFillColor() const;
+    [[nodiscard]] const Color& getFillColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline color of the shape
@@ -176,7 +176,7 @@ public:
     /// \see setOutlineColor
     ///
     ////////////////////////////////////////////////////////////
-    const Color& getOutlineColor() const;
+    [[nodiscard]] const Color& getOutlineColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline thickness of the shape
@@ -186,7 +186,7 @@ public:
     /// \see setOutlineThickness
     ///
     ////////////////////////////////////////////////////////////
-    float getOutlineThickness() const;
+    [[nodiscard]] float getOutlineThickness() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total number of points of the shape
@@ -196,7 +196,7 @@ public:
     /// \see getPoint
     ///
     ////////////////////////////////////////////////////////////
-    virtual std::size_t getPointCount() const = 0;
+    [[nodiscard]] virtual std::size_t getPointCount() const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a point of the shape
@@ -213,7 +213,7 @@ public:
     /// \see getPointCount
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2f getPoint(std::size_t index) const = 0;
+    [[nodiscard]] virtual Vector2f getPoint(std::size_t index) const = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the geometric center of the shape
@@ -225,7 +225,7 @@ public:
     /// \return The geometric center of the shape
     ///
     ////////////////////////////////////////////////////////////
-    virtual Vector2f getGeometricCenter() const;
+    [[nodiscard]] virtual Vector2f getGeometricCenter() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the local bounding rectangle of the entity
@@ -239,7 +239,7 @@ public:
     /// \return Local bounding rectangle of the entity
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getLocalBounds() const;
+    [[nodiscard]] FloatRect getLocalBounds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the global (non-minimal) bounding rectangle of the entity
@@ -260,7 +260,7 @@ public:
     /// \return Global bounding rectangle of the entity
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getGlobalBounds() const;
+    [[nodiscard]] FloatRect getGlobalBounds() const;
 
 protected:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -150,7 +150,7 @@ public:
     /// \see setTexture
     ///
     ////////////////////////////////////////////////////////////
-    const Texture& getTexture() const;
+    [[nodiscard]] const Texture& getTexture() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the sub-rectangle of the texture displayed by the sprite
@@ -160,7 +160,7 @@ public:
     /// \see setTextureRect
     ///
     ////////////////////////////////////////////////////////////
-    const IntRect& getTextureRect() const;
+    [[nodiscard]] const IntRect& getTextureRect() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the global color of the sprite
@@ -170,7 +170,7 @@ public:
     /// \see setColor
     ///
     ////////////////////////////////////////////////////////////
-    const Color& getColor() const;
+    [[nodiscard]] const Color& getColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the local bounding rectangle of the entity
@@ -184,7 +184,7 @@ public:
     /// \return Local bounding rectangle of the entity
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getLocalBounds() const;
+    [[nodiscard]] FloatRect getLocalBounds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the global bounding rectangle of the entity
@@ -198,7 +198,7 @@ public:
     /// \return Global bounding rectangle of the entity
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getGlobalBounds() const;
+    [[nodiscard]] FloatRect getGlobalBounds() const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/StencilMode.hpp
+++ b/include/SFML/Graphics/StencilMode.hpp
@@ -123,7 +123,7 @@ struct SFML_GRAPHICS_API StencilMode
 /// \return True if stencil modes are equal, false if they are different
 ///
 ////////////////////////////////////////////////////////////
-SFML_GRAPHICS_API bool operator==(const StencilMode& left, const StencilMode& right);
+[[nodiscard]] SFML_GRAPHICS_API bool operator==(const StencilMode& left, const StencilMode& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates StencilMode
@@ -135,7 +135,7 @@ SFML_GRAPHICS_API bool operator==(const StencilMode& left, const StencilMode& ri
 /// \return True if stencil modes are different, false if they are equal
 ///
 ////////////////////////////////////////////////////////////
-SFML_GRAPHICS_API bool operator!=(const StencilMode& left, const StencilMode& right);
+[[nodiscard]] SFML_GRAPHICS_API bool operator!=(const StencilMode& left, const StencilMode& right);
 
 } // namespace sf
 

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -260,7 +260,7 @@ public:
     /// \see setString
     ///
     ////////////////////////////////////////////////////////////
-    const String& getString() const;
+    [[nodiscard]] const String& getString() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the text's font
@@ -273,7 +273,7 @@ public:
     /// \see setFont
     ///
     ////////////////////////////////////////////////////////////
-    const Font& getFont() const;
+    [[nodiscard]] const Font& getFont() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the character size
@@ -283,7 +283,7 @@ public:
     /// \see setCharacterSize
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getCharacterSize() const;
+    [[nodiscard]] unsigned int getCharacterSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the letter spacing factor
@@ -293,7 +293,7 @@ public:
     /// \see setLetterSpacing
     ///
     ////////////////////////////////////////////////////////////
-    float getLetterSpacing() const;
+    [[nodiscard]] float getLetterSpacing() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the line spacing factor
@@ -303,7 +303,7 @@ public:
     /// \see setLineSpacing
     ///
     ////////////////////////////////////////////////////////////
-    float getLineSpacing() const;
+    [[nodiscard]] float getLineSpacing() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the text's style
@@ -313,7 +313,7 @@ public:
     /// \see setStyle
     ///
     ////////////////////////////////////////////////////////////
-    std::uint32_t getStyle() const;
+    [[nodiscard]] std::uint32_t getStyle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the fill color of the text
@@ -323,7 +323,7 @@ public:
     /// \see setFillColor
     ///
     ////////////////////////////////////////////////////////////
-    const Color& getFillColor() const;
+    [[nodiscard]] const Color& getFillColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline color of the text
@@ -333,7 +333,7 @@ public:
     /// \see setOutlineColor
     ///
     ////////////////////////////////////////////////////////////
-    const Color& getOutlineColor() const;
+    [[nodiscard]] const Color& getOutlineColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline thickness of the text
@@ -343,7 +343,7 @@ public:
     /// \see setOutlineThickness
     ///
     ////////////////////////////////////////////////////////////
-    float getOutlineThickness() const;
+    [[nodiscard]] float getOutlineThickness() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the position of the \a index-th character
@@ -360,7 +360,7 @@ public:
     /// \return Position of the character
     ///
     ////////////////////////////////////////////////////////////
-    Vector2f findCharacterPos(std::size_t index) const;
+    [[nodiscard]] Vector2f findCharacterPos(std::size_t index) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the local bounding rectangle of the entity
@@ -374,7 +374,7 @@ public:
     /// \return Local bounding rectangle of the entity
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getLocalBounds() const;
+    [[nodiscard]] FloatRect getLocalBounds() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the global bounding rectangle of the entity
@@ -388,7 +388,7 @@ public:
     /// \return Global bounding rectangle of the entity
     ///
     ////////////////////////////////////////////////////////////
-    FloatRect getGlobalBounds() const;
+    [[nodiscard]] FloatRect getGlobalBounds() const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -214,7 +214,7 @@ public:
     /// \return Size in pixels
     ///
     ////////////////////////////////////////////////////////////
-    Vector2u getSize() const;
+    [[nodiscard]] Vector2u getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy the texture pixels to an image
@@ -229,7 +229,7 @@ public:
     /// \see loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    Image copyToImage() const;
+    [[nodiscard]] Image copyToImage() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the whole texture from an array of pixels
@@ -404,7 +404,7 @@ public:
     /// \see setSmooth
     ///
     ////////////////////////////////////////////////////////////
-    bool isSmooth() const;
+    [[nodiscard]] bool isSmooth() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether the texture source is converted from sRGB or not
@@ -414,7 +414,7 @@ public:
     /// \see setSrgb
     ///
     ////////////////////////////////////////////////////////////
-    bool isSrgb() const;
+    [[nodiscard]] bool isSrgb() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable repeating
@@ -448,7 +448,7 @@ public:
     /// \see setRepeated
     ///
     ////////////////////////////////////////////////////////////
-    bool isRepeated() const;
+    [[nodiscard]] bool isRepeated() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Generate a mipmap using the current texture data
@@ -493,7 +493,7 @@ public:
     /// \return OpenGL handle of the texture or 0 if not yet created
     ///
     ////////////////////////////////////////////////////////////
-    unsigned int getNativeHandle() const;
+    [[nodiscard]] unsigned int getNativeHandle() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind a texture for rendering
@@ -538,7 +538,7 @@ public:
     /// \return Maximum size allowed for textures, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    static unsigned int getMaximumSize();
+    [[nodiscard]] static unsigned int getMaximumSize();
 
 private:
     friend class Text;
@@ -566,7 +566,7 @@ private:
     /// \return Valid nearest size (greater than or equal to specified size)
     ///
     ////////////////////////////////////////////////////////////
-    static unsigned int getValidSize(unsigned int size);
+    [[nodiscard]] static unsigned int getValidSize(unsigned int size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Invalidate the mipmap if one exists

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -288,7 +288,7 @@ private:
 /// \return New combined transform
 ///
 ////////////////////////////////////////////////////////////
-constexpr Transform operator*(const Transform& left, const Transform& right);
+[[nodiscard]] constexpr Transform operator*(const Transform& left, const Transform& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates sf::Transform
@@ -316,7 +316,7 @@ constexpr Transform& operator*=(Transform& left, const Transform& right);
 /// \return New transformed point
 ///
 ////////////////////////////////////////////////////////////
-constexpr Vector2f operator*(const Transform& left, const Vector2f& right);
+[[nodiscard]] constexpr Vector2f operator*(const Transform& left, const Vector2f& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates sf::Transform

--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -122,7 +122,7 @@ public:
     /// \see setPosition
     ///
     ////////////////////////////////////////////////////////////
-    const Vector2f& getPosition() const;
+    [[nodiscard]] const Vector2f& getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief get the orientation of the object
@@ -134,7 +134,7 @@ public:
     /// \see setRotation
     ///
     ////////////////////////////////////////////////////////////
-    Angle getRotation() const;
+    [[nodiscard]] Angle getRotation() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief get the current scale of the object
@@ -144,7 +144,7 @@ public:
     /// \see setScale
     ///
     ////////////////////////////////////////////////////////////
-    const Vector2f& getScale() const;
+    [[nodiscard]] const Vector2f& getScale() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief get the local origin of the object
@@ -154,7 +154,7 @@ public:
     /// \see setOrigin
     ///
     ////////////////////////////////////////////////////////////
-    const Vector2f& getOrigin() const;
+    [[nodiscard]] const Vector2f& getOrigin() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Move the object by a given offset
@@ -214,7 +214,7 @@ public:
     /// \see getInverseTransform
     ///
     ////////////////////////////////////////////////////////////
-    const Transform& getTransform() const;
+    [[nodiscard]] const Transform& getTransform() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief get the inverse of the combined transform of the object
@@ -224,7 +224,7 @@ public:
     /// \see getTransform
     ///
     ////////////////////////////////////////////////////////////
-    const Transform& getInverseTransform() const;
+    [[nodiscard]] const Transform& getInverseTransform() const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -90,7 +90,7 @@ public:
     /// \see getVertexCount
     ///
     ////////////////////////////////////////////////////////////
-    Vertex& operator[](std::size_t index);
+    [[nodiscard]] Vertex& operator[](std::size_t index);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only access to a vertex by its index
@@ -106,7 +106,7 @@ public:
     /// \see getVertexCount
     ///
     ////////////////////////////////////////////////////////////
-    const Vertex& operator[](std::size_t index) const;
+    [[nodiscard]] const Vertex& operator[](std::size_t index) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear the vertex array

--- a/include/SFML/Graphics/VertexBuffer.hpp
+++ b/include/SFML/Graphics/VertexBuffer.hpp
@@ -319,7 +319,7 @@ public:
     /// \return True if vertex buffers are supported, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    static bool isAvailable();
+    [[nodiscard]] static bool isAvailable();
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/View.hpp
+++ b/include/SFML/Graphics/View.hpp
@@ -151,7 +151,7 @@ public:
     /// \see getSize, setCenter
     ///
     ////////////////////////////////////////////////////////////
-    const Vector2f& getCenter() const;
+    [[nodiscard]] const Vector2f& getCenter() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the view
@@ -161,7 +161,7 @@ public:
     /// \see getCenter, setSize
     ///
     ////////////////////////////////////////////////////////////
-    const Vector2f& getSize() const;
+    [[nodiscard]] const Vector2f& getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current orientation of the view
@@ -171,7 +171,7 @@ public:
     /// \see setRotation
     ///
     ////////////////////////////////////////////////////////////
-    Angle getRotation() const;
+    [[nodiscard]] Angle getRotation() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the target viewport rectangle of the view
@@ -181,7 +181,7 @@ public:
     /// \see setViewport
     ///
     ////////////////////////////////////////////////////////////
-    const FloatRect& getViewport() const;
+    [[nodiscard]] const FloatRect& getViewport() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the scissor rectangle of the view
@@ -191,7 +191,7 @@ public:
     /// \see setScissor
     ///
     ////////////////////////////////////////////////////////////
-    const FloatRect& getScissor() const;
+    [[nodiscard]] const FloatRect& getScissor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Move the view relatively to its current position
@@ -240,7 +240,7 @@ public:
     /// \see getInverseTransform
     ///
     ////////////////////////////////////////////////////////////
-    const Transform& getTransform() const;
+    [[nodiscard]] const Transform& getTransform() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the inverse projection transform of the view
@@ -252,7 +252,7 @@ public:
     /// \see getTransform
     ///
     ////////////////////////////////////////////////////////////
-    const Transform& getInverseTransform() const;
+    [[nodiscard]] const Transform& getInverseTransform() const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -135,7 +135,7 @@ public:
     /// \see getPublicAddress
     ///
     ////////////////////////////////////////////////////////////
-    static std::optional<IpAddress> getLocalAddress();
+    [[nodiscard]] static std::optional<IpAddress> getLocalAddress();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the computer's public address
@@ -159,7 +159,7 @@ public:
     /// \see getLocalAddress
     ///
     ////////////////////////////////////////////////////////////
-    static std::optional<IpAddress> getPublicAddress(Time timeout = Time::Zero);
+    [[nodiscard]] static std::optional<IpAddress> getPublicAddress(Time timeout = Time::Zero);
 
     ////////////////////////////////////////////////////////////
     // Static member data
@@ -188,7 +188,7 @@ private:
 /// \return True if both addresses are equal
 ///
 ////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator==(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator==(const IpAddress& left, const IpAddress& right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of != operator to compare two IP addresses
@@ -199,7 +199,7 @@ SFML_NETWORK_API bool operator==(const IpAddress& left, const IpAddress& right);
 /// \return True if both addresses are different
 ///
 ////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator!=(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator!=(const IpAddress& left, const IpAddress& right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of < operator to compare two IP addresses
@@ -210,7 +210,7 @@ SFML_NETWORK_API bool operator!=(const IpAddress& left, const IpAddress& right);
 /// \return True if \a left is lesser than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator<(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator<(const IpAddress& left, const IpAddress& right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of > operator to compare two IP addresses
@@ -221,7 +221,7 @@ SFML_NETWORK_API bool operator<(const IpAddress& left, const IpAddress& right);
 /// \return True if \a left is greater than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator>(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator>(const IpAddress& left, const IpAddress& right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of <= operator to compare two IP addresses
@@ -232,7 +232,7 @@ SFML_NETWORK_API bool operator>(const IpAddress& left, const IpAddress& right);
 /// \return True if \a left is lesser or equal than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator<=(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator<=(const IpAddress& left, const IpAddress& right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of >= operator to compare two IP addresses
@@ -243,7 +243,7 @@ SFML_NETWORK_API bool operator<=(const IpAddress& left, const IpAddress& right);
 /// \return True if \a left is greater or equal than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_NETWORK_API bool operator>=(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator>=(const IpAddress& left, const IpAddress& right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of >> operator to extract an IP address from an input stream

--- a/include/SFML/Network/SocketSelector.hpp
+++ b/include/SFML/Network/SocketSelector.hpp
@@ -162,7 +162,7 @@ public:
     /// \see isReady
     ///
     ////////////////////////////////////////////////////////////
-    bool isReady(Socket& socket) const;
+    [[nodiscard]] bool isReady(Socket& socket) const;
 
 private:
     struct SocketSelectorImpl;

--- a/include/SFML/System/Err.hpp
+++ b/include/SFML/System/Err.hpp
@@ -38,7 +38,7 @@ namespace sf
 /// \brief Standard stream used by SFML to output warnings and errors
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API std::ostream& err();
+[[nodiscard]] SFML_SYSTEM_API std::ostream& err();
 
 } // namespace sf
 

--- a/include/SFML/System/NativeActivity.hpp
+++ b/include/SFML/System/NativeActivity.hpp
@@ -53,6 +53,6 @@ namespace sf
 /// \sfplatform{Android,SFML/System/NativeActivity.hpp}
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API ANativeActivity* getNativeActivity();
+[[nodiscard]] SFML_SYSTEM_API ANativeActivity* getNativeActivity();
 
 } // namespace sf

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -206,7 +206,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
-    static String fromUtf8(T begin, T end);
+    [[nodiscard]] static String fromUtf8(T begin, T end);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new sf::String from a UTF-16 encoded string
@@ -220,7 +220,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
-    static String fromUtf16(T begin, T end);
+    [[nodiscard]] static String fromUtf16(T begin, T end);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new sf::String from a UTF-32 encoded string
@@ -238,7 +238,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
-    static String fromUtf32(T begin, T end);
+    [[nodiscard]] static String fromUtf32(T begin, T end);
 
     ////////////////////////////////////////////////////////////
     /// \brief Implicit conversion operator to std::string (ANSI string)
@@ -356,7 +356,7 @@ public:
     /// \return Character at position \a index
     ///
     ////////////////////////////////////////////////////////////
-    char32_t operator[](std::size_t index) const;
+    [[nodiscard]] char32_t operator[](std::size_t index) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of [] operator to access a character by its position
@@ -369,7 +369,7 @@ public:
     /// \return Reference to the character at position \a index
     ///
     ////////////////////////////////////////////////////////////
-    char32_t& operator[](std::size_t index);
+    [[nodiscard]] char32_t& operator[](std::size_t index);
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear the string
@@ -503,7 +503,7 @@ public:
     /// \see end
     ///
     ////////////////////////////////////////////////////////////
-    Iterator begin();
+    [[nodiscard]] Iterator begin();
 
     ////////////////////////////////////////////////////////////
     /// \brief Return an iterator to the beginning of the string
@@ -527,7 +527,7 @@ public:
     /// \see begin
     ///
     ////////////////////////////////////////////////////////////
-    Iterator end();
+    [[nodiscard]] Iterator end();
 
     ////////////////////////////////////////////////////////////
     /// \brief Return an iterator to the end of the string
@@ -563,7 +563,7 @@ private:
 /// \return True if both strings are equal
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API bool operator==(const String& left, const String& right);
+[[nodiscard]] SFML_SYSTEM_API bool operator==(const String& left, const String& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates String
@@ -575,7 +575,7 @@ SFML_SYSTEM_API bool operator==(const String& left, const String& right);
 /// \return True if both strings are different
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API bool operator!=(const String& left, const String& right);
+[[nodiscard]] SFML_SYSTEM_API bool operator!=(const String& left, const String& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates String
@@ -587,7 +587,7 @@ SFML_SYSTEM_API bool operator!=(const String& left, const String& right);
 /// \return True if \a left is lexicographically before \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API bool operator<(const String& left, const String& right);
+[[nodiscard]] SFML_SYSTEM_API bool operator<(const String& left, const String& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates String
@@ -599,7 +599,7 @@ SFML_SYSTEM_API bool operator<(const String& left, const String& right);
 /// \return True if \a left is lexicographically after \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API bool operator>(const String& left, const String& right);
+[[nodiscard]] SFML_SYSTEM_API bool operator>(const String& left, const String& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates String
@@ -611,7 +611,7 @@ SFML_SYSTEM_API bool operator>(const String& left, const String& right);
 /// \return True if \a left is lexicographically before or equivalent to \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API bool operator<=(const String& left, const String& right);
+[[nodiscard]] SFML_SYSTEM_API bool operator<=(const String& left, const String& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates String
@@ -623,7 +623,7 @@ SFML_SYSTEM_API bool operator<=(const String& left, const String& right);
 /// \return True if \a left is lexicographically after or equivalent to \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API bool operator>=(const String& left, const String& right);
+[[nodiscard]] SFML_SYSTEM_API bool operator>=(const String& left, const String& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates String
@@ -635,7 +635,7 @@ SFML_SYSTEM_API bool operator>=(const String& left, const String& right);
 /// \return Concatenated string
 ///
 ////////////////////////////////////////////////////////////
-SFML_SYSTEM_API String operator+(const String& left, const String& right);
+[[nodiscard]] SFML_SYSTEM_API String operator+(const String& left, const String& right);
 
 } // namespace sf
 

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -133,7 +133,7 @@ private:
 /// \see milliseconds, microseconds
 ///
 ////////////////////////////////////////////////////////////
-constexpr Time seconds(float amount);
+[[nodiscard]] constexpr Time seconds(float amount);
 
 ////////////////////////////////////////////////////////////
 /// \relates Time
@@ -146,7 +146,7 @@ constexpr Time seconds(float amount);
 /// \see seconds, microseconds
 ///
 ////////////////////////////////////////////////////////////
-constexpr Time milliseconds(std::int32_t amount);
+[[nodiscard]] constexpr Time milliseconds(std::int32_t amount);
 
 ////////////////////////////////////////////////////////////
 /// \relates Time
@@ -159,7 +159,7 @@ constexpr Time milliseconds(std::int32_t amount);
 /// \see seconds, milliseconds
 ///
 ////////////////////////////////////////////////////////////
-constexpr Time microseconds(std::int64_t amount);
+[[nodiscard]] constexpr Time microseconds(std::int64_t amount);
 
 ////////////////////////////////////////////////////////////
 /// \relates Time

--- a/include/SFML/Window/Clipboard.hpp
+++ b/include/SFML/Window/Clipboard.hpp
@@ -50,7 +50,7 @@ namespace Clipboard
 /// \return Clipboard contents as sf::String object
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API String getString();
+[[nodiscard]] SFML_WINDOW_API String getString();
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the content of the clipboard as string data

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -127,7 +127,7 @@ public:
     /// \return True if available, false if unavailable
     ///
     ////////////////////////////////////////////////////////////
-    static bool isExtensionAvailable(std::string_view name);
+    [[nodiscard]] static bool isExtensionAvailable(std::string_view name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the address of an OpenGL function
@@ -140,7 +140,7 @@ public:
     /// \return Address of the OpenGL function, 0 on failure
     ///
     ////////////////////////////////////////////////////////////
-    static GlFunctionPointer getFunction(const char* name);
+    [[nodiscard]] static GlFunctionPointer getFunction(const char* name);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the currently active context
@@ -152,7 +152,7 @@ public:
     /// \return The currently active context or a null pointer if none is active
     ///
     ////////////////////////////////////////////////////////////
-    static const Context* getActiveContext();
+    [[nodiscard]] static const Context* getActiveContext();
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the currently active context's ID
@@ -163,7 +163,7 @@ public:
     /// \return The active context's ID or 0 if no context is currently active
     ///
     ////////////////////////////////////////////////////////////
-    static std::uint64_t getActiveContextId();
+    [[nodiscard]] static std::uint64_t getActiveContextId();
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct a in-memory context

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -332,7 +332,7 @@ private:
     // Helper functions
     ////////////////////////////////////////////////////////////
     template <typename T, typename... Ts>
-    static constexpr bool isInParameterPack(const std::variant<Ts...>&)
+    [[nodiscard]] static constexpr bool isInParameterPack(const std::variant<Ts...>&)
     {
         return (std::is_same_v<T, Ts> || ...);
     }

--- a/include/SFML/Window/Joystick.hpp
+++ b/include/SFML/Window/Joystick.hpp
@@ -82,7 +82,7 @@ struct SFML_WINDOW_API Identification
 /// \return True if the joystick is connected, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isConnected(unsigned int joystick);
+[[nodiscard]] SFML_WINDOW_API bool isConnected(unsigned int joystick);
 
 ////////////////////////////////////////////////////////////
 /// \brief Return the number of buttons supported by a joystick
@@ -94,7 +94,7 @@ SFML_WINDOW_API bool isConnected(unsigned int joystick);
 /// \return Number of buttons supported by the joystick
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API unsigned int getButtonCount(unsigned int joystick);
+[[nodiscard]] SFML_WINDOW_API unsigned int getButtonCount(unsigned int joystick);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a joystick supports a given axis
@@ -107,7 +107,7 @@ SFML_WINDOW_API unsigned int getButtonCount(unsigned int joystick);
 /// \return True if the joystick supports the axis, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool hasAxis(unsigned int joystick, Axis axis);
+[[nodiscard]] SFML_WINDOW_API bool hasAxis(unsigned int joystick, Axis axis);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a joystick button is pressed
@@ -120,7 +120,7 @@ SFML_WINDOW_API bool hasAxis(unsigned int joystick, Axis axis);
 /// \return True if the button is pressed, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isButtonPressed(unsigned int joystick, unsigned int button);
+[[nodiscard]] SFML_WINDOW_API bool isButtonPressed(unsigned int joystick, unsigned int button);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the current position of a joystick axis
@@ -133,7 +133,7 @@ SFML_WINDOW_API bool isButtonPressed(unsigned int joystick, unsigned int button)
 /// \return Current position of the axis, in range [-100 .. 100]
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API float getAxisPosition(unsigned int joystick, Axis axis);
+[[nodiscard]] SFML_WINDOW_API float getAxisPosition(unsigned int joystick, Axis axis);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the joystick information
@@ -143,7 +143,7 @@ SFML_WINDOW_API float getAxisPosition(unsigned int joystick, Axis axis);
 /// \return Structure containing joystick information.
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Identification getIdentification(unsigned int joystick);
+[[nodiscard]] SFML_WINDOW_API Identification getIdentification(unsigned int joystick);
 
 ////////////////////////////////////////////////////////////
 /// \brief Update the states of all joysticks

--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -343,7 +343,7 @@ static constexpr unsigned int ScancodeCount{static_cast<unsigned int>(Scan::Laun
 /// \return True if the key is pressed, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isKeyPressed(Key key);
+[[nodiscard]] SFML_WINDOW_API bool isKeyPressed(Key key);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a key is pressed
@@ -353,7 +353,7 @@ SFML_WINDOW_API bool isKeyPressed(Key key);
 /// \return True if the physical key is pressed, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isKeyPressed(Scancode code);
+[[nodiscard]] SFML_WINDOW_API bool isKeyPressed(Scancode code);
 
 ////////////////////////////////////////////////////////////
 /// \brief Localize a physical key to a logical one
@@ -368,7 +368,7 @@ SFML_WINDOW_API bool isKeyPressed(Scancode code);
 /// \see delocalize
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Key localize(Scancode code);
+[[nodiscard]] SFML_WINDOW_API Key localize(Scancode code);
 
 ////////////////////////////////////////////////////////////
 /// \brief Identify the physical key corresponding to a logical one
@@ -383,7 +383,7 @@ SFML_WINDOW_API Key localize(Scancode code);
 /// \see localize
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Scancode delocalize(Key key);
+[[nodiscard]] SFML_WINDOW_API Scancode delocalize(Key key);
 
 ////////////////////////////////////////////////////////////
 /// \brief Provide a string representation for a given scancode
@@ -406,7 +406,7 @@ SFML_WINDOW_API Scancode delocalize(Key key);
 /// \return The localized description of the code
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API String getDescription(Scancode code);
+[[nodiscard]] SFML_WINDOW_API String getDescription(Scancode code);
 
 ////////////////////////////////////////////////////////////
 /// \brief Show or hide the virtual keyboard

--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -79,7 +79,7 @@ enum class Wheel
 /// \return True if the button is pressed, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isButtonPressed(Button button);
+[[nodiscard]] SFML_WINDOW_API bool isButtonPressed(Button button);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the current position of the mouse in desktop coordinates
@@ -90,7 +90,7 @@ SFML_WINDOW_API bool isButtonPressed(Button button);
 /// \return Current position of the mouse
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Vector2i getPosition();
+[[nodiscard]] SFML_WINDOW_API Vector2i getPosition();
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the current position of the mouse in window coordinates
@@ -103,7 +103,7 @@ SFML_WINDOW_API Vector2i getPosition();
 /// \return Current position of the mouse
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Vector2i getPosition(const WindowBase& relativeTo);
+[[nodiscard]] SFML_WINDOW_API Vector2i getPosition(const WindowBase& relativeTo);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the current position of the mouse in desktop coordinates

--- a/include/SFML/Window/Sensor.hpp
+++ b/include/SFML/Window/Sensor.hpp
@@ -62,7 +62,7 @@ static constexpr unsigned int Count{6}; //!< The total number of sensor types
 /// \return True if the sensor is available, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isAvailable(Type sensor);
+[[nodiscard]] SFML_WINDOW_API bool isAvailable(Type sensor);
 
 ////////////////////////////////////////////////////////////
 /// \brief Enable or disable a sensor
@@ -87,7 +87,7 @@ SFML_WINDOW_API void setEnabled(Type sensor, bool enabled);
 /// \return The current sensor value
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Vector3f getValue(Type sensor);
+[[nodiscard]] SFML_WINDOW_API Vector3f getValue(Type sensor);
 } // namespace sf::Sensor
 
 

--- a/include/SFML/Window/Touch.hpp
+++ b/include/SFML/Window/Touch.hpp
@@ -50,7 +50,7 @@ namespace Touch
 /// \return True if \a finger is currently touching the screen, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isDown(unsigned int finger);
+[[nodiscard]] SFML_WINDOW_API bool isDown(unsigned int finger);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the current position of a touch in desktop coordinates
@@ -63,7 +63,7 @@ SFML_WINDOW_API bool isDown(unsigned int finger);
 /// \return Current position of \a finger, or undefined if it's not down
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Vector2i getPosition(unsigned int finger);
+[[nodiscard]] SFML_WINDOW_API Vector2i getPosition(unsigned int finger);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the current position of a touch in window coordinates
@@ -77,7 +77,7 @@ SFML_WINDOW_API Vector2i getPosition(unsigned int finger);
 /// \return Current position of \a finger, or undefined if it's not down
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API Vector2i getPosition(unsigned int finger, const WindowBase& relativeTo);
+[[nodiscard]] SFML_WINDOW_API Vector2i getPosition(unsigned int finger, const WindowBase& relativeTo);
 } // namespace Touch
 
 } // namespace sf

--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -66,7 +66,7 @@ public:
     /// \return Current desktop video mode
     ///
     ////////////////////////////////////////////////////////////
-    static VideoMode getDesktopMode();
+    [[nodiscard]] static VideoMode getDesktopMode();
 
     ////////////////////////////////////////////////////////////
     /// \brief Retrieve all the video modes supported in fullscreen mode
@@ -82,7 +82,7 @@ public:
     /// \return Array containing all the supported fullscreen modes
     ///
     ////////////////////////////////////////////////////////////
-    static const std::vector<VideoMode>& getFullscreenModes();
+    [[nodiscard]] static const std::vector<VideoMode>& getFullscreenModes();
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether or not the video mode is valid
@@ -113,7 +113,7 @@ public:
 /// \return True if modes are equal
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool operator==(const VideoMode& left, const VideoMode& right);
+[[nodiscard]] SFML_WINDOW_API bool operator==(const VideoMode& left, const VideoMode& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates VideoMode
@@ -125,7 +125,7 @@ SFML_WINDOW_API bool operator==(const VideoMode& left, const VideoMode& right);
 /// \return True if modes are different
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool operator!=(const VideoMode& left, const VideoMode& right);
+[[nodiscard]] SFML_WINDOW_API bool operator!=(const VideoMode& left, const VideoMode& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates VideoMode
@@ -137,7 +137,7 @@ SFML_WINDOW_API bool operator!=(const VideoMode& left, const VideoMode& right);
 /// \return True if \a left is lesser than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool operator<(const VideoMode& left, const VideoMode& right);
+[[nodiscard]] SFML_WINDOW_API bool operator<(const VideoMode& left, const VideoMode& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates VideoMode
@@ -149,7 +149,7 @@ SFML_WINDOW_API bool operator<(const VideoMode& left, const VideoMode& right);
 /// \return True if \a left is greater than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool operator>(const VideoMode& left, const VideoMode& right);
+[[nodiscard]] SFML_WINDOW_API bool operator>(const VideoMode& left, const VideoMode& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates VideoMode
@@ -161,7 +161,7 @@ SFML_WINDOW_API bool operator>(const VideoMode& left, const VideoMode& right);
 /// \return True if \a left is lesser or equal than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool operator<=(const VideoMode& left, const VideoMode& right);
+[[nodiscard]] SFML_WINDOW_API bool operator<=(const VideoMode& left, const VideoMode& right);
 
 ////////////////////////////////////////////////////////////
 /// \relates VideoMode
@@ -173,7 +173,7 @@ SFML_WINDOW_API bool operator<=(const VideoMode& left, const VideoMode& right);
 /// \return True if \a left is greater or equal than \a right
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool operator>=(const VideoMode& left, const VideoMode& right);
+[[nodiscard]] SFML_WINDOW_API bool operator>=(const VideoMode& left, const VideoMode& right);
 
 } // namespace sf
 

--- a/include/SFML/Window/Vulkan.hpp
+++ b/include/SFML/Window/Vulkan.hpp
@@ -78,7 +78,7 @@ namespace Vulkan
 /// \return True if Vulkan is supported, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API bool isAvailable(bool requireGraphics = true);
+[[nodiscard]] SFML_WINDOW_API bool isAvailable(bool requireGraphics = true);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get the address of a Vulkan function
@@ -88,7 +88,7 @@ SFML_WINDOW_API bool isAvailable(bool requireGraphics = true);
 /// \return Address of the Vulkan function, 0 on failure
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API VulkanFunctionPointer getFunction(const char* name);
+[[nodiscard]] SFML_WINDOW_API VulkanFunctionPointer getFunction(const char* name);
 
 ////////////////////////////////////////////////////////////
 /// \brief Get Vulkan instance extensions required for graphics
@@ -96,7 +96,7 @@ SFML_WINDOW_API VulkanFunctionPointer getFunction(const char* name);
 /// \return Vulkan instance extensions required for graphics
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API const std::vector<const char*>& getGraphicsRequiredInstanceExtensions();
+[[nodiscard]] SFML_WINDOW_API const std::vector<const char*>& getGraphicsRequiredInstanceExtensions();
 } // namespace Vulkan
 
 } // namespace sf

--- a/src/SFML/Window/FreeBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.hpp
@@ -85,7 +85,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -93,7 +93,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state

--- a/src/SFML/Window/NetBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/NetBSD/JoystickImpl.hpp
@@ -86,7 +86,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -94,7 +94,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state

--- a/src/SFML/Window/OpenBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/OpenBSD/JoystickImpl.hpp
@@ -78,7 +78,7 @@ public:
     /// \return Joystick capabilities
     ///
     ////////////////////////////////////////////////////////////
-    JoystickCaps getCapabilities() const;
+    [[nodiscard]] JoystickCaps getCapabilities() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the joystick identification
@@ -86,7 +86,7 @@ public:
     /// \return Joystick identification
     ///
     ////////////////////////////////////////////////////////////
-    Joystick::Identification getIdentification() const;
+    [[nodiscard]] Joystick::Identification getIdentification() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the joystick and get its new state


### PR DESCRIPTION
## Description

These functions were not flagged by clang-tidy. I searched for patterns like functions that start with `get` or `is` and are marked as `const`. Others were found just by reading various header files looking for more unmarked functions. As it turns out a _lot_ of our functions require using the return value. I think this is a good thing. I'd find it suspicious if we had a lot of functions with optional return values.

There are many, many private functions inside the src/ dir that could theoretically use `[[nodiscard]]` but I won't bother changing those since it would be a massive effort and offer relatively little marginal value. I plan on stopping the `[[nodiscard]]` work with the interface and therefore stop with this PR.