### PR TITLE
Fix how macOS fullscreen video modes are detected

### DIFF
--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -181,7 +181,6 @@
 {
     // Create a screen-sized window on the main display
     sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
-    sf::priv::scaleInWidthHeight(desktop, nil);
     NSRect windowRect = NSMakeRect(0, 0, desktop.width, desktop.height);
     m_window = [[SFWindow alloc] initWithContentRect:windowRect
                                            styleMask:NSBorderlessWindowMask
@@ -448,7 +447,6 @@
         // Special case when fullscreen: only resize the opengl view
         // and make sure the requested size is not bigger than the window.
         sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
-        sf::priv::scaleInWidthHeight(desktop, nil);
 
         width = std::min(width, desktop.width);
         height = std::min(height, desktop.height);

--- a/src/SFML/Window/OSX/Scaling.h
+++ b/src/SFML/Window/OSX/Scaling.h
@@ -58,13 +58,6 @@ void scaleIn(T& in, id<WindowImplDelegateProtocol> delegate)
 }
 
 template <class T>
-void scaleInWidthHeight(T& in, id<WindowImplDelegateProtocol> delegate)
-{
-    scaleIn(in.width, delegate);
-    scaleIn(in.height, delegate);
-}
-
-template <class T>
 void scaleInXY(T& in, id<WindowImplDelegateProtocol> delegate)
 {
     scaleIn(in.x, delegate);

--- a/src/SFML/Window/OSX/cg_sf_conversion.mm
+++ b/src/SFML/Window/OSX/cg_sf_conversion.mm
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/OSX/cg_sf_conversion.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Vector2.hpp>
 
 #import <SFML/Window/OSX/Scaling.h>
 
@@ -95,11 +96,10 @@ VideoMode convertCGModeToSFMode(CGDisplayModeRef cgmode)
     //
     // [1]: "APIs for Supporting High Resolution" > "Additions and Changes for OS X v10.8"
     // https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/APIs/APIs.html#//apple_ref/doc/uid/TP40012302-CH5-SW27
-    VideoMode mode(static_cast<unsigned int>(CGDisplayModeGetWidth(cgmode)), static_cast<unsigned int>(CGDisplayModeGetHeight(cgmode)), static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
-    scaleOutWidthHeight(mode, nil);
-    return mode;
+    Vector2u size = Vector2u(Vector2<size_t>(CGDisplayModeGetPixelWidth(cgmode), CGDisplayModeGetPixelHeight(cgmode)));
+    scaleInXY(size, nil);
+    return VideoMode(size.x, size.y, static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
 }
 
 } // namespace priv
 } // namespace sf
-


### PR DESCRIPTION
## Description

Attempt to fix #2300. Some quick local tests show that this does prevent crashing when trying to make a fullscreen window on macOS.

The equivalent fix for v3 is a bit simpler. https://github.com/SFML/SFML/compare/master...macos_fullscreen