### PR TITLE
Pass `sf::Vector2<T>`s by value

### DIFF
--- a/examples/raw_input/RawInput.cpp
+++ b/examples/raw_input/RawInput.cpp
@@ -42,7 +42,7 @@ int main()
                 break;
             }
 
-            static const auto vec2ToString = [](const sf::Vector2i& vec2)
+            static const auto vec2ToString = [](const sf::Vector2i vec2)
             { return '(' + std::to_string(vec2.x) + ", " + std::to_string(vec2.y) + ')'; };
 
             if (const auto* const mouseMoved = event->getIf<sf::Event::MouseMoved>())

--- a/include/SFML/Graphics/ConvexShape.hpp
+++ b/include/SFML/Graphics/ConvexShape.hpp
@@ -94,7 +94,7 @@ public:
     /// \see getPoint
     ///
     ////////////////////////////////////////////////////////////
-    void setPoint(std::size_t index, const Vector2f& point);
+    void setPoint(std::size_t index, Vector2f point);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of a point

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -356,7 +356,7 @@ private:
     /// \return Found rectangle within the texture
     ///
     ////////////////////////////////////////////////////////////
-    IntRect findGlyphRect(Page& page, const Vector2u& size) const;
+    IntRect findGlyphRect(Page& page, Vector2u size) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Make sure that the given size is the current one

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -61,7 +61,7 @@ public:
     /// \param color Fill color
     ///
     ////////////////////////////////////////////////////////////
-    explicit Image(const Vector2u& size, const Color& color = Color::Black);
+    explicit Image(Vector2u size, const Color& color = Color::Black);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the image from an array of pixels
@@ -75,7 +75,7 @@ public:
     /// \param pixels Array of pixels to copy to the image
     ///
     ////////////////////////////////////////////////////////////
-    Image(const Vector2u& size, const std::uint8_t* pixels);
+    Image(Vector2u size, const std::uint8_t* pixels);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the image from a file on disk
@@ -217,7 +217,7 @@ public:
     /// \return True if the operation was successful, false otherwise
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool copy(const Image& source, const Vector2u& dest, const IntRect& sourceRect = {}, bool applyAlpha = false);
+    [[nodiscard]] bool copy(const Image& source, Vector2u dest, const IntRect& sourceRect = {}, bool applyAlpha = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the color of a pixel
@@ -232,7 +232,7 @@ public:
     /// \see getPixel
     ///
     ////////////////////////////////////////////////////////////
-    void setPixel(const Vector2u& coords, const Color& color);
+    void setPixel(Vector2u coords, const Color& color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the color of a pixel
@@ -248,7 +248,7 @@ public:
     /// \see setPixel
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Color getPixel(const Vector2u& coords) const;
+    [[nodiscard]] Color getPixel(Vector2u coords) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a read-only pointer to the array of pixels

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -61,7 +61,7 @@ public:
     /// \param size     Size of the rectangle
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Rect(const Vector2<T>& position, const Vector2<T>& size);
+    constexpr Rect(Vector2<T> position, Vector2<T> size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from another type of rectangle
@@ -90,7 +90,7 @@ public:
     /// \see findIntersection
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr bool contains(const Vector2<T>& point) const;
+    [[nodiscard]] constexpr bool contains(Vector2<T> point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Check the intersection between two rectangles

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -32,7 +32,7 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Rect<T>::Rect(const Vector2<T>& thePosition, const Vector2<T>& theSize) : position(thePosition), size(theSize)
+constexpr Rect<T>::Rect(Vector2<T> thePosition, Vector2<T> theSize) : position(thePosition), size(theSize)
 {
 }
 
@@ -47,7 +47,7 @@ constexpr Rect<T>::Rect(const Rect<U>& rectangle) : position(rectangle.position)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr bool Rect<T>::contains(const Vector2<T>& point) const
+constexpr bool Rect<T>::contains(Vector2<T> point) const
 {
     // Not using 'std::min' and 'std::max' to avoid depending on '<algorithm>'
     const auto min = [](T a, T b) { return (a < b) ? a : b; };

--- a/include/SFML/Graphics/RectangleShape.hpp
+++ b/include/SFML/Graphics/RectangleShape.hpp
@@ -51,7 +51,7 @@ public:
     /// \param size Size of the rectangle
     ///
     ////////////////////////////////////////////////////////////
-    explicit RectangleShape(const Vector2f& size = {});
+    explicit RectangleShape(Vector2f size = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the size of the rectangle
@@ -61,7 +61,7 @@ public:
     /// \see getSize
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2f& size);
+    void setSize(Vector2f size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the rectangle
@@ -71,7 +71,7 @@ public:
     /// \see setSize
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Vector2f& getSize() const;
+    [[nodiscard]] Vector2f getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the number of points defining the shape

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -218,7 +218,7 @@ public:
     /// \see mapCoordsToPixel
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Vector2f mapPixelToCoords(const Vector2i& point) const;
+    [[nodiscard]] Vector2f mapPixelToCoords(Vector2i point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a point from target coordinates to world coordinates
@@ -249,7 +249,7 @@ public:
     /// \see mapCoordsToPixel
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Vector2f mapPixelToCoords(const Vector2i& point, const View& view) const;
+    [[nodiscard]] Vector2f mapPixelToCoords(Vector2i point, const View& view) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a point from world coordinates to target
@@ -269,7 +269,7 @@ public:
     /// \see mapPixelToCoords
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Vector2i mapCoordsToPixel(const Vector2f& point) const;
+    [[nodiscard]] Vector2i mapCoordsToPixel(Vector2f point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a point from world coordinates to target coordinates
@@ -296,7 +296,7 @@ public:
     /// \see mapPixelToCoords
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Vector2i mapCoordsToPixel(const Vector2f& point, const View& view) const;
+    [[nodiscard]] Vector2i mapCoordsToPixel(Vector2f point, const View& view) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Draw a drawable object to the render target

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -101,7 +101,7 @@ public:
     /// \return Render texture if creation has been successful, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<RenderTexture> create(const Vector2u& size, const ContextSettings& settings = {});
+    [[nodiscard]] static std::optional<RenderTexture> create(Vector2u size, const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the maximum anti-aliasing level supported by the system

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -330,7 +330,7 @@ public:
     /// \param vector Value of the vec2 vector
     ///
     ////////////////////////////////////////////////////////////
-    void setUniform(const std::string& name, const Glsl::Vec2& vector);
+    void setUniform(const std::string& name, Glsl::Vec2 vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Specify value for \p vec3 uniform
@@ -375,7 +375,7 @@ public:
     /// \param vector Value of the ivec2 vector
     ///
     ////////////////////////////////////////////////////////////
-    void setUniform(const std::string& name, const Glsl::Ivec2& vector);
+    void setUniform(const std::string& name, Glsl::Ivec2 vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Specify value for \p ivec3 uniform
@@ -419,7 +419,7 @@ public:
     /// \param vector Value of the bvec2 vector
     ///
     ////////////////////////////////////////////////////////////
-    void setUniform(const std::string& name, const Glsl::Bvec2& vector);
+    void setUniform(const std::string& name, Glsl::Bvec2 vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Specify value for \p bvec3 uniform

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -99,7 +99,7 @@ public:
     /// \return Texture if creation was successful, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> create(const Vector2u& size, bool sRgb = false);
+    [[nodiscard]] static std::optional<Texture> create(Vector2u size, bool sRgb = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a file on disk
@@ -267,7 +267,7 @@ public:
     /// \param dest   Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const std::uint8_t* pixels, const Vector2u& size, const Vector2u& dest);
+    void update(const std::uint8_t* pixels, Vector2u size, Vector2u dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update a part of this texture from another texture
@@ -304,7 +304,7 @@ public:
     /// \param dest    Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const Texture& texture, const Vector2u& dest);
+    void update(const Texture& texture, Vector2u dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the texture from an image
@@ -341,7 +341,7 @@ public:
     /// \param dest  Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const Image& image, const Vector2u& dest);
+    void update(const Image& image, Vector2u dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the texture from the contents of a window
@@ -378,7 +378,7 @@ public:
     /// \param dest   Coordinates of the destination position
     ///
     ////////////////////////////////////////////////////////////
-    void update(const Window& window, const Vector2u& dest);
+    void update(const Window& window, Vector2u dest);
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the smooth filter
@@ -551,7 +551,7 @@ private:
     /// Creates an empty texture.
     ///
     ////////////////////////////////////////////////////////////
-    Texture(const Vector2u& size, const Vector2u& actualSize, unsigned int texture, bool sRgb);
+    Texture(Vector2u size, Vector2u actualSize, unsigned int texture, bool sRgb);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get a valid image size according to hardware support

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -113,7 +113,7 @@ public:
     /// \return Transformed point
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr Vector2f transformPoint(const Vector2f& point) const;
+    [[nodiscard]] constexpr Vector2f transformPoint(Vector2f point) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Transform a rectangle
@@ -168,7 +168,7 @@ public:
     /// \see rotate, scale
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Transform& translate(const Vector2f& offset);
+    constexpr Transform& translate(Vector2f offset);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a rotation
@@ -212,7 +212,7 @@ public:
     /// \see translate, scale
     ///
     ////////////////////////////////////////////////////////////
-    SFML_GRAPHICS_API Transform& rotate(Angle angle, const Vector2f& center);
+    SFML_GRAPHICS_API Transform& rotate(Angle angle, Vector2f center);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a scaling
@@ -231,7 +231,7 @@ public:
     /// \see translate, rotate
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Transform& scale(const Vector2f& factors);
+    constexpr Transform& scale(Vector2f factors);
 
     ////////////////////////////////////////////////////////////
     /// \brief Combine the current transform with a scaling
@@ -256,7 +256,7 @@ public:
     /// \see translate, rotate
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Transform& scale(const Vector2f& factors, const Vector2f& center);
+    constexpr Transform& scale(Vector2f factors, Vector2f center);
 
     ////////////////////////////////////////////////////////////
     // Static member data
@@ -316,7 +316,7 @@ constexpr Transform& operator*=(Transform& left, const Transform& right);
 /// \return New transformed point
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Vector2f operator*(const Transform& left, const Vector2f& right);
+[[nodiscard]] constexpr Vector2f operator*(const Transform& left, Vector2f right);
 
 ////////////////////////////////////////////////////////////
 /// \relates sf::Transform

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -87,7 +87,7 @@ constexpr Transform Transform::getInverse() const
 
 
 ////////////////////////////////////////////////////////////
-constexpr Vector2f Transform::transformPoint(const Vector2f& point) const
+constexpr Vector2f Transform::transformPoint(Vector2f point) const
 {
     return {m_matrix[0] * point.x + m_matrix[4] * point.y + m_matrix[12],
             m_matrix[1] * point.x + m_matrix[5] * point.y + m_matrix[13]};
@@ -145,7 +145,7 @@ constexpr Transform& Transform::combine(const Transform& transform)
 
 
 ////////////////////////////////////////////////////////////
-constexpr Transform& Transform::translate(const Vector2f& offset)
+constexpr Transform& Transform::translate(Vector2f offset)
 {
     // clang-format off
     const Transform translation(1, 0, offset.x,
@@ -158,7 +158,7 @@ constexpr Transform& Transform::translate(const Vector2f& offset)
 
 
 ////////////////////////////////////////////////////////////
-constexpr Transform& Transform::scale(const Vector2f& factors)
+constexpr Transform& Transform::scale(Vector2f factors)
 {
     // clang-format off
     const Transform scaling(factors.x, 0,         0,
@@ -171,7 +171,7 @@ constexpr Transform& Transform::scale(const Vector2f& factors)
 
 
 ////////////////////////////////////////////////////////////
-constexpr Transform& Transform::scale(const Vector2f& factors, const Vector2f& center)
+constexpr Transform& Transform::scale(Vector2f factors, Vector2f center)
 {
     // clang-format off
     const Transform scaling(factors.x, 0,         center.x * (1 - factors.x),
@@ -198,7 +198,7 @@ constexpr Transform& operator*=(Transform& left, const Transform& right)
 
 
 ////////////////////////////////////////////////////////////
-constexpr Vector2f operator*(const Transform& left, const Vector2f& right)
+constexpr Vector2f operator*(const Transform& left, Vector2f right)
 {
     return left.transformPoint(right);
 }

--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -67,7 +67,7 @@ public:
     /// \see move, getPosition
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2f& position);
+    void setPosition(Vector2f position);
 
     ////////////////////////////////////////////////////////////
     /// \brief set the orientation of the object
@@ -95,7 +95,7 @@ public:
     /// \see scale, getScale
     ///
     ////////////////////////////////////////////////////////////
-    void setScale(const Vector2f& factors);
+    void setScale(Vector2f factors);
 
     ////////////////////////////////////////////////////////////
     /// \brief set the local origin of the object
@@ -112,7 +112,7 @@ public:
     /// \see getOrigin
     ///
     ////////////////////////////////////////////////////////////
-    void setOrigin(const Vector2f& origin);
+    void setOrigin(Vector2f origin);
 
     ////////////////////////////////////////////////////////////
     /// \brief get the position of the object
@@ -122,7 +122,7 @@ public:
     /// \see setPosition
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Vector2f& getPosition() const;
+    [[nodiscard]] Vector2f getPosition() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief get the orientation of the object
@@ -144,7 +144,7 @@ public:
     /// \see setScale
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Vector2f& getScale() const;
+    [[nodiscard]] Vector2f getScale() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief get the local origin of the object
@@ -154,7 +154,7 @@ public:
     /// \see setOrigin
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Vector2f& getOrigin() const;
+    [[nodiscard]] Vector2f getOrigin() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Move the object by a given offset
@@ -171,7 +171,7 @@ public:
     /// \see setPosition
     ///
     ////////////////////////////////////////////////////////////
-    void move(const Vector2f& offset);
+    void move(Vector2f offset);
 
     ////////////////////////////////////////////////////////////
     /// \brief Rotate the object
@@ -204,7 +204,7 @@ public:
     /// \see setScale
     ///
     ////////////////////////////////////////////////////////////
-    void scale(const Vector2f& factor);
+    void scale(Vector2f factor);
 
     ////////////////////////////////////////////////////////////
     /// \brief get the combined transform of the object

--- a/include/SFML/Graphics/View.hpp
+++ b/include/SFML/Graphics/View.hpp
@@ -68,7 +68,7 @@ public:
     /// \param size   Size of zone to display
     ///
     ////////////////////////////////////////////////////////////
-    View(const Vector2f& center, const Vector2f& size);
+    View(Vector2f center, Vector2f size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the center of the view
@@ -78,7 +78,7 @@ public:
     /// \see setSize, getCenter
     ///
     ////////////////////////////////////////////////////////////
-    void setCenter(const Vector2f& center);
+    void setCenter(Vector2f center);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the size of the view
@@ -88,7 +88,7 @@ public:
     /// \see setCenter, getCenter
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2f& size);
+    void setSize(Vector2f size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the orientation of the view
@@ -151,7 +151,7 @@ public:
     /// \see getSize, setCenter
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Vector2f& getCenter() const;
+    [[nodiscard]] Vector2f getCenter() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the view
@@ -161,7 +161,7 @@ public:
     /// \see getCenter, setSize
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Vector2f& getSize() const;
+    [[nodiscard]] Vector2f getSize() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current orientation of the view
@@ -201,7 +201,7 @@ public:
     /// \see setCenter, rotate, zoom
     ///
     ////////////////////////////////////////////////////////////
-    void move(const Vector2f& offset);
+    void move(Vector2f offset);
 
     ////////////////////////////////////////////////////////////
     /// \brief Rotate the view relatively to its current orientation

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -69,7 +69,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename U>
-    constexpr explicit Vector2(const Vector2<U>& vector);
+    constexpr explicit Vector2(Vector2<U> vector);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from polar coordinates <i><b>(floating-point)</b></i>
@@ -120,7 +120,7 @@ public:
     /// \pre Neither \c *this nor \c rhs is a zero vector.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] SFML_SYSTEM_API Angle angleTo(const Vector2& rhs) const;
+    [[nodiscard]] SFML_SYSTEM_API Angle angleTo(Vector2 rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Signed angle from +X or (1,0) vector <i><b>(floating-point)</b></i>.
@@ -151,7 +151,7 @@ public:
     /// \pre \c axis must not have length zero.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] SFML_SYSTEM_API Vector2 projectedOnto(const Vector2& axis) const;
+    [[nodiscard]] SFML_SYSTEM_API Vector2 projectedOnto(Vector2 axis) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Returns a perpendicular vector.
@@ -169,7 +169,7 @@ public:
     /// \brief Dot product of two 2D vectors.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr T dot(const Vector2& rhs) const;
+    [[nodiscard]] constexpr T dot(Vector2 rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Z component of the cross product of two 2D vectors.
@@ -178,7 +178,7 @@ public:
     /// and returns the result's Z component (X and Y components are always zero).
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr T cross(const Vector2& rhs) const;
+    [[nodiscard]] constexpr T cross(Vector2 rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise multiplication of \c *this and \c rhs.
@@ -189,7 +189,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr Vector2 cwiseMul(const Vector2& rhs) const;
+    [[nodiscard]] constexpr Vector2 cwiseMul(Vector2 rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -201,7 +201,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr Vector2 cwiseDiv(const Vector2& rhs) const;
+    [[nodiscard]] constexpr Vector2 cwiseDiv(Vector2 rhs) const;
 
 
     ////////////////////////////////////////////////////////////
@@ -235,7 +235,7 @@ using Vector2f = Vector2<float>;
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator-(const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator-(Vector2<T> right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -251,7 +251,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator+=(Vector2<T>& left, const Vector2<T>& right);
+constexpr Vector2<T>& operator+=(Vector2<T>& left, Vector2<T> right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -267,7 +267,7 @@ constexpr Vector2<T>& operator+=(Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator-=(Vector2<T>& left, const Vector2<T>& right);
+constexpr Vector2<T>& operator-=(Vector2<T>& left, Vector2<T> right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -280,7 +280,7 @@ constexpr Vector2<T>& operator-=(Vector2<T>& left, const Vector2<T>& right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator+(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator+(Vector2<T> left, Vector2<T> right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -293,7 +293,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator-(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator-(Vector2<T> left, Vector2<T> right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -306,7 +306,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator*(const Vector2<T>& left, T right);
+[[nodiscard]] constexpr Vector2<T> operator*(Vector2<T> left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -319,7 +319,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator*(T left, const Vector2<T>& right);
+[[nodiscard]] constexpr Vector2<T> operator*(T left, Vector2<T> right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -348,7 +348,7 @@ constexpr Vector2<T>& operator*=(Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr Vector2<T> operator/(const Vector2<T>& left, T right);
+[[nodiscard]] constexpr Vector2<T> operator/(Vector2<T> left, T right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -379,7 +379,7 @@ constexpr Vector2<T>& operator/=(Vector2<T>& left, T right);
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr bool operator==(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr bool operator==(Vector2<T> left, Vector2<T> right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Vector2
@@ -394,7 +394,7 @@ template <typename T>
 ///
 ////////////////////////////////////////////////////////////
 template <typename T>
-[[nodiscard]] constexpr bool operator!=(const Vector2<T>& left, const Vector2<T>& right);
+[[nodiscard]] constexpr bool operator!=(Vector2<T> left, Vector2<T> right);
 
 } // namespace sf
 

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -49,7 +49,7 @@ constexpr Vector2<T>::Vector2(T x, T y) : x(x), y(y)
 ////////////////////////////////////////////////////////////
 template <typename T>
 template <typename U>
-constexpr Vector2<T>::Vector2(const Vector2<U>& vector) : x(static_cast<T>(vector.x)), y(static_cast<T>(vector.y))
+constexpr Vector2<T>::Vector2(Vector2<U> vector) : x(static_cast<T>(vector.x)), y(static_cast<T>(vector.y))
 {
 }
 
@@ -72,7 +72,7 @@ constexpr Vector2<T> Vector2<T>::perpendicular() const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr T Vector2<T>::dot(const Vector2<T>& rhs) const
+constexpr T Vector2<T>::dot(Vector2<T> rhs) const
 {
     return x * rhs.x + y * rhs.y;
 }
@@ -80,7 +80,7 @@ constexpr T Vector2<T>::dot(const Vector2<T>& rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr T Vector2<T>::cross(const Vector2<T>& rhs) const
+constexpr T Vector2<T>::cross(Vector2<T> rhs) const
 {
     return x * rhs.y - y * rhs.x;
 }
@@ -88,7 +88,7 @@ constexpr T Vector2<T>::cross(const Vector2<T>& rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> Vector2<T>::cwiseMul(const Vector2<T>& rhs) const
+constexpr Vector2<T> Vector2<T>::cwiseMul(Vector2<T> rhs) const
 {
     return Vector2<T>(x * rhs.x, y * rhs.y);
 }
@@ -96,7 +96,7 @@ constexpr Vector2<T> Vector2<T>::cwiseMul(const Vector2<T>& rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> Vector2<T>::cwiseDiv(const Vector2<T>& rhs) const
+constexpr Vector2<T> Vector2<T>::cwiseDiv(Vector2<T> rhs) const
 {
     assert(rhs.x != 0 && "Vector2::cwiseDiv() cannot divide by 0");
     assert(rhs.y != 0 && "Vector2::cwiseDiv() cannot divide by 0");
@@ -106,7 +106,7 @@ constexpr Vector2<T> Vector2<T>::cwiseDiv(const Vector2<T>& rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> operator-(const Vector2<T>& right)
+constexpr Vector2<T> operator-(Vector2<T> right)
 {
     return Vector2<T>(-right.x, -right.y);
 }
@@ -114,7 +114,7 @@ constexpr Vector2<T> operator-(const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator+=(Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T>& operator+=(Vector2<T>& left, Vector2<T> right)
 {
     left.x += right.x;
     left.y += right.y;
@@ -125,7 +125,7 @@ constexpr Vector2<T>& operator+=(Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T>& operator-=(Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T>& operator-=(Vector2<T>& left, Vector2<T> right)
 {
     left.x -= right.x;
     left.y -= right.y;
@@ -136,7 +136,7 @@ constexpr Vector2<T>& operator-=(Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> operator+(const Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T> operator+(Vector2<T> left, Vector2<T> right)
 {
     return Vector2<T>(left.x + right.x, left.y + right.y);
 }
@@ -144,7 +144,7 @@ constexpr Vector2<T> operator+(const Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> operator-(const Vector2<T>& left, const Vector2<T>& right)
+constexpr Vector2<T> operator-(Vector2<T> left, Vector2<T> right)
 {
     return Vector2<T>(left.x - right.x, left.y - right.y);
 }
@@ -152,7 +152,7 @@ constexpr Vector2<T> operator-(const Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> operator*(const Vector2<T>& left, T right)
+constexpr Vector2<T> operator*(Vector2<T> left, T right)
 {
     return Vector2<T>(left.x * right, left.y * right);
 }
@@ -160,7 +160,7 @@ constexpr Vector2<T> operator*(const Vector2<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> operator*(T left, const Vector2<T>& right)
+constexpr Vector2<T> operator*(T left, Vector2<T> right)
 {
     return Vector2<T>(right.x * left, right.y * left);
 }
@@ -179,7 +179,7 @@ constexpr Vector2<T>& operator*=(Vector2<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> operator/(const Vector2<T>& left, T right)
+constexpr Vector2<T> operator/(Vector2<T> left, T right)
 {
     assert(right != 0 && "Vector2::operator/ cannot divide by 0");
     return Vector2<T>(left.x / right, left.y / right);
@@ -200,7 +200,7 @@ constexpr Vector2<T>& operator/=(Vector2<T>& left, T right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr bool operator==(const Vector2<T>& left, const Vector2<T>& right)
+constexpr bool operator==(Vector2<T> left, Vector2<T> right)
 {
     return (left.x == right.x) && (left.y == right.y);
 }
@@ -208,7 +208,7 @@ constexpr bool operator==(const Vector2<T>& left, const Vector2<T>& right)
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr bool operator!=(const Vector2<T>& left, const Vector2<T>& right)
+constexpr bool operator!=(Vector2<T> left, Vector2<T> right)
 {
     return (left.x != right.x) || (left.y != right.y);
 }

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -175,7 +175,7 @@ public:
     /// \param size     Back buffer size
     ///
     ////////////////////////////////////////////////////////////
-    Context(const ContextSettings& settings, const Vector2u& size);
+    Context(const ContextSettings& settings, Vector2u size);
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -114,7 +114,7 @@ enum class Wheel
 /// \param position New position of the mouse
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API void setPosition(const Vector2i& position);
+SFML_WINDOW_API void setPosition(Vector2i position);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the current position of the mouse in window coordinates
@@ -126,7 +126,7 @@ SFML_WINDOW_API void setPosition(const Vector2i& position);
 /// \param relativeTo Reference window
 ///
 ////////////////////////////////////////////////////////////
-SFML_WINDOW_API void setPosition(const Vector2i& position, const WindowBase& relativeTo);
+SFML_WINDOW_API void setPosition(Vector2i position, const WindowBase& relativeTo);
 } // namespace Mouse
 
 } // namespace sf

--- a/include/SFML/Window/VideoMode.hpp
+++ b/include/SFML/Window/VideoMode.hpp
@@ -58,7 +58,7 @@ public:
     /// \param modeBitsPerPixel Pixel depths in bits per pixel
     ///
     ////////////////////////////////////////////////////////////
-    explicit VideoMode(const Vector2u& modeSize, unsigned int modeBitsPerPixel = 32);
+    explicit VideoMode(Vector2u modeSize, unsigned int modeBitsPerPixel = 32);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current desktop video mode

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -337,7 +337,7 @@ public:
     /// \see getPosition
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2i& position);
+    void setPosition(Vector2i position);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the rendering region of the window
@@ -360,7 +360,7 @@ public:
     /// \see getSize
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2u& size);
+    void setSize(Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
@@ -408,7 +408,7 @@ public:
     /// \see setTitle
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(const Vector2u& size, const std::uint8_t* pixels);
+    void setIcon(Vector2u size, const std::uint8_t* pixels);
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Graphics/ConvexShape.cpp
+++ b/src/SFML/Graphics/ConvexShape.cpp
@@ -55,7 +55,7 @@ std::size_t ConvexShape::getPointCount() const
 
 
 ////////////////////////////////////////////////////////////
-void ConvexShape::setPoint(std::size_t index, const Vector2f& point)
+void ConvexShape::setPoint(std::size_t index, Vector2f point)
 {
     assert(index < m_points.size() && "Index is out of bounds");
     m_points[index] = point;

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -624,7 +624,7 @@ Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool 
 
 
 ////////////////////////////////////////////////////////////
-IntRect Font::findGlyphRect(Page& page, const Vector2u& size) const
+IntRect Font::findGlyphRect(Page& page, Vector2u size) const
 {
     // Find the line that fits well the glyph
     Row*  row       = nullptr;

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -96,7 +96,7 @@ using StbPtr = std::unique_ptr<stbi_uc, StbDeleter>;
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Image::Image(const Vector2u& size, const Color& color)
+Image::Image(Vector2u size, const Color& color)
 {
     if (size.x && size.y)
     {
@@ -132,7 +132,7 @@ Image::Image(const Vector2u& size, const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-Image::Image(const Vector2u& size, const std::uint8_t* pixels)
+Image::Image(Vector2u size, const std::uint8_t* pixels)
 {
     if (pixels && size.x && size.y)
     {
@@ -376,7 +376,7 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
 
 
 ////////////////////////////////////////////////////////////
-[[nodiscard]] bool Image::copy(const Image& source, const Vector2u& dest, const IntRect& sourceRect, bool applyAlpha)
+[[nodiscard]] bool Image::copy(const Image& source, Vector2u dest, const IntRect& sourceRect, bool applyAlpha)
 {
     // Make sure that both images are valid
     if (source.m_size.x == 0 || source.m_size.y == 0 || m_size.x == 0 || m_size.y == 0)
@@ -464,7 +464,7 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
 
 
 ////////////////////////////////////////////////////////////
-void Image::setPixel(const Vector2u& coords, const Color& color)
+void Image::setPixel(Vector2u coords, const Color& color)
 {
     assert(coords.x < m_size.x && "Image::setPixel() x coordinate is out of bounds");
     assert(coords.y < m_size.y && "Image::setPixel() y coordinate is out of bounds");
@@ -479,7 +479,7 @@ void Image::setPixel(const Vector2u& coords, const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-Color Image::getPixel(const Vector2u& coords) const
+Color Image::getPixel(Vector2u coords) const
 {
     assert(coords.x < m_size.x && "Image::getPixel() x coordinate is out of bounds");
     assert(coords.y < m_size.y && "Image::getPixel() y coordinate is out of bounds");

--- a/src/SFML/Graphics/RectangleShape.cpp
+++ b/src/SFML/Graphics/RectangleShape.cpp
@@ -31,14 +31,14 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-RectangleShape::RectangleShape(const Vector2f& size)
+RectangleShape::RectangleShape(Vector2f size)
 {
     setSize(size);
 }
 
 
 ////////////////////////////////////////////////////////////
-void RectangleShape::setSize(const Vector2f& size)
+void RectangleShape::setSize(Vector2f size)
 {
     m_size = size;
     update();
@@ -46,7 +46,7 @@ void RectangleShape::setSize(const Vector2f& size)
 
 
 ////////////////////////////////////////////////////////////
-const Vector2f& RectangleShape::getSize() const
+Vector2f RectangleShape::getSize() const
 {
     return m_size;
 }

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -296,14 +296,14 @@ IntRect RenderTarget::getScissor(const View& view) const
 
 
 ////////////////////////////////////////////////////////////
-Vector2f RenderTarget::mapPixelToCoords(const Vector2i& point) const
+Vector2f RenderTarget::mapPixelToCoords(Vector2i point) const
 {
     return mapPixelToCoords(point, getView());
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2f RenderTarget::mapPixelToCoords(const Vector2i& point, const View& view) const
+Vector2f RenderTarget::mapPixelToCoords(Vector2i point, const View& view) const
 {
     // First, convert from viewport coordinates to homogeneous coordinates
     const FloatRect viewport   = FloatRect(getViewport(view));
@@ -316,14 +316,14 @@ Vector2f RenderTarget::mapPixelToCoords(const Vector2i& point, const View& view)
 
 
 ////////////////////////////////////////////////////////////
-Vector2i RenderTarget::mapCoordsToPixel(const Vector2f& point) const
+Vector2i RenderTarget::mapCoordsToPixel(Vector2f point) const
 {
     return mapCoordsToPixel(point, getView());
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2i RenderTarget::mapCoordsToPixel(const Vector2f& point, const View& view) const
+Vector2i RenderTarget::mapCoordsToPixel(Vector2f point, const View& view) const
 {
     // First, transform the point by the view matrix
     const Vector2f normalized = view.getTransform().transformPoint(point);

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -50,7 +50,7 @@ RenderTexture& RenderTexture::operator=(RenderTexture&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
-std::optional<RenderTexture> RenderTexture::create(const Vector2u& size, const ContextSettings& settings)
+std::optional<RenderTexture> RenderTexture::create(Vector2u size, const ContextSettings& settings)
 {
     // Create the texture
     auto texture = sf::Texture::create(size, settings.sRgbCapable);

--- a/src/SFML/Graphics/RenderTextureImpl.hpp
+++ b/src/SFML/Graphics/RenderTextureImpl.hpp
@@ -78,7 +78,7 @@ public:
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    virtual bool create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings) = 0;
+    virtual bool create(Vector2u size, unsigned int textureId, const ContextSettings& settings) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering

--- a/src/SFML/Graphics/RenderTextureImplDefault.cpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.cpp
@@ -57,7 +57,7 @@ unsigned int RenderTextureImplDefault::getMaximumAntialiasingLevel()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTextureImplDefault::create(const Vector2u& size, unsigned int, const ContextSettings& settings)
+bool RenderTextureImplDefault::create(Vector2u size, unsigned int, const ContextSettings& settings)
 {
     // Store the dimensions
     m_size = size;

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -82,7 +82,7 @@ private:
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    bool create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings) override;
+    bool create(Vector2u size, unsigned int textureId, const ContextSettings& settings) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -139,7 +139,7 @@ void RenderTextureImplFBO::unbind()
 
 
 ////////////////////////////////////////////////////////////
-bool RenderTextureImplFBO::create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings)
+bool RenderTextureImplFBO::create(Vector2u size, unsigned int textureId, const ContextSettings& settings)
 {
     // Store the dimensions
     m_size = size;

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -99,7 +99,7 @@ private:
     /// \return True if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
-    bool create(const Vector2u& size, unsigned int textureId, const ContextSettings& settings) override;
+    bool create(Vector2u size, unsigned int textureId, const ContextSettings& settings) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Create an FBO in the current context

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -470,7 +470,7 @@ void Shader::setUniform(const std::string& name, float x)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Vec2& v)
+void Shader::setUniform(const std::string& name, Glsl::Vec2 v)
 {
     const UniformBinder binder(*this, name);
     if (binder.location != -1)
@@ -506,7 +506,7 @@ void Shader::setUniform(const std::string& name, int x)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Ivec2& v)
+void Shader::setUniform(const std::string& name, Glsl::Ivec2 v)
 {
     const UniformBinder binder(*this, name);
     if (binder.location != -1)
@@ -540,7 +540,7 @@ void Shader::setUniform(const std::string& name, bool x)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& name, const Glsl::Bvec2& v)
+void Shader::setUniform(const std::string& name, Glsl::Bvec2 v)
 {
     setUniform(name, Glsl::Ivec2(v));
 }
@@ -1048,7 +1048,7 @@ void Shader::setUniform(const std::string& /* name */, float)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& /* name */, const Glsl::Vec2&)
+void Shader::setUniform(const std::string& /* name */, Glsl::Vec2)
 {
 }
 
@@ -1072,7 +1072,7 @@ void Shader::setUniform(const std::string& /* name */, int)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& /* name */, const Glsl::Ivec2&)
+void Shader::setUniform(const std::string& /* name */, Glsl::Ivec2)
 {
 }
 
@@ -1096,7 +1096,7 @@ void Shader::setUniform(const std::string& /* name */, bool)
 
 
 ////////////////////////////////////////////////////////////
-void Shader::setUniform(const std::string& /* name */, const Glsl::Bvec2&)
+void Shader::setUniform(const std::string& /* name */, Glsl::Bvec2)
 {
 }
 

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -37,7 +37,7 @@
 namespace
 {
 // Compute the normal of a segment
-sf::Vector2f computeNormal(const sf::Vector2f& p1, const sf::Vector2f& p2)
+sf::Vector2f computeNormal(sf::Vector2f p1, sf::Vector2f p2)
 {
     sf::Vector2f normal = (p2 - p1).perpendicular();
     const float  length = normal.length();

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -66,7 +66,7 @@ std::uint64_t getUniqueId() noexcept
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Texture::Texture(const Vector2u& size, const Vector2u& actualSize, unsigned int texture, bool sRgb) :
+Texture::Texture(Vector2u size, Vector2u actualSize, unsigned int texture, bool sRgb) :
 m_size(size),
 m_actualSize(actualSize),
 m_texture(texture),
@@ -165,7 +165,7 @@ Texture& Texture::operator=(Texture&& right) noexcept
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Texture> Texture::create(const Vector2u& size, bool sRgb)
+std::optional<Texture> Texture::create(Vector2u size, bool sRgb)
 {
     // Check if texture parameters are valid before creating it
     if ((size.x == 0) || (size.y == 0))
@@ -480,7 +480,7 @@ void Texture::update(const std::uint8_t* pixels)
 
 
 ////////////////////////////////////////////////////////////
-void Texture::update(const std::uint8_t* pixels, const Vector2u& size, const Vector2u& dest)
+void Texture::update(const std::uint8_t* pixels, Vector2u size, Vector2u dest)
 {
     assert(dest.x + size.x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + size.y <= m_size.y && "Destination y coordinate is outside of texture");
@@ -524,7 +524,7 @@ void Texture::update(const Texture& texture)
 
 
 ////////////////////////////////////////////////////////////
-void Texture::update(const Texture& texture, const Vector2u& dest)
+void Texture::update(const Texture& texture, Vector2u dest)
 {
     assert(dest.x + texture.m_size.x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + texture.m_size.y <= m_size.y && "Destination y coordinate is outside of texture");
@@ -655,7 +655,7 @@ void Texture::update(const Image& image)
 
 
 ////////////////////////////////////////////////////////////
-void Texture::update(const Image& image, const Vector2u& dest)
+void Texture::update(const Image& image, Vector2u dest)
 {
     update(image.getPixelsPtr(), image.getSize(), dest);
 }
@@ -669,7 +669,7 @@ void Texture::update(const Window& window)
 
 
 ////////////////////////////////////////////////////////////
-void Texture::update(const Window& window, const Vector2u& dest)
+void Texture::update(const Window& window, Vector2u dest)
 {
     assert(dest.x + window.getSize().x <= m_size.x && "Destination x coordinate is outside of texture");
     assert(dest.y + window.getSize().y <= m_size.y && "Destination y coordinate is outside of texture");

--- a/src/SFML/Graphics/Transform.cpp
+++ b/src/SFML/Graphics/Transform.cpp
@@ -52,7 +52,7 @@ Transform& Transform::rotate(Angle angle)
 
 
 ////////////////////////////////////////////////////////////
-Transform& Transform::rotate(Angle angle, const Vector2f& center)
+Transform& Transform::rotate(Angle angle, Vector2f center)
 {
     const float rad = angle.asRadians();
     const float cos = std::cos(rad);

--- a/src/SFML/Graphics/Transformable.cpp
+++ b/src/SFML/Graphics/Transformable.cpp
@@ -33,7 +33,7 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-void Transformable::setPosition(const Vector2f& position)
+void Transformable::setPosition(Vector2f position)
 {
     m_position                   = position;
     m_transformNeedUpdate        = true;
@@ -52,7 +52,7 @@ void Transformable::setRotation(Angle angle)
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::setScale(const Vector2f& factors)
+void Transformable::setScale(Vector2f factors)
 {
     m_scale                      = factors;
     m_transformNeedUpdate        = true;
@@ -61,7 +61,7 @@ void Transformable::setScale(const Vector2f& factors)
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::setOrigin(const Vector2f& origin)
+void Transformable::setOrigin(Vector2f origin)
 {
     m_origin                     = origin;
     m_transformNeedUpdate        = true;
@@ -70,7 +70,7 @@ void Transformable::setOrigin(const Vector2f& origin)
 
 
 ////////////////////////////////////////////////////////////
-const Vector2f& Transformable::getPosition() const
+Vector2f Transformable::getPosition() const
 {
     return m_position;
 }
@@ -84,21 +84,21 @@ Angle Transformable::getRotation() const
 
 
 ////////////////////////////////////////////////////////////
-const Vector2f& Transformable::getScale() const
+Vector2f Transformable::getScale() const
 {
     return m_scale;
 }
 
 
 ////////////////////////////////////////////////////////////
-const Vector2f& Transformable::getOrigin() const
+Vector2f Transformable::getOrigin() const
 {
     return m_origin;
 }
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::move(const Vector2f& offset)
+void Transformable::move(Vector2f offset)
 {
     setPosition(m_position + offset);
 }
@@ -112,7 +112,7 @@ void Transformable::rotate(Angle angle)
 
 
 ////////////////////////////////////////////////////////////
-void Transformable::scale(const Vector2f& factor)
+void Transformable::scale(Vector2f factor)
 {
     setScale({m_scale.x * factor.x, m_scale.y * factor.y});
 }

--- a/src/SFML/Graphics/View.cpp
+++ b/src/SFML/Graphics/View.cpp
@@ -40,13 +40,13 @@ View::View(const FloatRect& rectangle) : m_center(rectangle.getCenter()), m_size
 
 
 ////////////////////////////////////////////////////////////
-View::View(const Vector2f& center, const Vector2f& size) : m_center(center), m_size(size)
+View::View(Vector2f center, Vector2f size) : m_center(center), m_size(size)
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-void View::setCenter(const Vector2f& center)
+void View::setCenter(Vector2f center)
 {
     m_center              = center;
     m_transformUpdated    = false;
@@ -55,7 +55,7 @@ void View::setCenter(const Vector2f& center)
 
 
 ////////////////////////////////////////////////////////////
-void View::setSize(const Vector2f& size)
+void View::setSize(Vector2f size)
 {
     m_size = size;
 
@@ -96,14 +96,14 @@ void View::setScissor(const FloatRect& scissor)
 
 
 ////////////////////////////////////////////////////////////
-const Vector2f& View::getCenter() const
+Vector2f View::getCenter() const
 {
     return m_center;
 }
 
 
 ////////////////////////////////////////////////////////////
-const Vector2f& View::getSize() const
+Vector2f View::getSize() const
 {
     return m_size;
 }
@@ -131,7 +131,7 @@ const FloatRect& View::getScissor() const
 
 
 ////////////////////////////////////////////////////////////
-void View::move(const Vector2f& offset)
+void View::move(Vector2f offset)
 {
     setCenter(m_center + offset);
 }

--- a/src/SFML/System/Vector2.cpp
+++ b/src/SFML/System/Vector2.cpp
@@ -45,7 +45,7 @@ Vector2<T> Vector2<T>::normalized() const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-Angle Vector2<T>::angleTo(const Vector2<T>& rhs) const
+Angle Vector2<T>::angleTo(Vector2<T> rhs) const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::angleTo() is only supported for floating point types");
 
@@ -83,7 +83,7 @@ Vector2<T> Vector2<T>::rotatedBy(Angle phi) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-Vector2<T> Vector2<T>::projectedOnto(const Vector2<T>& axis) const
+Vector2<T> Vector2<T>::projectedOnto(Vector2<T> axis) const
 {
     static_assert(std::is_floating_point_v<T>, "Vector2::projectedOnto() is only supported for floating point types");
 

--- a/src/SFML/Window/Android/InputImpl.cpp
+++ b/src/SFML/Window/Android/InputImpl.cpp
@@ -195,14 +195,14 @@ Vector2i getMousePosition(const WindowBase& /* relativeTo */)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& /* position */)
+void setMousePosition(Vector2i /* position */)
 {
     // Injecting events is impossible on Android
 }
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position, const WindowBase& /* relativeTo */)
+void setMousePosition(Vector2i position, const WindowBase& /* relativeTo */)
 {
     setMousePosition(position);
 }

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -131,7 +131,7 @@ Vector2i WindowImplAndroid::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setPosition(const Vector2i& /* position */)
+void WindowImplAndroid::setPosition(Vector2i /* position */)
 {
     // Not applicable
 }
@@ -145,7 +145,7 @@ Vector2u WindowImplAndroid::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setSize(const Vector2u& /* size */)
+void WindowImplAndroid::setSize(Vector2u /* size */)
 {
 }
 
@@ -172,7 +172,7 @@ void WindowImplAndroid::setTitle(const String& /* title */)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplAndroid::setIcon(const Vector2u& /* size */, const std::uint8_t* /* pixels */)
+void WindowImplAndroid::setIcon(Vector2u /* size */, const std::uint8_t* /* pixels */)
 {
     // Not applicable
 }

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -93,7 +93,7 @@ public:
     /// \param position New position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2i& position) override;
+    void setPosition(Vector2i position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the client size of the window
@@ -109,7 +109,7 @@ public:
     /// \param size New size, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2u& size) override;
+    void setSize(Vector2u size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
@@ -146,7 +146,7 @@ public:
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(const Vector2u& size, const std::uint8_t* pixels) override;
+    void setIcon(Vector2u size, const std::uint8_t* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/Context.cpp
+++ b/src/SFML/Window/Context.cpp
@@ -140,8 +140,7 @@ GlFunctionPointer Context::getFunction(const char* name)
 
 
 ////////////////////////////////////////////////////////////
-Context::Context(const ContextSettings& settings, const Vector2u& size) :
-m_context(priv::GlContext::create(settings, size))
+Context::Context(const ContextSettings& settings, Vector2u size) : m_context(priv::GlContext::create(settings, size))
 {
     if (!setActive(true))
         err() << "Failed to set context as active during construction" << std::endl;

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -555,7 +555,7 @@ DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, cons
 
 
 ////////////////////////////////////////////////////////////
-DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, const Vector2u& size)
+DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, Vector2u size)
 {
     contextCount++;
 
@@ -710,7 +710,7 @@ void DRMContext::createContext(DRMContext* shared)
 
 
 ////////////////////////////////////////////////////////////
-void DRMContext::createSurface(const Vector2u& size, unsigned int /*bpp*/, bool scanout)
+void DRMContext::createSurface(Vector2u size, unsigned int /*bpp*/, bool scanout)
 {
     std::uint32_t flags = GBM_BO_USE_RENDERING;
 

--- a/src/SFML/Window/DRM/DRMContext.hpp
+++ b/src/SFML/Window/DRM/DRMContext.hpp
@@ -87,7 +87,7 @@ public:
     /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    DRMContext(DRMContext* shared, const ContextSettings& settings, const Vector2u& size);
+    DRMContext(DRMContext* shared, const ContextSettings& settings, Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -143,7 +143,7 @@ public:
     /// \param scanout True to present the surface to the screen
     ///
     ////////////////////////////////////////////////////////////
-    void createSurface(const Vector2u& size, unsigned int bpp, bool scanout);
+    void createSurface(Vector2u size, unsigned int bpp, bool scanout);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destroy the EGL surface

--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -628,7 +628,7 @@ Vector2i getMousePosition(const WindowBase& /*relativeTo*/)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position)
+void setMousePosition(Vector2i position)
 {
     const std::lock_guard lock(inputMutex);
     mousePos = position;
@@ -636,7 +636,7 @@ void setMousePosition(const Vector2i& position)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position, const WindowBase& /*relativeTo*/)
+void setMousePosition(Vector2i position, const WindowBase& /*relativeTo*/)
 {
     setMousePosition(position);
 }

--- a/src/SFML/Window/DRM/WindowImplDRM.cpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.cpp
@@ -103,7 +103,7 @@ Vector2i WindowImplDRM::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplDRM::setPosition(const Vector2i& /*position*/)
+void WindowImplDRM::setPosition(Vector2i /*position*/)
 {
 }
 
@@ -116,7 +116,7 @@ Vector2u WindowImplDRM::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplDRM::setSize(const Vector2u& /*size*/)
+void WindowImplDRM::setSize(Vector2u /*size*/)
 {
 }
 
@@ -140,7 +140,7 @@ void WindowImplDRM::setTitle(const String& /*title*/)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplDRM::setIcon(const Vector2u& /*size*/, const std::uint8_t* /*pixels*/)
+void WindowImplDRM::setIcon(Vector2u /*size*/, const std::uint8_t* /*pixels*/)
 {
 }
 

--- a/src/SFML/Window/DRM/WindowImplDRM.hpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.hpp
@@ -87,7 +87,7 @@ public:
     /// \param position New position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2i& position) override;
+    void setPosition(Vector2i position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the client size of the window
@@ -103,7 +103,7 @@ public:
     /// \param size New size, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2u& size) override;
+    void setSize(Vector2u size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
@@ -140,7 +140,7 @@ public:
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(const Vector2u& size, const std::uint8_t* pixels) override;
+    void setIcon(Vector2u size, const std::uint8_t* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -173,7 +173,7 @@ EglContext::EglContext(EglContext*                        shared,
 
 
 ////////////////////////////////////////////////////////////
-EglContext::EglContext(EglContext* /*shared*/, const ContextSettings& /*settings*/, const Vector2u& /*size*/)
+EglContext::EglContext(EglContext* /*shared*/, const ContextSettings& /*settings*/, Vector2u /*size*/)
 {
     EglContextImpl::ensureInit();
 

--- a/src/SFML/Window/EglContext.hpp
+++ b/src/SFML/Window/EglContext.hpp
@@ -72,7 +72,7 @@ public:
     /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    EglContext(EglContext* shared, const ContextSettings& settings, const Vector2u& size);
+    EglContext(EglContext* shared, const ContextSettings& settings, Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -628,7 +628,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, co
 
 
 ////////////////////////////////////////////////////////////
-std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, const Vector2u& size)
+std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, Vector2u size)
 {
     // Make sure that there's an active context (context creation may need extensions, and thus a valid context)
     const auto sharedContext = SharedContext::get();

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -128,7 +128,7 @@ public:
     /// \return Pointer to the created context
     ///
     ////////////////////////////////////////////////////////////
-    static std::unique_ptr<GlContext> create(const ContextSettings& settings, const Vector2u& size);
+    static std::unique_ptr<GlContext> create(const ContextSettings& settings, Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Check whether a given OpenGL extension is available

--- a/src/SFML/Window/InputImpl.hpp
+++ b/src/SFML/Window/InputImpl.hpp
@@ -121,7 +121,7 @@ Vector2i getMousePosition(const WindowBase& relativeTo);
 /// \param position New position of the mouse
 ///
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position);
+void setMousePosition(Vector2i position);
 
 ////////////////////////////////////////////////////////////
 /// \brief Set the current position of the mouse in window coordinates
@@ -134,7 +134,7 @@ void setMousePosition(const Vector2i& position);
 /// \param relativeTo Reference window
 ///
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position, const WindowBase& relativeTo);
+void setMousePosition(Vector2i position, const WindowBase& relativeTo);
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a touch event is currently down

--- a/src/SFML/Window/Mouse.cpp
+++ b/src/SFML/Window/Mouse.cpp
@@ -53,14 +53,14 @@ Vector2i Mouse::getPosition(const WindowBase& relativeTo)
 
 
 ////////////////////////////////////////////////////////////
-void Mouse::setPosition(const Vector2i& position)
+void Mouse::setPosition(Vector2i position)
 {
     priv::InputImpl::setMousePosition(position);
 }
 
 
 ////////////////////////////////////////////////////////////
-void Mouse::setPosition(const Vector2i& position, const WindowBase& relativeTo)
+void Mouse::setPosition(Vector2i position, const WindowBase& relativeTo)
 {
     priv::InputImpl::setMousePosition(position, relativeTo);
 }

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -133,7 +133,7 @@ GlxContext::GlxContext(GlxContext* shared, const ContextSettings& settings, cons
 
 
 ////////////////////////////////////////////////////////////
-GlxContext::GlxContext(GlxContext* shared, const ContextSettings& settings, const Vector2u& size)
+GlxContext::GlxContext(GlxContext* shared, const ContextSettings& settings, Vector2u size)
 {
     // Save the creation settings
     m_settings = settings;
@@ -453,7 +453,7 @@ void GlxContext::updateSettingsFromWindow()
 
 
 ////////////////////////////////////////////////////////////
-void GlxContext::createSurface(GlxContext* shared, const Vector2u& size, unsigned int bitsPerPixel)
+void GlxContext::createSurface(GlxContext* shared, Vector2u size, unsigned int bitsPerPixel)
 {
     // Choose the visual according to the context settings
     XVisualInfo visualInfo = selectBestVisual(m_display.get(), bitsPerPixel, m_settings);

--- a/src/SFML/Window/Unix/GlxContext.hpp
+++ b/src/SFML/Window/Unix/GlxContext.hpp
@@ -72,7 +72,7 @@ public:
     /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    GlxContext(GlxContext* shared, const ContextSettings& settings, const Vector2u& size);
+    GlxContext(GlxContext* shared, const ContextSettings& settings, Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -154,7 +154,7 @@ private:
     /// \param bitsPerPixel Pixel depth, in bits per pixel
     ///
     ////////////////////////////////////////////////////////////
-    void createSurface(GlxContext* shared, const Vector2u& size, unsigned int bitsPerPixel);
+    void createSurface(GlxContext* shared, Vector2u size, unsigned int bitsPerPixel);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the context's drawing surface from an existing window

--- a/src/SFML/Window/Unix/InputImpl.cpp
+++ b/src/SFML/Window/Unix/InputImpl.cpp
@@ -164,7 +164,7 @@ Vector2i getMousePosition(const WindowBase& relativeTo)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position)
+void setMousePosition(Vector2i position)
 {
     // Open a connection with the X server
     const auto display = openDisplay();
@@ -175,7 +175,7 @@ void setMousePosition(const Vector2i& position)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position, const WindowBase& relativeTo)
+void setMousePosition(Vector2i position, const WindowBase& relativeTo)
 {
     // Open a connection with the X server
     const auto display = openDisplay();

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -872,7 +872,7 @@ Vector2i WindowImplX11::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplX11::setPosition(const Vector2i& position)
+void WindowImplX11::setPosition(Vector2i position)
 {
     XMoveWindow(m_display.get(), m_window, position.x, position.y);
     XFlush(m_display.get());
@@ -889,7 +889,7 @@ Vector2u WindowImplX11::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplX11::setSize(const Vector2u& size)
+void WindowImplX11::setSize(Vector2u size)
 {
     // If resizing is disable for the window we have to update the size hints (required by some window managers).
     if (m_useSizeHints)
@@ -969,7 +969,7 @@ void WindowImplX11::setTitle(const String& title)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplX11::setIcon(const Vector2u& size, const std::uint8_t* pixels)
+void WindowImplX11::setIcon(Vector2u size, const std::uint8_t* pixels)
 {
     // X11 wants BGRA pixels: swap red and blue channels
     // Note: this memory will be freed by X11Ptr<XImage> deleter

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -95,7 +95,7 @@ public:
     /// \param position New position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2i& position) override;
+    void setPosition(Vector2i position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the client size of the window
@@ -111,7 +111,7 @@ public:
     /// \param size New size, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2u& size) override;
+    void setSize(Vector2u size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
@@ -148,7 +148,7 @@ public:
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(const Vector2u& size, const std::uint8_t* pixels) override;
+    void setIcon(Vector2u size, const std::uint8_t* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/VideoMode.cpp
+++ b/src/SFML/Window/VideoMode.cpp
@@ -35,9 +35,7 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-VideoMode::VideoMode(const Vector2u& modeSize, unsigned int modeBitsPerPixel) :
-size(modeSize),
-bitsPerPixel(modeBitsPerPixel)
+VideoMode::VideoMode(Vector2u modeSize, unsigned int modeBitsPerPixel) : size(modeSize), bitsPerPixel(modeBitsPerPixel)
 {
 }
 

--- a/src/SFML/Window/Win32/InputImpl.cpp
+++ b/src/SFML/Window/Win32/InputImpl.cpp
@@ -717,14 +717,14 @@ Vector2i getMousePosition(const WindowBase& relativeTo)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position)
+void setMousePosition(Vector2i position)
 {
     SetCursorPos(position.x, position.y);
 }
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position, const WindowBase& relativeTo)
+void setMousePosition(Vector2i position, const WindowBase& relativeTo)
 {
     WindowHandle handle = relativeTo.getNativeHandle();
     if (handle)

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -124,7 +124,7 @@ WglContext::WglContext(WglContext* shared, const ContextSettings& settings, cons
 
 
 ////////////////////////////////////////////////////////////
-WglContext::WglContext(WglContext* shared, const ContextSettings& settings, const Vector2u& size)
+WglContext::WglContext(WglContext* shared, const ContextSettings& settings, Vector2u size)
 {
     WglContextImpl::ensureInit();
 
@@ -570,7 +570,7 @@ void WglContext::updateSettingsFromPixelFormat()
 
 
 ////////////////////////////////////////////////////////////
-void WglContext::createSurface(WglContext* shared, const Vector2u& size, unsigned int bitsPerPixel)
+void WglContext::createSurface(WglContext* shared, Vector2u size, unsigned int bitsPerPixel)
 {
     // Check if the shared context already exists and pbuffers are supported
     if (shared && shared->m_deviceContext && SF_GLAD_WGL_ARB_pbuffer)

--- a/src/SFML/Window/Win32/WglContext.hpp
+++ b/src/SFML/Window/Win32/WglContext.hpp
@@ -77,7 +77,7 @@ public:
     /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    WglContext(WglContext* shared, const ContextSettings& settings, const Vector2u& size);
+    WglContext(WglContext* shared, const ContextSettings& settings, Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -163,7 +163,7 @@ private:
     /// \param bitsPerPixel Pixel depth, in bits per pixel
     ///
     ////////////////////////////////////////////////////////////
-    void createSurface(WglContext* shared, const Vector2u& size, unsigned int bitsPerPixel);
+    void createSurface(WglContext* shared, Vector2u size, unsigned int bitsPerPixel);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the context's drawing surface from an existing window

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -331,7 +331,7 @@ Vector2i WindowImplWin32::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplWin32::setPosition(const Vector2i& position)
+void WindowImplWin32::setPosition(Vector2i position)
 {
     SetWindowPos(m_handle, nullptr, position.x, position.y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
 
@@ -351,7 +351,7 @@ Vector2u WindowImplWin32::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplWin32::setSize(const Vector2u& size)
+void WindowImplWin32::setSize(Vector2u size)
 {
     const auto [width, height] = contentSizeToWindowSize(size);
     SetWindowPos(m_handle, nullptr, 0, 0, width, height, SWP_NOMOVE | SWP_NOZORDER);
@@ -366,7 +366,7 @@ void WindowImplWin32::setTitle(const String& title)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplWin32::setIcon(const Vector2u& size, const std::uint8_t* pixels)
+void WindowImplWin32::setIcon(Vector2u size, const std::uint8_t* pixels)
 {
     // First destroy the previous one
     if (m_icon)
@@ -580,7 +580,7 @@ void WindowImplWin32::grabCursor(bool grabbed)
 
 
 ////////////////////////////////////////////////////////////
-Vector2i WindowImplWin32::contentSizeToWindowSize(const Vector2u& size)
+Vector2i WindowImplWin32::contentSizeToWindowSize(Vector2u size)
 {
     // SetWindowPos wants the total size of the window (including title bar and borders) so we have to compute it
     RECT rectangle = {0, 0, static_cast<long>(size.x), static_cast<long>(size.y)};

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -99,7 +99,7 @@ public:
     /// \param position New position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2i& position) override;
+    void setPosition(Vector2i position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the client size of the window
@@ -115,7 +115,7 @@ public:
     /// \param size New size, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2u& size) override;
+    void setSize(Vector2u size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the title of the window
@@ -132,7 +132,7 @@ public:
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(const Vector2u& size, const std::uint8_t* pixels) override;
+    void setIcon(Vector2u size, const std::uint8_t* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
@@ -256,7 +256,7 @@ private:
     /// \return Converted size including window chrome
     ///
     ////////////////////////////////////////////////////////////
-    Vector2i contentSizeToWindowSize(const Vector2u& size);
+    Vector2i contentSizeToWindowSize(Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a Win32 virtual key code to a SFML key code

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -170,7 +170,7 @@ Vector2i WindowBase::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowBase::setPosition(const Vector2i& position)
+void WindowBase::setPosition(Vector2i position)
 {
     if (m_impl)
         m_impl->setPosition(position);
@@ -185,7 +185,7 @@ Vector2u WindowBase::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowBase::setSize(const Vector2u& size)
+void WindowBase::setSize(Vector2u size)
 {
     if (m_impl)
     {
@@ -259,7 +259,7 @@ void WindowBase::setTitle(const String& title)
 
 
 ////////////////////////////////////////////////////////////
-void WindowBase::setIcon(const Vector2u& size, const std::uint8_t* pixels)
+void WindowBase::setIcon(Vector2u size, const std::uint8_t* pixels)
 {
     if (m_impl)
         m_impl->setIcon(size, pixels);

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -183,7 +183,7 @@ public:
     /// \param position New position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual void setPosition(const Vector2i& position) = 0;
+    virtual void setPosition(Vector2i position) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the client size of the window
@@ -199,7 +199,7 @@ public:
     /// \param size New size, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    virtual void setSize(const Vector2u& size) = 0;
+    virtual void setSize(Vector2u size) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
@@ -236,7 +236,7 @@ public:
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    virtual void setIcon(const Vector2u& size, const std::uint8_t* pixels) = 0;
+    virtual void setIcon(Vector2u size, const std::uint8_t* pixels) = 0;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/iOS/EaglContext.hpp
+++ b/src/SFML/Window/iOS/EaglContext.hpp
@@ -79,7 +79,7 @@ public:
     /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    EaglContext(EaglContext* shared, const ContextSettings& settings, const Vector2u& size);
+    EaglContext(EaglContext* shared, const ContextSettings& settings, Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -118,7 +118,7 @@ m_context(nil)
 
 
 ////////////////////////////////////////////////////////////
-EaglContext::EaglContext(EaglContext* /* shared */, const ContextSettings& /* settings */, const Vector2u& /* size */) :
+EaglContext::EaglContext(EaglContext* /* shared */, const ContextSettings& /* settings */, Vector2u /* size */) :
 m_context(nil)
 {
     ensureInit();

--- a/src/SFML/Window/iOS/InputImpl.mm
+++ b/src/SFML/Window/iOS/InputImpl.mm
@@ -105,14 +105,14 @@ Vector2i getMousePosition(const WindowBase& /* relativeTo */)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& /* position */)
+void setMousePosition(Vector2i /* position */)
 {
     // Not applicable
 }
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& /* position */, const WindowBase& /* relativeTo */)
+void setMousePosition(Vector2i /* position */, const WindowBase& /* relativeTo */)
 {
     // Not applicable
 }

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -88,7 +88,7 @@ public:
     /// \param position New position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2i& position) override;
+    void setPosition(Vector2i position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the client size of the window
@@ -104,7 +104,7 @@ public:
     /// \param size New size, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2u& size) override;
+    void setSize(Vector2u size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
@@ -141,7 +141,7 @@ public:
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(const Vector2u& size, const std::uint8_t* pixels) override;
+    void setIcon(Vector2u size, const std::uint8_t* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -119,7 +119,7 @@ Vector2i WindowImplUIKit::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setPosition(const Vector2i& /* position */)
+void WindowImplUIKit::setPosition(Vector2i /* position */)
 {
 }
 
@@ -134,7 +134,7 @@ Vector2u WindowImplUIKit::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setSize(const Vector2u& size)
+void WindowImplUIKit::setSize(Vector2u size)
 {
     // TODO ...
 
@@ -172,7 +172,7 @@ void WindowImplUIKit::setTitle(const String& /* title */)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplUIKit::setIcon(const Vector2u& /* size */, const std::uint8_t* /* pixels */)
+void WindowImplUIKit::setIcon(Vector2u /* size */, const std::uint8_t* /* pixels */)
 {
     // Not applicable
 }

--- a/src/SFML/Window/macOS/InputImpl.mm
+++ b/src/SFML/Window/macOS/InputImpl.mm
@@ -204,7 +204,7 @@ Vector2i getMousePosition(const sf::WindowBase& relativeTo)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position)
+void setMousePosition(Vector2i position)
 {
     const AutoreleasePool pool;
     // Here we don't need to reverse the coordinates.
@@ -223,7 +223,7 @@ void setMousePosition(const Vector2i& position)
 
 
 ////////////////////////////////////////////////////////////
-void setMousePosition(const Vector2i& position, const WindowBase& relativeTo)
+void setMousePosition(Vector2i position, const WindowBase& relativeTo)
 {
     const AutoreleasePool pool;
     SFOpenGLView* const   view = getSFOpenGLViewFromSFMLWindow(relativeTo);

--- a/src/SFML/Window/macOS/SFContext.hpp
+++ b/src/SFML/Window/macOS/SFContext.hpp
@@ -89,7 +89,7 @@ public:
     /// \param size     Back buffer width and height, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    SFContext(SFContext* shared, const ContextSettings& settings, const Vector2u& size);
+    SFContext(SFContext* shared, const ContextSettings& settings, Vector2u size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/src/SFML/Window/macOS/SFContext.mm
+++ b/src/SFML/Window/macOS/SFContext.mm
@@ -65,7 +65,7 @@ SFContext::SFContext(SFContext* shared, const ContextSettings& settings, const W
 
 
 ////////////////////////////////////////////////////////////
-SFContext::SFContext(SFContext* shared, const ContextSettings& settings, const Vector2u& size)
+SFContext::SFContext(SFContext* shared, const ContextSettings& settings, Vector2u size)
 {
     const AutoreleasePool pool;
     // Ensure the process is setup in order to create a valid window.

--- a/src/SFML/Window/macOS/WindowImplCocoa.hpp
+++ b/src/SFML/Window/macOS/WindowImplCocoa.hpp
@@ -259,7 +259,7 @@ public:
     /// \param position New position of the window, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setPosition(const Vector2i& position) override;
+    void setPosition(Vector2i position) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the client size of the window
@@ -275,7 +275,7 @@ public:
     /// \param size New size, in pixels
     ///
     ////////////////////////////////////////////////////////////
-    void setSize(const Vector2u& size) override;
+    void setSize(Vector2u size) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
@@ -312,7 +312,7 @@ public:
     /// \param pixels Pointer to the pixels in memory, format must be RGBA 32 bits
     ///
     ////////////////////////////////////////////////////////////
-    void setIcon(const Vector2u& size, const std::uint8_t* pixels) override;
+    void setIcon(Vector2u size, const std::uint8_t* pixels) override;
 
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window

--- a/src/SFML/Window/macOS/WindowImplCocoa.mm
+++ b/src/SFML/Window/macOS/WindowImplCocoa.mm
@@ -356,7 +356,7 @@ Vector2i WindowImplCocoa::getPosition() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::setPosition(const Vector2i& position)
+void WindowImplCocoa::setPosition(Vector2i position)
 {
     const AutoreleasePool pool;
     sf::Vector2i          backingPosition = position;
@@ -377,7 +377,7 @@ Vector2u WindowImplCocoa::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::setSize(const Vector2u& size)
+void WindowImplCocoa::setSize(Vector2u size)
 {
     sf::Vector2u backingSize = size;
     scaleInXY(backingSize, m_delegate);
@@ -415,7 +415,7 @@ void WindowImplCocoa::setTitle(const String& title)
 
 
 ////////////////////////////////////////////////////////////
-void WindowImplCocoa::setIcon(const Vector2u& size, const std::uint8_t* pixels)
+void WindowImplCocoa::setIcon(Vector2u size, const std::uint8_t* pixels)
 {
     const AutoreleasePool pool;
     [m_delegate setIconTo:size with:pixels];

--- a/test/Graphics/RenderTarget.test.cpp
+++ b/test/Graphics/RenderTarget.test.cpp
@@ -87,7 +87,7 @@ TEST_CASE("[Graphics] sf::RenderTarget")
               sf::IntRect({0, 0}, {640, 480}));
     }
 
-    SECTION("mapPixelToCoords(const Vector2i&)")
+    SECTION("mapPixelToCoords(Vector2i)")
     {
         sf::View view;
         view.move({5, 5});
@@ -105,7 +105,7 @@ TEST_CASE("[Graphics] sf::RenderTarget")
         CHECK_THAT(y3, Catch::Matchers::WithinRel(505, 1e-5));
     }
 
-    SECTION("mapPixelToCoords(const Vector2i&, const View&)")
+    SECTION("mapPixelToCoords(Vector2i, const View&)")
     {
         sf::View view;
         view.move({5, 5});
@@ -119,7 +119,7 @@ TEST_CASE("[Graphics] sf::RenderTarget")
         CHECK_THAT(y2, Catch::Matchers::WithinRel(505, 1e-5));
     }
 
-    SECTION("mapCoordsToPixel(const Vector2f&)")
+    SECTION("mapCoordsToPixel(Vector2f)")
     {
         sf::View view;
         view.move({5, 5});
@@ -131,7 +131,7 @@ TEST_CASE("[Graphics] sf::RenderTarget")
         CHECK(renderTarget.mapCoordsToPixel({0, -250}) == sf::Vector2i(156, -122));
     }
 
-    SECTION("mapCoordsToPixel(const Vector2f&, const View&)")
+    SECTION("mapCoordsToPixel(Vector2f, const View&)")
     {
         sf::View view;
         view.move({5, 5});

--- a/test/Graphics/Shape.test.cpp
+++ b/test/Graphics/Shape.test.cpp
@@ -12,7 +12,7 @@
 class TriangleShape : public sf::Shape
 {
 public:
-    explicit TriangleShape(const sf::Vector2f& size) : m_size(size)
+    explicit TriangleShape(sf::Vector2f size) : m_size(size)
     {
         update();
     }

--- a/test/System/Angle.test.cpp
+++ b/test/System/Angle.test.cpp
@@ -13,6 +13,7 @@ TEST_CASE("[System] sf::Angle")
         STATIC_CHECK(std::is_copy_assignable_v<sf::Angle>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Angle>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Angle>);
+        STATIC_CHECK(std::is_trivially_copyable_v<sf::Angle>);
     }
 
     SECTION("Construction")

--- a/test/System/Time.test.cpp
+++ b/test/System/Time.test.cpp
@@ -15,6 +15,7 @@ TEST_CASE("[System] sf::Time")
         STATIC_CHECK(std::is_copy_assignable_v<sf::Time>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Time>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Time>);
+        STATIC_CHECK(std::is_trivially_copyable_v<sf::Time>);
     }
 
     SECTION("Construction")

--- a/test/System/Vector2.test.cpp
+++ b/test/System/Vector2.test.cpp
@@ -17,6 +17,7 @@ TEMPLATE_TEST_CASE("[System] sf::Vector2", "", int, float)
         STATIC_CHECK(std::is_copy_assignable_v<sf::Vector2<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector2<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector2<TestType>>);
+        STATIC_CHECK(std::is_trivially_copyable_v<sf::Vector2<TestType>>);
     }
 
     SECTION("Construction")


### PR DESCRIPTION
## Description

Addresses part of #3047.

As a rule of thumb, if the type is trivially copyable and is less than or equal to the CPU register width times two then you ought to pass it by value. This will lead to more efficient code generation. We already do this with `sf::Time` and `sf::Angle` with are both 4 bytes so I added tests for trivial copyability to those two types as well.

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-in