### PR TITLE
Use lowercase literal suffixes

### DIFF
--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -236,7 +236,7 @@ Shader::~Shader()
 
 ////////////////////////////////////////////////////////////
 Shader::Shader(Shader&& source) noexcept :
-m_shaderProgram(std::exchange(source.m_shaderProgram, 0U)),
+m_shaderProgram(std::exchange(source.m_shaderProgram, 0u)),
 m_currentTexture(std::exchange(source.m_currentTexture, -1)),
 m_textures(std::move(source.m_textures)),
 m_uniforms(std::move(source.m_uniforms))
@@ -260,7 +260,7 @@ Shader& Shader::operator=(Shader&& right) noexcept
     }
 
     // Move the contents of right.
-    m_shaderProgram  = std::exchange(right.m_shaderProgram, 0U);
+    m_shaderProgram  = std::exchange(right.m_shaderProgram, 0u);
     m_currentTexture = std::exchange(right.m_currentTexture, -1);
     m_textures       = std::move(right.m_textures);
     m_uniforms       = std::move(right.m_uniforms);

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -209,7 +209,7 @@ std::uint32_t findCrtcForEncoder(const drmModeRes& resources, const drmModeEncod
     {
         // Possible_crtcs is a bitmask as described here:
         // https://dvdhrm.wordpress.com/2012/09/13/linux-drm-mode-setting-api
-        const std::uint32_t crtcMask = 1U << i;
+        const std::uint32_t crtcMask = 1u << i;
         const std::uint32_t crtcId   = resources.crtcs[i];
         if (encoder.possible_crtcs & crtcMask)
         {


### PR DESCRIPTION
## Description

By convention we use lowercase suffixes for literals like `3.14f` or `100u`. Uppercase `F` and `U` mean the same thing as their lowercase counterpart but is unconventional for SFML. I searched for any remaining uses of uppercase literal suffixes and could not find any.