### PR TITLE
Reimplement legacy constructor/load/open methods and add throwing constructors

### DIFF
--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -21,15 +21,15 @@
 ///     sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 ///     // Load a sprite to display
-///     const auto texture = sf::Texture::loadFromFile("cute_image.jpg").value();
+///     const sf::Texture texture("cute_image.jpg");
 ///     sf::Sprite sprite(texture);
 ///
 ///     // Create a graphical text to display
-///     const auto font = sf::Font::openFromFile("arial.ttf").value();
+///     const sf::Font font("arial.ttf");
 ///     sf::Text text(font, "Hello SFML", 50);
 ///
 ///     // Load a music to play
-///     auto music = sf::Music::openFromFile("nice_music.ogg").value();
+///     sf::Music music("nice_music.ogg");
 ///
 ///     // Play the music
 ///     music.play();

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -86,13 +86,13 @@ int main(int argc, char* argv[])
     sf::RenderWindow window(screen, "");
     window.setFramerateLimit(30);
 
-    const auto texture = sf::Texture::loadFromFile("image.png").value();
+    const auto texture = sf::Texture::createFromFile("image.png").value();
 
     sf::Sprite image(texture);
     image.setPosition(sf::Vector2f(screen.size) / 2.f);
     image.setOrigin(sf::Vector2f(texture.getSize()) / 2.f);
 
-    const auto font = sf::Font::openFromFile("tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile("tuffy.ttf").value();
 
     sf::Text text(font, "Tap anywhere to move the logo.", 64);
     text.setFillColor(sf::Color::Black);

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -86,13 +86,13 @@ int main(int argc, char* argv[])
     sf::RenderWindow window(screen, "");
     window.setFramerateLimit(30);
 
-    const auto texture = sf::Texture::createFromFile("image.png").value();
+    const sf::Texture texture("image.png");
 
     sf::Sprite image(texture);
     image.setPosition(sf::Vector2f(screen.size) / 2.f);
     image.setOrigin(sf::Vector2f(texture.getSize()) / 2.f);
 
-    const auto font = sf::Font::createFromFile("tuffy.ttf").value();
+    const sf::Font font("tuffy.ttf");
 
     sf::Text text(font, "Tap anywhere to move the logo.", 64);
     text.setFillColor(sf::Color::Black);

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -52,9 +52,9 @@ struct SFMLmainWindow
 
     std::filesystem::path resPath{[[[NSBundle mainBundle] resourcePath] tostdstring]};
     sf::RenderWindow      renderWindow;
-    sf::Font              font{sf::Font::openFromFile(resPath / "tuffy.ttf").value()};
+    sf::Font              font{sf::Font::createFromFile(resPath / "tuffy.ttf").value()};
     sf::Text              text{font};
-    sf::Texture           logo{sf::Texture::loadFromFile(resPath / "logo.png").value()};
+    sf::Texture           logo{sf::Texture::createFromFile(resPath / "logo.png").value()};
     sf::Sprite            sprite{logo};
     sf::Color             background{sf::Color::Blue};
 };

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -52,9 +52,9 @@ struct SFMLmainWindow
 
     std::filesystem::path resPath{[[[NSBundle mainBundle] resourcePath] tostdstring]};
     sf::RenderWindow      renderWindow;
-    sf::Font              font{sf::Font::createFromFile(resPath / "tuffy.ttf").value()};
+    sf::Font              font{resPath / "tuffy.ttf"};
     sf::Text              text{font};
-    sf::Texture           logo{sf::Texture::createFromFile(resPath / "logo.png").value()};
+    sf::Texture           logo{resPath / "logo.png"};
     sf::Sprite            sprite{logo};
     sf::Color             background{sf::Color::Blue};
 };

--- a/examples/event_handling/EventHandling.cpp
+++ b/examples/event_handling/EventHandling.cpp
@@ -316,7 +316,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     sf::RenderWindow m_window{sf::VideoMode({800u, 600u}), "SFML Event Handling", sf::Style::Titlebar | sf::Style::Close};
-    const sf::Font   m_font{sf::Font::openFromFile("resources/tuffy.ttf").value()};
+    const sf::Font   m_font{sf::Font::createFromFile("resources/tuffy.ttf").value()};
     sf::Text         m_logText{m_font, "", 20};
     sf::Text         m_handlerText{m_font, "Current Handler: Classic", 24};
     sf::Text         m_instructions{m_font, "Press Enter to change handler type", 24};

--- a/examples/event_handling/EventHandling.cpp
+++ b/examples/event_handling/EventHandling.cpp
@@ -316,7 +316,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     sf::RenderWindow m_window{sf::VideoMode({800u, 600u}), "SFML Event Handling", sf::Style::Titlebar | sf::Style::Close};
-    const sf::Font   m_font{sf::Font::createFromFile("resources/tuffy.ttf").value()};
+    const sf::Font   m_font{"resources/tuffy.ttf"};
     sf::Text         m_logText{m_font, "", 20};
     sf::Text         m_handlerText{m_font, "Current Handler: Classic", 24};
     sf::Text         m_instructions{m_font, "Press Enter to change handler type", 24};

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -91,14 +91,14 @@ int main()
     sf::RenderWindow window(sf::VideoMode({windowWidth, windowHeight}), "SFML Island", sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
-    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
+    const sf::Font font("resources/tuffy.ttf");
 
     // Create all of our graphics resources
-    sf::Text                  hudText(font);
-    sf::Text                  statusText(font);
-    std::optional<sf::Shader> terrainShader;
-    sf::RenderStates          terrainStates;
-    sf::VertexBuffer          terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Usage::Static);
+    sf::Text         hudText(font);
+    sf::Text         statusText(font);
+    sf::Shader       terrainShader;
+    sf::RenderStates terrainStates;
+    sf::VertexBuffer terrain(sf::PrimitiveType::Triangles, sf::VertexBuffer::Usage::Static);
 
     // Set up our text drawables
     statusText.setCharacterSize(28);
@@ -120,7 +120,7 @@ int main()
     {
         statusText.setString("Shaders and/or Vertex Buffers Unsupported");
     }
-    else if (!(terrainShader = sf::Shader::createFromFile("resources/terrain.vert", "resources/terrain.frag")))
+    else if (!terrainShader.loadFromFile("resources/terrain.vert", "resources/terrain.frag"))
     {
         statusText.setString("Failed to load shader program");
     }
@@ -148,7 +148,7 @@ int main()
         statusText.setString("Generating Terrain...");
 
         // Set up the render states
-        terrainStates = sf::RenderStates(&*terrainShader);
+        terrainStates = sf::RenderStates(&terrainShader);
     }
 
     // Center the status text
@@ -186,7 +186,8 @@ int main()
             }
 
             // Arrow key pressed:
-            if (terrainShader.has_value() && event->is<sf::Event::KeyPressed>())
+            // TODO Replace use of getNativeHandle() when validity function is added
+            if (terrainShader.getNativeHandle() != 0 && event->is<sf::Event::KeyPressed>())
             {
                 switch (event->getIf<sf::Event::KeyPressed>()->code)
                 {
@@ -216,7 +217,7 @@ int main()
 
         window.draw(statusText);
 
-        if (terrainShader.has_value())
+        if (terrainShader.getNativeHandle() != 0)
         {
             {
                 const std::lock_guard lock(workQueueMutex);
@@ -236,7 +237,7 @@ int main()
                         bufferUploadPending = false;
                     }
 
-                    terrainShader->setUniform("lightFactor", lightFactor);
+                    terrainShader.setUniform("lightFactor", lightFactor);
                     window.draw(terrain, terrainStates);
                 }
             }

--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -91,7 +91,7 @@ int main()
     sf::RenderWindow window(sf::VideoMode({windowWidth, windowHeight}), "SFML Island", sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
-    const auto font = sf::Font::openFromFile("resources/tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
 
     // Create all of our graphics resources
     sf::Text                  hudText(font);
@@ -120,7 +120,7 @@ int main()
     {
         statusText.setString("Shaders and/or Vertex Buffers Unsupported");
     }
-    else if (!(terrainShader = sf::Shader::loadFromFile("resources/terrain.vert", "resources/terrain.frag")))
+    else if (!(terrainShader = sf::Shader::createFromFile("resources/terrain.vert", "resources/terrain.frag")))
     {
         statusText.setString("Failed to load shader program");
     }

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -94,7 +94,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the text font
-    const auto font = sf::Font::openFromFile("resources/tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
 
     // Set up our string conversion parameters
     sstr.precision(2);

--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -94,7 +94,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the text font
-    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
+    const sf::Font font("resources/tuffy.ttf");
 
     // Set up our string conversion parameters
     sstr.precision(2);

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -58,11 +58,11 @@ int main()
         window.setMaximumSize(sf::Vector2u(1200, 900));
 
         // Create a sprite for the background
-        const auto backgroundTexture = sf::Texture::createFromFile(resourcesDir() / "background.jpg", sRgb).value();
-        const sf::Sprite background(backgroundTexture);
+        const sf::Texture backgroundTexture(resourcesDir() / "background.jpg", sRgb);
+        const sf::Sprite  background(backgroundTexture);
 
         // Create some text to draw on top of our OpenGL object
-        const auto font = sf::Font::createFromFile(resourcesDir() / "tuffy.ttf").value();
+        const sf::Font font(resourcesDir() / "tuffy.ttf");
 
         sf::Text text(font, "SFML / OpenGL demo");
         sf::Text sRgbInstructions(font, "Press space to toggle sRGB conversion");
@@ -75,7 +75,7 @@ int main()
         mipmapInstructions.setPosition({200.f, 550.f});
 
         // Load a texture to apply to our 3D cube
-        auto texture = sf::Texture::createFromFile(resourcesDir() / "logo.png").value();
+        sf::Texture texture(resourcesDir() / "logo.png");
 
         // Attempt to generate a mipmap for our cube texture
         // We don't check the return value here since
@@ -219,7 +219,7 @@ int main()
                     if (mipmapEnabled)
                     {
                         // We simply reload the texture to disable mipmapping
-                        texture = sf::Texture::createFromFile(resourcesDir() / "logo.png").value();
+                        texture = sf::Texture(resourcesDir() / "logo.png");
 
                         // Rebind the texture
                         sf::Texture::bind(&texture);

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -58,11 +58,11 @@ int main()
         window.setMaximumSize(sf::Vector2u(1200, 900));
 
         // Create a sprite for the background
-        const auto       backgroundTexture = sf::Texture::loadFromFile(resourcesDir() / "background.jpg", sRgb).value();
+        const auto backgroundTexture = sf::Texture::createFromFile(resourcesDir() / "background.jpg", sRgb).value();
         const sf::Sprite background(backgroundTexture);
 
         // Create some text to draw on top of our OpenGL object
-        const auto font = sf::Font::openFromFile(resourcesDir() / "tuffy.ttf").value();
+        const auto font = sf::Font::createFromFile(resourcesDir() / "tuffy.ttf").value();
 
         sf::Text text(font, "SFML / OpenGL demo");
         sf::Text sRgbInstructions(font, "Press space to toggle sRGB conversion");
@@ -75,7 +75,7 @@ int main()
         mipmapInstructions.setPosition({200.f, 550.f});
 
         // Load a texture to apply to our 3D cube
-        auto texture = sf::Texture::loadFromFile(resourcesDir() / "logo.png").value();
+        auto texture = sf::Texture::createFromFile(resourcesDir() / "logo.png").value();
 
         // Attempt to generate a mipmap for our cube texture
         // We don't check the return value here since
@@ -219,7 +219,7 @@ int main()
                     if (mipmapEnabled)
                     {
                         // We simply reload the texture to disable mipmapping
-                        texture = sf::Texture::loadFromFile(resourcesDir() / "logo.png").value();
+                        texture = sf::Texture::createFromFile(resourcesDir() / "logo.png").value();
 
                         // Rebind the texture
                         sf::Texture::bind(&texture);

--- a/examples/raw_input/RawInput.cpp
+++ b/examples/raw_input/RawInput.cpp
@@ -19,7 +19,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the application font
-    const auto font = sf::Font::openFromFile("resources/tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
 
     // Create the mouse position text
     sf::Text mousePosition(font, "", 20);

--- a/examples/raw_input/RawInput.cpp
+++ b/examples/raw_input/RawInput.cpp
@@ -19,7 +19,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the application font
-    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
+    const sf::Font font("resources/tuffy.ttf");
 
     // Create the mouse position text
     sf::Text mousePosition(font, "", 20);

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -278,69 +278,66 @@ private:
 ////////////////////////////////////////////////////////////
 std::optional<Pixelate> tryLoadPixelate()
 {
-    auto texture = sf::Texture::createFromFile("resources/background.jpg");
-    if (!texture.has_value())
+    sf::Texture texture;
+    if (!texture.loadFromFile("resources/background.jpg"))
         return std::nullopt;
 
-    auto shader = sf::Shader::createFromFile("resources/pixelate.frag", sf::Shader::Type::Fragment);
-    if (!shader.has_value())
+    sf::Shader shader;
+    if (!shader.loadFromFile("resources/pixelate.frag", sf::Shader::Type::Fragment))
         return std::nullopt;
 
-    return std::make_optional<Pixelate>(std::move(*texture), std::move(*shader));
+    return std::make_optional<Pixelate>(std::move(texture), std::move(shader));
 }
 
 std::optional<WaveBlur> tryLoadWaveBlur(const sf::Font& font)
 {
-    auto shader = sf::Shader::createFromFile("resources/wave.vert", "resources/blur.frag");
-    if (!shader.has_value())
+    sf::Shader shader;
+    if (!shader.loadFromFile("resources/wave.vert", "resources/blur.frag"))
         return std::nullopt;
 
-    return std::make_optional<WaveBlur>(font, std::move(*shader));
+    return std::make_optional<WaveBlur>(font, std::move(shader));
 }
 
 std::optional<StormBlink> tryLoadStormBlink()
 {
-    auto shader = sf::Shader::createFromFile("resources/storm.vert", "resources/blink.frag");
-    if (!shader.has_value())
+    sf::Shader shader;
+    if (!shader.loadFromFile("resources/storm.vert", "resources/blink.frag"))
         return std::nullopt;
 
-    return std::make_optional<StormBlink>(std::move(*shader));
+    return std::make_optional<StormBlink>(std::move(shader));
 }
 
 std::optional<Edge> tryLoadEdge()
 {
     // Create the off-screen surface
-    auto surface = sf::RenderTexture::create({800, 600});
-    if (!surface.has_value())
+    sf::RenderTexture surface;
+    if (!surface.resize({800, 600}))
         return std::nullopt;
 
-    surface->setSmooth(true);
+    surface.setSmooth(true);
 
     // Load the background texture
-    auto backgroundTexture = sf::Texture::createFromFile("resources/sfml.png");
-    if (!backgroundTexture.has_value())
+    sf::Texture backgroundTexture;
+    if (!backgroundTexture.loadFromFile("resources/sfml.png"))
         return std::nullopt;
 
-    backgroundTexture->setSmooth(true);
+    backgroundTexture.setSmooth(true);
 
     // Load the entity texture
-    auto entityTexture = sf::Texture::createFromFile("resources/devices.png");
-    if (!entityTexture.has_value())
+    sf::Texture entityTexture;
+    if (!entityTexture.loadFromFile("resources/devices.png"))
         return std::nullopt;
 
-    entityTexture->setSmooth(true);
+    entityTexture.setSmooth(true);
 
     // Load the shader
-    auto shader = sf::Shader::createFromFile("resources/edge.frag", sf::Shader::Type::Fragment);
-    if (!shader.has_value())
+    sf::Shader shader;
+    if (!shader.loadFromFile("resources/edge.frag", sf::Shader::Type::Fragment))
         return std::nullopt;
 
-    shader->setUniform("texture", sf::Shader::CurrentTexture);
+    shader.setUniform("texture", sf::Shader::CurrentTexture);
 
-    return std::make_optional<Edge>(std::move(*surface),
-                                    std::move(*backgroundTexture),
-                                    std::move(*entityTexture),
-                                    std::move(*shader));
+    return std::make_optional<Edge>(std::move(surface), std::move(backgroundTexture), std::move(entityTexture), std::move(shader));
 }
 
 std::optional<Geometry> tryLoadGeometry()
@@ -350,25 +347,23 @@ std::optional<Geometry> tryLoadGeometry()
         return std::nullopt;
 
     // Load the logo texture
-    auto logoTexture = sf::Texture::createFromFile("resources/logo.png");
-    if (!logoTexture.has_value())
+    sf::Texture logoTexture;
+    if (!logoTexture.loadFromFile("resources/logo.png"))
         return std::nullopt;
 
-    logoTexture->setSmooth(true);
+    logoTexture.setSmooth(true);
 
     // Load the shader
-    auto shader = sf::Shader::createFromFile("resources/billboard.vert",
-                                             "resources/billboard.geom",
-                                             "resources/billboard.frag");
-    if (!shader.has_value())
+    sf::Shader shader;
+    if (!shader.loadFromFile("resources/billboard.vert", "resources/billboard.geom", "resources/billboard.frag"))
         return std::nullopt;
 
-    shader->setUniform("texture", sf::Shader::CurrentTexture);
+    shader.setUniform("texture", sf::Shader::CurrentTexture);
 
     // Set the render resolution (used for proper scaling)
-    shader->setUniform("resolution", sf::Vector2f(800, 600));
+    shader.setUniform("resolution", sf::Vector2f(800, 600));
 
-    return std::make_optional<Geometry>(std::move(*logoTexture), std::move(*shader));
+    return std::make_optional<Geometry>(std::move(logoTexture), std::move(shader));
 }
 
 } // namespace
@@ -394,7 +389,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the application font
-    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
+    const sf::Font font("resources/tuffy.ttf");
 
     // Create the effects
     std::optional pixelateEffect   = tryLoadPixelate();
@@ -418,8 +413,8 @@ int main()
     std::size_t current = 0;
 
     // Create the messages background
-    const auto textBackgroundTexture = sf::Texture::createFromFile("resources/text-background.png").value();
-    sf::Sprite textBackground(textBackgroundTexture);
+    const sf::Texture textBackgroundTexture("resources/text-background.png");
+    sf::Sprite        textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));
 

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -278,11 +278,11 @@ private:
 ////////////////////////////////////////////////////////////
 std::optional<Pixelate> tryLoadPixelate()
 {
-    auto texture = sf::Texture::loadFromFile("resources/background.jpg");
+    auto texture = sf::Texture::createFromFile("resources/background.jpg");
     if (!texture.has_value())
         return std::nullopt;
 
-    auto shader = sf::Shader::loadFromFile("resources/pixelate.frag", sf::Shader::Type::Fragment);
+    auto shader = sf::Shader::createFromFile("resources/pixelate.frag", sf::Shader::Type::Fragment);
     if (!shader.has_value())
         return std::nullopt;
 
@@ -291,7 +291,7 @@ std::optional<Pixelate> tryLoadPixelate()
 
 std::optional<WaveBlur> tryLoadWaveBlur(const sf::Font& font)
 {
-    auto shader = sf::Shader::loadFromFile("resources/wave.vert", "resources/blur.frag");
+    auto shader = sf::Shader::createFromFile("resources/wave.vert", "resources/blur.frag");
     if (!shader.has_value())
         return std::nullopt;
 
@@ -300,7 +300,7 @@ std::optional<WaveBlur> tryLoadWaveBlur(const sf::Font& font)
 
 std::optional<StormBlink> tryLoadStormBlink()
 {
-    auto shader = sf::Shader::loadFromFile("resources/storm.vert", "resources/blink.frag");
+    auto shader = sf::Shader::createFromFile("resources/storm.vert", "resources/blink.frag");
     if (!shader.has_value())
         return std::nullopt;
 
@@ -317,21 +317,21 @@ std::optional<Edge> tryLoadEdge()
     surface->setSmooth(true);
 
     // Load the background texture
-    auto backgroundTexture = sf::Texture::loadFromFile("resources/sfml.png");
+    auto backgroundTexture = sf::Texture::createFromFile("resources/sfml.png");
     if (!backgroundTexture.has_value())
         return std::nullopt;
 
     backgroundTexture->setSmooth(true);
 
     // Load the entity texture
-    auto entityTexture = sf::Texture::loadFromFile("resources/devices.png");
+    auto entityTexture = sf::Texture::createFromFile("resources/devices.png");
     if (!entityTexture.has_value())
         return std::nullopt;
 
     entityTexture->setSmooth(true);
 
     // Load the shader
-    auto shader = sf::Shader::loadFromFile("resources/edge.frag", sf::Shader::Type::Fragment);
+    auto shader = sf::Shader::createFromFile("resources/edge.frag", sf::Shader::Type::Fragment);
     if (!shader.has_value())
         return std::nullopt;
 
@@ -350,16 +350,16 @@ std::optional<Geometry> tryLoadGeometry()
         return std::nullopt;
 
     // Load the logo texture
-    auto logoTexture = sf::Texture::loadFromFile("resources/logo.png");
+    auto logoTexture = sf::Texture::createFromFile("resources/logo.png");
     if (!logoTexture.has_value())
         return std::nullopt;
 
     logoTexture->setSmooth(true);
 
     // Load the shader
-    auto shader = sf::Shader::loadFromFile("resources/billboard.vert",
-                                           "resources/billboard.geom",
-                                           "resources/billboard.frag");
+    auto shader = sf::Shader::createFromFile("resources/billboard.vert",
+                                             "resources/billboard.geom",
+                                             "resources/billboard.frag");
     if (!shader.has_value())
         return std::nullopt;
 
@@ -394,7 +394,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the application font
-    const auto font = sf::Font::openFromFile("resources/tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile("resources/tuffy.ttf").value();
 
     // Create the effects
     std::optional pixelateEffect   = tryLoadPixelate();
@@ -418,7 +418,7 @@ int main()
     std::size_t current = 0;
 
     // Create the messages background
-    const auto textBackgroundTexture = sf::Texture::loadFromFile("resources/text-background.png").value();
+    const auto textBackgroundTexture = sf::Texture::createFromFile("resources/text-background.png").value();
     sf::Sprite textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -13,7 +13,7 @@
 void playSound()
 {
     // Load a sound buffer from a wav file
-    const auto buffer = sf::SoundBuffer::createFromFile("resources/killdeer.wav").value();
+    const sf::SoundBuffer buffer("resources/killdeer.wav");
 
     // Display sound information
     std::cout << "killdeer.wav:" << '\n'
@@ -46,7 +46,7 @@ void playSound()
 void playMusic(const std::filesystem::path& filename)
 {
     // Load an ogg music file
-    auto music = sf::Music::createFromFile("resources" / filename).value();
+    sf::Music music("resources" / filename);
 
     // Display music information
     std::cout << filename << ":" << '\n'

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -13,7 +13,7 @@
 void playSound()
 {
     // Load a sound buffer from a wav file
-    const auto buffer = sf::SoundBuffer::loadFromFile("resources/killdeer.wav").value();
+    const auto buffer = sf::SoundBuffer::createFromFile("resources/killdeer.wav").value();
 
     // Display sound information
     std::cout << "killdeer.wav:" << '\n'
@@ -46,7 +46,7 @@ void playSound()
 void playMusic(const std::filesystem::path& filename)
 {
     // Load an ogg music file
-    auto music = sf::Music::openFromFile("resources" / filename).value();
+    auto music = sf::Music::createFromFile("resources" / filename).value();
 
     // Display music information
     std::cout << filename << ":" << '\n'

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -115,7 +115,7 @@ public:
         m_listener.setFillColor(sf::Color::Red);
 
         // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
@@ -177,7 +177,7 @@ public:
     m_volumeText(getFont(), "Volume: " + std::to_string(m_volume))
     {
         // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
@@ -283,7 +283,7 @@ public:
         makeCone(m_soundConeInner, innerConeAngle);
 
         // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
@@ -677,7 +677,7 @@ protected:
         m_instructions.setPosition({windowWidth / 2.f - 250.f, windowHeight * 3.f / 4.f});
 
         // Load the music file
-        if (!(m_music = sf::Music::openFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
@@ -1077,7 +1077,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the application font and pass it to the Effect class
-    const auto font = sf::Font::openFromFile(resourcesDir() / "tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile(resourcesDir() / "tuffy.ttf").value();
     Effect::setFont(font);
 
     // Create the effects
@@ -1106,7 +1106,7 @@ int main()
     effects[current]->start();
 
     // Create the messages background
-    const auto textBackgroundTexture = sf::Texture::loadFromFile(resourcesDir() / "text-background.png").value();
+    const auto textBackgroundTexture = sf::Texture::createFromFile(resourcesDir() / "text-background.png").value();
     sf::Sprite textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -115,23 +115,23 @@ public:
         m_listener.setFillColor(sf::Color::Red);
 
         // Load the music file
-        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
         }
 
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // Set attenuation to a nice value
-        m_music->setAttenuation(0.04f);
+        m_music.setAttenuation(0.04f);
     }
 
     void onUpdate(float /*time*/, float x, float y) override
     {
         m_position = {windowWidth * x - 10.f, windowHeight * y - 10.f};
-        m_music->setPosition({m_position.x, m_position.y, 0.f});
+        m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
     void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
@@ -149,19 +149,19 @@ public:
         // Synchronize listener audio position with graphical position
         sf::Listener::setPosition({m_listener.getPosition().x, m_listener.getPosition().y, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
     void onStop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 private:
-    sf::CircleShape          m_listener{20.f};
-    sf::CircleShape          m_soundShape{20.f};
-    sf::Vector2f             m_position;
-    std::optional<sf::Music> m_music;
+    sf::CircleShape m_listener{20.f};
+    sf::CircleShape m_soundShape{20.f};
+    sf::Vector2f    m_position;
+    sf::Music       m_music;
 };
 
 
@@ -177,23 +177,23 @@ public:
     m_volumeText(getFont(), "Volume: " + std::to_string(m_volume))
     {
         // Load the music file
-        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
         }
 
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // We don't care about attenuation in this effect
-        m_music->setAttenuation(0.f);
+        m_music.setAttenuation(0.f);
 
         // Set initial pitch
-        m_music->setPitch(m_pitch);
+        m_music.setPitch(m_pitch);
 
         // Set initial volume
-        m_music->setVolume(m_volume);
+        m_music.setVolume(m_volume);
 
         m_pitchText.setPosition({windowWidth / 2.f - 120.f, windowHeight / 2.f - 80.f});
         m_volumeText.setPosition({windowWidth / 2.f - 120.f, windowHeight / 2.f - 30.f});
@@ -204,8 +204,8 @@ public:
         m_pitch  = std::clamp(2.f * x, 0.f, 2.f);
         m_volume = std::clamp(100.f * (1.f - y), 0.f, 100.f);
 
-        m_music->setPitch(m_pitch);
-        m_music->setVolume(m_volume);
+        m_music.setPitch(m_pitch);
+        m_music.setVolume(m_volume);
 
         m_pitchText.setString("Pitch: " + std::to_string(m_pitch));
         m_volumeText.setString("Volume: " + std::to_string(m_volume));
@@ -223,20 +223,20 @@ public:
         // so that the music is right on top of the listener
         sf::Listener::setPosition({0.f, 0.f, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
     void onStop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 private:
-    float                    m_pitch{1.f};
-    float                    m_volume{100.f};
-    sf::Text                 m_pitchText;
-    sf::Text                 m_volumeText;
-    std::optional<sf::Music> m_music;
+    float     m_pitch{1.f};
+    float     m_volume{100.f};
+    sf::Text  m_pitchText;
+    sf::Text  m_volumeText;
+    sf::Music m_music;
 };
 
 
@@ -283,23 +283,23 @@ public:
         makeCone(m_soundConeInner, innerConeAngle);
 
         // Load the music file
-        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
         }
 
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // Set attenuation factor
-        m_music->setAttenuation(m_attenuation);
+        m_music.setAttenuation(m_attenuation);
 
         // Set direction to face "downwards"
-        m_music->setDirection({0.f, 1.f, 0.f});
+        m_music.setDirection({0.f, 1.f, 0.f});
 
         // Set cone
-        m_music->setCone({innerConeAngle, outerConeAngle, 0.f});
+        m_music.setCone({innerConeAngle, outerConeAngle, 0.f});
 
         m_text.setString(
             "Attenuation factor dampens full volume of sound while within inner cone based on distance to "
@@ -314,7 +314,7 @@ public:
     void onUpdate(float /*time*/, float x, float y) override
     {
         m_position = {windowWidth * x - 10.f, windowHeight * y - 10.f};
-        m_music->setPosition({m_position.x, m_position.y, 0.f});
+        m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
     void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
@@ -336,22 +336,22 @@ public:
         // Synchronize listener audio position with graphical position
         sf::Listener::setPosition({m_listener.getPosition().x, m_listener.getPosition().y, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
     void onStop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 private:
-    sf::CircleShape          m_listener{20.f};
-    sf::CircleShape          m_soundShape{20.f};
-    sf::ConvexShape          m_soundConeOuter;
-    sf::ConvexShape          m_soundConeInner;
-    sf::Text                 m_text;
-    sf::Vector2f             m_position;
-    std::optional<sf::Music> m_music;
+    sf::CircleShape m_listener{20.f};
+    sf::CircleShape m_soundShape{20.f};
+    sf::ConvexShape m_soundConeOuter;
+    sf::ConvexShape m_soundConeInner;
+    sf::Text        m_text;
+    sf::Vector2f    m_position;
+    sf::Music       m_music;
 
     float m_attenuation{0.01f};
 };
@@ -636,7 +636,7 @@ public:
     void onUpdate([[maybe_unused]] float time, float x, float y) override
     {
         m_position = {windowWidth * x - 10.f, windowHeight * y - 10.f};
-        m_music->setPosition({m_position.x, m_position.y, 0.f});
+        m_music.setPosition({m_position.x, m_position.y, 0.f});
     }
 
     void onDraw(sf::RenderTarget& target, sf::RenderStates states) const override
@@ -656,12 +656,12 @@ public:
         // Synchronize listener audio position with graphical position
         sf::Listener::setPosition({m_listener.getPosition().x, m_listener.getPosition().y, 0.f});
 
-        m_music->play();
+        m_music.play();
     }
 
     void onStop() override
     {
-        m_music->stop();
+        m_music.stop();
     }
 
 protected:
@@ -677,22 +677,22 @@ protected:
         m_instructions.setPosition({windowWidth / 2.f - 250.f, windowHeight * 3.f / 4.f});
 
         // Load the music file
-        if (!(m_music = sf::Music::createFromFile(resourcesDir() / "doodle_pop.ogg")))
+        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
         {
             std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
             std::abort();
         }
 
         // Set the music to loop
-        m_music->setLoop(true);
+        m_music.setLoop(true);
 
         // Set attenuation to a nice value
-        m_music->setAttenuation(0.0f);
+        m_music.setAttenuation(0.0f);
     }
 
     sf::Music& getMusic()
     {
-        return *m_music;
+        return m_music;
     }
 
     const std::shared_ptr<bool>& getEnabled() const
@@ -709,13 +709,13 @@ private:
         m_enabledText.setString(*m_enabled ? "Processing: Enabled" : "Processing: Disabled");
     }
 
-    sf::CircleShape          m_listener{20.f};
-    sf::CircleShape          m_soundShape{20.f};
-    sf::Vector2f             m_position;
-    std::optional<sf::Music> m_music;
-    std::shared_ptr<bool>    m_enabled{std::make_shared<bool>(true)};
-    sf::Text                 m_enabledText;
-    sf::Text                 m_instructions;
+    sf::CircleShape       m_listener{20.f};
+    sf::CircleShape       m_soundShape{20.f};
+    sf::Vector2f          m_position;
+    sf::Music             m_music;
+    std::shared_ptr<bool> m_enabled{std::make_shared<bool>(true)};
+    sf::Text              m_enabledText;
+    sf::Text              m_instructions;
 };
 
 
@@ -1077,7 +1077,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the application font and pass it to the Effect class
-    const auto font = sf::Font::createFromFile(resourcesDir() / "tuffy.ttf").value();
+    const sf::Font font(resourcesDir() / "tuffy.ttf");
     Effect::setFont(font);
 
     // Create the effects
@@ -1106,8 +1106,8 @@ int main()
     effects[current]->start();
 
     // Create the messages background
-    const auto textBackgroundTexture = sf::Texture::createFromFile(resourcesDir() / "text-background.png").value();
-    sf::Sprite textBackground(textBackgroundTexture);
+    const sf::Texture textBackgroundTexture(resourcesDir() / "text-background.png");
+    sf::Sprite        textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));
 

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -49,11 +49,11 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the sounds used in the game
-    const auto ballSoundBuffer = sf::SoundBuffer::loadFromFile(resourcesDir() / "ball.wav").value();
+    const auto ballSoundBuffer = sf::SoundBuffer::createFromFile(resourcesDir() / "ball.wav").value();
     sf::Sound  ballSound(ballSoundBuffer);
 
     // Create the SFML logo texture:
-    const auto sfmlLogoTexture = sf::Texture::loadFromFile(resourcesDir() / "sfml_logo.png").value();
+    const auto sfmlLogoTexture = sf::Texture::createFromFile(resourcesDir() / "sfml_logo.png").value();
     sf::Sprite sfmlLogo(sfmlLogoTexture);
     sfmlLogo.setPosition({170.f, 50.f});
 
@@ -82,7 +82,7 @@ int main()
     ball.setOrigin({ballRadius / 2.f, ballRadius / 2.f});
 
     // Open the text font
-    const auto font = sf::Font::openFromFile(resourcesDir() / "tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile(resourcesDir() / "tuffy.ttf").value();
 
     // Initialize the pause message
     sf::Text pauseMessage(font);

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -49,12 +49,12 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the sounds used in the game
-    const auto ballSoundBuffer = sf::SoundBuffer::createFromFile(resourcesDir() / "ball.wav").value();
-    sf::Sound  ballSound(ballSoundBuffer);
+    const sf::SoundBuffer ballSoundBuffer(resourcesDir() / "ball.wav");
+    sf::Sound             ballSound(ballSoundBuffer);
 
     // Create the SFML logo texture:
-    const auto sfmlLogoTexture = sf::Texture::createFromFile(resourcesDir() / "sfml_logo.png").value();
-    sf::Sprite sfmlLogo(sfmlLogoTexture);
+    const sf::Texture sfmlLogoTexture(resourcesDir() / "sfml_logo.png");
+    sf::Sprite        sfmlLogo(sfmlLogoTexture);
     sfmlLogo.setPosition({170.f, 50.f});
 
     // Create the left paddle
@@ -82,7 +82,7 @@ int main()
     ball.setOrigin({ballRadius / 2.f, ballRadius / 2.f});
 
     // Open the text font
-    const auto font = sf::Font::createFromFile(resourcesDir() / "tuffy.ttf").value();
+    const sf::Font font(resourcesDir() / "tuffy.ttf");
 
     // Initialize the pause message
     sf::Text pauseMessage(font);

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -923,7 +923,7 @@ public:
 
         // Use the vertex shader SPIR-V code to create a vertex shader module
         {
-            auto file = sf::FileInputStream::open("resources/shader.vert.spv");
+            auto file = sf::FileInputStream::create("resources/shader.vert.spv");
             if (!file)
             {
                 vulkanAvailable = false;
@@ -951,7 +951,7 @@ public:
 
         // Use the fragment shader SPIR-V code to create a fragment shader module
         {
-            auto file = sf::FileInputStream::open("resources/shader.frag.spv");
+            auto file = sf::FileInputStream::create("resources/shader.frag.spv");
             if (!file)
             {
                 vulkanAvailable = false;
@@ -1801,7 +1801,7 @@ public:
     void setupTextureImage()
     {
         // Load the image data
-        const auto maybeImageData = sf::Image::loadFromFile("resources/logo.png");
+        const auto maybeImageData = sf::Image::createFromFile("resources/logo.png");
 
         if (!maybeImageData)
         {

--- a/examples/vulkan/Vulkan.cpp
+++ b/examples/vulkan/Vulkan.cpp
@@ -923,17 +923,17 @@ public:
 
         // Use the vertex shader SPIR-V code to create a vertex shader module
         {
-            auto file = sf::FileInputStream::create("resources/shader.vert.spv");
-            if (!file)
+            sf::FileInputStream file;
+            if (!file.open("resources/shader.vert.spv"))
             {
                 vulkanAvailable = false;
                 return;
             }
 
-            const auto                 fileSize = file->getSize().value();
+            const auto                 fileSize = file.getSize().value();
             std::vector<std::uint32_t> buffer(fileSize / sizeof(std::uint32_t));
 
-            if (file->read(buffer.data(), fileSize) != file->getSize())
+            if (file.read(buffer.data(), fileSize) != file.getSize())
             {
                 vulkanAvailable = false;
                 return;
@@ -951,17 +951,17 @@ public:
 
         // Use the fragment shader SPIR-V code to create a fragment shader module
         {
-            auto file = sf::FileInputStream::create("resources/shader.frag.spv");
-            if (!file)
+            sf::FileInputStream file;
+            if (!file.open("resources/shader.frag.spv"))
             {
                 vulkanAvailable = false;
                 return;
             }
 
-            const auto                 fileSize = file->getSize().value();
+            const auto                 fileSize = file.getSize().value();
             std::vector<std::uint32_t> buffer(fileSize / sizeof(std::uint32_t));
 
-            if (file->read(buffer.data(), fileSize) != file->getSize())
+            if (file.read(buffer.data(), fileSize) != file.getSize())
             {
                 vulkanAvailable = false;
                 return;
@@ -1801,15 +1801,12 @@ public:
     void setupTextureImage()
     {
         // Load the image data
-        const auto maybeImageData = sf::Image::createFromFile("resources/logo.png");
-
-        if (!maybeImageData)
+        sf::Image imageData;
+        if (!imageData.loadFromFile("resources/logo.png"))
         {
             vulkanAvailable = false;
             return;
         }
-
-        const auto& imageData = *maybeImageData;
 
         // Create a staging buffer to transfer the data with
         const VkDeviceSize imageSize = imageData.getSize().x * imageData.getSize().y * 4;

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -111,8 +111,8 @@ int main()
     sf::RenderWindow sfmlView2(view2);
 
     // Load some textures to display
-    const auto texture1 = sf::Texture::loadFromFile("resources/image1.jpg").value();
-    const auto texture2 = sf::Texture::loadFromFile("resources/image2.jpg").value();
+    const auto texture1 = sf::Texture::createFromFile("resources/image1.jpg").value();
+    const auto texture2 = sf::Texture::createFromFile("resources/image2.jpg").value();
     sf::Sprite sprite1(texture1);
     sf::Sprite sprite2(texture2);
     sprite1.setOrigin(sf::Vector2f(texture1.getSize()) / 2.f);

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -111,10 +111,10 @@ int main()
     sf::RenderWindow sfmlView2(view2);
 
     // Load some textures to display
-    const auto texture1 = sf::Texture::createFromFile("resources/image1.jpg").value();
-    const auto texture2 = sf::Texture::createFromFile("resources/image2.jpg").value();
-    sf::Sprite sprite1(texture1);
-    sf::Sprite sprite2(texture2);
+    const sf::Texture texture1("resources/image1.jpg");
+    const sf::Texture texture2("resources/image2.jpg");
+    sf::Sprite        sprite1(texture1);
+    sf::Sprite        sprite2(texture2);
     sprite1.setOrigin(sf::Vector2f(texture1.getSize()) / 2.f);
     sprite1.setPosition(sprite1.getOrigin());
 

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -53,7 +53,61 @@ class SFML_AUDIO_API InputSoundFile
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Construct an input sound file that is not associated
+    /// with a file to read.
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile() = default;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open a sound file from the disk for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC, MP3.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// Because of minimp3_ex limitation, for MP3 files with big (>16kb) APEv2 tag,
+    /// it may not be properly removed, tag data will be treated as MP3 data
+    /// and there is a low chance of garbage decoded at the end of file.
+    /// See also: https://github.com/lieff/minimp3
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool openFromFile(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a sound file in memory for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool openFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a sound file from a custom stream for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool openFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a sound file from the disk for reading
     ///
     /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC, MP3.
     /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
@@ -68,10 +122,10 @@ public:
     /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<InputSoundFile> openFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<InputSoundFile> createFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Open a sound file in memory for reading
+    /// \brief Create a sound file in memory for reading
     ///
     /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
     /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
@@ -82,10 +136,10 @@ public:
     /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<InputSoundFile> openFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] static std::optional<InputSoundFile> createFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Open a sound file from a custom stream for reading
+    /// \brief Create a sound file from a custom stream for reading
     ///
     /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
     /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
@@ -95,7 +149,7 @@ public:
     /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<InputSoundFile> openFromStream(InputStream& stream);
+    [[nodiscard]] static std::optional<InputSoundFile> createFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total number of audio samples in the file
@@ -213,14 +267,6 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// Useful for implementing close()
-    ///
-    ////////////////////////////////////////////////////////////
-    InputSoundFile() = default;
-
-    ////////////////////////////////////////////////////////////
     /// \brief Deleter for input streams that only conditionally deletes
     ///
     ////////////////////////////////////////////////////////////
@@ -236,16 +282,6 @@ private:
 
         bool owned{true};
     };
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Constructor from reader, stream, and attributes
-    ///
-    ////////////////////////////////////////////////////////////
-    InputSoundFile(std::unique_ptr<SoundFileReader>&&            reader,
-                   std::unique_ptr<InputStream, StreamDeleter>&& stream,
-                   std::uint64_t                                 sampleCount,
-                   unsigned int                                  sampleRate,
-                   std::vector<SoundChannel>&&                   channelMap);
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -275,7 +311,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a sound file
-/// auto file = sf::InputSoundFile::openFromFile("music.ogg").value();
+/// auto file = sf::InputSoundFile::createFromFile("music.ogg").value();
 ///
 /// // Print the sound attributes
 /// std::cout << "duration: " << file.getDuration().asSeconds() << '\n'

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -33,7 +33,6 @@
 
 #include <filesystem>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include <cstddef>
@@ -60,6 +59,51 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile() = default;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a sound file from the disk for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC, MP3.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// Because of minimp3_ex limitation, for MP3 files with big (>16kb) APEv2 tag,
+    /// it may not be properly removed, tag data will be treated as MP3 data
+    /// and there is a low chance of garbage decoded at the end of file.
+    /// See also: https://github.com/lieff/minimp3
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \throws std::runtime_error if opening the file was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a sound file in memory for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if opening the file was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a sound file from a custom stream for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if opening the file was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a sound file from the disk for reading
@@ -105,51 +149,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool openFromStream(InputStream& stream);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create a sound file from the disk for reading
-    ///
-    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC, MP3.
-    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
-    ///
-    /// Because of minimp3_ex limitation, for MP3 files with big (>16kb) APEv2 tag,
-    /// it may not be properly removed, tag data will be treated as MP3 data
-    /// and there is a low chance of garbage decoded at the end of file.
-    /// See also: https://github.com/lieff/minimp3
-    ///
-    /// \param filename Path of the sound file to load
-    ///
-    /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<InputSoundFile> createFromFile(const std::filesystem::path& filename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create a sound file in memory for reading
-    ///
-    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
-    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
-    ///
-    /// \param data        Pointer to the file data in memory
-    /// \param sizeInBytes Size of the data to load, in bytes
-    ///
-    /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<InputSoundFile> createFromMemory(const void* data, std::size_t sizeInBytes);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create a sound file from a custom stream for reading
-    ///
-    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
-    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
-    ///
-    /// \param stream Source stream to read from
-    ///
-    /// \return Input sound file if the file was successfully opened, otherwise `std::nullopt`
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<InputSoundFile> createFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total number of audio samples in the file
@@ -311,7 +310,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a sound file
-/// auto file = sf::InputSoundFile::createFromFile("music.ogg").value();
+/// sf::InputSoundFile file("music.ogg");
 ///
 /// // Print the sound attributes
 /// std::cout << "duration: " << file.getDuration().asSeconds() << '\n'

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -67,6 +67,14 @@ public:
     using TimeSpan = Span<Time>;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Construct an empty music that does not contain any data.
+    ///
+    ////////////////////////////////////////////////////////////
+    Music();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -98,12 +106,12 @@ public:
     ///
     /// \param filename Path of the music file to open
     ///
-    /// \return Music if loading succeeded, `std::nullopt` if it failed
+    /// \return True if loading succeeded, false if it failed
     ///
     /// \see openFromMemory, openFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Music> openFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] bool openFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a music from an audio file in memory
@@ -121,12 +129,12 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \return Music if loading succeeded, `std::nullopt` if it failed
+    /// \return True if loading succeeded, false if it failed
     ///
     /// \see openFromFile, openFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Music> openFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] bool openFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Open a music from an audio file in a custom stream
@@ -142,12 +150,77 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return Music if loading succeeded, `std::nullopt` if it failed
+    /// \return True if loading succeeded, false if it failed
     ///
     /// \see openFromFile, openFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Music> openFromStream(InputStream& stream);
+    [[nodiscard]] bool openFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a music from an audio file
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the file must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param filename Path of the music file to open
+    ///
+    /// \return Music if loading succeeded, `std::nullopt` if it failed
+    ///
+    /// \see createFromMemory, createFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<Music> createFromFile(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a music from an audio file in memory
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather streamed
+    /// continuously, the \a data buffer must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed. That is,
+    /// you can't deallocate the buffer right after calling this function.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return Music if loading succeeded, `std::nullopt` if it failed
+    ///
+    /// \see createFromFile, createFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<Music> createFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a music from an audio file in a custom stream
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the \a stream must remain accessible
+    /// until the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return Music if loading succeeded, `std::nullopt` if it failed
+    ///
+    /// \see createFromFile, createFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<Music> createFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total duration of the music
@@ -232,19 +305,6 @@ protected:
 
 private:
     ////////////////////////////////////////////////////////////
-    /// \brief Try opening the music file from an optional input sound file
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Music> tryOpenFromInputSoundFile(std::optional<InputSoundFile>&& optFile,
-                                                                        const char*                     errorContext);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Initialize the internal state after loading a new music
-    ///
-    ////////////////////////////////////////////////////////////
-    explicit Music(InputSoundFile&& file);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Helper to convert an sf::Time to a sample position
     ///
     /// \param position Time to convert to samples
@@ -300,7 +360,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a music from an audio file
-/// auto music = sf::Music::openFromFile("music.ogg").value();
+/// auto music = sf::Music::createFromFile("music.ogg").value();
 ///
 /// // Change some parameters
 /// music.setPosition({0, 1, 10}); // change its 3D position

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -75,6 +75,71 @@ public:
     Music();
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct a music from an audio file
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the file must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param filename Path of the music file to open
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromMemory, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Music(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a music from an audio file in memory
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather streamed
+    /// continuously, the \a data buffer must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed. That is,
+    /// you can't deallocate the buffer right after calling this function.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromFile, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Music(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a music from an audio file in a custom stream
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the \a stream must remain accessible
+    /// until the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromFile, openFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    Music(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -156,71 +221,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool openFromStream(InputStream& stream);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create a music from an audio file
-    ///
-    /// This function doesn't start playing the music (call play()
-    /// to do so).
-    /// See the documentation of sf::InputSoundFile for the list
-    /// of supported formats.
-    ///
-    /// \warning Since the music is not loaded at once but rather
-    /// streamed continuously, the file must remain accessible until
-    /// the sf::Music object loads a new music or is destroyed.
-    ///
-    /// \param filename Path of the music file to open
-    ///
-    /// \return Music if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromMemory, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Music> createFromFile(const std::filesystem::path& filename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create a music from an audio file in memory
-    ///
-    /// This function doesn't start playing the music (call play()
-    /// to do so).
-    /// See the documentation of sf::InputSoundFile for the list
-    /// of supported formats.
-    ///
-    /// \warning Since the music is not loaded at once but rather streamed
-    /// continuously, the \a data buffer must remain accessible until
-    /// the sf::Music object loads a new music or is destroyed. That is,
-    /// you can't deallocate the buffer right after calling this function.
-    ///
-    /// \param data        Pointer to the file data in memory
-    /// \param sizeInBytes Size of the data to load, in bytes
-    ///
-    /// \return Music if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Music> createFromMemory(const void* data, std::size_t sizeInBytes);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create a music from an audio file in a custom stream
-    ///
-    /// This function doesn't start playing the music (call play()
-    /// to do so).
-    /// See the documentation of sf::InputSoundFile for the list
-    /// of supported formats.
-    ///
-    /// \warning Since the music is not loaded at once but rather
-    /// streamed continuously, the \a stream must remain accessible
-    /// until the sf::Music object loads a new music or is destroyed.
-    ///
-    /// \param stream Source stream to read from
-    ///
-    /// \return Music if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromMemory
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Music> createFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total duration of the music
@@ -360,7 +360,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a music from an audio file
-/// auto music = sf::Music::createFromFile("music.ogg").value();
+/// sf::Music music("music.ogg");
 ///
 /// // Change some parameters
 /// music.setPosition({0, 1, 10}); // change its 3D position

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -34,7 +34,6 @@
 
 #include <filesystem>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include <cstdint>
@@ -59,6 +58,24 @@ public:
     OutputSoundFile() = default;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound file from the disk for writing
+    ///
+    /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.
+    ///
+    /// \param filename     Path of the sound file to write
+    /// \param sampleRate   Sample rate of the sound
+    /// \param channelCount Number of channels in the sound
+    /// \param channelMap   Map of position in sample frame to sound channel
+    ///
+    /// \throws std::runtime_error if the file could not be opened successfully
+    ///
+    ////////////////////////////////////////////////////////////
+    OutputSoundFile(const std::filesystem::path&     filename,
+                    unsigned int                     sampleRate,
+                    unsigned int                     channelCount,
+                    const std::vector<SoundChannel>& channelMap);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the sound file from the disk for writing
     ///
     /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.
@@ -75,25 +92,6 @@ public:
                                     unsigned int                     sampleRate,
                                     unsigned int                     channelCount,
                                     const std::vector<SoundChannel>& channelMap);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the sound file from the disk for writing
-    ///
-    /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.
-    ///
-    /// \param filename     Path of the sound file to write
-    /// \param sampleRate   Sample rate of the sound
-    /// \param channelCount Number of channels in the sound
-    /// \param channelMap   Map of position in sample frame to sound channel
-    ///
-    /// \return Output sound file if the file was successfully opened
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<OutputSoundFile> createFromFile(
-        const std::filesystem::path&     filename,
-        unsigned int                     sampleRate,
-        unsigned int                     channelCount,
-        const std::vector<SoundChannel>& channelMap);
 
     ////////////////////////////////////////////////////////////
     /// \brief Write audio samples to the file
@@ -132,7 +130,7 @@ private:
 /// Usage example:
 /// \code
 /// // Create a sound file, ogg/vorbis format, 44100 Hz, stereo
-/// auto file = sf::OutputSoundFile::createFromFile("music.ogg", 44100, 2).value();
+/// sf::OutputSoundFile file("music.ogg", 44100, 2, {sf::SoundChannel::FrontLeft, sf::SoundChannel::FrontRight});
 ///
 /// while (...)
 /// {

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -50,7 +50,34 @@ class SFML_AUDIO_API OutputSoundFile
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Construct an output sound file that is not associated
+    /// with a file to write.
+    ///
+    ////////////////////////////////////////////////////////////
+    OutputSoundFile() = default;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the sound file from the disk for writing
+    ///
+    /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.
+    ///
+    /// \param filename     Path of the sound file to write
+    /// \param sampleRate   Sample rate of the sound
+    /// \param channelCount Number of channels in the sound
+    /// \param channelMap   Map of position in sample frame to sound channel
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool openFromFile(const std::filesystem::path&     filename,
+                                    unsigned int                     sampleRate,
+                                    unsigned int                     channelCount,
+                                    const std::vector<SoundChannel>& channelMap);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the sound file from the disk for writing
     ///
     /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.
     ///
@@ -62,7 +89,7 @@ public:
     /// \return Output sound file if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<OutputSoundFile> openFromFile(
+    [[nodiscard]] static std::optional<OutputSoundFile> createFromFile(
         const std::filesystem::path&     filename,
         unsigned int                     sampleRate,
         unsigned int                     channelCount,
@@ -85,12 +112,6 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
-    /// \brief Constructor from writer
-    ///
-    ////////////////////////////////////////////////////////////
-    explicit OutputSoundFile(std::unique_ptr<SoundFileWriter>&& writer);
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     std::unique_ptr<SoundFileWriter> m_writer; //!< Writer that handles I/O on the file's format
@@ -111,7 +132,7 @@ private:
 /// Usage example:
 /// \code
 /// // Create a sound file, ogg/vorbis format, 44100 Hz, stereo
-/// auto file = sf::OutputSoundFile::openFromFile("music.ogg", 44100, 2).value();
+/// auto file = sf::OutputSoundFile::createFromFile("music.ogg", 44100, 2).value();
 ///
 /// while (...)
 /// {

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -274,7 +274,7 @@ private:
 ///
 /// Usage example:
 /// \code
-/// const auto buffer = sf::SoundBuffer::loadFromFile("sound.wav").value();
+/// const auto buffer = sf::SoundBuffer::createFromFile("sound.wav").value();
 /// sf::Sound sound(buffer);
 /// sound.play();
 /// \endcode

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -274,7 +274,7 @@ private:
 ///
 /// Usage example:
 /// \code
-/// const auto buffer = sf::SoundBuffer::createFromFile("sound.wav").value();
+/// const sf::SoundBuffer buffer("sound.wav");
 /// sf::Sound sound(buffer);
 /// sound.play();
 /// \endcode

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -56,6 +56,15 @@ class SFML_AUDIO_API SoundBuffer
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Construct an empty sound buffer that does not contain
+    /// any samples.
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer() = default;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
     ///
     /// \param copy Instance to copy
@@ -77,12 +86,12 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    /// \return True if loading succeeded, false if it failed
     ///
     /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> loadFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from a file in memory
@@ -93,12 +102,12 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    /// \return True if loading succeeded, false if it failed
     ///
     /// \see loadFromFile, loadFromStream, loadFromSamples
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> loadFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from a custom stream
@@ -108,12 +117,12 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    /// \return True if loading succeeded, false if it failed
     ///
     /// \see loadFromFile, loadFromMemory, loadFromSamples
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> loadFromStream(InputStream& stream);
+    [[nodiscard]] bool loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the sound buffer from an array of audio samples
@@ -126,12 +135,80 @@ public:
     /// \param sampleRate   Sample rate (number of samples to play per second)
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    /// \return True if loading succeeded, false if it failed
     ///
     /// \see loadFromFile, loadFromMemory, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> loadFromSamples(
+    [[nodiscard]] bool loadFromSamples(const std::int16_t*              samples,
+                                       std::uint64_t                    sampleCount,
+                                       unsigned int                     channelCount,
+                                       unsigned int                     sampleRate,
+                                       const std::vector<SoundChannel>& channelMap);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the sound buffer from a file
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    ///
+    /// \see createFromMemory, createFromStream, createFromSamples, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<SoundBuffer> createFromFile(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the sound buffer from a file in memory
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    ///
+    /// \see createFromFile, createFromStream, createFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<SoundBuffer> createFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the sound buffer from a custom stream
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    ///
+    /// \see createFromFile, createFromMemory, createFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<SoundBuffer> createFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the sound buffer from an array of audio samples
+    ///
+    /// The assumed format of the audio samples is 16 bits signed integer.
+    ///
+    /// \param samples      Pointer to the array of samples in memory
+    /// \param sampleCount  Number of samples in the array
+    /// \param channelCount Number of channels (1 = mono, 2 = stereo, ...)
+    /// \param sampleRate   Sample rate (number of samples to play per second)
+    /// \param channelMap   Map of position in sample frame to sound channel
+    ///
+    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
+    ///
+    /// \see createFromFile, createFromMemory, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<SoundBuffer> createFromSamples(
         const std::int16_t*              samples,
         std::uint64_t                    sampleCount,
         unsigned int                     channelCount,
@@ -148,7 +225,7 @@ public:
     ///
     /// \return True if saving succeeded, false if it failed
     ///
-    /// \see loadFromFile, loadFromMemory, loadFromSamples
+    /// \see createFromFile, createFromMemory, createFromSamples
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool saveToFile(const std::filesystem::path& filename) const;
@@ -244,12 +321,6 @@ private:
     friend class Sound;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Construct from vector of samples
-    ///
-    ////////////////////////////////////////////////////////////
-    explicit SoundBuffer(std::vector<std::int16_t>&& samples);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Initialize the internal state after loading a new sound
     ///
     /// \param file Sound file providing access to the new loaded sound
@@ -257,7 +328,7 @@ private:
     /// \return True on successful initialization, false on failure
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> initialize(InputSoundFile& file);
+    [[nodiscard]] bool initialize(InputSoundFile& file);
 
     ////////////////////////////////////////////////////////////
     /// \brief Update the internal buffer with the cached audio samples
@@ -318,7 +389,7 @@ private:
 /// are like texture pixels, and a sf::SoundBuffer is similar to
 /// a sf::Texture.
 ///
-/// A sound buffer can be loaded from a file (see loadFromFile()
+/// A sound buffer can be loaded from a file (see createFromFile()
 /// for the complete list of supported formats), from memory, from
 /// a custom stream (see sf::InputStream) or directly from an array
 /// of samples. It can also be saved back to a file.
@@ -344,7 +415,7 @@ private:
 /// Usage example:
 /// \code
 /// // Load a new sound buffer from a file
-/// const auto buffer = sf::SoundBuffer::loadFromFile("sound.wav").value();
+/// const auto buffer = sf::SoundBuffer::createFromFile("sound.wav").value();
 ///
 /// // Create a sound source bound to the buffer
 /// sf::Sound sound1(buffer);

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -34,7 +34,6 @@
 #include <SFML/System/Time.hpp>
 
 #include <filesystem>
-#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -71,6 +70,74 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     SoundBuffer(const SoundBuffer& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from a file
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from a file in memory
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromStream, loadFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from a custom stream
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound buffer from an array of audio samples
+    ///
+    /// The assumed format of the audio samples is 16 bit signed integer.
+    ///
+    /// \param samples      Pointer to the array of samples in memory
+    /// \param sampleCount  Number of samples in the array
+    /// \param channelCount Number of channels (1 = mono, 2 = stereo, ...)
+    /// \param sampleRate   Sample rate (number of samples to play per second)
+    /// \param channelMap   Map of position in sample frame to sound channel
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(const std::int16_t*              samples,
+                std::uint64_t                    sampleCount,
+                unsigned int                     channelCount,
+                unsigned int                     sampleRate,
+                const std::vector<SoundChannel>& channelMap);
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -147,75 +214,6 @@ public:
                                        const std::vector<SoundChannel>& channelMap);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Create the sound buffer from a file
-    ///
-    /// See the documentation of sf::InputSoundFile for the list
-    /// of supported formats.
-    ///
-    /// \param filename Path of the sound file to load
-    ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromMemory, createFromStream, createFromSamples, saveToFile
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> createFromFile(const std::filesystem::path& filename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the sound buffer from a file in memory
-    ///
-    /// See the documentation of sf::InputSoundFile for the list
-    /// of supported formats.
-    ///
-    /// \param data        Pointer to the file data in memory
-    /// \param sizeInBytes Size of the data to load, in bytes
-    ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromStream, createFromSamples
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> createFromMemory(const void* data, std::size_t sizeInBytes);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the sound buffer from a custom stream
-    ///
-    /// See the documentation of sf::InputSoundFile for the list
-    /// of supported formats.
-    ///
-    /// \param stream Source stream to read from
-    ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromMemory, createFromSamples
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> createFromStream(InputStream& stream);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the sound buffer from an array of audio samples
-    ///
-    /// The assumed format of the audio samples is 16 bits signed integer.
-    ///
-    /// \param samples      Pointer to the array of samples in memory
-    /// \param sampleCount  Number of samples in the array
-    /// \param channelCount Number of channels (1 = mono, 2 = stereo, ...)
-    /// \param sampleRate   Sample rate (number of samples to play per second)
-    /// \param channelMap   Map of position in sample frame to sound channel
-    ///
-    /// \return Sound buffer if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromMemory, saveToFile
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<SoundBuffer> createFromSamples(
-        const std::int16_t*              samples,
-        std::uint64_t                    sampleCount,
-        unsigned int                     channelCount,
-        unsigned int                     sampleRate,
-        const std::vector<SoundChannel>& channelMap);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Save the sound buffer to an audio file
     ///
     /// See the documentation of sf::OutputSoundFile for the list
@@ -224,8 +222,6 @@ public:
     /// \param filename Path of the sound file to write
     ///
     /// \return True if saving succeeded, false if it failed
-    ///
-    /// \see createFromFile, createFromMemory, createFromSamples
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool saveToFile(const std::filesystem::path& filename) const;
@@ -389,8 +385,7 @@ private:
 /// are like texture pixels, and a sf::SoundBuffer is similar to
 /// a sf::Texture.
 ///
-/// A sound buffer can be loaded from a file (see createFromFile()
-/// for the complete list of supported formats), from memory, from
+/// A sound buffer can be loaded from a file, from memory, from
 /// a custom stream (see sf::InputStream) or directly from an array
 /// of samples. It can also be saved back to a file.
 ///
@@ -415,7 +410,7 @@ private:
 /// Usage example:
 /// \code
 /// // Load a new sound buffer from a file
-/// const auto buffer = sf::SoundBuffer::createFromFile("sound.wav").value();
+/// const sf::SoundBuffer buffer("sound.wav");
 ///
 /// // Create a sound source bound to the buffer
 /// sf::Sound sound1(buffer);

--- a/include/SFML/Audio/SoundBufferRecorder.hpp
+++ b/include/SFML/Audio/SoundBufferRecorder.hpp
@@ -97,8 +97,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::vector<std::int16_t>  m_samples; //!< Temporary sample buffer to hold the recorded data
-    std::optional<SoundBuffer> m_buffer;  //!< Sound buffer that will contain the recorded data
+    std::vector<std::int16_t> m_samples; //!< Temporary sample buffer to hold the recorded data
+    SoundBuffer               m_buffer;  //!< Sound buffer that will contain the recorded data
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -74,7 +74,80 @@ public:
     };
 
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Construct an empty font that does not contain any glyphs.
+    ///
+    ////////////////////////////////////////////////////////////
+    Font() = default;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the font from a file
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Note that this function knows nothing about the standard
+    /// fonts installed on the user's system, thus you can't
+    /// load them directly.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the file has to remain accessible until
+    /// the sf::Font object loads a new font or is destroyed.
+    ///
+    /// \param filename Path of the font file to load
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see openFromMemory, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool openFromFile(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open the font from a file in memory
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the buffer pointed by \a data has to remain
+    /// valid until the sf::Font object loads a new font or
+    /// is destroyed.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see openFromFile, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool openFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open the font from a custom stream
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Warning: SFML cannot preload all the font data in this
+    /// function, so the contents of \a stream have to remain
+    /// valid as long as the font is used.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the stream has to remain accessible until
+    /// the sf::Font object loads a new font or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see openFromFile, openFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool openFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the font from a file
     ///
     /// The supported font formats are: TrueType, Type 1, CFF,
     /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
@@ -90,13 +163,13 @@ public:
     ///
     /// \return Font if opening succeeded, `std::nullopt` if it failed
     ///
-    /// \see openFromMemory, openFromStream
+    /// \see createFromMemory, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Font> openFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<Font> createFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Open the font from a file in memory
+    /// \brief Create the font from a file in memory
     ///
     /// The supported font formats are: TrueType, Type 1, CFF,
     /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
@@ -110,13 +183,13 @@ public:
     ///
     /// \return Font if opening succeeded, `std::nullopt` if it failed
     ///
-    /// \see openFromFile, openFromStream
+    /// \see createFromFile, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Font> openFromMemory(const void* data, std::size_t sizeInBytes);
+    [[nodiscard]] static std::optional<Font> createFromMemory(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Open the font from a custom stream
+    /// \brief Create the font from a custom stream
     ///
     /// The supported font formats are: TrueType, Type 1, CFF,
     /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
@@ -129,10 +202,10 @@ public:
     ///
     /// \return Font if opening succeeded, `std::nullopt` if it failed
     ///
-    /// \see openFromFile, openFromMemory
+    /// \see createFromFile, createFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Font> openFromStream(InputStream& stream);
+    [[nodiscard]] static std::optional<Font> createFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the font information
@@ -315,14 +388,19 @@ private:
     ////////////////////////////////////////////////////////////
     struct Page
     {
-        [[nodiscard]] static std::optional<Page> create(bool smooth);
-        explicit Page(Texture&& texture);
+        explicit Page(bool smooth);
 
         GlyphTable       glyphs;     //!< Table mapping code points to their corresponding glyph
         Texture          texture;    //!< Texture containing the pixels of the glyphs
         unsigned int     nextRow{3}; //!< Y position of the next new row in the texture
         std::vector<Row> rows;       //!< List containing the position of all the existing rows
     };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Free all the internal resources
+    ///
+    ////////////////////////////////////////////////////////////
+    void cleanup();
 
     ////////////////////////////////////////////////////////////
     /// \brief Find or create the glyphs page corresponding to the given character size
@@ -375,12 +453,6 @@ private:
     using PageTable = std::unordered_map<unsigned int, Page>; //!< Table mapping a character size to its page (texture)
 
     ////////////////////////////////////////////////////////////
-    /// \brief Create a font from font handles and a family name
-    ///
-    ////////////////////////////////////////////////////////////
-    Font(std::shared_ptr<FontHandles>&& fontHandles, std::string&& familyName);
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     std::shared_ptr<FontHandles> m_fontHandles;    //!< Shared information about the internal font instance
@@ -402,7 +474,7 @@ private:
 ///
 /// Fonts can be opened from a file, from memory or from a custom
 /// stream, and supports the most common types of fonts. See
-/// the openFromFile function for the complete list of supported formats.
+/// the createFromFile function for the complete list of supported formats.
 ///
 /// Once it is opened, a sf::Font instance provides three
 /// types of information about the font:
@@ -433,7 +505,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a new font
-/// const auto font = sf::Font::openFromFile("arial.ttf").value();
+/// const auto font = sf::Font::createFromFile("arial.ttf").value();
 ///
 /// // Create a text which uses our font
 /// sf::Text text1(font);

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -37,7 +37,6 @@
 
 #include <filesystem>
 #include <memory>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -82,6 +81,71 @@ public:
     Font() = default;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the font from a file
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Note that this function knows nothing about the standard
+    /// fonts installed on the user's system, thus you can't
+    /// load them directly.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the file has to remain accessible until
+    /// the sf::Font object opens a new font or is destroyed.
+    ///
+    /// \param filename Path of the font file to open
+    ///
+    /// \throws std::runtime_error if opening was unsuccessful
+    ///
+    /// \see openFromFile, openFromMemory, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Font(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the font from a file in memory
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the buffer pointed by \a data has to remain
+    /// valid until the sf::Font object opens a new font or
+    /// is destroyed.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromFile, openFromMemory, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Font(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the font from a custom stream
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Warning: SFML cannot preload all the font data in this
+    /// function, so the contents of \a stream have to remain
+    /// valid as long as the font is used.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the stream has to remain accessible until
+    /// the sf::Font object opens a new font or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see openFromFile, openFromMemory, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Font(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the font from a file
     ///
     /// The supported font formats are: TrueType, Type 1, CFF,
@@ -92,11 +156,11 @@ public:
     ///
     /// \warning SFML cannot preload all the font data in this
     /// function, so the file has to remain accessible until
-    /// the sf::Font object loads a new font or is destroyed.
+    /// the sf::Font object opens a new font or is destroyed.
     ///
     /// \param filename Path of the font file to load
     ///
-    /// \return True if loading succeeded, false if it failed
+    /// \return True if opening succeeded, false if it failed
     ///
     /// \see openFromMemory, openFromStream
     ///
@@ -111,13 +175,13 @@ public:
     ///
     /// \warning SFML cannot preload all the font data in this
     /// function, so the buffer pointed by \a data has to remain
-    /// valid until the sf::Font object loads a new font or
+    /// valid until the sf::Font object opens a new font or
     /// is destroyed.
     ///
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \return True if loading succeeded, false if it failed
+    /// \return True if opening succeeded, false if it failed
     ///
     /// \see openFromFile, openFromStream
     ///
@@ -129,83 +193,19 @@ public:
     ///
     /// The supported font formats are: TrueType, Type 1, CFF,
     /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
-    /// Warning: SFML cannot preload all the font data in this
-    /// function, so the contents of \a stream have to remain
-    /// valid as long as the font is used.
     ///
     /// \warning SFML cannot preload all the font data in this
     /// function, so the stream has to remain accessible until
-    /// the sf::Font object loads a new font or is destroyed.
+    /// the sf::Font object opens a new font or is destroyed.
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return True if loading succeeded, false if it failed
+    /// \return True if opening succeeded, false if it failed
     ///
     /// \see openFromFile, openFromMemory
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool openFromStream(InputStream& stream);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the font from a file
-    ///
-    /// The supported font formats are: TrueType, Type 1, CFF,
-    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
-    /// Note that this function knows nothing about the standard
-    /// fonts installed on the user's system, thus you can't
-    /// load them directly.
-    ///
-    /// \warning SFML cannot preload all the font data in this
-    /// function, so the file has to remain accessible until
-    /// the sf::Font object is destroyed.
-    ///
-    /// \param filename Path of the font file to load
-    ///
-    /// \return Font if opening succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromMemory, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Font> createFromFile(const std::filesystem::path& filename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the font from a file in memory
-    ///
-    /// The supported font formats are: TrueType, Type 1, CFF,
-    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
-    ///
-    /// \warning SFML cannot preload all the font data in this
-    /// function, so the buffer pointed by \a data has to remain
-    /// valid until the sf::Font object is destroyed.
-    ///
-    /// \param data        Pointer to the file data in memory
-    /// \param sizeInBytes Size of the data to load, in bytes
-    ///
-    /// \return Font if opening succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Font> createFromMemory(const void* data, std::size_t sizeInBytes);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the font from a custom stream
-    ///
-    /// The supported font formats are: TrueType, Type 1, CFF,
-    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
-    ///
-    /// \warning SFML cannot preload all the font data in this
-    /// function, so the stream has to remain accessible until
-    /// the sf::Font object is destroyed.
-    ///
-    /// \param stream Source stream to read from
-    ///
-    /// \return Font if opening succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromMemory
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Font> createFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the font information
@@ -474,7 +474,7 @@ private:
 ///
 /// Fonts can be opened from a file, from memory or from a custom
 /// stream, and supports the most common types of fonts. See
-/// the createFromFile function for the complete list of supported formats.
+/// the openFromFile function for the complete list of supported formats.
 ///
 /// Once it is opened, a sf::Font instance provides three
 /// types of information about the font:
@@ -505,7 +505,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a new font
-/// const auto font = sf::Font::createFromFile("arial.ttf").value();
+/// const sf::Font font("arial.ttf");
 ///
 /// // Create a text which uses our font
 /// sf::Text text1(font);

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -55,6 +55,14 @@ class SFML_GRAPHICS_API Image
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Constructs an image with width 0 and height 0.
+    ///
+    ////////////////////////////////////////////////////////////
+    Image() = default;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Construct the image and fill it with a unique color
     ///
     /// \param size  Width and height of the image
@@ -78,6 +86,81 @@ public:
     Image(Vector2u size, const std::uint8_t* pixels);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Resize the image and fill it with a unique color
+    ///
+    /// \param size  Width and height of the image
+    /// \param color Fill color
+    ///
+    ////////////////////////////////////////////////////////////
+    void resize(Vector2u size, Color color = Color::Black);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Resize the image from an array of pixels
+    ///
+    /// The \a pixel array is assumed to contain 32-bits RGBA pixels,
+    /// and have the given \a width and \a height. If not, this is
+    /// an undefined behavior.
+    /// If \a pixels is null, an empty image is created.
+    ///
+    /// \param size   Width and height of the image
+    /// \param pixels Array of pixels to copy to the image
+    ///
+    ////////////////////////////////////////////////////////////
+    void resize(Vector2u size, const std::uint8_t* pixels);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the image from a file on disk
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param filename Path of the image file to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromMemory, loadFromStream, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the image from a file in memory
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the image from a custom stream
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Load the image from a file on disk
     ///
     /// The supported image formats are bmp, png, tga, jpg, gif,
@@ -89,10 +172,10 @@ public:
     ///
     /// \return Image if loading was successful, `std::nullopt` otherwise
     ///
-    /// \see loadFromMemory, loadFromStream, saveToFile
+    /// \see createFromMemory, createFromStream, saveToFile
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Image> loadFromFile(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<Image> createFromFile(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the image from a file in memory
@@ -107,10 +190,10 @@ public:
     ///
     /// \return Image if loading was successful, `std::nullopt` otherwise
     ///
-    /// \see loadFromFile, loadFromStream
+    /// \see createFromFile, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Image> loadFromMemory(const void* data, std::size_t size);
+    [[nodiscard]] static std::optional<Image> createFromMemory(const void* data, std::size_t size);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the image from a custom stream
@@ -124,10 +207,10 @@ public:
     ///
     /// \return Image if loading was successful, `std::nullopt` otherwise
     ///
-    /// \see loadFromFile, loadFromMemory
+    /// \see createFromFile, createFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Image> loadFromStream(InputStream& stream);
+    [[nodiscard]] static std::optional<Image> createFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the image to a file on disk
@@ -141,7 +224,7 @@ public:
     ///
     /// \return True if saving was successful
     ///
-    /// \see create, loadFromFile, loadFromMemory
+    /// \see create, createFromFile, createFromMemory
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool saveToFile(const std::filesystem::path& filename) const;
@@ -159,7 +242,7 @@ public:
     /// \return Buffer with encoded data if saving was successful,
     ///     otherwise std::nullopt
     ///
-    /// \see create, loadFromFile, loadFromMemory, saveToFile
+    /// \see create, createFromFile, createFromMemory, saveToFile
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] std::optional<std::vector<std::uint8_t>> saveToMemory(std::string_view format) const;
@@ -279,12 +362,6 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
-    /// \brief Directly initialize data members
-    ///
-    ////////////////////////////////////////////////////////////
-    Image(Vector2u size, std::vector<std::uint8_t>&& pixels);
-
-    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
     Vector2u                  m_size;   //!< Image size
@@ -309,7 +386,7 @@ private:
 /// channels -- just like a sf::Color.
 /// All the functions that return an array of pixels follow
 /// this rule, and all parameters that you pass to sf::Image
-/// functions (such as loadFromMemory) must use this
+/// functions (such as createFromMemory) must use this
 /// representation as well.
 ///
 /// A sf::Image can be copied, but it is a heavy resource and
@@ -319,7 +396,7 @@ private:
 /// Usage example:
 /// \code
 /// // Load an image file from a file
-/// const auto background = sf::Image::loadFromFile("background.jpg").value();
+/// const auto background = sf::Image::createFromFile("background.jpg").value();
 ///
 /// // Create a 20x20 image filled with black color
 /// sf::Image image({20, 20}, sf::Color::Black);

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -59,6 +59,8 @@ public:
     ///
     /// Constructs an image with width 0 and height 0.
     ///
+    /// \see resize
+    ///
     ////////////////////////////////////////////////////////////
     Image() = default;
 
@@ -84,6 +86,55 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     Image(Vector2u size, const std::uint8_t* pixels);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the image from a file on disk
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    ///
+    /// \param filename Path of the image file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Image(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the image from a file in memory
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Image(const void* data, std::size_t size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the image from a custom stream
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr, pic and pnm. Some format options are not supported,
+    /// like jpeg with arithmetic coding or ASCII pnm.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Image(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Resize the image and fill it with a unique color
@@ -138,7 +189,7 @@ public:
     ///
     /// \return True if loading was successful
     ///
-    /// \see loadFromFile, loadFromStream
+    /// \see loadFromFile, loadFromStream, saveToMemory
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool loadFromMemory(const void* data, std::size_t size);
@@ -161,58 +212,6 @@ public:
     [[nodiscard]] bool loadFromStream(InputStream& stream);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Load the image from a file on disk
-    ///
-    /// The supported image formats are bmp, png, tga, jpg, gif,
-    /// psd, hdr, pic and pnm. Some format options are not supported,
-    /// like jpeg with arithmetic coding or ASCII pnm.
-    /// If this function fails, the image is left unchanged.
-    ///
-    /// \param filename Path of the image file to load
-    ///
-    /// \return Image if loading was successful, `std::nullopt` otherwise
-    ///
-    /// \see createFromMemory, createFromStream, saveToFile
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Image> createFromFile(const std::filesystem::path& filename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the image from a file in memory
-    ///
-    /// The supported image formats are bmp, png, tga, jpg, gif,
-    /// psd, hdr, pic and pnm. Some format options are not supported,
-    /// like jpeg with arithmetic coding or ASCII pnm.
-    /// If this function fails, the image is left unchanged.
-    ///
-    /// \param data Pointer to the file data in memory
-    /// \param size Size of the data to load, in bytes
-    ///
-    /// \return Image if loading was successful, `std::nullopt` otherwise
-    ///
-    /// \see createFromFile, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Image> createFromMemory(const void* data, std::size_t size);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the image from a custom stream
-    ///
-    /// The supported image formats are bmp, png, tga, jpg, gif,
-    /// psd, hdr, pic and pnm. Some format options are not supported,
-    /// like jpeg with arithmetic coding or ASCII pnm.
-    /// If this function fails, the image is left unchanged.
-    ///
-    /// \param stream Source stream to read from
-    ///
-    /// \return Image if loading was successful, `std::nullopt` otherwise
-    ///
-    /// \see createFromFile, createFromMemory
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Image> createFromStream(InputStream& stream);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Save the image to a file on disk
     ///
     /// The format of the image is automatically deduced from
@@ -224,7 +223,7 @@ public:
     ///
     /// \return True if saving was successful
     ///
-    /// \see create, createFromFile, createFromMemory
+    /// \see saveToMemory, loadFromFile
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool saveToFile(const std::filesystem::path& filename) const;
@@ -242,7 +241,7 @@ public:
     /// \return Buffer with encoded data if saving was successful,
     ///     otherwise std::nullopt
     ///
-    /// \see create, createFromFile, createFromMemory, saveToFile
+    /// \see saveToFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] std::optional<std::vector<std::uint8_t>> saveToMemory(std::string_view format) const;
@@ -386,7 +385,7 @@ private:
 /// channels -- just like a sf::Color.
 /// All the functions that return an array of pixels follow
 /// this rule, and all parameters that you pass to sf::Image
-/// functions (such as createFromMemory) must use this
+/// functions (such as loadFromMemory) must use this
 /// representation as well.
 ///
 /// A sf::Image can be copied, but it is a heavy resource and
@@ -396,7 +395,7 @@ private:
 /// Usage example:
 /// \code
 /// // Load an image file from a file
-/// const auto background = sf::Image::createFromFile("background.jpg").value();
+/// const sf::Image background("background.jpg");
 ///
 /// // Create a 20x20 image filled with black color
 /// sf::Image image({20, 20}, sf::Color::Black);

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -55,6 +55,16 @@ class SFML_GRAPHICS_API RenderTexture : public RenderTarget
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Constructs a render-texture with width 0 and height 0.
+    ///
+    /// \see resize
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderTexture();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -83,6 +93,25 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     RenderTexture& operator=(RenderTexture&&) noexcept;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Resize the render-texture
+    ///
+    /// The last parameter, \a settings, is useful if you want to enable
+    /// multi-sampling or use the render-texture for OpenGL rendering that
+    /// requires a depth or stencil buffer. Otherwise it is unnecessary, and
+    /// you should leave this parameter at its default value.
+    ///
+    /// After resizing, the contents of the render-texture are undefined.
+    /// Call `RenderTexture::clear` first to ensure a single color fill.
+    ///
+    /// \param size     Width and height of the render-texture
+    /// \param settings Additional settings for the underlying OpenGL texture and context
+    ///
+    /// \return True if resizing has been successful
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool resize(Vector2u size, const ContextSettings& settings = ContextSettings());
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the render-texture
@@ -240,12 +269,6 @@ public:
     [[nodiscard]] const Texture& getTexture() const;
 
 private:
-    ////////////////////////////////////////////////////////////
-    /// \brief Construct from texture
-    ///
-    ////////////////////////////////////////////////////////////
-    explicit RenderTexture(Texture&& texture);
-
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -37,7 +37,6 @@
 #include <SFML/System/Vector2.hpp>
 
 #include <memory>
-#include <optional>
 
 
 namespace sf
@@ -63,6 +62,25 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     RenderTexture();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a render-texture
+    ///
+    /// The last parameter, \a settings, is useful if you want to enable
+    /// multi-sampling or use the render-texture for OpenGL rendering that
+    /// requires a depth or stencil buffer. Otherwise it is unnecessary, and
+    /// you should leave this parameter at its default value.
+    ///
+    /// After creation, the contents of the render-texture are undefined.
+    /// Call `RenderTexture::clear` first to ensure a single color fill.
+    ///
+    /// \param size     Width and height of the render-texture
+    /// \param settings Additional settings for the underlying OpenGL texture and context
+    ///
+    /// \throws std::runtime_error if creation was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderTexture(Vector2u size, const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor
@@ -108,29 +126,10 @@ public:
     /// \param size     Width and height of the render-texture
     /// \param settings Additional settings for the underlying OpenGL texture and context
     ///
-    /// \return True if resizing has been successful
+    /// \return True if resizing has been successful, false if it failed
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool resize(Vector2u size, const ContextSettings& settings = ContextSettings());
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the render-texture
-    ///
-    /// The last parameter, \a settings, is useful if you want to enable
-    /// multi-sampling or use the render-texture for OpenGL rendering that
-    /// requires a depth or stencil buffer. Otherwise it is unnecessary, and
-    /// you should leave this parameter at its default value.
-    ///
-    /// After creation, the contents of the render-texture are undefined.
-    /// Call `RenderTexture::clear` first to ensure a single color fill.
-    ///
-    /// \param size     Width and height of the render-texture
-    /// \param settings Additional settings for the underlying OpenGL texture and context
-    ///
-    /// \return Render texture if creation has been successful, otherwise `std::nullopt`
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<RenderTexture> create(Vector2u size, const ContextSettings& settings = {});
+    [[nodiscard]] bool resize(Vector2u size, const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the maximum anti-aliasing level supported by the system
@@ -302,7 +301,7 @@ private:
 /// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 /// // Create a new render-texture
-/// auto texture = sf::RenderTexture::create({500, 500}).value();
+/// sf::RenderTexture texture({500, 500});
 ///
 /// // The main loop
 /// while (window.isOpen())

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -87,7 +87,7 @@ public:
                  const String&          title,
                  std::uint32_t          style    = Style::Default,
                  State                  state    = State::Windowed,
-                 const ContextSettings& settings = ContextSettings());
+                 const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct a new window
@@ -106,7 +106,7 @@ public:
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    RenderWindow(VideoMode mode, const String& title, State state, const ContextSettings& settings = ContextSettings());
+    RenderWindow(VideoMode mode, const String& title, State state, const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the window from an existing control
@@ -124,7 +124,7 @@ public:
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    explicit RenderWindow(WindowHandle handle, const ContextSettings& settings = ContextSettings());
+    explicit RenderWindow(WindowHandle handle, const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the size of the rendering region of the window
@@ -266,9 +266,9 @@ private:
 /// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML OpenGL");
 ///
 /// // Create a sprite and a text to display
-/// const auto texture = sf::Texture::createFromFile("circle.png").value();
+/// const sf::Texture texture("circle.png");
 /// sf::Sprite sprite(texture);
-/// const auto font = sf::Font::createFromFile("arial.ttf").value();
+/// const sf::Font font("arial.ttf");
 /// sf::Text text(font);
 /// ...
 ///

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -266,9 +266,9 @@ private:
 /// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML OpenGL");
 ///
 /// // Create a sprite and a text to display
-/// const auto texture = sf::Texture::loadFromFile("circle.png").value();
+/// const auto texture = sf::Texture::createFromFile("circle.png").value();
 /// sf::Sprite sprite(texture);
-/// const auto font = sf::Font::openFromFile("arial.ttf").value();
+/// const auto font = sf::Font::createFromFile("arial.ttf").value();
 /// sf::Text text(font);
 /// ...
 ///

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -86,6 +86,17 @@ public:
     static inline CurrentTextureType CurrentTexture;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor creates an empty shader.
+    ///
+    /// Binding an empty shader has the same effect as not
+    /// binding any shader.
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader() = default;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -115,6 +126,202 @@ public:
     ////////////////////////////////////////////////////////////
     Shader& operator=(Shader&& right) noexcept;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a file
+    ///
+    /// This function loads a single shader, vertex, geometry or
+    /// fragment, identified by the second argument.
+    /// The source must be a text file containing a valid
+    /// shader in GLSL language. GLSL is a C-like language
+    /// dedicated to OpenGL shaders; you'll probably need to
+    /// read a good documentation for it before writing your
+    /// own shaders.
+    ///
+    /// \param filename Path of the vertex, geometry or fragment shader file to load
+    /// \param type     Type of shader (vertex, geometry or fragment)
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from files
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromFile(const std::filesystem::path& vertexShaderFilename,
+                                    const std::filesystem::path& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from files
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param geometryShaderFilename Path of the geometry shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromFile(const std::filesystem::path& vertexShaderFilename,
+                                    const std::filesystem::path& geometryShaderFilename,
+                                    const std::filesystem::path& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a source code in memory
+    ///
+    /// This function loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param shader String containing the source code of the shader
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromMemory(std::string_view shader, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from source codes in memory
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromMemory(std::string_view vertexShader, std::string_view fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from source codes in memory
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param geometryShader String containing the source code of the geometry shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromMemory(std::string_view vertexShader,
+                                      std::string_view geometryShader,
+                                      std::string_view fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a custom stream
+    ///
+    /// This function loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for it
+    /// before writing your own shaders.
+    ///
+    /// \param stream Source stream to read from
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromStream(InputStream& stream, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from custom streams
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from custom streams
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param geometryShaderStream Source stream to read the geometry shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromStream(InputStream& vertexShaderStream,
+                                      InputStream& geometryShaderStream,
+                                      InputStream& fragmentShaderStream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry or fragment shader from a file
@@ -132,10 +339,10 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromMemory, loadFromStream
+    /// \see createFromMemory, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromFile(const std::filesystem::path& filename, Type type);
+    [[nodiscard]] static std::optional<Shader> createFromFile(const std::filesystem::path& filename, Type type);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load both the vertex and fragment shaders from files
@@ -153,11 +360,11 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromMemory, loadFromStream
+    /// \see createFromMemory, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromFile(const std::filesystem::path& vertexShaderFilename,
-                                                            const std::filesystem::path& fragmentShaderFilename);
+    [[nodiscard]] static std::optional<Shader> createFromFile(const std::filesystem::path& vertexShaderFilename,
+                                                              const std::filesystem::path& fragmentShaderFilename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry and fragment shaders from files
@@ -176,12 +383,12 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromMemory, loadFromStream
+    /// \see createFromMemory, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromFile(const std::filesystem::path& vertexShaderFilename,
-                                                            const std::filesystem::path& geometryShaderFilename,
-                                                            const std::filesystem::path& fragmentShaderFilename);
+    [[nodiscard]] static std::optional<Shader> createFromFile(const std::filesystem::path& vertexShaderFilename,
+                                                              const std::filesystem::path& geometryShaderFilename,
+                                                              const std::filesystem::path& fragmentShaderFilename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry or fragment shader from a source code in memory
@@ -198,10 +405,10 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromFile, loadFromStream
+    /// \see createFromFile, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromMemory(std::string_view shader, Type type);
+    [[nodiscard]] static std::optional<Shader> createFromMemory(std::string_view shader, Type type);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load both the vertex and fragment shaders from source codes in memory
@@ -219,10 +426,10 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromFile, loadFromStream
+    /// \see createFromFile, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromMemory(std::string_view vertexShader, std::string_view fragmentShader);
+    [[nodiscard]] static std::optional<Shader> createFromMemory(std::string_view vertexShader, std::string_view fragmentShader);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry and fragment shaders from source codes in memory
@@ -241,12 +448,12 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromFile, loadFromStream
+    /// \see createFromFile, createFromStream
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromMemory(std::string_view vertexShader,
-                                                              std::string_view geometryShader,
-                                                              std::string_view fragmentShader);
+    [[nodiscard]] static std::optional<Shader> createFromMemory(std::string_view vertexShader,
+                                                                std::string_view geometryShader,
+                                                                std::string_view fragmentShader);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry or fragment shader from a custom stream
@@ -263,10 +470,10 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromFile, loadFromMemory
+    /// \see createFromFile, createFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromStream(InputStream& stream, Type type);
+    [[nodiscard]] static std::optional<Shader> createFromStream(InputStream& stream, Type type);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load both the vertex and fragment shaders from custom streams
@@ -284,11 +491,11 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromFile, loadFromMemory
+    /// \see createFromFile, createFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromStream(InputStream& vertexShaderStream,
-                                                              InputStream& fragmentShaderStream);
+    [[nodiscard]] static std::optional<Shader> createFromStream(InputStream& vertexShaderStream,
+                                                                InputStream& fragmentShaderStream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry and fragment shaders from custom streams
@@ -307,12 +514,12 @@ public:
     ///
     /// \return Shader if loading succeeded, `std::nullopt` if it failed
     ///
-    /// \see loadFromFile, loadFromMemory
+    /// \see createFromFile, createFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> loadFromStream(InputStream& vertexShaderStream,
-                                                              InputStream& geometryShaderStream,
-                                                              InputStream& fragmentShaderStream);
+    [[nodiscard]] static std::optional<Shader> createFromStream(InputStream& vertexShaderStream,
+                                                                InputStream& geometryShaderStream,
+                                                                InputStream& fragmentShaderStream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Specify value for \p float uniform
@@ -646,12 +853,6 @@ public:
 
 private:
     ////////////////////////////////////////////////////////////
-    /// \brief Construct from shader program
-    ///
-    ////////////////////////////////////////////////////////////
-    explicit Shader(unsigned int shaderProgram);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Compile the shader(s) and create the program
     ///
     /// If one of the arguments is a null pointer, the corresponding shader
@@ -661,12 +862,12 @@ private:
     /// \param geometryShaderCode Source code of the geometry shader
     /// \param fragmentShaderCode Source code of the fragment shader
     ///
-    /// \return Shader on success, `std::nullopt` if any error happened
+    /// \return True on success, false if any error happened
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> compile(std::string_view vertexShaderCode,
-                                                       std::string_view geometryShaderCode,
-                                                       std::string_view fragmentShaderCode);
+    [[nodiscard]] bool compile(std::string_view vertexShaderCode,
+                               std::string_view geometryShaderCode,
+                               std::string_view fragmentShaderCode);
 
     ////////////////////////////////////////////////////////////
     /// \brief Bind all the textures used by the shader

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -34,7 +34,6 @@
 #include <SFML/Window/GlResource.hpp>
 
 #include <filesystem>
-#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -125,6 +124,198 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     Shader& operator=(Shader&& right) noexcept;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from a shader file
+    ///
+    /// This constructor loads a single shader, vertex, geometry or
+    /// fragment, identified by the second argument.
+    /// The source must be a text file containing a valid
+    /// shader in GLSL language. GLSL is a C-like language
+    /// dedicated to OpenGL shaders; you'll probably need to
+    /// read a good documentation for it before writing your
+    /// own shaders.
+    ///
+    /// \param filename Path of the vertex, geometry or fragment shader file to load
+    /// \param type     Type of shader (vertex, geometry or fragment)
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(const std::filesystem::path& filename, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from vertex and fragment shader files
+    ///
+    /// This constructor loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(const std::filesystem::path& vertexShaderFilename, const std::filesystem::path& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from vertex, geometry and fragment shader files
+    ///
+    /// This constructor loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param geometryShaderFilename Path of the geometry shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(const std::filesystem::path& vertexShaderFilename,
+           const std::filesystem::path& geometryShaderFilename,
+           const std::filesystem::path& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from shader in memory
+    ///
+    /// This constructor loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param shader String containing the source code of the shader
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(std::string_view shader, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from vertex and fragment shaders in memory
+    ///
+    /// This constructor loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(std::string_view vertexShader, std::string_view fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from vertex, geometry and fragment shaders in memory
+    ///
+    /// This constructor loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param geometryShader String containing the source code of the geometry shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(std::string_view vertexShader, std::string_view geometryShader, std::string_view fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from a shader stream
+    ///
+    /// This constructor loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for it
+    /// before writing your own shaders.
+    ///
+    /// \param stream Source stream to read from
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(InputStream& stream, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from vertex and fragment shader streams
+    ///
+    /// This constructor loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(InputStream& vertexShaderStream, InputStream& fragmentShaderStream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from vertex, geometry and fragment shader streams
+    ///
+    /// This constructor loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param geometryShaderStream Source stream to read the geometry shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader(InputStream& vertexShaderStream, InputStream& geometryShaderStream, InputStream& fragmentShaderStream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the vertex, geometry or fragment shader from a file
@@ -322,204 +513,6 @@ public:
     [[nodiscard]] bool loadFromStream(InputStream& vertexShaderStream,
                                       InputStream& geometryShaderStream,
                                       InputStream& fragmentShaderStream);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the vertex, geometry or fragment shader from a file
-    ///
-    /// This function loads a single shader, vertex, geometry or
-    /// fragment, identified by the second argument.
-    /// The source must be a text file containing a valid
-    /// shader in GLSL language. GLSL is a C-like language
-    /// dedicated to OpenGL shaders; you'll probably need to
-    /// read a good documentation for it before writing your
-    /// own shaders.
-    ///
-    /// \param filename Path of the vertex, geometry or fragment shader file to load
-    /// \param type     Type of shader (vertex, geometry or fragment)
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromMemory, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromFile(const std::filesystem::path& filename, Type type);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load both the vertex and fragment shaders from files
-    ///
-    /// This function loads both the vertex and the fragment
-    /// shaders. If one of them fails to load, the shader is left
-    /// empty (the valid shader is unloaded).
-    /// The sources must be text files containing valid shaders
-    /// in GLSL language. GLSL is a C-like language dedicated to
-    /// OpenGL shaders; you'll probably need to read a good documentation
-    /// for it before writing your own shaders.
-    ///
-    /// \param vertexShaderFilename   Path of the vertex shader file to load
-    /// \param fragmentShaderFilename Path of the fragment shader file to load
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromMemory, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromFile(const std::filesystem::path& vertexShaderFilename,
-                                                              const std::filesystem::path& fragmentShaderFilename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the vertex, geometry and fragment shaders from files
-    ///
-    /// This function loads the vertex, geometry and fragment
-    /// shaders. If one of them fails to load, the shader is left
-    /// empty (the valid shader is unloaded).
-    /// The sources must be text files containing valid shaders
-    /// in GLSL language. GLSL is a C-like language dedicated to
-    /// OpenGL shaders; you'll probably need to read a good documentation
-    /// for it before writing your own shaders.
-    ///
-    /// \param vertexShaderFilename   Path of the vertex shader file to load
-    /// \param geometryShaderFilename Path of the geometry shader file to load
-    /// \param fragmentShaderFilename Path of the fragment shader file to load
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromMemory, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromFile(const std::filesystem::path& vertexShaderFilename,
-                                                              const std::filesystem::path& geometryShaderFilename,
-                                                              const std::filesystem::path& fragmentShaderFilename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the vertex, geometry or fragment shader from a source code in memory
-    ///
-    /// This function loads a single shader, vertex, geometry
-    /// or fragment, identified by the second argument.
-    /// The source code must be a valid shader in GLSL language.
-    /// GLSL is a C-like language dedicated to OpenGL shaders;
-    /// you'll probably need to read a good documentation for
-    /// it before writing your own shaders.
-    ///
-    /// \param shader String containing the source code of the shader
-    /// \param type   Type of shader (vertex, geometry or fragment)
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromMemory(std::string_view shader, Type type);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load both the vertex and fragment shaders from source codes in memory
-    ///
-    /// This function loads both the vertex and the fragment
-    /// shaders. If one of them fails to load, the shader is left
-    /// empty (the valid shader is unloaded).
-    /// The sources must be valid shaders in GLSL language. GLSL is
-    /// a C-like language dedicated to OpenGL shaders; you'll
-    /// probably need to read a good documentation for it before
-    /// writing your own shaders.
-    ///
-    /// \param vertexShader   String containing the source code of the vertex shader
-    /// \param fragmentShader String containing the source code of the fragment shader
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromMemory(std::string_view vertexShader, std::string_view fragmentShader);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the vertex, geometry and fragment shaders from source codes in memory
-    ///
-    /// This function loads the vertex, geometry and fragment
-    /// shaders. If one of them fails to load, the shader is left
-    /// empty (the valid shader is unloaded).
-    /// The sources must be valid shaders in GLSL language. GLSL is
-    /// a C-like language dedicated to OpenGL shaders; you'll
-    /// probably need to read a good documentation for it before
-    /// writing your own shaders.
-    ///
-    /// \param vertexShader   String containing the source code of the vertex shader
-    /// \param geometryShader String containing the source code of the geometry shader
-    /// \param fragmentShader String containing the source code of the fragment shader
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromStream
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromMemory(std::string_view vertexShader,
-                                                                std::string_view geometryShader,
-                                                                std::string_view fragmentShader);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the vertex, geometry or fragment shader from a custom stream
-    ///
-    /// This function loads a single shader, vertex, geometry
-    /// or fragment, identified by the second argument.
-    /// The source code must be a valid shader in GLSL language.
-    /// GLSL is a C-like language dedicated to OpenGL shaders;
-    /// you'll probably need to read a good documentation for it
-    /// before writing your own shaders.
-    ///
-    /// \param stream Source stream to read from
-    /// \param type   Type of shader (vertex, geometry or fragment)
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromMemory
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromStream(InputStream& stream, Type type);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load both the vertex and fragment shaders from custom streams
-    ///
-    /// This function loads both the vertex and the fragment
-    /// shaders. If one of them fails to load, the shader is left
-    /// empty (the valid shader is unloaded).
-    /// The source codes must be valid shaders in GLSL language.
-    /// GLSL is a C-like language dedicated to OpenGL shaders;
-    /// you'll probably need to read a good documentation for
-    /// it before writing your own shaders.
-    ///
-    /// \param vertexShaderStream   Source stream to read the vertex shader from
-    /// \param fragmentShaderStream Source stream to read the fragment shader from
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromMemory
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromStream(InputStream& vertexShaderStream,
-                                                                InputStream& fragmentShaderStream);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the vertex, geometry and fragment shaders from custom streams
-    ///
-    /// This function loads the vertex, geometry and fragment
-    /// shaders. If one of them fails to load, the shader is left
-    /// empty (the valid shader is unloaded).
-    /// The source codes must be valid shaders in GLSL language.
-    /// GLSL is a C-like language dedicated to OpenGL shaders;
-    /// you'll probably need to read a good documentation for
-    /// it before writing your own shaders.
-    ///
-    /// \param vertexShaderStream   Source stream to read the vertex shader from
-    /// \param geometryShaderStream Source stream to read the geometry shader from
-    /// \param fragmentShaderStream Source stream to read the fragment shader from
-    ///
-    /// \return Shader if loading succeeded, `std::nullopt` if it failed
-    ///
-    /// \see createFromFile, createFromMemory
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Shader> createFromStream(InputStream& vertexShaderStream,
-                                                                InputStream& geometryShaderStream,
-                                                                InputStream& fragmentShaderStream);
 
     ////////////////////////////////////////////////////////////
     /// \brief Specify value for \p float uniform

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -261,7 +261,7 @@ private:
 /// Usage example:
 /// \code
 /// // Load a texture
-/// const auto texture = sf::Texture::createFromFile("texture.png").value();
+/// const sf::Texture texture("texture.png");
 ///
 /// // Create a sprite
 /// sf::Sprite sprite(texture);

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -261,7 +261,7 @@ private:
 /// Usage example:
 /// \code
 /// // Load a texture
-/// const auto texture = sf::Texture::loadFromFile("texture.png").value();
+/// const auto texture = sf::Texture::createFromFile("texture.png").value();
 ///
 /// // Create a sprite
 /// sf::Sprite sprite(texture);

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -469,7 +469,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a font
-/// const auto font = sf::Font::createFromFile("arial.ttf").value();
+/// const sf::Font font("arial.ttf");
 ///
 /// // Create a text
 /// sf::Text text(font, "hello");

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -469,7 +469,7 @@ private:
 /// Usage example:
 /// \code
 /// // Open a font
-/// const auto font = sf::Font::openFromFile("arial.ttf").value();
+/// const auto font = sf::Font::createFromFile("arial.ttf").value();
 ///
 /// // Create a text
 /// sf::Text text(font, "hello");

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -57,6 +57,14 @@ class SFML_GRAPHICS_API Texture : GlResource
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates a texture with width 0 and height 0.
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -89,9 +97,148 @@ public:
     Texture& operator=(Texture&&) noexcept;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Create the texture
+    /// \brief Resize the texture
     ///
     /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param size Width and height of the texture
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    ///
+    /// \return True if resizing was successful
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool resize(Vector2u size, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from a file on disk
+    ///
+    /// This function is a shortcut for the following code:
+    /// \code
+    /// sf::Image image;
+    /// if (!image.loadFromFile(filename))
+    ///     return false;
+    /// if (!texture.loadFromImage(image, area))
+    ///     return false;
+    /// \endcode
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param filename Path of the image file to load
+    /// \param sRgb     True to enable sRGB conversion, false to disable it
+    /// \param area     Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename, bool sRgb = false, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from a file in memory
+    ///
+    /// This function is a shortcut for the following code:
+    /// \code
+    /// sf::Image image;
+    /// if (!image.loadFromMemory(data, size))
+    ///     return false;
+    /// if (!texture.loadFromImage(image, area))
+    ///     return false;
+    /// \endcode
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    /// \param area Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t size, bool sRgb = false, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from a custom stream
+    ///
+    /// This function is a shortcut for the following code:
+    /// \code
+    /// sf::Image image;
+    /// if (!image.loadFromStream(stream))
+    ///     return false;
+    /// if (!texture.loadFromImage(image, area))
+    ///     return false;
+    /// \endcode
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param stream Source stream to read from
+    /// \param sRgb   True to enable sRGB conversion, false to disable it
+    /// \param area   Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromStream(InputStream& stream, bool sRgb = false, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from an image
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param image Image to load into the texture
+    /// \param sRgb  True to enable sRGB conversion, false to disable it
+    /// \param area  Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool loadFromImage(const Image& image, bool sRgb = false, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a texture
     ///
     /// \param size Width and height of the texture
     /// \param sRgb True to enable sRGB conversion, false to disable it
@@ -121,12 +268,12 @@ public:
     ///
     /// \return Texture if loading was successful, otherwise `std::nullopt`
     ///
-    /// \see loadFromMemory, loadFromStream, loadFromImage
+    /// \see createFromMemory, createFromStream, createFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromFile(const std::filesystem::path& filename,
-                                                             bool                         sRgb = false,
-                                                             const IntRect&               area = {});
+    [[nodiscard]] static std::optional<Texture> createFromFile(const std::filesystem::path& filename,
+                                                               bool                         sRgb = false,
+                                                               const IntRect&               area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a file in memory
@@ -149,10 +296,10 @@ public:
     ///
     /// \return Texture if loading was successful, otherwise `std::nullopt`
     ///
-    /// \see loadFromFile, loadFromStream, loadFromImage
+    /// \see createFromFile, createFromStream, createFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromMemory(
+    [[nodiscard]] static std::optional<Texture> createFromMemory(
         const void*    data,
         std::size_t    size,
         bool           sRgb = false,
@@ -178,10 +325,12 @@ public:
     ///
     /// \return Texture if loading was successful, otherwise `std::nullopt`
     ///
-    /// \see loadFromFile, loadFromMemory, loadFromImage
+    /// \see createFromFile, createFromMemory, createFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromStream(InputStream& stream, bool sRgb = false, const IntRect& area = {});
+    [[nodiscard]] static std::optional<Texture> createFromStream(InputStream&   stream,
+                                                                 bool           sRgb = false,
+                                                                 const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from an image
@@ -203,10 +352,10 @@ public:
     ///
     /// \return Texture if loading was successful, otherwise `std::nullopt`
     ///
-    /// \see loadFromFile, loadFromMemory
+    /// \see createFromFile, createFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromImage(const Image& image, bool sRgb = false, const IntRect& area = {});
+    [[nodiscard]] static std::optional<Texture> createFromImage(const Image& image, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the texture
@@ -226,7 +375,7 @@ public:
     ///
     /// \return Image containing the texture's pixels
     ///
-    /// \see loadFromImage
+    /// \see createFromImage
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] Image copyToImage() const;
@@ -546,14 +695,6 @@ private:
     friend class RenderTarget;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Default constructor
-    ///
-    /// Creates an empty texture.
-    ///
-    ////////////////////////////////////////////////////////////
-    Texture(Vector2u size, Vector2u actualSize, unsigned int texture, bool sRgb);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Get a valid image size according to hardware support
     ///
     /// This function checks whether the graphics driver supports
@@ -630,7 +771,7 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// However, if you want to perform some modifications on the pixels
 /// before creating the final texture, you can load your file to a
 /// sf::Image, do whatever you need with the pixels, and then call
-/// Texture::loadFromImage.
+/// Texture::createFromImage.
 ///
 /// Since they live in the graphics card memory, the pixels of a texture
 /// cannot be accessed without a slow copy first. And they cannot be
@@ -662,7 +803,7 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// // drawing a sprite
 ///
 /// // Load a texture from a file
-/// const auto texture = sf::Texture::loadFromFile("texture.png").value();
+/// const auto texture = sf::Texture::createFromFile("texture.png").value();
 ///
 /// // Assign it to a sprite
 /// sf::Sprite sprite(texture);

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -37,7 +37,6 @@
 #include <SFML/System/Vector2.hpp>
 
 #include <filesystem>
-#include <optional>
 
 #include <cstddef>
 #include <cstdint>
@@ -60,6 +59,8 @@ public:
     /// \brief Default constructor
     ///
     /// Creates a texture with width 0 and height 0.
+    ///
+    /// \see resize
     ///
     ////////////////////////////////////////////////////////////
     Texture();
@@ -97,6 +98,174 @@ public:
     Texture& operator=(Texture&&) noexcept;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a file on disk
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param filename Path of the image file to load
+    /// \param sRgb     True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(const std::filesystem::path& filename, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of a file on disk
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param filename Path of the image file to load
+    /// \param sRgb     True to enable sRGB conversion, false to disable it
+    /// \param area     Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const std::filesystem::path& filename, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a file in memory
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const void* data, std::size_t size, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of a file in memory
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    /// \param area Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const void* data, std::size_t size, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a custom stream
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param stream Source stream to read from
+    /// \param sRgb   True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(InputStream& stream, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of a custom stream
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param stream Source stream to read from
+    /// \param sRgb   True to enable sRGB conversion, false to disable it
+    /// \param area   Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(InputStream& stream, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from an image
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param image Image to load into the texture
+    /// \param sRgb  True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(const Image& image, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture from a sub-rectangle of an image
+    ///
+    /// The \a area argument is used to load only a sub-rectangle
+    /// of the whole image.
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// \param image Image to load into the texture
+    /// \param sRgb  True to enable sRGB conversion, false to disable it
+    /// \param area  Area of the image to load
+    ///
+    /// \throws std::runtime_error if loading was unsuccessful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const Image& image, bool sRgb, const IntRect& area);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the texture with a given size
+    ///
+    /// \param size Width and height of the texture
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    ///
+    /// \throws std::runtime_error if construction was unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Texture(Vector2u size, bool sRgb = false);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Resize the texture
     ///
     /// If this function fails, the texture is left unchanged.
@@ -104,22 +273,13 @@ public:
     /// \param size Width and height of the texture
     /// \param sRgb True to enable sRGB conversion, false to disable it
     ///
-    /// \return True if resizing was successful
+    /// \return True if resizing was successful, false if it failed
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool resize(Vector2u size, bool sRgb = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a file on disk
-    ///
-    /// This function is a shortcut for the following code:
-    /// \code
-    /// sf::Image image;
-    /// if (!image.loadFromFile(filename))
-    ///     return false;
-    /// if (!texture.loadFromImage(image, area))
-    ///     return false;
-    /// \endcode
     ///
     /// The \a area argument can be used to load only a sub-rectangle
     /// of the whole image. If you want the entire image then leave
@@ -136,24 +296,15 @@ public:
     /// \param sRgb     True to enable sRGB conversion, false to disable it
     /// \param area     Area of the image to load
     ///
-    /// \return True if loading was successful
+    /// \return True if loading was successful, false if it failed
     ///
     /// \see loadFromMemory, loadFromStream, loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename, bool sRgb = false, const IntRect& area = IntRect());
+    [[nodiscard]] bool loadFromFile(const std::filesystem::path& filename, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a file in memory
-    ///
-    /// This function is a shortcut for the following code:
-    /// \code
-    /// sf::Image image;
-    /// if (!image.loadFromMemory(data, size))
-    ///     return false;
-    /// if (!texture.loadFromImage(image, area))
-    ///     return false;
-    /// \endcode
     ///
     /// The \a area argument can be used to load only a sub-rectangle
     /// of the whole image. If you want the entire image then leave
@@ -171,24 +322,15 @@ public:
     /// \param sRgb True to enable sRGB conversion, false to disable it
     /// \param area Area of the image to load
     ///
-    /// \return True if loading was successful
+    /// \return True if loading was successful, false if it failed
     ///
     /// \see loadFromFile, loadFromStream, loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t size, bool sRgb = false, const IntRect& area = IntRect());
+    [[nodiscard]] bool loadFromMemory(const void* data, std::size_t size, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a custom stream
-    ///
-    /// This function is a shortcut for the following code:
-    /// \code
-    /// sf::Image image;
-    /// if (!image.loadFromStream(stream))
-    ///     return false;
-    /// if (!texture.loadFromImage(image, area))
-    ///     return false;
-    /// \endcode
     ///
     /// The \a area argument can be used to load only a sub-rectangle
     /// of the whole image. If you want the entire image then leave
@@ -205,12 +347,12 @@ public:
     /// \param sRgb   True to enable sRGB conversion, false to disable it
     /// \param area   Area of the image to load
     ///
-    /// \return True if loading was successful
+    /// \return True if loading was successful, false if it failed
     ///
     /// \see loadFromFile, loadFromMemory, loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromStream(InputStream& stream, bool sRgb = false, const IntRect& area = IntRect());
+    [[nodiscard]] bool loadFromStream(InputStream& stream, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from an image
@@ -230,132 +372,12 @@ public:
     /// \param sRgb  True to enable sRGB conversion, false to disable it
     /// \param area  Area of the image to load
     ///
-    /// \return True if loading was successful
+    /// \return True if loading was successful, false if it failed
     ///
     /// \see loadFromFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool loadFromImage(const Image& image, bool sRgb = false, const IntRect& area = IntRect());
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create a texture
-    ///
-    /// \param size Width and height of the texture
-    /// \param sRgb True to enable sRGB conversion, false to disable it
-    ///
-    /// \return Texture if creation was successful, otherwise `std::nullopt`
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> create(Vector2u size, bool sRgb = false);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the texture from a file on disk
-    ///
-    /// The \a area argument can be used to load only a sub-rectangle
-    /// of the whole image. If you want the entire image then leave
-    /// the default value (which is an empty IntRect).
-    /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size.
-    ///
-    /// The maximum size for a texture depends on the graphics
-    /// driver and can be retrieved with the getMaximumSize function.
-    ///
-    /// If this function fails, the texture is left unchanged.
-    ///
-    /// \param filename Path of the image file to load
-    /// \param sRgb     True to enable sRGB conversion, false to disable it
-    /// \param area     Area of the image to load
-    ///
-    /// \return Texture if loading was successful, otherwise `std::nullopt`
-    ///
-    /// \see createFromMemory, createFromStream, createFromImage
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> createFromFile(const std::filesystem::path& filename,
-                                                               bool                         sRgb = false,
-                                                               const IntRect&               area = {});
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the texture from a file in memory
-    ///
-    /// The \a area argument can be used to load only a sub-rectangle
-    /// of the whole image. If you want the entire image then leave
-    /// the default value (which is an empty IntRect).
-    /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size.
-    ///
-    /// The maximum size for a texture depends on the graphics
-    /// driver and can be retrieved with the getMaximumSize function.
-    ///
-    /// If this function fails, the texture is left unchanged.
-    ///
-    /// \param data Pointer to the file data in memory
-    /// \param size Size of the data to load, in bytes
-    /// \param sRgb True to enable sRGB conversion, false to disable it
-    /// \param area Area of the image to load
-    ///
-    /// \return Texture if loading was successful, otherwise `std::nullopt`
-    ///
-    /// \see createFromFile, createFromStream, createFromImage
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> createFromMemory(
-        const void*    data,
-        std::size_t    size,
-        bool           sRgb = false,
-        const IntRect& area = {});
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the texture from a custom stream
-    ///
-    /// The \a area argument can be used to load only a sub-rectangle
-    /// of the whole image. If you want the entire image then leave
-    /// the default value (which is an empty IntRect).
-    /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size.
-    ///
-    /// The maximum size for a texture depends on the graphics
-    /// driver and can be retrieved with the getMaximumSize function.
-    ///
-    /// If this function fails, the texture is left unchanged.
-    ///
-    /// \param stream Source stream to read from
-    /// \param sRgb   True to enable sRGB conversion, false to disable it
-    /// \param area   Area of the image to load
-    ///
-    /// \return Texture if loading was successful, otherwise `std::nullopt`
-    ///
-    /// \see createFromFile, createFromMemory, createFromImage
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> createFromStream(InputStream&   stream,
-                                                                 bool           sRgb = false,
-                                                                 const IntRect& area = {});
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Load the texture from an image
-    ///
-    /// The \a area argument can be used to load only a sub-rectangle
-    /// of the whole image. If you want the entire image then leave
-    /// the default value (which is an empty IntRect).
-    /// If the \a area rectangle crosses the bounds of the image, it
-    /// is adjusted to fit the image size.
-    ///
-    /// The maximum size for a texture depends on the graphics
-    /// driver and can be retrieved with the getMaximumSize function.
-    ///
-    /// If this function fails, the texture is left unchanged.
-    ///
-    /// \param image Image to load into the texture
-    /// \param sRgb   True to enable sRGB conversion, false to disable it
-    /// \param area  Area of the image to load
-    ///
-    /// \return Texture if loading was successful, otherwise `std::nullopt`
-    ///
-    /// \see createFromFile, createFromMemory
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> createFromImage(const Image& image, bool sRgb = false, const IntRect& area = {});
+    [[nodiscard]] bool loadFromImage(const Image& image, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the texture
@@ -375,7 +397,7 @@ public:
     ///
     /// \return Image containing the texture's pixels
     ///
-    /// \see createFromImage
+    /// \see loadFromImage
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] Image copyToImage() const;
@@ -771,7 +793,7 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// However, if you want to perform some modifications on the pixels
 /// before creating the final texture, you can load your file to a
 /// sf::Image, do whatever you need with the pixels, and then call
-/// Texture::createFromImage.
+/// Texture(const Image&).
 ///
 /// Since they live in the graphics card memory, the pixels of a texture
 /// cannot be accessed without a slow copy first. And they cannot be
@@ -803,7 +825,7 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// // drawing a sprite
 ///
 /// // Load a texture from a file
-/// const auto texture = sf::Texture::createFromFile("texture.png").value();
+/// const sf::Texture texture("texture.png");
 ///
 /// // Assign it to a sprite
 /// sf::Sprite sprite(texture);
@@ -817,7 +839,7 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// // streaming real-time data, like video frames
 ///
 /// // Create an empty texture
-/// auto texture = sf::Texture::create({640, 480}).value();
+/// sf::Texture texture({640, 480});
 ///
 /// // Create a sprite that will display the texture
 /// sf::Sprite sprite(texture);

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -96,6 +96,16 @@ public:
     FileInputStream& operator=(FileInputStream&&) noexcept;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct the stream from a file path
+    ///
+    /// \param filename Name of the file to open
+    ///
+    /// \throws std::runtime_error on error
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit FileInputStream(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Open the stream from a file path
     ///
     /// \param filename Name of the file to open
@@ -104,16 +114,6 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(const std::filesystem::path& filename);
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Create the stream from a file path
-    ///
-    /// \param filename Name of the file to open
-    ///
-    /// \return File input stream on success, `std::nullopt` on error
-    ///
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<FileInputStream> create(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Read data from the stream

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -57,6 +57,15 @@ class SFML_SYSTEM_API FileInputStream : public InputStream
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Construct a file input stream that is not associated
+    /// with a file to read.
+    ///
+    ////////////////////////////////////////////////////////////
+    FileInputStream();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Default destructor
     ///
     ////////////////////////////////////////////////////////////
@@ -91,10 +100,20 @@ public:
     ///
     /// \param filename Name of the file to open
     ///
+    /// \return True on success, false on error
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool open(const std::filesystem::path& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the stream from a file path
+    ///
+    /// \param filename Name of the file to open
+    ///
     /// \return File input stream on success, `std::nullopt` on error
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<FileInputStream> open(const std::filesystem::path& filename);
+    [[nodiscard]] static std::optional<FileInputStream> create(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Read data from the stream
@@ -145,20 +164,6 @@ private:
     {
         void operator()(std::FILE* file);
     };
-
-    ////////////////////////////////////////////////////////////
-    /// \brief Construct from file
-    ///
-    ////////////////////////////////////////////////////////////
-    explicit FileInputStream(std::unique_ptr<std::FILE, FileCloser>&& file);
-
-#ifdef SFML_SYSTEM_ANDROID
-    ////////////////////////////////////////////////////////////
-    /// \brief Construct from resource stream
-    ///
-    ////////////////////////////////////////////////////////////
-    explicit FileInputStream(std::unique_ptr<priv::ResourceStream>&& androidFile);
-#endif
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/System/InputStream.hpp
+++ b/include/SFML/System/InputStream.hpp
@@ -103,12 +103,12 @@ public:
 /// from which SFML can load resources.
 ///
 /// SFML resource classes like sf::Texture and
-/// sf::SoundBuffer provide createFromFile and createFromMemory functions,
+/// sf::SoundBuffer provide loadFromFile and loadFromMemory functions,
 /// which read data from conventional sources. However, if you
 /// have data coming from a different source (over a network,
 /// embedded, encrypted, compressed, etc) you can derive your
 /// own class from sf::InputStream and load SFML resources with
-/// their createFromStream function.
+/// their loadFromStream function.
 ///
 /// Usage example:
 /// \code
@@ -142,7 +142,7 @@ public:
 ///     // Handle error...
 /// }
 ///
-/// const auto texture = sf::Texture::createFromStream(stream).value();
+/// const sf::Texture texture(stream);
 ///
 /// // musics...
 /// sf::Music music;

--- a/include/SFML/System/InputStream.hpp
+++ b/include/SFML/System/InputStream.hpp
@@ -103,12 +103,12 @@ public:
 /// from which SFML can load resources.
 ///
 /// SFML resource classes like sf::Texture and
-/// sf::SoundBuffer provide loadFromFile and loadFromMemory functions,
+/// sf::SoundBuffer provide createFromFile and createFromMemory functions,
 /// which read data from conventional sources. However, if you
 /// have data coming from a different source (over a network,
 /// embedded, encrypted, compressed, etc) you can derive your
 /// own class from sf::InputStream and load SFML resources with
-/// their loadFromStream function.
+/// their createFromStream function.
 ///
 /// Usage example:
 /// \code
@@ -142,7 +142,7 @@ public:
 ///     // Handle error...
 /// }
 ///
-/// const auto texture = sf::Texture::loadFromStream(stream).value();
+/// const auto texture = sf::Texture::createFromStream(stream).value();
 ///
 /// // musics...
 /// sf::Music music;

--- a/include/SFML/System/MemoryInputStream.hpp
+++ b/include/SFML/System/MemoryInputStream.hpp
@@ -56,15 +56,6 @@ public:
     MemoryInputStream(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Open the stream from its data
-    ///
-    /// \param data        Pointer to the data in memory
-    /// \param sizeInBytes Size of the data, in bytes
-    ///
-    ////////////////////////////////////////////////////////////
-    void open(const void* data, std::size_t sizeInBytes);
-
-    ////////////////////////////////////////////////////////////
     /// \brief Read data from the stream
     ///
     /// After reading, the stream's reading position must be

--- a/include/SFML/System/MemoryInputStream.hpp
+++ b/include/SFML/System/MemoryInputStream.hpp
@@ -56,6 +56,15 @@ public:
     MemoryInputStream(const void* data, std::size_t sizeInBytes);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Open the stream from its data
+    ///
+    /// \param data        Pointer to the data in memory
+    /// \param sizeInBytes Size of the data, in bytes
+    ///
+    ////////////////////////////////////////////////////////////
+    void open(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Read data from the stream
     ///
     /// After reading, the stream's reading position must be

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -174,7 +174,7 @@ public:
     ///         `std::nullopt` otherwise
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Cursor> loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
+    [[nodiscard]] static std::optional<Cursor> createFromPixels(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a native system cursor
@@ -190,7 +190,7 @@ public:
     ///         `std::nullopt` otherwise
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Cursor> loadFromSystem(Type type);
+    [[nodiscard]] static std::optional<Cursor> createFromSystem(Type type);
 
 private:
     friend class WindowBase;
@@ -232,8 +232,8 @@ private:
 /// associated with either a native system cursor or a custom
 /// cursor.
 ///
-/// After loading the cursor the graphical appearance
-/// with either loadFromPixels() or loadFromSystem(), the
+/// After loading the cursor graphical appearance
+/// with either createFromPixels() or createFromSystem(), the
 /// cursor can be changed with sf::WindowBase::setMouseCursor().
 ///
 /// The behavior is undefined if the cursor is destroyed while
@@ -245,7 +245,7 @@ private:
 ///
 /// // ... create window as usual ...
 ///
-/// const auto cursor = sf::Cursor::loadFromSystem(sf::Cursor::Type::Hand).value();
+/// const auto cursor = sf::Cursor::createFromSystem(sf::Cursor::Type::Hand).value();
 /// window.setMouseCursor(cursor);
 /// \endcode
 ///

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -145,6 +145,55 @@ public:
     Cursor& operator=(Cursor&&) noexcept;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct a cursor with the provided image
+    ///
+    /// \a pixels must be an array of \a width by \a height pixels
+    /// in 32-bit RGBA format. If not, this will cause undefined behavior.
+    ///
+    /// If \a pixels is null or either \a width or \a height are 0,
+    /// the current cursor is left unchanged and the function will
+    /// return false.
+    ///
+    /// In addition to specifying the pixel data, you can also
+    /// specify the location of the hotspot of the cursor. The
+    /// hotspot is the pixel coordinate within the cursor image
+    /// which will be located exactly where the mouse pointer
+    /// position is. Any mouse actions that are performed will
+    /// return the window/screen location of the hotspot.
+    ///
+    /// \warning On Unix platforms which do not support colored
+    ///          cursors, the pixels are mapped into a monochrome
+    ///          bitmap: pixels with an alpha channel to 0 are
+    ///          transparent, black if the RGB channel are close
+    ///          to zero, and white otherwise.
+    ///
+    /// \param pixels  Array of pixels of the image
+    /// \param size    Width and height of the image
+    /// \param hotspot (x,y) location of the hotspot
+    ///
+    /// \throws std::runtime_error if the cursor could not be constructed
+    ///
+    ////////////////////////////////////////////////////////////
+    Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a native system cursor
+    ///
+    /// Refer to the list of cursor available on each system
+    /// (see sf::Cursor::Type) to know whether a given cursor is
+    /// expected to load successfully or is not supported by
+    /// the operating system.
+    ///
+    /// \param type Native system cursor type
+    ///
+    /// \throws std::runtime_error if the corresponding cursor
+    ///         is not natively supported by the operating
+    ///         system
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Cursor(Type type);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Create a cursor with the provided image
     ///
     /// \a pixels must be an array of \a width by \a height pixels

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -89,7 +89,7 @@ public:
            const String&          title,
            std::uint32_t          style    = Style::Default,
            State                  state    = State::Windowed,
-           const ContextSettings& settings = ContextSettings());
+           const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct a new window
@@ -108,7 +108,7 @@ public:
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    Window(VideoMode mode, const String& title, State state, const ContextSettings& settings = ContextSettings());
+    Window(VideoMode mode, const String& title, State state, const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the window from an existing control
@@ -124,7 +124,7 @@ public:
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////
-    explicit Window(WindowHandle handle, const ContextSettings& settings = ContextSettings());
+    explicit Window(WindowHandle handle, const ContextSettings& settings = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Destructor

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -456,8 +456,8 @@ public:
     ///
     /// \param cursor Native system cursor type to display
     ///
-    /// \see sf::Cursor::loadFromSystem
-    /// \see sf::Cursor::loadFromPixels
+    /// \see sf::Cursor::createFromSystem
+    /// \see sf::Cursor::createFromPixels
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursor(const Cursor& cursor);

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -67,6 +67,30 @@ void InputSoundFile::StreamDeleter::operator()(InputStream* ptr) const
 
 
 ////////////////////////////////////////////////////////////
+InputSoundFile::InputSoundFile(const std::filesystem::path& filename)
+{
+    if (!openFromFile(filename))
+        throw std::runtime_error("Failed to open input sound file");
+}
+
+
+////////////////////////////////////////////////////////////
+InputSoundFile::InputSoundFile(const void* data, std::size_t sizeInBytes)
+{
+    if (!openFromMemory(data, sizeInBytes))
+        throw std::runtime_error("Failed to open input sound file from memory");
+}
+
+
+////////////////////////////////////////////////////////////
+InputSoundFile::InputSoundFile(InputStream& stream)
+{
+    if (!openFromStream(stream))
+        throw std::runtime_error("Failed to open input sound file from stream");
+}
+
+
+////////////////////////////////////////////////////////////
 bool InputSoundFile::openFromFile(const std::filesystem::path& filename)
 {
     // If the file is already open, first close it
@@ -189,42 +213,6 @@ bool InputSoundFile::openFromStream(InputStream& stream)
     m_channelMap  = info->channelMap;
 
     return true;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<InputSoundFile> InputSoundFile::createFromFile(const std::filesystem::path& filename)
-{
-    auto inputSoundFile = std::make_optional<InputSoundFile>();
-
-    if (!inputSoundFile->openFromFile(filename))
-        return std::nullopt;
-
-    return inputSoundFile;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<InputSoundFile> InputSoundFile::createFromMemory(const void* data, std::size_t sizeInBytes)
-{
-    auto inputSoundFile = std::make_optional<InputSoundFile>();
-
-    if (!inputSoundFile->openFromMemory(data, sizeInBytes))
-        return std::nullopt;
-
-    return inputSoundFile;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<InputSoundFile> InputSoundFile::createFromStream(InputStream& stream)
-{
-    auto inputSoundFile = std::make_optional<InputSoundFile>();
-
-    if (!inputSoundFile->openFromStream(stream))
-        return std::nullopt;
-
-    return inputSoundFile;
 }
 
 

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -65,6 +65,30 @@ Music::Music() : m_impl(std::make_unique<Impl>())
 
 
 ////////////////////////////////////////////////////////////
+Music::Music(const std::filesystem::path& filename) : Music()
+{
+    if (!openFromFile(filename))
+        throw std::runtime_error("Failed to open music from file");
+}
+
+
+////////////////////////////////////////////////////////////
+Music::Music(const void* data, std::size_t sizeInBytes) : Music()
+{
+    if (!openFromMemory(data, sizeInBytes))
+        throw std::runtime_error("Failed to open music from memory");
+}
+
+
+////////////////////////////////////////////////////////////
+Music::Music(InputStream& stream) : Music()
+{
+    if (!openFromStream(stream))
+        throw std::runtime_error("Failed to open music from stream");
+}
+
+
+////////////////////////////////////////////////////////////
 Music::~Music()
 {
     // We must stop before destroying the file
@@ -149,42 +173,6 @@ bool Music::openFromStream(InputStream& stream)
     SoundStream::initialize(m_impl->file.getChannelCount(), m_impl->file.getSampleRate(), m_impl->file.getChannelMap());
 
     return true;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Music> Music::createFromFile(const std::filesystem::path& filename)
-{
-    auto music = std::make_optional<Music>();
-
-    if (!music->openFromFile(filename))
-        return std::nullopt;
-
-    return music;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Music> Music::createFromMemory(const void* data, std::size_t sizeInBytes)
-{
-    auto music = std::make_optional<Music>();
-
-    if (!music->openFromMemory(data, sizeInBytes))
-        return std::nullopt;
-
-    return music;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Music> Music::createFromStream(InputStream& stream)
-{
-    auto music = std::make_optional<Music>();
-
-    if (!music->openFromStream(stream))
-        return std::nullopt;
-
-    return music;
 }
 
 

--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -37,6 +37,17 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
+OutputSoundFile::OutputSoundFile(const std::filesystem::path&     filename,
+                                 unsigned int                     sampleRate,
+                                 unsigned int                     channelCount,
+                                 const std::vector<SoundChannel>& channelMap)
+{
+    if (!openFromFile(filename, sampleRate, channelCount, channelMap))
+        throw std::runtime_error("Failed to open output sound file");
+}
+
+
+////////////////////////////////////////////////////////////
 bool OutputSoundFile::openFromFile(const std::filesystem::path&     filename,
                                    unsigned int                     sampleRate,
                                    unsigned int                     channelCount,
@@ -62,22 +73,6 @@ bool OutputSoundFile::openFromFile(const std::filesystem::path&     filename,
     }
 
     return true;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<OutputSoundFile> OutputSoundFile::createFromFile(
-    const std::filesystem::path&     filename,
-    unsigned int                     sampleRate,
-    unsigned int                     channelCount,
-    const std::vector<SoundChannel>& channelMap)
-{
-    auto outputSoundFile = std::make_optional<OutputSoundFile>();
-
-    if (!outputSoundFile->openFromFile(filename, sampleRate, channelCount, channelMap))
-        return std::nullopt;
-
-    return outputSoundFile;
 }
 
 

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -40,6 +40,42 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
+SoundBuffer::SoundBuffer(const std::filesystem::path& filename)
+{
+    if (!loadFromFile(filename))
+        throw std::runtime_error("Failed to open sound buffer from file");
+}
+
+
+////////////////////////////////////////////////////////////
+SoundBuffer::SoundBuffer(const void* data, std::size_t sizeInBytes)
+{
+    if (!loadFromMemory(data, sizeInBytes))
+        throw std::runtime_error("Failed to open sound buffer from memory");
+}
+
+
+////////////////////////////////////////////////////////////
+SoundBuffer::SoundBuffer(InputStream& stream)
+{
+    if (!loadFromStream(stream))
+        throw std::runtime_error("Failed to open sound buffer from stream");
+}
+
+
+////////////////////////////////////////////////////////////
+SoundBuffer::SoundBuffer(const std::int16_t*              samples,
+                         std::uint64_t                    sampleCount,
+                         unsigned int                     channelCount,
+                         unsigned int                     sampleRate,
+                         const std::vector<SoundChannel>& channelMap)
+{
+    if (!loadFromSamples(samples, sampleCount, channelCount, sampleRate, channelMap))
+        throw std::runtime_error("Failed to open sound buffer from samples");
+}
+
+
+////////////////////////////////////////////////////////////
 SoundBuffer::SoundBuffer(const SoundBuffer& copy)
 {
     // don't copy the attached sounds
@@ -127,59 +163,6 @@ bool SoundBuffer::loadFromSamples(const std::int16_t*              samples,
           << "samplerate: " << sampleRate << ")" << std::endl;
 
     return false;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<SoundBuffer> SoundBuffer::createFromFile(const std::filesystem::path& filename)
-{
-    auto soundBuffer = std::make_optional<SoundBuffer>();
-
-    if (!soundBuffer->loadFromFile(filename))
-        return std::nullopt;
-
-    return soundBuffer;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<SoundBuffer> SoundBuffer::createFromMemory(const void* data, std::size_t sizeInBytes)
-{
-    auto soundBuffer = std::make_optional<SoundBuffer>();
-
-    if (!soundBuffer->loadFromMemory(data, sizeInBytes))
-        return std::nullopt;
-
-    return soundBuffer;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<SoundBuffer> SoundBuffer::createFromStream(InputStream& stream)
-{
-    auto soundBuffer = std::make_optional<SoundBuffer>();
-
-    if (!soundBuffer->loadFromStream(stream))
-        return std::nullopt;
-
-    return soundBuffer;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<SoundBuffer> SoundBuffer::createFromSamples(
-    const std::int16_t*              samples,
-    std::uint64_t                    sampleCount,
-    unsigned int                     channelCount,
-    unsigned int                     sampleRate,
-    const std::vector<SoundChannel>& channelMap)
-{
-    auto soundBuffer = std::make_optional<SoundBuffer>();
-
-    if (!soundBuffer->loadFromSamples(samples, sampleCount, channelCount, sampleRate, channelMap))
-        return std::nullopt;
-
-    return soundBuffer;
 }
 
 

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -48,7 +48,7 @@ SoundBufferRecorder::~SoundBufferRecorder()
 bool SoundBufferRecorder::onStart()
 {
     m_samples.clear();
-    m_buffer.reset();
+    m_buffer = SoundBuffer();
 
     return true;
 }
@@ -69,12 +69,7 @@ void SoundBufferRecorder::onStop()
     if (m_samples.empty())
         return;
 
-    m_buffer = sf::SoundBuffer::loadFromSamples(m_samples.data(),
-                                                m_samples.size(),
-                                                getChannelCount(),
-                                                getSampleRate(),
-                                                getChannelMap());
-    if (!m_buffer)
+    if (!m_buffer.loadFromSamples(m_samples.data(), m_samples.size(), getChannelCount(), getSampleRate(), getChannelMap()))
         err() << "Failed to stop capturing audio data" << std::endl;
 }
 
@@ -82,8 +77,7 @@ void SoundBufferRecorder::onStop()
 ////////////////////////////////////////////////////////////
 const SoundBuffer& SoundBufferRecorder::getBuffer() const
 {
-    assert(m_buffer && "SoundBufferRecorder::getBuffer() Cannot return reference to null buffer");
-    return *m_buffer;
+    return m_buffer;
 }
 
 } // namespace sf

--- a/src/SFML/Audio/SoundBufferRecorder.cpp
+++ b/src/SFML/Audio/SoundBufferRecorder.cpp
@@ -48,7 +48,7 @@ SoundBufferRecorder::~SoundBufferRecorder()
 bool SoundBufferRecorder::onStart()
 {
     m_samples.clear();
-    m_buffer = SoundBuffer();
+    m_buffer = {};
 
     return true;
 }

--- a/src/SFML/Audio/SoundFileFactory.cpp
+++ b/src/SFML/Audio/SoundFileFactory.cpp
@@ -48,8 +48,8 @@ namespace sf
 std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromFilename(const std::filesystem::path& filename)
 {
     // Wrap the input file into a file stream
-    auto stream = FileInputStream::open(filename);
-    if (!stream)
+    FileInputStream stream;
+    if (!stream.open(filename))
     {
         err() << "Failed to open sound file (couldn't open stream)\n" << formatDebugPathInfo(filename) << std::endl;
         return nullptr;
@@ -58,13 +58,13 @@ std::unique_ptr<SoundFileReader> SoundFileFactory::createReaderFromFilename(cons
     // Test the filename in all the registered factories
     for (const auto& [fpCreate, fpCheck] : getReaderFactoryMap())
     {
-        if (!stream->seek(0).has_value())
+        if (!stream.seek(0).has_value())
         {
             err() << "Failed to seek sound stream" << std::endl;
             return nullptr;
         }
 
-        if (fpCheck(*stream))
+        if (fpCheck(stream))
             return fpCreate();
     }
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -110,6 +110,30 @@ Image::Image(Vector2u size, const std::uint8_t* pixels)
 
 
 ////////////////////////////////////////////////////////////
+Image::Image(const std::filesystem::path& filename)
+{
+    if (!loadFromFile(filename))
+        throw std::runtime_error("Failed to open image from file");
+}
+
+
+////////////////////////////////////////////////////////////
+Image::Image(const void* data, std::size_t size)
+{
+    if (!loadFromMemory(data, size))
+        throw std::runtime_error("Failed to open image from memory");
+}
+
+
+////////////////////////////////////////////////////////////
+Image::Image(InputStream& stream)
+{
+    if (!loadFromStream(stream))
+        throw std::runtime_error("Failed to open image from stream");
+}
+
+
+////////////////////////////////////////////////////////////
 void Image::resize(Vector2u size, Color color)
 {
     if (size.x && size.y)
@@ -257,7 +281,7 @@ bool Image::loadFromStream(InputStream& stream)
     m_pixels.clear();
 
     // Make sure that the stream's reading position is at the beginning
-    if (!stream.seek(0))
+    if (!stream.seek(0).has_value())
     {
         err() << "Failed to seek image stream" << std::endl;
         return false;
@@ -289,42 +313,6 @@ bool Image::loadFromStream(InputStream& stream)
     // Error, failed to load the image
     err() << "Failed to load image from stream. Reason: " << stbi_failure_reason() << std::endl;
     return false;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Image> Image::createFromFile(const std::filesystem::path& filename)
-{
-    auto image = std::make_optional<Image>();
-
-    if (!image->loadFromFile(filename))
-        return std::nullopt;
-
-    return image;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Image> Image::createFromMemory(const void* data, std::size_t size)
-{
-    auto image = std::make_optional<Image>();
-
-    if (!image->loadFromMemory(data, size))
-        return std::nullopt;
-
-    return image;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Image> Image::createFromStream(InputStream& stream)
-{
-    auto image = std::make_optional<Image>();
-
-    if (!image->loadFromStream(stream))
-        return std::nullopt;
-
-    return image;
 }
 
 

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -34,9 +34,15 @@
 #include <memory>
 #include <ostream>
 
+#include <cassert>
+
 
 namespace sf
 {
+////////////////////////////////////////////////////////////
+RenderTexture::RenderTexture() = default;
+
+
 ////////////////////////////////////////////////////////////
 RenderTexture::~RenderTexture() = default;
 
@@ -50,43 +56,53 @@ RenderTexture& RenderTexture::operator=(RenderTexture&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
-std::optional<RenderTexture> RenderTexture::create(Vector2u size, const ContextSettings& settings)
+bool RenderTexture::resize(Vector2u size, const ContextSettings& settings)
 {
     // Create the texture
-    auto texture = sf::Texture::create(size, settings.sRgbCapable);
-    if (!texture)
+    // Set texture to be in sRGB scale if requested
+    if (!m_texture.resize(size, settings.sRgbCapable))
     {
         err() << "Impossible to create render texture (failed to create the target texture)" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
-    RenderTexture renderTexture(std::move(*texture));
-
     // We disable smoothing by default for render textures
-    renderTexture.setSmooth(false);
+    setSmooth(false);
 
     // Create the implementation
     if (priv::RenderTextureImplFBO::isAvailable())
     {
         // Use frame-buffer object (FBO)
-        renderTexture.m_impl = std::make_unique<priv::RenderTextureImplFBO>();
+        m_impl = std::make_unique<priv::RenderTextureImplFBO>();
 
         // Mark the texture as being a framebuffer object attachment
-        renderTexture.m_texture.m_fboAttachment = true;
+        m_texture.m_fboAttachment = true;
     }
     else
     {
         // Use default implementation
-        renderTexture.m_impl = std::make_unique<priv::RenderTextureImplDefault>();
+        m_impl = std::make_unique<priv::RenderTextureImplDefault>();
     }
 
     // Initialize the render texture
     // We pass the actual size of our texture since OpenGL ES requires that all attachments have identical sizes
-    if (!renderTexture.m_impl->create(renderTexture.m_texture.m_actualSize, renderTexture.m_texture.m_texture, settings))
-        return std::nullopt;
+    if (!m_impl->create(m_texture.m_actualSize, m_texture.m_texture, settings))
+        return false;
 
     // We can now initialize the render target part
-    renderTexture.initialize();
+    RenderTarget::initialize();
+
+    return true;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<RenderTexture> RenderTexture::create(Vector2u size, const ContextSettings& settings)
+{
+    auto renderTexture = std::make_optional<RenderTexture>();
+
+    if (!renderTexture->resize(size, settings))
+        return std::nullopt;
 
     return renderTexture;
 }
@@ -143,7 +159,7 @@ bool RenderTexture::generateMipmap()
 bool RenderTexture::setActive(bool active)
 {
     // Update RenderTarget tracking
-    if (m_impl->activate(active))
+    if (m_impl && m_impl->activate(active))
         return RenderTarget::setActive(active);
 
     return false;
@@ -153,23 +169,26 @@ bool RenderTexture::setActive(bool active)
 ////////////////////////////////////////////////////////////
 void RenderTexture::display()
 {
-    if (priv::RenderTextureImplFBO::isAvailable())
+    if (m_impl)
     {
-        // Perform a RenderTarget-only activation if we are using FBOs
-        if (!RenderTarget::setActive())
-            return;
-    }
-    else
-    {
-        // Perform a full activation if we are not using FBOs
-        if (!setActive())
-            return;
-    }
+        if (priv::RenderTextureImplFBO::isAvailable())
+        {
+            // Perform a RenderTarget-only activation if we are using FBOs
+            if (!RenderTarget::setActive())
+                return;
+        }
+        else
+        {
+            // Perform a full activation if we are not using FBOs
+            if (!setActive())
+                return;
+        }
 
-    // Update the target texture
-    m_impl->updateTexture(m_texture.m_texture);
-    m_texture.m_pixelsFlipped = true;
-    m_texture.invalidateMipmap();
+        // Update the target texture
+        m_impl->updateTexture(m_texture.m_texture);
+        m_texture.m_pixelsFlipped = true;
+        m_texture.invalidateMipmap();
+    }
 }
 
 
@@ -183,6 +202,7 @@ Vector2u RenderTexture::getSize() const
 ////////////////////////////////////////////////////////////
 bool RenderTexture::isSrgb() const
 {
+    assert(m_impl && "Must call RenderTexture::create first");
     return m_impl->isSrgb();
 }
 
@@ -192,12 +212,5 @@ const Texture& RenderTexture::getTexture() const
 {
     return m_texture;
 }
-
-
-////////////////////////////////////////////////////////////
-RenderTexture::RenderTexture(Texture&& texture) : m_texture(std::move(texture))
-{
-}
-
 
 } // namespace sf

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -44,6 +44,14 @@ RenderTexture::RenderTexture() = default;
 
 
 ////////////////////////////////////////////////////////////
+RenderTexture::RenderTexture(Vector2u size, const ContextSettings& settings)
+{
+    if (!resize(size, settings))
+        throw std::runtime_error("Failed to create render texture");
+}
+
+
+////////////////////////////////////////////////////////////
 RenderTexture::~RenderTexture() = default;
 
 
@@ -93,18 +101,6 @@ bool RenderTexture::resize(Vector2u size, const ContextSettings& settings)
     RenderTarget::initialize();
 
     return true;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<RenderTexture> RenderTexture::create(Vector2u size, const ContextSettings& settings)
-{
-    auto renderTexture = std::make_optional<RenderTexture>();
-
-    if (!renderTexture->resize(size, settings))
-        return std::nullopt;
-
-    return renderTexture;
 }
 
 
@@ -169,26 +165,26 @@ bool RenderTexture::setActive(bool active)
 ////////////////////////////////////////////////////////////
 void RenderTexture::display()
 {
-    if (m_impl)
-    {
-        if (priv::RenderTextureImplFBO::isAvailable())
-        {
-            // Perform a RenderTarget-only activation if we are using FBOs
-            if (!RenderTarget::setActive())
-                return;
-        }
-        else
-        {
-            // Perform a full activation if we are not using FBOs
-            if (!setActive())
-                return;
-        }
+    if (!m_impl)
+        return;
 
-        // Update the target texture
-        m_impl->updateTexture(m_texture.m_texture);
-        m_texture.m_pixelsFlipped = true;
-        m_texture.invalidateMipmap();
+    if (priv::RenderTextureImplFBO::isAvailable())
+    {
+        // Perform a RenderTarget-only activation if we are using FBOs
+        if (!RenderTarget::setActive())
+            return;
     }
+    else
+    {
+        // Perform a full activation if we are not using FBOs
+        if (!setActive())
+            return;
+    }
+
+    // Update the target texture
+    m_impl->updateTexture(m_texture.m_texture);
+    m_texture.m_pixelsFlipped = true;
+    m_texture.invalidateMipmap();
 }
 
 
@@ -202,7 +198,7 @@ Vector2u RenderTexture::getSize() const
 ////////////////////////////////////////////////////////////
 bool RenderTexture::isSrgb() const
 {
-    assert(m_impl && "Must call RenderTexture::create first");
+    assert(m_impl && "RenderTexture::isSrgb() Must first initialize render texture");
     return m_impl->isSrgb();
 }
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -45,7 +45,6 @@
 #include <utility>
 #include <vector>
 
-#include <cassert>
 #include <cstdint>
 
 #ifndef SFML_OPENGL_ES
@@ -252,10 +251,10 @@ Shader& Shader::operator=(Shader&& right) noexcept
         return *this;
     }
     // Explicit scope for RAII
+    if (m_shaderProgram)
     {
         // Destroy effect program
         const TransientContextLock lock;
-        assert(m_shaderProgram);
         glCheck(GLEXT_glDeleteObject(castToGlHandle(m_shaderProgram)));
     }
 
@@ -268,14 +267,14 @@ Shader& Shader::operator=(Shader&& right) noexcept
 }
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& filename, Type type)
+bool Shader::loadFromFile(const std::filesystem::path& filename, Type type)
 {
     // Read the file
     std::vector<char> shader;
     if (!getFileContents(filename, shader))
     {
         err() << "Failed to open shader file\n" << formatDebugPathInfo(filename) << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Compile the shader program
@@ -290,15 +289,15 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& filename
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexShaderFilename,
-                                           const std::filesystem::path& fragmentShaderFilename)
+bool Shader::loadFromFile(const std::filesystem::path& vertexShaderFilename,
+                          const std::filesystem::path& fragmentShaderFilename)
 {
     // Read the vertex shader file
     std::vector<char> vertexShader;
     if (!getFileContents(vertexShaderFilename, vertexShader))
     {
         err() << "Failed to open vertex shader file\n" << formatDebugPathInfo(vertexShaderFilename) << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Read the fragment shader file
@@ -306,7 +305,7 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexSh
     if (!getFileContents(fragmentShaderFilename, fragmentShader))
     {
         err() << "Failed to open fragment shader file\n" << formatDebugPathInfo(fragmentShaderFilename) << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Compile the shader program
@@ -315,16 +314,16 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexSh
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexShaderFilename,
-                                           const std::filesystem::path& geometryShaderFilename,
-                                           const std::filesystem::path& fragmentShaderFilename)
+bool Shader::loadFromFile(const std::filesystem::path& vertexShaderFilename,
+                          const std::filesystem::path& geometryShaderFilename,
+                          const std::filesystem::path& fragmentShaderFilename)
 {
     // Read the vertex shader file
     std::vector<char> vertexShader;
     if (!getFileContents(vertexShaderFilename, vertexShader))
     {
         err() << "Failed to open vertex shader file\n" << formatDebugPathInfo(vertexShaderFilename) << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Read the geometry shader file
@@ -332,7 +331,7 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexSh
     if (!getFileContents(geometryShaderFilename, geometryShader))
     {
         err() << "Failed to open geometry shader file\n" << formatDebugPathInfo(geometryShaderFilename) << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Read the fragment shader file
@@ -340,7 +339,7 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexSh
     if (!getFileContents(fragmentShaderFilename, fragmentShader))
     {
         err() << "Failed to open fragment shader file\n" << formatDebugPathInfo(fragmentShaderFilename) << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Compile the shader program
@@ -349,7 +348,7 @@ std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& vertexSh
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromMemory(std::string_view shader, Type type)
+bool Shader::loadFromMemory(std::string_view shader, Type type)
 {
     // Compile the shader program
     if (type == Type::Vertex)
@@ -363,7 +362,7 @@ std::optional<Shader> Shader::loadFromMemory(std::string_view shader, Type type)
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromMemory(std::string_view vertexShader, std::string_view fragmentShader)
+bool Shader::loadFromMemory(std::string_view vertexShader, std::string_view fragmentShader)
 {
     // Compile the shader program
     return compile(vertexShader, {}, fragmentShader);
@@ -371,9 +370,7 @@ std::optional<Shader> Shader::loadFromMemory(std::string_view vertexShader, std:
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromMemory(std::string_view vertexShader,
-                                             std::string_view geometryShader,
-                                             std::string_view fragmentShader)
+bool Shader::loadFromMemory(std::string_view vertexShader, std::string_view geometryShader, std::string_view fragmentShader)
 {
     // Compile the shader program
     return compile(vertexShader, geometryShader, fragmentShader);
@@ -381,14 +378,14 @@ std::optional<Shader> Shader::loadFromMemory(std::string_view vertexShader,
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromStream(InputStream& stream, Type type)
+bool Shader::loadFromStream(InputStream& stream, Type type)
 {
     // Read the shader code from the stream
     std::vector<char> shader;
     if (!getStreamContents(stream, shader))
     {
         err() << "Failed to read shader from stream" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Compile the shader program
@@ -403,14 +400,14 @@ std::optional<Shader> Shader::loadFromStream(InputStream& stream, Type type)
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream)
+bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream)
 {
     // Read the vertex shader code from the stream
     std::vector<char> vertexShader;
     if (!getStreamContents(vertexShaderStream, vertexShader))
     {
         err() << "Failed to read vertex shader from stream" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Read the fragment shader code from the stream
@@ -418,7 +415,7 @@ std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream, In
     if (!getStreamContents(fragmentShaderStream, fragmentShader))
     {
         err() << "Failed to read fragment shader from stream" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Compile the shader program
@@ -427,16 +424,14 @@ std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream, In
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream,
-                                             InputStream& geometryShaderStream,
-                                             InputStream& fragmentShaderStream)
+bool Shader::loadFromStream(InputStream& vertexShaderStream, InputStream& geometryShaderStream, InputStream& fragmentShaderStream)
 {
     // Read the vertex shader code from the stream
     std::vector<char> vertexShader;
     if (!getStreamContents(vertexShaderStream, vertexShader))
     {
         err() << "Failed to read vertex shader from stream" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Read the geometry shader code from the stream
@@ -444,7 +439,7 @@ std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream,
     if (!getStreamContents(geometryShaderStream, geometryShader))
     {
         err() << "Failed to read geometry shader from stream" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Read the fragment shader code from the stream
@@ -452,11 +447,126 @@ std::optional<Shader> Shader::loadFromStream(InputStream& vertexShaderStream,
     if (!getStreamContents(fragmentShaderStream, fragmentShader))
     {
         err() << "Failed to read fragment shader from stream" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Compile the shader program
     return compile(vertexShader.data(), geometryShader.data(), fragmentShader.data());
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromFile(const std::filesystem::path& filename, Type type)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromFile(filename, type))
+        return std::nullopt;
+
+    return shader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromFile(const std::filesystem::path& vertexShaderFilename,
+                                             const std::filesystem::path& fragmentShaderFilename)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromFile(vertexShaderFilename, fragmentShaderFilename))
+        return std::nullopt;
+
+    return shader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromFile(const std::filesystem::path& vertexShaderFilename,
+                                             const std::filesystem::path& geometryShaderFilename,
+                                             const std::filesystem::path& fragmentShaderFilename)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromFile(vertexShaderFilename, geometryShaderFilename, fragmentShaderFilename))
+        return std::nullopt;
+
+    return shader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromMemory(std::string_view shader, Type type)
+{
+    auto newShader = std::make_optional<Shader>();
+
+    if (!newShader->loadFromMemory(shader, type))
+        return std::nullopt;
+
+    return newShader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromMemory(std::string_view vertexShader, std::string_view fragmentShader)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromMemory(vertexShader, fragmentShader))
+        return std::nullopt;
+
+    return shader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromMemory(std::string_view vertexShader,
+                                               std::string_view geometryShader,
+                                               std::string_view fragmentShader)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromMemory(vertexShader, geometryShader, fragmentShader))
+        return std::nullopt;
+
+    return shader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromStream(InputStream& stream, Type type)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromStream(stream, type))
+        return std::nullopt;
+
+    return shader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromStream(vertexShaderStream, fragmentShaderStream))
+        return std::nullopt;
+
+    return shader;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromStream(InputStream& vertexShaderStream,
+                                               InputStream& geometryShaderStream,
+                                               InputStream& fragmentShaderStream)
+{
+    auto shader = std::make_optional<Shader>();
+
+    if (!shader->loadFromStream(vertexShaderStream, geometryShaderStream, fragmentShaderStream))
+        return std::nullopt;
+
+    return shader;
 }
 
 
@@ -581,32 +691,33 @@ void Shader::setUniform(const std::string& name, const Glsl::Mat4& matrix)
 ////////////////////////////////////////////////////////////
 void Shader::setUniform(const std::string& name, const Texture& texture)
 {
-    assert(m_shaderProgram);
-
-    const TransientContextLock lock;
-
-    // Find the location of the variable in the shader
-    const int location = getUniformLocation(name);
-    if (location != -1)
+    if (m_shaderProgram)
     {
-        // Store the location -> texture mapping
-        const auto it = m_textures.find(location);
-        if (it == m_textures.end())
-        {
-            // New entry, make sure there are enough texture units
-            if (m_textures.size() + 1 >= getMaxTextureUnits())
-            {
-                err() << "Impossible to use texture " << std::quoted(name)
-                      << " for shader: all available texture units are used" << std::endl;
-                return;
-            }
+        const TransientContextLock lock;
 
-            m_textures[location] = &texture;
-        }
-        else
+        // Find the location of the variable in the shader
+        const int location = getUniformLocation(name);
+        if (location != -1)
         {
-            // Location already used, just replace the texture
-            it->second = &texture;
+            // Store the location -> texture mapping
+            const auto it = m_textures.find(location);
+            if (it == m_textures.end())
+            {
+                // New entry, make sure there are enough texture units
+                if (m_textures.size() + 1 >= getMaxTextureUnits())
+                {
+                    err() << "Impossible to use texture " << std::quoted(name)
+                          << " for shader: all available texture units are used" << std::endl;
+                    return;
+                }
+
+                m_textures[location] = &texture;
+            }
+            else
+            {
+                // Location already used, just replace the texture
+                it->second = &texture;
+            }
         }
     }
 }
@@ -615,12 +726,13 @@ void Shader::setUniform(const std::string& name, const Texture& texture)
 ////////////////////////////////////////////////////////////
 void Shader::setUniform(const std::string& name, CurrentTextureType)
 {
-    assert(m_shaderProgram);
+    if (m_shaderProgram)
+    {
+        const TransientContextLock lock;
 
-    const TransientContextLock lock;
-
-    // Find the location of the variable in the shader
-    m_currentTexture = getUniformLocation(name);
+        // Find the location of the variable in the shader
+        m_currentTexture = getUniformLocation(name);
+    }
 }
 
 
@@ -772,15 +884,7 @@ bool Shader::isGeometryAvailable()
 
 
 ////////////////////////////////////////////////////////////
-Shader::Shader(unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
-{
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
-                                      std::string_view geometryShaderCode,
-                                      std::string_view fragmentShaderCode)
+bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometryShaderCode, std::string_view fragmentShaderCode)
 {
     const TransientContextLock lock;
 
@@ -789,15 +893,15 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
     {
         err() << "Failed to create a shader: your system doesn't support shaders "
               << "(you should test Shader::isAvailable() before trying to use the Shader class)" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Make sure we can use geometry shaders
-    if (geometryShaderCode.data() && !isGeometryAvailable())
+    if (!geometryShaderCode.empty() && !isGeometryAvailable())
     {
         err() << "Failed to create a shader: your system doesn't support geometry shaders "
               << "(you should test Shader::isGeometryAvailable() before trying to use geometry shaders)" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     // Create the program
@@ -805,7 +909,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
     glCheck(shaderProgram = GLEXT_glCreateProgramObject());
 
     // Create the vertex shader if needed
-    if (vertexShaderCode.data())
+    if (!vertexShaderCode.empty())
     {
         // Create and compile the shader
         GLEXT_GLhandle vertexShader{};
@@ -825,7 +929,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
             err() << "Failed to compile vertex shader:" << '\n' << log << std::endl;
             glCheck(GLEXT_glDeleteObject(vertexShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
-            return std::nullopt;
+            return false;
         }
 
         // Attach the shader to the program, and delete it (not needed anymore)
@@ -834,7 +938,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
     }
 
     // Create the geometry shader if needed
-    if (geometryShaderCode.data())
+    if (!geometryShaderCode.empty())
     {
         // Create and compile the shader
         const GLEXT_GLhandle geometryShader   = GLEXT_glCreateShaderObject(GLEXT_GL_GEOMETRY_SHADER);
@@ -853,7 +957,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
             err() << "Failed to compile geometry shader:" << '\n' << log << std::endl;
             glCheck(GLEXT_glDeleteObject(geometryShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
-            return std::nullopt;
+            return false;
         }
 
         // Attach the shader to the program, and delete it (not needed anymore)
@@ -862,7 +966,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
     }
 
     // Create the fragment shader if needed
-    if (fragmentShaderCode.data())
+    if (!fragmentShaderCode.empty())
     {
         // Create and compile the shader
         GLEXT_GLhandle fragmentShader{};
@@ -882,7 +986,7 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
             err() << "Failed to compile fragment shader:" << '\n' << log << std::endl;
             glCheck(GLEXT_glDeleteObject(fragmentShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
-            return std::nullopt;
+            return false;
         }
 
         // Attach the shader to the program, and delete it (not needed anymore)
@@ -902,14 +1006,28 @@ std::optional<Shader> Shader::compile(std::string_view vertexShaderCode,
         glCheck(GLEXT_glGetInfoLog(shaderProgram, sizeof(log), nullptr, log));
         err() << "Failed to link shader:" << '\n' << log << std::endl;
         glCheck(GLEXT_glDeleteObject(shaderProgram));
-        return std::nullopt;
+        return false;
     }
+
+    // Destroy the shader if it was already created
+    if (m_shaderProgram)
+    {
+        glCheck(GLEXT_glDeleteObject(castToGlHandle(m_shaderProgram)));
+        m_shaderProgram = 0;
+    }
+
+    // Reset the internal state
+    m_currentTexture = -1;
+    m_textures.clear();
+    m_uniforms.clear();
+
+    m_shaderProgram = castFromGlHandle(shaderProgram);
 
     // Force an OpenGL flush, so that the shader will appear updated
     // in all contexts immediately (solves problems in multi-threaded apps)
     glCheck(glFlush());
 
-    return Shader(castFromGlHandle(shaderProgram));
+    return true;
 }
 
 
@@ -972,70 +1090,140 @@ Shader& Shader::operator=(Shader&& right) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& /* filename */, Type /* type */)
+bool Shader::loadFromFile(const std::filesystem::path& /* filename */, Type /* type */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromFile(const std::filesystem::path& /* vertexShaderFilename */,
+                          const std::filesystem::path& /* fragmentShaderFilename */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromFile(const std::filesystem::path& /* vertexShaderFilename */,
+                          const std::filesystem::path& /* geometryShaderFilename */,
+                          const std::filesystem::path& /* fragmentShaderFilename */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromMemory(std::string_view /* shader */, Type /* type */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromMemory(std::string_view /* vertexShader */, std::string_view /* fragmentShader */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromMemory(std::string_view /* vertexShader */,
+                            std::string_view /* geometryShader */,
+                            std::string_view /* fragmentShader */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromStream(InputStream& /* stream */, Type /* type */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromStream(InputStream& /* vertexShaderStream */, InputStream& /* fragmentShaderStream */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Shader::loadFromStream(InputStream& /* vertexShaderStream */,
+                            InputStream& /* geometryShaderStream */,
+                            InputStream& /* fragmentShaderStream */)
+{
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<Shader> Shader::createFromFile(const std::filesystem::path& /* filename */, Type /* type */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& /* vertexShaderFilename */,
-                                           const std::filesystem::path& /* fragmentShaderFilename */)
+std::optional<Shader> Shader::createFromFile(const std::filesystem::path& /* vertexShaderFilename */,
+                                             const std::filesystem::path& /* fragmentShaderFilename */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromFile(const std::filesystem::path& /* vertexShaderFilename */,
-                                           const std::filesystem::path& /* geometryShaderFilename */,
-                                           const std::filesystem::path& /* fragmentShaderFilename */)
+std::optional<Shader> Shader::createFromFile(const std::filesystem::path& /* vertexShaderFilename */,
+                                             const std::filesystem::path& /* geometryShaderFilename */,
+                                             const std::filesystem::path& /* fragmentShaderFilename */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromMemory(std::string_view /* shader */, Type /* type */)
+std::optional<Shader> Shader::createFromMemory(std::string_view /* shader */, Type /* type */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromMemory(std::string_view /* vertexShader */, std::string_view /* fragmentShader */)
+std::optional<Shader> Shader::createFromMemory(std::string_view /* vertexShader */, std::string_view /* fragmentShader */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromMemory(std::string_view /* vertexShader */,
-                                             std::string_view /* geometryShader */,
-                                             std::string_view /* fragmentShader */)
+std::optional<Shader> Shader::createFromMemory(std::string_view /* vertexShader */,
+                                               std::string_view /* geometryShader */,
+                                               std::string_view /* fragmentShader */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromStream(InputStream& /* stream */, Type /* type */)
+std::optional<Shader> Shader::createFromStream(InputStream& /* stream */, Type /* type */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromStream(InputStream& /* vertexShaderStream */, InputStream& /* fragmentShaderStream */)
+std::optional<Shader> Shader::createFromStream(InputStream& /* vertexShaderStream */, InputStream& /* fragmentShaderStream */)
 {
     return std::nullopt;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::loadFromStream(InputStream& /* vertexShaderStream */,
-                                             InputStream& /* geometryShaderStream */,
-                                             InputStream& /* fragmentShaderStream */)
+std::optional<Shader> Shader::createFromStream(InputStream& /* vertexShaderStream */,
+                                               InputStream& /* geometryShaderStream */,
+                                               InputStream& /* fragmentShaderStream */)
 {
     return std::nullopt;
 }
@@ -1201,17 +1389,11 @@ bool Shader::isGeometryAvailable()
 
 
 ////////////////////////////////////////////////////////////
-Shader::Shader(unsigned int shaderProgram) : m_shaderProgram(shaderProgram)
+bool Shader::compile(std::string_view /* vertexShaderCode */,
+                     std::string_view /* geometryShaderCode */,
+                     std::string_view /* fragmentShaderCode */)
 {
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Shader> Shader::compile(std::string_view /* vertexShaderCode */,
-                                      std::string_view /* geometryShaderCode */,
-                                      std::string_view /* fragmentShaderCode */)
-{
-    return std::nullopt;
+    return false;
 }
 
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -72,6 +72,78 @@ Texture::Texture() : m_cacheId(TextureImpl::getUniqueId())
 
 
 ////////////////////////////////////////////////////////////
+Texture::Texture(const std::filesystem::path& filename, bool sRgb) : Texture()
+{
+    if (!loadFromFile(filename, sRgb))
+        throw std::runtime_error("Failed to load texture from file");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(const std::filesystem::path& filename, bool sRgb, const IntRect& area) : Texture()
+{
+    if (!loadFromFile(filename, sRgb, area))
+        throw std::runtime_error("Failed to load texture from file");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(const void* data, std::size_t size, bool sRgb) : Texture()
+{
+    if (!loadFromMemory(data, size, sRgb))
+        throw std::runtime_error("Failed to load texture from memory");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(const void* data, std::size_t size, bool sRgb, const IntRect& area) : Texture()
+{
+    if (!loadFromMemory(data, size, sRgb, area))
+        throw std::runtime_error("Failed to load texture from memory");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(InputStream& stream, bool sRgb) : Texture()
+{
+    if (!loadFromStream(stream, sRgb))
+        throw std::runtime_error("Failed to load texture from stream");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(InputStream& stream, bool sRgb, const IntRect& area) : Texture()
+{
+    if (!loadFromStream(stream, sRgb, area))
+        throw std::runtime_error("Failed to load texture from stream");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(const Image& image, bool sRgb) : Texture()
+{
+    if (!loadFromImage(image, sRgb))
+        throw std::runtime_error("Failed to load texture from image");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(const Image& image, bool sRgb, const IntRect& area) : Texture()
+{
+    if (!loadFromImage(image, sRgb, area))
+        throw std::runtime_error("Failed to load texture from image");
+}
+
+
+////////////////////////////////////////////////////////////
+Texture::Texture(Vector2u size, bool sRgb) : Texture()
+{
+    if (!resize(size, sRgb))
+        throw std::runtime_error("Failed to create texture");
+}
+
+
+////////////////////////////////////////////////////////////
 Texture::Texture(const Texture& copy) :
 GlResource(copy),
 m_isSmooth(copy.m_isSmooth),
@@ -358,66 +430,6 @@ bool Texture::loadFromImage(const Image& image, bool sRgb, const IntRect& area)
 
     // Error message generated in called function.
     return false;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Texture> Texture::create(Vector2u size, bool sRgb)
-{
-    auto texture = std::make_optional<Texture>();
-
-    if (!texture->resize(size, sRgb))
-        return std::nullopt;
-
-    return texture;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Texture> Texture::createFromFile(const std::filesystem::path& filename, bool sRgb, const IntRect& area)
-{
-    auto texture = std::make_optional<Texture>();
-
-    if (!texture->loadFromFile(filename, sRgb, area))
-        return std::nullopt;
-
-    return texture;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Texture> Texture::createFromMemory(const void* data, std::size_t size, bool sRgb, const IntRect& area)
-{
-    auto texture = std::make_optional<Texture>();
-
-    if (!texture->loadFromMemory(data, size, sRgb, area))
-        return std::nullopt;
-
-    return texture;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Texture> Texture::createFromStream(InputStream& stream, bool sRgb, const IntRect& area)
-{
-    auto texture = std::make_optional<Texture>();
-
-    if (!texture->loadFromStream(stream, sRgb, area))
-        return std::nullopt;
-
-    return texture;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<Texture> Texture::createFromImage(const Image& image, bool sRgb, const IntRect& area)
-{
-    auto texture = std::make_optional<Texture>();
-
-    if (!texture->loadFromImage(image, sRgb, area))
-        return std::nullopt;
-
-    return texture;
 }
 
 

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -48,6 +48,14 @@ FileInputStream::FileInputStream() = default;
 
 
 ////////////////////////////////////////////////////////////
+FileInputStream::FileInputStream(const std::filesystem::path& filename)
+{
+    if (!open(filename))
+        throw std::runtime_error("Failed to open file input stream");
+}
+
+
+////////////////////////////////////////////////////////////
 FileInputStream::~FileInputStream() = default;
 
 
@@ -75,18 +83,6 @@ bool FileInputStream::open(const std::filesystem::path& filename)
     m_file.reset(std::fopen(filename.c_str(), "rb"));
 #endif
     return m_file != nullptr;
-}
-
-
-////////////////////////////////////////////////////////////
-std::optional<FileInputStream> FileInputStream::create(const std::filesystem::path& filename)
-{
-    auto fileInputStream = std::make_optional<FileInputStream>();
-
-    if (!fileInputStream->open(filename))
-        return std::nullopt;
-
-    return fileInputStream;
 }
 
 

--- a/src/SFML/System/MemoryInputStream.cpp
+++ b/src/SFML/System/MemoryInputStream.cpp
@@ -35,18 +35,10 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-MemoryInputStream::MemoryInputStream(const void* data, std::size_t sizeInBytes)
+MemoryInputStream::MemoryInputStream(const void* data, std::size_t sizeInBytes) :
+m_data(static_cast<const std::byte*>(data)),
+m_size(sizeInBytes)
 {
-    open(data, sizeInBytes);
-}
-
-
-////////////////////////////////////////////////////////////
-void MemoryInputStream::open(const void* data, std::size_t sizeInBytes)
-{
-    m_data   = static_cast<const std::byte*>(data);
-    m_size   = sizeInBytes;
-    m_offset = 0;
 }
 
 

--- a/src/SFML/System/MemoryInputStream.cpp
+++ b/src/SFML/System/MemoryInputStream.cpp
@@ -29,24 +29,33 @@
 
 #include <algorithm>
 
-#include <cassert>
 #include <cstring>
 
 
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-MemoryInputStream::MemoryInputStream(const void* data, std::size_t sizeInBytes) :
-m_data(static_cast<const std::byte*>(data)),
-m_size(sizeInBytes)
+MemoryInputStream::MemoryInputStream(const void* data, std::size_t sizeInBytes)
 {
-    assert(m_data && "MemoryInputStream must be initialized with non-null data");
+    open(data, sizeInBytes);
+}
+
+
+////////////////////////////////////////////////////////////
+void MemoryInputStream::open(const void* data, std::size_t sizeInBytes)
+{
+    m_data   = static_cast<const std::byte*>(data);
+    m_size   = sizeInBytes;
+    m_offset = 0;
 }
 
 
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> MemoryInputStream::read(void* data, std::size_t size)
 {
+    if (!m_data)
+        return std::nullopt;
+
     const std::size_t count = std::min(size, m_size - m_offset);
     if (count > 0)
     {
@@ -61,6 +70,9 @@ std::optional<std::size_t> MemoryInputStream::read(void* data, std::size_t size)
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> MemoryInputStream::seek(std::size_t position)
 {
+    if (!m_data)
+        return std::nullopt;
+
     m_offset = position < m_size ? position : m_size;
     return m_offset;
 }
@@ -69,6 +81,9 @@ std::optional<std::size_t> MemoryInputStream::seek(std::size_t position)
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> MemoryInputStream::tell()
 {
+    if (!m_data)
+        return std::nullopt;
+
     return m_offset;
 }
 
@@ -76,6 +91,9 @@ std::optional<std::size_t> MemoryInputStream::tell()
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> MemoryInputStream::getSize()
 {
+    if (!m_data)
+        return std::nullopt;
+
     return m_size;
 }
 

--- a/src/SFML/Window/Cursor.cpp
+++ b/src/SFML/Window/Cursor.cpp
@@ -44,6 +44,25 @@ Cursor::Cursor() : m_impl(std::make_unique<priv::CursorImpl>())
 
 
 ////////////////////////////////////////////////////////////
+Cursor::Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot) : Cursor()
+{
+    if ((pixels == nullptr) || (size.x == 0) || (size.y == 0))
+        throw std::runtime_error("Failed to create cursor from pixels (invalid arguments)");
+
+    if (!m_impl->loadFromPixels(pixels, size, hotspot))
+        throw std::runtime_error("Failed to create cursor from pixels");
+}
+
+
+////////////////////////////////////////////////////////////
+Cursor::Cursor(Type type) : Cursor()
+{
+    if (!m_impl->loadFromSystem(type))
+        throw std::runtime_error("Failed to create cursor from type");
+}
+
+
+////////////////////////////////////////////////////////////
 Cursor::~Cursor() = default;
 
 

--- a/src/SFML/Window/Cursor.cpp
+++ b/src/SFML/Window/Cursor.cpp
@@ -56,11 +56,11 @@ Cursor& Cursor::operator=(Cursor&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Cursor> Cursor::loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot)
+std::optional<Cursor> Cursor::createFromPixels(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot)
 {
     if ((pixels == nullptr) || (size.x == 0) || (size.y == 0))
     {
-        err() << "Failed to load cursor from pixels (invalid arguments)" << std::endl;
+        err() << "Failed to create cursor from pixels (invalid arguments)" << std::endl;
         return std::nullopt;
     }
 
@@ -76,7 +76,7 @@ std::optional<Cursor> Cursor::loadFromPixels(const std::uint8_t* pixels, Vector2
 
 
 ////////////////////////////////////////////////////////////
-std::optional<Cursor> Cursor::loadFromSystem(Type type)
+std::optional<Cursor> Cursor::createFromSystem(Type type)
 {
     Cursor cursor;
     if (!cursor.m_impl->loadFromSystem(type))

--- a/src/SFML/Window/Win32/CursorImpl.hpp
+++ b/src/SFML/Window/Win32/CursorImpl.hpp
@@ -74,7 +74,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Create a cursor with the provided image
     ///
-    /// Refer to sf::Cursor::loadFromPixels().
+    /// Refer to sf::Cursor::createFromPixels().
     ///
     ////////////////////////////////////////////////////////////
     bool loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
@@ -82,7 +82,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Create a native system cursor
     ///
-    /// Refer to sf::Cursor::loadFromSystem().
+    /// Refer to sf::Cursor::createFromSystem().
     ///
     ////////////////////////////////////////////////////////////
     bool loadFromSystem(Cursor::Type type);

--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -15,25 +15,37 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(!std::is_default_constructible_v<sf::InputSoundFile>);
         STATIC_CHECK(!std::is_copy_constructible_v<sf::InputSoundFile>);
         STATIC_CHECK(!std::is_copy_assignable_v<sf::InputSoundFile>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::InputSoundFile>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::InputSoundFile>);
     }
 
+    SECTION("Construction")
+    {
+        const sf::InputSoundFile inputSoundFile;
+        CHECK(inputSoundFile.getSampleCount() == 0);
+        CHECK(inputSoundFile.getChannelCount() == 0);
+        CHECK(inputSoundFile.getSampleRate() == 0);
+        CHECK(inputSoundFile.getDuration() == sf::Time::Zero);
+        CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+        CHECK(inputSoundFile.getSampleOffset() == 0);
+    }
+
     SECTION("openFromFile()")
     {
+        sf::InputSoundFile inputSoundFile;
+
         SECTION("Invalid file")
         {
-            CHECK(!sf::InputSoundFile::openFromFile("does/not/exist.wav"));
+            CHECK(!inputSoundFile.openFromFile("does/not/exist.wav"));
         }
 
         SECTION("Valid file")
         {
             SECTION("flac")
             {
-                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
+                REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -44,7 +56,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("mp3")
             {
-                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.mp3").value();
+                REQUIRE(inputSoundFile.openFromFile("Audio/ding.mp3"));
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -55,7 +67,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("ogg")
             {
-                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/doodle_pop.ogg").value();
+                REQUIRE(inputSoundFile.openFromFile("Audio/doodle_pop.ogg"));
                 CHECK(inputSoundFile.getSampleCount() == 2'116'992);
                 CHECK(inputSoundFile.getChannelCount() == 2);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -66,7 +78,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("wav")
             {
-                const auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/killdeer.wav").value();
+                REQUIRE(inputSoundFile.openFromFile("Audio/killdeer.wav"));
                 CHECK(inputSoundFile.getSampleCount() == 112'941);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 22'050);
@@ -79,8 +91,9 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("openFromMemory()")
     {
-        const auto memory         = loadIntoMemory("Audio/killdeer.wav");
-        const auto inputSoundFile = sf::InputSoundFile::openFromMemory(memory.data(), memory.size()).value();
+        const auto         memory = loadIntoMemory("Audio/killdeer.wav");
+        sf::InputSoundFile inputSoundFile;
+        REQUIRE(inputSoundFile.openFromMemory(memory.data(), memory.size()));
         CHECK(inputSoundFile.getSampleCount() == 112'941);
         CHECK(inputSoundFile.getChannelCount() == 1);
         CHECK(inputSoundFile.getSampleRate() == 22'050);
@@ -91,10 +104,139 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("openFromStream()")
     {
+        sf::InputSoundFile  inputSoundFile;
+        sf::FileInputStream stream;
+
+        SECTION("Invalid stream")
+        {
+            CHECK(!inputSoundFile.openFromStream(stream));
+        }
+
+        SECTION("Valid stream")
+        {
+            SECTION("flac")
+            {
+                REQUIRE(stream.open("Audio/ding.flac"));
+                REQUIRE(inputSoundFile.openFromStream(stream));
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("mp3")
+            {
+                REQUIRE(stream.open("Audio/ding.mp3"));
+                REQUIRE(inputSoundFile.openFromStream(stream));
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("ogg")
+            {
+                REQUIRE(stream.open("Audio/doodle_pop.ogg"));
+                REQUIRE(inputSoundFile.openFromStream(stream));
+                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
+                CHECK(inputSoundFile.getChannelCount() == 2);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("wav")
+            {
+                REQUIRE(stream.open("Audio/killdeer.wav"));
+                REQUIRE(inputSoundFile.openFromStream(stream));
+                CHECK(inputSoundFile.getSampleCount() == 112'941);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 22'050);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+        }
+    }
+
+    SECTION("createFromFile()")
+    {
+        SECTION("Invalid file")
+        {
+            CHECK(!sf::InputSoundFile::createFromFile("does/not/exist.wav"));
+        }
+
+        SECTION("Valid file")
+        {
+            SECTION("flac")
+            {
+                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("mp3")
+            {
+                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.mp3").value();
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("ogg")
+            {
+                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/doodle_pop.ogg").value();
+                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
+                CHECK(inputSoundFile.getChannelCount() == 2);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("wav")
+            {
+                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/killdeer.wav").value();
+                CHECK(inputSoundFile.getSampleCount() == 112'941);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 22'050);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+        }
+    }
+
+    SECTION("createFromMemory()")
+    {
+        const auto memory         = loadIntoMemory("Audio/killdeer.wav");
+        const auto inputSoundFile = sf::InputSoundFile::createFromMemory(memory.data(), memory.size()).value();
+        CHECK(inputSoundFile.getSampleCount() == 112'941);
+        CHECK(inputSoundFile.getChannelCount() == 1);
+        CHECK(inputSoundFile.getSampleRate() == 22'050);
+        CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+        CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+        CHECK(inputSoundFile.getSampleOffset() == 0);
+    }
+
+    SECTION("createFromStream()")
+    {
         SECTION("flac")
         {
-            auto       stream         = sf::FileInputStream::open("Audio/ding.flac").value();
-            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            auto       stream         = sf::FileInputStream::create("Audio/ding.flac").value();
+            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
             CHECK(inputSoundFile.getSampleCount() == 87'798);
             CHECK(inputSoundFile.getChannelCount() == 1);
             CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -105,8 +247,8 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("mp3")
         {
-            auto       stream         = sf::FileInputStream::open("Audio/ding.mp3").value();
-            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            auto       stream         = sf::FileInputStream::create("Audio/ding.mp3").value();
+            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
             CHECK(inputSoundFile.getSampleCount() == 87'798);
             CHECK(inputSoundFile.getChannelCount() == 1);
             CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -117,8 +259,8 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("ogg")
         {
-            auto       stream         = sf::FileInputStream::open("Audio/doodle_pop.ogg").value();
-            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            auto       stream         = sf::FileInputStream::create("Audio/doodle_pop.ogg").value();
+            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
             CHECK(inputSoundFile.getSampleCount() == 2'116'992);
             CHECK(inputSoundFile.getChannelCount() == 2);
             CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -129,8 +271,8 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("wav")
         {
-            auto       stream         = sf::FileInputStream::open("Audio/killdeer.wav").value();
-            const auto inputSoundFile = sf::InputSoundFile::openFromStream(stream).value();
+            auto       stream         = sf::FileInputStream::create("Audio/killdeer.wav").value();
+            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
             CHECK(inputSoundFile.getSampleCount() == 112'941);
             CHECK(inputSoundFile.getChannelCount() == 1);
             CHECK(inputSoundFile.getSampleRate() == 22'050);
@@ -144,7 +286,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
     {
         SECTION("flac")
         {
-            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
+            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(22'675));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -152,7 +294,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("mp3")
         {
-            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.mp3").value();
+            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.mp3").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(22'675));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -160,7 +302,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("ogg")
         {
-            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/doodle_pop.ogg").value();
+            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/doodle_pop.ogg").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(11'337));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -168,7 +310,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("wav")
         {
-            auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/killdeer.wav").value();
+            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/killdeer.wav").value();
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(45'351));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -177,7 +319,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("seek(Time)")
     {
-        auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
+        auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
         inputSoundFile.seek(sf::milliseconds(100));
         CHECK(inputSoundFile.getSampleCount() == 87'798);
         CHECK(inputSoundFile.getChannelCount() == 1);
@@ -189,7 +331,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("read()")
     {
-        auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
+        auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
 
         SECTION("Null address")
         {
@@ -207,7 +349,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
         {
             SECTION("flac")
             {
-                inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
+                inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{0, 1, -1, 4});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -216,7 +358,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("mp3")
             {
-                inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.mp3").value();
+                inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.mp3").value();
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{0, -2, 0, 2});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -225,7 +367,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("ogg")
             {
-                inputSoundFile = sf::InputSoundFile::openFromFile("Audio/doodle_pop.ogg").value();
+                inputSoundFile = sf::InputSoundFile::createFromFile("Audio/doodle_pop.ogg").value();
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{-827, -985, -1168, -1319});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -241,7 +383,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("close()")
     {
-        auto inputSoundFile = sf::InputSoundFile::openFromFile("Audio/ding.flac").value();
+        auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
         inputSoundFile.close();
         CHECK(inputSoundFile.getSampleCount() == 0);
         CHECK(inputSoundFile.getChannelCount() == 0);

--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -23,13 +23,131 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("Construction")
     {
-        const sf::InputSoundFile inputSoundFile;
-        CHECK(inputSoundFile.getSampleCount() == 0);
-        CHECK(inputSoundFile.getChannelCount() == 0);
-        CHECK(inputSoundFile.getSampleRate() == 0);
-        CHECK(inputSoundFile.getDuration() == sf::Time::Zero);
-        CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-        CHECK(inputSoundFile.getSampleOffset() == 0);
+        SECTION("Default constructor")
+        {
+            const sf::InputSoundFile inputSoundFile;
+            CHECK(inputSoundFile.getSampleCount() == 0);
+            CHECK(inputSoundFile.getChannelCount() == 0);
+            CHECK(inputSoundFile.getSampleRate() == 0);
+            CHECK(inputSoundFile.getDuration() == sf::Time::Zero);
+            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+            CHECK(inputSoundFile.getSampleOffset() == 0);
+        }
+
+        SECTION("Invalid file")
+        {
+            CHECK_THROWS_AS(sf::InputSoundFile("does/not/exist.wav"), std::runtime_error);
+        }
+
+        SECTION("Valid file")
+        {
+            SECTION("flac")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/ding.flac");
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("mp3")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/ding.mp3");
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("ogg")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/doodle_pop.ogg");
+                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
+                CHECK(inputSoundFile.getChannelCount() == 2);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("wav")
+            {
+                const sf::InputSoundFile inputSoundFile("Audio/killdeer.wav");
+                CHECK(inputSoundFile.getSampleCount() == 112'941);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 22'050);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+        }
+
+        SECTION("Memory")
+        {
+            const auto               memory = loadIntoMemory("Audio/killdeer.wav");
+            const sf::InputSoundFile inputSoundFile(memory.data(), memory.size());
+            CHECK(inputSoundFile.getSampleCount() == 112'941);
+            CHECK(inputSoundFile.getChannelCount() == 1);
+            CHECK(inputSoundFile.getSampleRate() == 22'050);
+            CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+            CHECK(inputSoundFile.getSampleOffset() == 0);
+        }
+
+        SECTION("Stream")
+        {
+            SECTION("flac")
+            {
+                sf::FileInputStream      stream("Audio/ding.flac");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("mp3")
+            {
+                sf::FileInputStream      stream("Audio/ding.mp3");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 87'798);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("ogg")
+            {
+                sf::FileInputStream      stream("Audio/doodle_pop.ogg");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
+                CHECK(inputSoundFile.getChannelCount() == 2);
+                CHECK(inputSoundFile.getSampleRate() == 44'100);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+
+            SECTION("wav")
+            {
+                sf::FileInputStream      stream("Audio/killdeer.wav");
+                const sf::InputSoundFile inputSoundFile(stream);
+                CHECK(inputSoundFile.getSampleCount() == 112'941);
+                CHECK(inputSoundFile.getChannelCount() == 1);
+                CHECK(inputSoundFile.getSampleRate() == 22'050);
+                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
+                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
+                CHECK(inputSoundFile.getSampleOffset() == 0);
+            }
+        }
     }
 
     SECTION("openFromFile()")
@@ -164,129 +282,11 @@ TEST_CASE("[Audio] sf::InputSoundFile")
         }
     }
 
-    SECTION("createFromFile()")
-    {
-        SECTION("Invalid file")
-        {
-            CHECK(!sf::InputSoundFile::createFromFile("does/not/exist.wav"));
-        }
-
-        SECTION("Valid file")
-        {
-            SECTION("flac")
-            {
-                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
-                CHECK(inputSoundFile.getSampleCount() == 87'798);
-                CHECK(inputSoundFile.getChannelCount() == 1);
-                CHECK(inputSoundFile.getSampleRate() == 44'100);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
-
-            SECTION("mp3")
-            {
-                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.mp3").value();
-                CHECK(inputSoundFile.getSampleCount() == 87'798);
-                CHECK(inputSoundFile.getChannelCount() == 1);
-                CHECK(inputSoundFile.getSampleRate() == 44'100);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
-
-            SECTION("ogg")
-            {
-                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/doodle_pop.ogg").value();
-                CHECK(inputSoundFile.getSampleCount() == 2'116'992);
-                CHECK(inputSoundFile.getChannelCount() == 2);
-                CHECK(inputSoundFile.getSampleRate() == 44'100);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
-
-            SECTION("wav")
-            {
-                const auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/killdeer.wav").value();
-                CHECK(inputSoundFile.getSampleCount() == 112'941);
-                CHECK(inputSoundFile.getChannelCount() == 1);
-                CHECK(inputSoundFile.getSampleRate() == 22'050);
-                CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
-                CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-                CHECK(inputSoundFile.getSampleOffset() == 0);
-            }
-        }
-    }
-
-    SECTION("createFromMemory()")
-    {
-        const auto memory         = loadIntoMemory("Audio/killdeer.wav");
-        const auto inputSoundFile = sf::InputSoundFile::createFromMemory(memory.data(), memory.size()).value();
-        CHECK(inputSoundFile.getSampleCount() == 112'941);
-        CHECK(inputSoundFile.getChannelCount() == 1);
-        CHECK(inputSoundFile.getSampleRate() == 22'050);
-        CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
-        CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-        CHECK(inputSoundFile.getSampleOffset() == 0);
-    }
-
-    SECTION("createFromStream()")
-    {
-        SECTION("flac")
-        {
-            auto       stream         = sf::FileInputStream::create("Audio/ding.flac").value();
-            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
-            CHECK(inputSoundFile.getSampleCount() == 87'798);
-            CHECK(inputSoundFile.getChannelCount() == 1);
-            CHECK(inputSoundFile.getSampleRate() == 44'100);
-            CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
-            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-            CHECK(inputSoundFile.getSampleOffset() == 0);
-        }
-
-        SECTION("mp3")
-        {
-            auto       stream         = sf::FileInputStream::create("Audio/ding.mp3").value();
-            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
-            CHECK(inputSoundFile.getSampleCount() == 87'798);
-            CHECK(inputSoundFile.getChannelCount() == 1);
-            CHECK(inputSoundFile.getSampleRate() == 44'100);
-            CHECK(inputSoundFile.getDuration() == sf::microseconds(1'990'884));
-            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-            CHECK(inputSoundFile.getSampleOffset() == 0);
-        }
-
-        SECTION("ogg")
-        {
-            auto       stream         = sf::FileInputStream::create("Audio/doodle_pop.ogg").value();
-            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
-            CHECK(inputSoundFile.getSampleCount() == 2'116'992);
-            CHECK(inputSoundFile.getChannelCount() == 2);
-            CHECK(inputSoundFile.getSampleRate() == 44'100);
-            CHECK(inputSoundFile.getDuration() == sf::microseconds(24'002'176));
-            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-            CHECK(inputSoundFile.getSampleOffset() == 0);
-        }
-
-        SECTION("wav")
-        {
-            auto       stream         = sf::FileInputStream::create("Audio/killdeer.wav").value();
-            const auto inputSoundFile = sf::InputSoundFile::createFromStream(stream).value();
-            CHECK(inputSoundFile.getSampleCount() == 112'941);
-            CHECK(inputSoundFile.getChannelCount() == 1);
-            CHECK(inputSoundFile.getSampleRate() == 22'050);
-            CHECK(inputSoundFile.getDuration() == sf::microseconds(5'122'040));
-            CHECK(inputSoundFile.getTimeOffset() == sf::Time::Zero);
-            CHECK(inputSoundFile.getSampleOffset() == 0);
-        }
-    }
-
     SECTION("seek(std::uint64_t)")
     {
         SECTION("flac")
         {
-            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
+            sf::InputSoundFile inputSoundFile("Audio/ding.flac");
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(22'675));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -294,7 +294,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("mp3")
         {
-            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.mp3").value();
+            sf::InputSoundFile inputSoundFile("Audio/ding.mp3");
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(22'675));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -302,7 +302,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("ogg")
         {
-            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/doodle_pop.ogg").value();
+            sf::InputSoundFile inputSoundFile("Audio/doodle_pop.ogg");
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(11'337));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -310,7 +310,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("wav")
         {
-            auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/killdeer.wav").value();
+            sf::InputSoundFile inputSoundFile("Audio/killdeer.wav");
             inputSoundFile.seek(1'000);
             CHECK(inputSoundFile.getTimeOffset() == sf::microseconds(45'351));
             CHECK(inputSoundFile.getSampleOffset() == 1'000);
@@ -319,7 +319,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("seek(Time)")
     {
-        auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
+        sf::InputSoundFile inputSoundFile("Audio/ding.flac");
         inputSoundFile.seek(sf::milliseconds(100));
         CHECK(inputSoundFile.getSampleCount() == 87'798);
         CHECK(inputSoundFile.getChannelCount() == 1);
@@ -331,7 +331,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("read()")
     {
-        auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
+        sf::InputSoundFile inputSoundFile("Audio/ding.flac");
 
         SECTION("Null address")
         {
@@ -349,7 +349,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
         {
             SECTION("flac")
             {
-                inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
+                inputSoundFile = sf::InputSoundFile("Audio/ding.flac");
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{0, 1, -1, 4});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -358,7 +358,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("mp3")
             {
-                inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.mp3").value();
+                inputSoundFile = sf::InputSoundFile("Audio/ding.mp3");
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{0, -2, 0, 2});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -367,7 +367,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("ogg")
             {
-                inputSoundFile = sf::InputSoundFile::createFromFile("Audio/doodle_pop.ogg").value();
+                inputSoundFile = sf::InputSoundFile("Audio/doodle_pop.ogg");
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
                 CHECK(samples == std::array<std::int16_t, 4>{-827, -985, -1168, -1319});
                 CHECK(inputSoundFile.read(samples.data(), samples.size()) == 4);
@@ -383,7 +383,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
     SECTION("close()")
     {
-        auto inputSoundFile = sf::InputSoundFile::createFromFile("Audio/ding.flac").value();
+        sf::InputSoundFile inputSoundFile("Audio/ding.flac");
         inputSoundFile.close();
         CHECK(inputSoundFile.getSampleCount() == 0);
         CHECK(inputSoundFile.getChannelCount() == 0);

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -32,18 +32,84 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         CHECK(timeSpan.length == sf::Time::Zero);
     }
 
-    SECTION("Construction")
+    SECTION("Constructor")
     {
-        const sf::Music music;
-        CHECK(music.getDuration() == sf::Time::Zero);
-        const auto [offset, length] = music.getLoopPoints();
-        CHECK(offset == sf::Time::Zero);
-        CHECK(length == sf::Time::Zero);
-        CHECK(music.getChannelCount() == 0);
-        CHECK(music.getSampleRate() == 0);
-        CHECK(music.getStatus() == sf::Music::Status::Stopped);
-        CHECK(music.getPlayingOffset() == sf::Time::Zero);
-        CHECK(!music.getLoop());
+        SECTION("Default constructor")
+        {
+            const sf::Music music;
+            CHECK(music.getDuration() == sf::Time::Zero);
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::Time::Zero);
+            CHECK(music.getChannelCount() == 0);
+            CHECK(music.getSampleRate() == 0);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
+        }
+
+        SECTION("File")
+        {
+            SECTION("Invalid file")
+            {
+                CHECK_THROWS_AS(sf::Music("does/not/exist.wav"), std::runtime_error);
+            }
+
+            SECTION("Valid file")
+            {
+                const sf::Music music("Audio/ding.mp3");
+                CHECK(music.getDuration() == sf::microseconds(1990884));
+                const auto [offset, length] = music.getLoopPoints();
+                CHECK(offset == sf::Time::Zero);
+                CHECK(length == sf::microseconds(1990884));
+                CHECK(music.getChannelCount() == 1);
+                CHECK(music.getSampleRate() == 44100);
+                CHECK(music.getStatus() == sf::Music::Status::Stopped);
+                CHECK(music.getPlayingOffset() == sf::Time::Zero);
+                CHECK(!music.getLoop());
+            }
+        }
+
+        SECTION("Memory")
+        {
+            std::vector<std::byte> memory(10, std::byte{0xCA});
+
+            SECTION("Invalid buffer")
+            {
+                CHECK_THROWS_AS(sf::Music(memory.data(), memory.size()), std::runtime_error);
+            }
+
+            SECTION("Valid buffer")
+            {
+                memory = loadIntoMemory("Audio/ding.flac");
+
+                const sf::Music music(memory.data(), memory.size());
+                CHECK(music.getDuration() == sf::microseconds(1990884));
+                const auto [offset, length] = music.getLoopPoints();
+                CHECK(offset == sf::Time::Zero);
+                CHECK(length == sf::microseconds(1990884));
+                CHECK(music.getChannelCount() == 1);
+                CHECK(music.getSampleRate() == 44100);
+                CHECK(music.getStatus() == sf::Music::Status::Stopped);
+                CHECK(music.getPlayingOffset() == sf::Time::Zero);
+                CHECK(!music.getLoop());
+            }
+        }
+
+        SECTION("Stream")
+        {
+            sf::FileInputStream stream("Audio/doodle_pop.ogg");
+            const sf::Music     music(stream);
+            CHECK(music.getDuration() == sf::microseconds(24002176));
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::microseconds(24002176));
+            CHECK(music.getChannelCount() == 2);
+            CHECK(music.getSampleRate() == 44100);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
+        }
     }
 
     SECTION("openFromFile()")
@@ -149,72 +215,9 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         }
     }
 
-    SECTION("createFromFile()")
-    {
-        SECTION("Invalid file")
-        {
-            CHECK(!sf::Music::createFromFile("does/not/exist.wav"));
-        }
-
-        SECTION("Valid file")
-        {
-            const auto music = sf::Music::createFromFile("Audio/ding.mp3").value();
-            CHECK(music.getDuration() == sf::microseconds(1990884));
-            const auto [offset, length] = music.getLoopPoints();
-            CHECK(offset == sf::Time::Zero);
-            CHECK(length == sf::microseconds(1990884));
-            CHECK(music.getChannelCount() == 1);
-            CHECK(music.getSampleRate() == 44100);
-            CHECK(music.getStatus() == sf::Music::Status::Stopped);
-            CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
-        }
-    }
-
-    SECTION("createFromMemory()")
-    {
-        std::vector<std::byte> memory(10, std::byte{0xCA});
-
-        SECTION("Invalid buffer")
-        {
-            CHECK(!sf::Music::createFromMemory(memory.data(), memory.size()));
-        }
-
-        SECTION("Valid buffer")
-        {
-            memory = loadIntoMemory("Audio/ding.flac");
-
-            const auto music = sf::Music::createFromMemory(memory.data(), memory.size()).value();
-            CHECK(music.getDuration() == sf::microseconds(1990884));
-            const auto [offset, length] = music.getLoopPoints();
-            CHECK(offset == sf::Time::Zero);
-            CHECK(length == sf::microseconds(1990884));
-            CHECK(music.getChannelCount() == 1);
-            CHECK(music.getSampleRate() == 44100);
-            CHECK(music.getStatus() == sf::Music::Status::Stopped);
-            CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
-        }
-    }
-
-    SECTION("createFromStream()")
-    {
-        auto       stream = sf::FileInputStream::create("Audio/doodle_pop.ogg").value();
-        const auto music  = sf::Music::createFromStream(stream).value();
-        CHECK(music.getDuration() == sf::microseconds(24002176));
-        const auto [offset, length] = music.getLoopPoints();
-        CHECK(offset == sf::Time::Zero);
-        CHECK(length == sf::microseconds(24002176));
-        CHECK(music.getChannelCount() == 2);
-        CHECK(music.getSampleRate() == 44100);
-        CHECK(music.getStatus() == sf::Music::Status::Stopped);
-        CHECK(music.getPlayingOffset() == sf::Time::Zero);
-        CHECK(!music.getLoop());
-    }
-
     SECTION("play/pause/stop")
     {
-        auto music = sf::Music::createFromFile("Audio/ding.mp3").value();
+        sf::Music music("Audio/ding.mp3");
 
         // Wait for background thread to start
         music.play();
@@ -237,7 +240,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
     SECTION("setLoopPoints()")
     {
-        auto music = sf::Music::createFromFile("Audio/killdeer.wav").value();
+        sf::Music music("Audio/killdeer.wav");
         music.setLoopPoints({sf::seconds(1), sf::seconds(2)});
         const auto [offset, length] = music.getLoopPoints();
         CHECK(offset == sf::seconds(1));

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -32,16 +32,41 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         CHECK(timeSpan.length == sf::Time::Zero);
     }
 
+    SECTION("Construction")
+    {
+        const sf::Music music;
+        CHECK(music.getDuration() == sf::Time::Zero);
+        const auto [offset, length] = music.getLoopPoints();
+        CHECK(offset == sf::Time::Zero);
+        CHECK(length == sf::Time::Zero);
+        CHECK(music.getChannelCount() == 0);
+        CHECK(music.getSampleRate() == 0);
+        CHECK(music.getStatus() == sf::Music::Status::Stopped);
+        CHECK(music.getPlayingOffset() == sf::Time::Zero);
+        CHECK(!music.getLoop());
+    }
+
     SECTION("openFromFile()")
     {
+        sf::Music music;
+
         SECTION("Invalid file")
         {
-            CHECK(!sf::Music::openFromFile("does/not/exist.wav"));
+            REQUIRE(!music.openFromFile("does/not/exist.wav"));
+            CHECK(music.getDuration() == sf::Time::Zero);
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::Time::Zero);
+            CHECK(music.getChannelCount() == 0);
+            CHECK(music.getSampleRate() == 0);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
         }
 
         SECTION("Valid file")
         {
-            const auto music = sf::Music::openFromFile("Audio/ding.mp3").value();
+            REQUIRE(music.openFromFile("Audio/ding.mp3"));
             CHECK(music.getDuration() == sf::microseconds(1990884));
             const auto [offset, length] = music.getLoopPoints();
             CHECK(offset == sf::Time::Zero);
@@ -56,18 +81,27 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
     SECTION("openFromMemory()")
     {
-        std::vector<std::byte> memory(10, std::byte{0xCA});
+        std::vector<std::byte> memory;
+        sf::Music              music;
 
         SECTION("Invalid buffer")
         {
-            CHECK(!sf::Music::openFromMemory(memory.data(), memory.size()));
+            REQUIRE(!music.openFromMemory(memory.data(), memory.size()));
+            CHECK(music.getDuration() == sf::Time::Zero);
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::Time::Zero);
+            CHECK(music.getChannelCount() == 0);
+            CHECK(music.getSampleRate() == 0);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
         }
 
         SECTION("Valid buffer")
         {
             memory = loadIntoMemory("Audio/ding.flac");
-
-            const auto music = sf::Music::openFromMemory(memory.data(), memory.size()).value();
+            REQUIRE(music.openFromMemory(memory.data(), memory.size()));
             CHECK(music.getDuration() == sf::microseconds(1990884));
             const auto [offset, length] = music.getLoopPoints();
             CHECK(offset == sf::Time::Zero);
@@ -82,8 +116,91 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
     SECTION("openFromStream()")
     {
-        auto       stream = sf::FileInputStream::open("Audio/doodle_pop.ogg").value();
-        const auto music  = sf::Music::openFromStream(stream).value();
+        sf::FileInputStream stream;
+        sf::Music           music;
+
+        SECTION("Invalid stream")
+        {
+            CHECK(!music.openFromStream(stream));
+            CHECK(music.getDuration() == sf::Time::Zero);
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::Time::Zero);
+            CHECK(music.getChannelCount() == 0);
+            CHECK(music.getSampleRate() == 0);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
+        }
+
+        SECTION("Valid stream")
+        {
+            REQUIRE(stream.open("Audio/doodle_pop.ogg"));
+            REQUIRE(music.openFromStream(stream));
+            CHECK(music.getDuration() == sf::microseconds(24002176));
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::microseconds(24002176));
+            CHECK(music.getChannelCount() == 2);
+            CHECK(music.getSampleRate() == 44100);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
+        }
+    }
+
+    SECTION("createFromFile()")
+    {
+        SECTION("Invalid file")
+        {
+            CHECK(!sf::Music::createFromFile("does/not/exist.wav"));
+        }
+
+        SECTION("Valid file")
+        {
+            const auto music = sf::Music::createFromFile("Audio/ding.mp3").value();
+            CHECK(music.getDuration() == sf::microseconds(1990884));
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::microseconds(1990884));
+            CHECK(music.getChannelCount() == 1);
+            CHECK(music.getSampleRate() == 44100);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
+        }
+    }
+
+    SECTION("createFromMemory()")
+    {
+        std::vector<std::byte> memory(10, std::byte{0xCA});
+
+        SECTION("Invalid buffer")
+        {
+            CHECK(!sf::Music::createFromMemory(memory.data(), memory.size()));
+        }
+
+        SECTION("Valid buffer")
+        {
+            memory = loadIntoMemory("Audio/ding.flac");
+
+            const auto music = sf::Music::createFromMemory(memory.data(), memory.size()).value();
+            CHECK(music.getDuration() == sf::microseconds(1990884));
+            const auto [offset, length] = music.getLoopPoints();
+            CHECK(offset == sf::Time::Zero);
+            CHECK(length == sf::microseconds(1990884));
+            CHECK(music.getChannelCount() == 1);
+            CHECK(music.getSampleRate() == 44100);
+            CHECK(music.getStatus() == sf::Music::Status::Stopped);
+            CHECK(music.getPlayingOffset() == sf::Time::Zero);
+            CHECK(!music.getLoop());
+        }
+    }
+
+    SECTION("createFromStream()")
+    {
+        auto       stream = sf::FileInputStream::create("Audio/doodle_pop.ogg").value();
+        const auto music  = sf::Music::createFromStream(stream).value();
         CHECK(music.getDuration() == sf::microseconds(24002176));
         const auto [offset, length] = music.getLoopPoints();
         CHECK(offset == sf::Time::Zero);
@@ -97,7 +214,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
     SECTION("play/pause/stop")
     {
-        auto music = sf::Music::openFromFile("Audio/ding.mp3").value();
+        auto music = sf::Music::createFromFile("Audio/ding.mp3").value();
 
         // Wait for background thread to start
         music.play();
@@ -120,7 +237,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
     SECTION("setLoopPoints()")
     {
-        auto music = sf::Music::openFromFile("Audio/killdeer.wav").value();
+        auto music = sf::Music::createFromFile("Audio/killdeer.wav").value();
         music.setLoopPoints({sf::seconds(1), sf::seconds(2)});
         const auto [offset, length] = music.getLoopPoints();
         CHECK(offset == sf::seconds(1));

--- a/test/Audio/OutputSoundFile.test.cpp
+++ b/test/Audio/OutputSoundFile.test.cpp
@@ -2,7 +2,6 @@
 
 #include <type_traits>
 
-static_assert(!std::is_default_constructible_v<sf::OutputSoundFile>);
 static_assert(!std::is_copy_constructible_v<sf::OutputSoundFile>);
 static_assert(!std::is_copy_assignable_v<sf::OutputSoundFile>);
 static_assert(std::is_nothrow_move_constructible_v<sf::OutputSoundFile>);

--- a/test/Audio/OutputSoundFile.test.cpp
+++ b/test/Audio/OutputSoundFile.test.cpp
@@ -2,6 +2,7 @@
 
 #include <type_traits>
 
+static_assert(std::is_default_constructible_v<sf::OutputSoundFile>);
 static_assert(!std::is_copy_constructible_v<sf::OutputSoundFile>);
 static_assert(!std::is_copy_assignable_v<sf::OutputSoundFile>);
 static_assert(std::is_nothrow_move_constructible_v<sf::OutputSoundFile>);

--- a/test/Audio/Sound.test.cpp
+++ b/test/Audio/Sound.test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
         STATIC_CHECK(std::has_virtual_destructor_v<sf::Sound>);
     }
 
-    const auto soundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
+    const sf::SoundBuffer soundBuffer("Audio/ding.flac");
 
     SECTION("Construction")
     {
@@ -52,7 +52,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
 
         SECTION("Assignment")
         {
-            const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
+            const sf::SoundBuffer otherSoundBuffer("Audio/ding.flac");
             sf::Sound             soundCopy(otherSoundBuffer);
             soundCopy = sound;
             CHECK(&soundCopy.getBuffer() == &soundBuffer);
@@ -64,7 +64,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
 
     SECTION("Set/get buffer")
     {
-        const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
+        const sf::SoundBuffer otherSoundBuffer("Audio/ding.flac");
         sf::Sound             sound(soundBuffer);
         sound.setBuffer(otherSoundBuffer);
         CHECK(&sound.getBuffer() == &otherSoundBuffer);

--- a/test/Audio/Sound.test.cpp
+++ b/test/Audio/Sound.test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
         STATIC_CHECK(std::has_virtual_destructor_v<sf::Sound>);
     }
 
-    const auto soundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();
+    const auto soundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
 
     SECTION("Construction")
     {
@@ -52,7 +52,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
 
         SECTION("Assignment")
         {
-            const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();
+            const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
             sf::Sound             soundCopy(otherSoundBuffer);
             soundCopy = sound;
             CHECK(&soundCopy.getBuffer() == &soundBuffer);
@@ -64,7 +64,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
 
     SECTION("Set/get buffer")
     {
-        const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::loadFromFile("Audio/ding.flac").value();
+        const sf::SoundBuffer otherSoundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
         sf::Sound             sound(soundBuffer);
         sound.setBuffer(otherSoundBuffer);
         CHECK(&sound.getBuffer() == &otherSoundBuffer);

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -24,17 +24,69 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
 
     SECTION("Construction")
     {
-        const sf::SoundBuffer soundBuffer;
-        CHECK(soundBuffer.getSamples() == nullptr);
-        CHECK(soundBuffer.getSampleCount() == 0);
-        CHECK(soundBuffer.getSampleRate() == 44100);
-        CHECK(soundBuffer.getChannelCount() == 1);
-        CHECK(soundBuffer.getDuration() == sf::Time::Zero);
+        SECTION("Default constructor")
+        {
+            const sf::SoundBuffer soundBuffer;
+            CHECK(soundBuffer.getSamples() == nullptr);
+            CHECK(soundBuffer.getSampleCount() == 0);
+            CHECK(soundBuffer.getSampleRate() == 44100);
+            CHECK(soundBuffer.getChannelCount() == 1);
+            CHECK(soundBuffer.getDuration() == sf::Time::Zero);
+        }
+
+        SECTION("File")
+        {
+            SECTION("Invalid filename")
+            {
+                CHECK_THROWS_AS(sf::SoundBuffer("does/not/exist.wav"), std::runtime_error);
+            }
+
+            SECTION("Valid file")
+            {
+                const sf::SoundBuffer soundBuffer("Audio/ding.flac");
+                CHECK(soundBuffer.getSamples() != nullptr);
+                CHECK(soundBuffer.getSampleCount() == 87798);
+                CHECK(soundBuffer.getSampleRate() == 44100);
+                CHECK(soundBuffer.getChannelCount() == 1);
+                CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
+            }
+        }
+
+        SECTION("Memory")
+        {
+            SECTION("Invalid memory")
+            {
+                constexpr std::array<std::byte, 5> memory{};
+                CHECK_THROWS_AS(sf::SoundBuffer(memory.data(), memory.size()), std::runtime_error);
+            }
+
+            SECTION("Valid memory")
+            {
+                const auto            memory = loadIntoMemory("Audio/ding.flac");
+                const sf::SoundBuffer soundBuffer(memory.data(), memory.size());
+                CHECK(soundBuffer.getSamples() != nullptr);
+                CHECK(soundBuffer.getSampleCount() == 87798);
+                CHECK(soundBuffer.getSampleRate() == 44100);
+                CHECK(soundBuffer.getChannelCount() == 1);
+                CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
+            }
+        }
+
+        SECTION("Stream")
+        {
+            sf::FileInputStream   stream("Audio/ding.flac");
+            const sf::SoundBuffer soundBuffer(stream);
+            CHECK(soundBuffer.getSamples() != nullptr);
+            CHECK(soundBuffer.getSampleCount() == 87798);
+            CHECK(soundBuffer.getSampleRate() == 44100);
+            CHECK(soundBuffer.getChannelCount() == 1);
+            CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
+        }
     }
 
     SECTION("Copy semantics")
     {
-        const auto soundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
+        const sf::SoundBuffer soundBuffer("Audio/ding.flac");
 
         SECTION("Construction")
         {
@@ -48,8 +100,8 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
 
         SECTION("Assignment")
         {
-            sf::SoundBuffer soundBufferCopy = sf::SoundBuffer::createFromFile("Audio/doodle_pop.ogg").value();
-            soundBufferCopy                 = soundBuffer;
+            sf::SoundBuffer soundBufferCopy("Audio/doodle_pop.ogg");
+            soundBufferCopy = soundBuffer;
             CHECK(soundBufferCopy.getSamples() != nullptr);
             CHECK(soundBufferCopy.getSampleCount() == 87798);
             CHECK(soundBufferCopy.getSampleRate() == 44100);
@@ -123,65 +175,16 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
         }
     }
 
-    SECTION("createFromFile()")
-    {
-        SECTION("Invalid filename")
-        {
-            CHECK(!sf::SoundBuffer::createFromFile("does/not/exist.wav"));
-        }
-
-        SECTION("Valid file")
-        {
-            const auto soundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
-            CHECK(soundBuffer.getSamples() != nullptr);
-            CHECK(soundBuffer.getSampleCount() == 87798);
-            CHECK(soundBuffer.getSampleRate() == 44100);
-            CHECK(soundBuffer.getChannelCount() == 1);
-            CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
-        }
-    }
-
-    SECTION("createFromMemory()")
-    {
-        SECTION("Invalid memory")
-        {
-            constexpr std::array<std::byte, 5> memory{};
-            CHECK(!sf::SoundBuffer::createFromMemory(memory.data(), memory.size()));
-        }
-
-        SECTION("Valid memory")
-        {
-            const auto memory      = loadIntoMemory("Audio/ding.flac");
-            const auto soundBuffer = sf::SoundBuffer::createFromMemory(memory.data(), memory.size()).value();
-            CHECK(soundBuffer.getSamples() != nullptr);
-            CHECK(soundBuffer.getSampleCount() == 87798);
-            CHECK(soundBuffer.getSampleRate() == 44100);
-            CHECK(soundBuffer.getChannelCount() == 1);
-            CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
-        }
-    }
-
-    SECTION("createFromStream()")
-    {
-        auto       stream      = sf::FileInputStream::create("Audio/ding.flac").value();
-        const auto soundBuffer = sf::SoundBuffer::createFromStream(stream).value();
-        CHECK(soundBuffer.getSamples() != nullptr);
-        CHECK(soundBuffer.getSampleCount() == 87798);
-        CHECK(soundBuffer.getSampleRate() == 44100);
-        CHECK(soundBuffer.getChannelCount() == 1);
-        CHECK(soundBuffer.getDuration() == sf::microseconds(1990884));
-    }
-
     SECTION("saveToFile()")
     {
         const auto filename = std::filesystem::temp_directory_path() / "ding.flac";
 
         {
-            const auto soundBuffer = sf::SoundBuffer::createFromFile("Audio/ding.flac").value();
+            const sf::SoundBuffer soundBuffer("Audio/ding.flac");
             REQUIRE(soundBuffer.saveToFile(filename));
         }
 
-        const auto soundBuffer = sf::SoundBuffer::createFromFile(filename).value();
+        const sf::SoundBuffer soundBuffer(filename);
         CHECK(soundBuffer.getSamples() != nullptr);
         CHECK(soundBuffer.getSampleCount() == 87798);
         CHECK(soundBuffer.getSampleRate() == 44100);

--- a/test/Audio/SoundFileFactory.test.cpp
+++ b/test/Audio/SoundFileFactory.test.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <filesystem>
-#include <optional>
 #include <type_traits>
 
 #include <cstdint>
@@ -110,30 +109,29 @@ TEST_CASE("[Audio] sf::SoundFileFactory")
 
     SECTION("createReaderFromStream()")
     {
-        std::optional<sf::FileInputStream> stream;
+        sf::FileInputStream stream;
 
         SECTION("flac")
         {
-            stream = sf::FileInputStream::create("Audio/ding.flac");
+            REQUIRE(stream.open("Audio/ding.flac"));
         }
 
         SECTION("mp3")
         {
-            stream = sf::FileInputStream::create("Audio/ding.mp3");
+            REQUIRE(stream.open("Audio/ding.mp3"));
         }
 
         SECTION("ogg")
         {
-            stream = sf::FileInputStream::create("Audio/doodle_pop.ogg");
+            REQUIRE(stream.open("Audio/doodle_pop.ogg"));
         }
 
         SECTION("wav")
         {
-            stream = sf::FileInputStream::create("Audio/killdeer.wav");
+            REQUIRE(stream.open("Audio/killdeer.wav"));
         }
 
-        REQUIRE(stream);
-        CHECK(sf::SoundFileFactory::createReaderFromStream(*stream));
+        CHECK(sf::SoundFileFactory::createReaderFromStream(stream));
     }
 
     SECTION("createWriterFromFilename()")

--- a/test/Audio/SoundFileFactory.test.cpp
+++ b/test/Audio/SoundFileFactory.test.cpp
@@ -114,22 +114,22 @@ TEST_CASE("[Audio] sf::SoundFileFactory")
 
         SECTION("flac")
         {
-            stream = sf::FileInputStream::open("Audio/ding.flac");
+            stream = sf::FileInputStream::create("Audio/ding.flac");
         }
 
         SECTION("mp3")
         {
-            stream = sf::FileInputStream::open("Audio/ding.mp3");
+            stream = sf::FileInputStream::create("Audio/ding.mp3");
         }
 
         SECTION("ogg")
         {
-            stream = sf::FileInputStream::open("Audio/doodle_pop.ogg");
+            stream = sf::FileInputStream::create("Audio/doodle_pop.ogg");
         }
 
         SECTION("wav")
         {
-            stream = sf::FileInputStream::open("Audio/killdeer.wav");
+            stream = sf::FileInputStream::create("Audio/killdeer.wav");
         }
 
         REQUIRE(stream);

--- a/test/Graphics/Drawable.test.cpp
+++ b/test/Graphics/Drawable.test.cpp
@@ -46,7 +46,7 @@ TEST_CASE("[Graphics] sf::Drawable", runDisplayTests())
     SECTION("draw()")
     {
         const DrawableTest drawableTest;
-        auto               renderTexture = sf::RenderTexture::create({32, 32}).value();
+        sf::RenderTexture  renderTexture({32, 32});
         CHECK(drawableTest.callCount() == 0);
         renderTexture.draw(drawableTest);
         CHECK(drawableTest.callCount() == 1);

--- a/test/Graphics/Font.test.cpp
+++ b/test/Graphics/Font.test.cpp
@@ -15,23 +15,35 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(!std::is_default_constructible_v<sf::Font>);
         STATIC_CHECK(std::is_copy_constructible_v<sf::Font>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Font>);
         STATIC_CHECK(std::is_move_constructible_v<sf::Font>);
         STATIC_CHECK(std::is_move_assignable_v<sf::Font>);
     }
 
+    SECTION("Construction")
+    {
+        const sf::Font font;
+        CHECK(font.getInfo().family.empty());
+        CHECK(!font.hasGlyph(0));
+        CHECK(font.getLineSpacing(0) == 0);
+        CHECK(font.getUnderlinePosition(0) == 0);
+        CHECK(font.getUnderlineThickness(0) == 0);
+        CHECK(font.isSmooth());
+    }
+
     SECTION("openFromFile()")
     {
+        sf::Font font;
+
         SECTION("Invalid filename")
         {
-            CHECK(!sf::Font::openFromFile("does/not/exist.ttf"));
+            CHECK(!font.openFromFile("does/not/exist.ttf"));
         }
 
-        SECTION("Valid file")
+        SECTION("Successful load")
         {
-            const auto font = sf::Font::openFromFile("Graphics/tuffy.ttf").value();
+            REQUIRE(font.openFromFile("Graphics/tuffy.ttf"));
             CHECK(font.getInfo().family == "Tuffy");
             const auto& glyph = font.getGlyph(0x45, 16, false);
             CHECK(glyph.advance == 9);
@@ -58,17 +70,19 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
 
     SECTION("openFromMemory()")
     {
+        sf::Font font;
+
         SECTION("Invalid data and size")
         {
-            CHECK(!sf::Font::openFromMemory(nullptr, 1));
+            CHECK(!font.openFromMemory(nullptr, 1));
             const std::byte testByte{0xCD};
-            CHECK(!sf::Font::openFromMemory(&testByte, 0));
+            CHECK(!font.openFromMemory(&testByte, 0));
         }
 
-        SECTION("Valid data")
+        SECTION("Successful load")
         {
             const auto memory = loadIntoMemory("Graphics/tuffy.ttf");
-            const auto font   = sf::Font::openFromMemory(memory.data(), memory.size()).value();
+            REQUIRE(font.openFromMemory(memory.data(), memory.size()));
             CHECK(font.getInfo().family == "Tuffy");
             const auto& glyph = font.getGlyph(0x45, 16, false);
             CHECK(glyph.advance == 9);
@@ -95,8 +109,117 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
 
     SECTION("openFromStream()")
     {
-        auto       stream = sf::FileInputStream::open("Graphics/tuffy.ttf").value();
-        const auto font   = sf::Font::openFromStream(stream).value();
+        sf::Font            font;
+        sf::FileInputStream stream;
+
+        SECTION("Invalid stream")
+        {
+            CHECK(!font.openFromStream(stream));
+        }
+
+        SECTION("Successful load")
+        {
+            REQUIRE(stream.open("Graphics/tuffy.ttf"));
+            REQUIRE(font.openFromStream(stream));
+            CHECK(font.getInfo().family == "Tuffy");
+            const auto& glyph = font.getGlyph(0x45, 16, false);
+            CHECK(glyph.advance == 9);
+            CHECK(glyph.lsbDelta == 9);
+            CHECK(glyph.rsbDelta == 16);
+            CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
+            CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
+            CHECK(font.hasGlyph(0x41));
+            CHECK(font.hasGlyph(0xC0));
+            CHECK(font.getKerning(0x41, 0x42, 12) == -1);
+            CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
+            CHECK(font.getLineSpacing(24) == 30);
+            CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
+            CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
+            const auto& texture = font.getTexture(10);
+            CHECK(texture.getSize() == sf::Vector2u(128, 128));
+            CHECK(texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() != 0);
+            CHECK(font.isSmooth());
+        }
+    }
+
+    SECTION("createFromFile()")
+    {
+        SECTION("Invalid filename")
+        {
+            CHECK(!sf::Font::createFromFile("does/not/exist.ttf"));
+        }
+
+        SECTION("Valid file")
+        {
+            const auto font = sf::Font::createFromFile("Graphics/tuffy.ttf").value();
+            CHECK(font.getInfo().family == "Tuffy");
+            const auto& glyph = font.getGlyph(0x45, 16, false);
+            CHECK(glyph.advance == 9);
+            CHECK(glyph.lsbDelta == 9);
+            CHECK(glyph.rsbDelta == 16);
+            CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
+            CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
+            CHECK(font.hasGlyph(0x41));
+            CHECK(font.hasGlyph(0xC0));
+            CHECK(font.getKerning(0x41, 0x42, 12) == -1);
+            CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
+            CHECK(font.getLineSpacing(24) == 30);
+            CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
+            CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
+            const auto& texture = font.getTexture(10);
+            CHECK(texture.getSize() == sf::Vector2u(128, 128));
+            CHECK(texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() != 0);
+            CHECK(font.isSmooth());
+        }
+    }
+
+    SECTION("createFromMemory()")
+    {
+        SECTION("Invalid data and size")
+        {
+            CHECK(!sf::Font::createFromMemory(nullptr, 1));
+            const std::byte testByte{0xCD};
+            CHECK(!sf::Font::createFromMemory(&testByte, 0));
+        }
+
+        SECTION("Valid data")
+        {
+            const auto memory = loadIntoMemory("Graphics/tuffy.ttf");
+            const auto font   = sf::Font::createFromMemory(memory.data(), memory.size()).value();
+            CHECK(font.getInfo().family == "Tuffy");
+            const auto& glyph = font.getGlyph(0x45, 16, false);
+            CHECK(glyph.advance == 9);
+            CHECK(glyph.lsbDelta == 9);
+            CHECK(glyph.rsbDelta == 16);
+            CHECK(glyph.bounds == sf::FloatRect({0, -12}, {8, 12}));
+            CHECK(glyph.textureRect == sf::IntRect({2, 5}, {8, 12}));
+            CHECK(font.hasGlyph(0x41));
+            CHECK(font.hasGlyph(0xC0));
+            CHECK(font.getKerning(0x41, 0x42, 12) == -1);
+            CHECK(font.getKerning(0x43, 0x44, 24, true) == 0);
+            CHECK(font.getLineSpacing(24) == 30);
+            CHECK(font.getUnderlinePosition(36) == Approx(2.20312f));
+            CHECK(font.getUnderlineThickness(48) == Approx(1.17188f));
+            const auto& texture = font.getTexture(10);
+            CHECK(texture.getSize() == sf::Vector2u(128, 128));
+            CHECK(texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() != 0);
+            CHECK(font.isSmooth());
+        }
+    }
+
+    SECTION("createFromStream()")
+    {
+        auto       stream = sf::FileInputStream::create("Graphics/tuffy.ttf").value();
+        const auto font   = sf::Font::createFromStream(stream).value();
         CHECK(font.getInfo().family == "Tuffy");
         const auto& glyph = font.getGlyph(0x45, 16, false);
         CHECK(glyph.advance == 9);
@@ -122,7 +245,7 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
 
     SECTION("Set/get smooth")
     {
-        auto font = sf::Font::openFromFile("Graphics/tuffy.ttf").value();
+        auto font = sf::Font::createFromFile("Graphics/tuffy.ttf").value();
         font.setSmooth(false);
         CHECK(!font.isSmooth());
     }

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -13,11 +13,17 @@ TEST_CASE("[Graphics] sf::Image")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(!std::is_default_constructible_v<sf::Image>);
         STATIC_CHECK(std::is_copy_constructible_v<sf::Image>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Image>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Image>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Image>);
+    }
+
+    SECTION("Default constructor")
+    {
+        const sf::Image image;
+        CHECK(image.getSize() == sf::Vector2u());
+        CHECK(image.getPixelsPtr() == nullptr);
     }
 
     SECTION("Construction")
@@ -78,74 +84,137 @@ TEST_CASE("[Graphics] sf::Image")
         }
     }
 
+    SECTION("Resize")
+    {
+        SECTION("resize(Vector2)")
+        {
+            sf::Image image;
+            image.resize(sf::Vector2u(10, 10));
+            CHECK(image.getSize() == sf::Vector2u(10, 10));
+            CHECK(image.getPixelsPtr() != nullptr);
+
+            for (std::uint32_t i = 0; i < 10; ++i)
+            {
+                for (std::uint32_t j = 0; j < 10; ++j)
+                {
+                    CHECK(image.getPixel(sf::Vector2u(i, j)) == sf::Color::Black);
+                }
+            }
+        }
+
+        SECTION("resize(Vector2, Color)")
+        {
+            sf::Image image;
+            image.resize(sf::Vector2u(10, 10), sf::Color::Red);
+
+            CHECK(image.getSize() == sf::Vector2u(10, 10));
+            CHECK(image.getPixelsPtr() != nullptr);
+
+            for (std::uint32_t i = 0; i < 10; ++i)
+            {
+                for (std::uint32_t j = 0; j < 10; ++j)
+                {
+                    CHECK(image.getPixel(sf::Vector2u(i, j)) == sf::Color::Red);
+                }
+            }
+        }
+
+        SECTION("resize(Vector2, std::uint8_t*)")
+        {
+            // 10 x 10, with 4 colour channels array
+            std::array<std::uint8_t, 400> pixels{};
+            for (std::size_t i = 0; i < pixels.size(); i += 4)
+            {
+                pixels[i]     = 255; // r
+                pixels[i + 1] = 0;   // g
+                pixels[i + 2] = 0;   // b
+                pixels[i + 3] = 255; // a
+            }
+
+            sf::Image image;
+            image.resize(sf::Vector2u(10, 10), pixels.data());
+
+            CHECK(image.getSize() == sf::Vector2u(10, 10));
+            CHECK(image.getPixelsPtr() != nullptr);
+
+            for (std::uint32_t i = 0; i < 10; ++i)
+            {
+                for (std::uint32_t j = 0; j < 10; ++j)
+                {
+                    CHECK(image.getPixel(sf::Vector2u(i, j)) == sf::Color::Red);
+                }
+            }
+        }
+    }
+
     SECTION("loadFromFile()")
     {
+        sf::Image image;
+
         SECTION("Invalid file")
         {
-            CHECK(!sf::Image::loadFromFile("."));
-            CHECK(!sf::Image::loadFromFile("this/does/not/exist.jpg"));
+            CHECK(!image.loadFromFile("."));
+            CHECK(!image.loadFromFile("this/does/not/exist.jpg"));
+
+            CHECK(image.getSize() == sf::Vector2u(0, 0));
+            CHECK(image.getPixelsPtr() == nullptr);
         }
 
         SECTION("Successful load")
         {
-            std::optional<sf::Image> image;
-
             SECTION("bmp")
             {
-                image = sf::Image::loadFromFile("Graphics/sfml-logo-big.bmp").value();
-                REQUIRE(image.has_value());
-                CHECK(image->getPixel({0, 0}) == sf::Color::White);
-                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+                REQUIRE(image.loadFromFile("Graphics/sfml-logo-big.bmp"));
+                CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
             }
 
             SECTION("png")
             {
-                image = sf::Image::loadFromFile("Graphics/sfml-logo-big.png").value();
-                REQUIRE(image.has_value());
-                CHECK(image->getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
-                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+                REQUIRE(image.loadFromFile("Graphics/sfml-logo-big.png"));
+                CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
+                CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
             }
 
             SECTION("jpg")
             {
-                image = sf::Image::loadFromFile("Graphics/sfml-logo-big.jpg").value();
-                REQUIRE(image.has_value());
-                CHECK(image->getPixel({0, 0}) == sf::Color::White);
-                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+                REQUIRE(image.loadFromFile("Graphics/sfml-logo-big.jpg"));
+                CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
             }
 
             SECTION("gif")
             {
-                image = sf::Image::loadFromFile("Graphics/sfml-logo-big.gif").value();
-                REQUIRE(image.has_value());
-                CHECK(image->getPixel({0, 0}) == sf::Color::White);
-                CHECK(image->getPixel({200, 150}) == sf::Color(146, 210, 62));
+                REQUIRE(image.loadFromFile("Graphics/sfml-logo-big.gif"));
+                CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                CHECK(image.getPixel({200, 150}) == sf::Color(146, 210, 62));
             }
 
             SECTION("psd")
             {
-                image = sf::Image::loadFromFile("Graphics/sfml-logo-big.psd").value();
-                REQUIRE(image.has_value());
-                CHECK(image->getPixel({0, 0}) == sf::Color::White);
-                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+                REQUIRE(image.loadFromFile("Graphics/sfml-logo-big.psd"));
+                CHECK(image.getPixel({0, 0}) == sf::Color::White);
+                CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
             }
 
-            CHECK(image->getSize() == sf::Vector2u(1001, 304));
-            CHECK(image->getPixelsPtr() != nullptr);
+            CHECK(image.getSize() == sf::Vector2u(1001, 304));
+            CHECK(image.getPixelsPtr() != nullptr);
         }
     }
 
     SECTION("loadFromMemory()")
     {
+        sf::Image image;
+
         SECTION("Invalid pointer")
         {
-            CHECK(!sf::Image::loadFromMemory(nullptr, 1));
+            CHECK(!image.loadFromMemory(nullptr, 1));
         }
 
         SECTION("Invalid size")
         {
             const std::byte testByte{0xAB};
-            CHECK(!sf::Image::loadFromMemory(&testByte, 0));
+            CHECK(!image.loadFromMemory(&testByte, 0));
         }
 
         SECTION("Failed load")
@@ -162,13 +231,19 @@ TEST_CASE("[Graphics] sf::Image")
                 memory = {1, 2, 3, 4};
             }
 
-            CHECK(!sf::Image::loadFromMemory(memory.data(), memory.size()));
+            CHECK(!image.loadFromMemory(memory.data(), memory.size()));
         }
 
         SECTION("Successful load")
         {
-            const auto memory = sf::Image({24, 24}, sf::Color::Green).saveToMemory("png").value();
-            const auto image  = sf::Image::loadFromMemory(memory.data(), memory.size()).value();
+            const auto memory = []()
+            {
+                sf::Image savedImage;
+                savedImage.resize({24, 24}, sf::Color::Green);
+                return savedImage.saveToMemory("png").value();
+            }();
+
+            CHECK(image.loadFromMemory(memory.data(), memory.size()));
             CHECK(image.getSize() == sf::Vector2u(24, 24));
             CHECK(image.getPixelsPtr() != nullptr);
             CHECK(image.getPixel({0, 0}) == sf::Color::Green);
@@ -178,8 +253,127 @@ TEST_CASE("[Graphics] sf::Image")
 
     SECTION("loadFromStream()")
     {
-        auto       stream = sf::FileInputStream::open("Graphics/sfml-logo-big.png").value();
-        const auto image  = sf::Image::loadFromStream(stream).value();
+        sf::Image           image;
+        sf::FileInputStream stream;
+
+        SECTION("Invalid stream")
+        {
+            CHECK(!image.loadFromStream(stream));
+        }
+
+        SECTION("Successful load")
+        {
+            CHECK(stream.open("Graphics/sfml-logo-big.png"));
+            REQUIRE(image.loadFromStream(stream));
+            CHECK(image.getSize() == sf::Vector2u(1001, 304));
+            CHECK(image.getPixelsPtr() != nullptr);
+            CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
+            CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+        }
+    }
+
+    SECTION("createFromFile()")
+    {
+        SECTION("Invalid file")
+        {
+            CHECK(!sf::Image::createFromFile("."));
+            CHECK(!sf::Image::createFromFile("this/does/not/exist.jpg"));
+        }
+
+        SECTION("Successful load")
+        {
+            std::optional<sf::Image> image;
+
+            SECTION("bmp")
+            {
+                image = sf::Image::createFromFile("Graphics/sfml-logo-big.bmp").value();
+                REQUIRE(image.has_value());
+                CHECK(image->getPixel({0, 0}) == sf::Color::White);
+                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+            }
+
+            SECTION("png")
+            {
+                image = sf::Image::createFromFile("Graphics/sfml-logo-big.png").value();
+                REQUIRE(image.has_value());
+                CHECK(image->getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
+                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+            }
+
+            SECTION("jpg")
+            {
+                image = sf::Image::createFromFile("Graphics/sfml-logo-big.jpg").value();
+                REQUIRE(image.has_value());
+                CHECK(image->getPixel({0, 0}) == sf::Color::White);
+                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+            }
+
+            SECTION("gif")
+            {
+                image = sf::Image::createFromFile("Graphics/sfml-logo-big.gif").value();
+                REQUIRE(image.has_value());
+                CHECK(image->getPixel({0, 0}) == sf::Color::White);
+                CHECK(image->getPixel({200, 150}) == sf::Color(146, 210, 62));
+            }
+
+            SECTION("psd")
+            {
+                image = sf::Image::createFromFile("Graphics/sfml-logo-big.psd").value();
+                REQUIRE(image.has_value());
+                CHECK(image->getPixel({0, 0}) == sf::Color::White);
+                CHECK(image->getPixel({200, 150}) == sf::Color(144, 208, 62));
+            }
+
+            CHECK(image->getSize() == sf::Vector2u(1001, 304));
+            CHECK(image->getPixelsPtr() != nullptr);
+        }
+    }
+
+    SECTION("createFromMemory()")
+    {
+        SECTION("Invalid pointer")
+        {
+            CHECK(!sf::Image::createFromMemory(nullptr, 1));
+        }
+
+        SECTION("Invalid size")
+        {
+            const std::byte testByte{0xAB};
+            CHECK(!sf::Image::createFromMemory(&testByte, 0));
+        }
+
+        SECTION("Failed load")
+        {
+            std::vector<std::uint8_t> memory;
+
+            SECTION("Empty")
+            {
+                memory.clear();
+            }
+
+            SECTION("Junk data")
+            {
+                memory = {1, 2, 3, 4};
+            }
+
+            CHECK(!sf::Image::createFromMemory(memory.data(), memory.size()));
+        }
+
+        SECTION("Successful load")
+        {
+            const auto memory = sf::Image({24, 24}, sf::Color::Green).saveToMemory("png").value();
+            const auto image  = sf::Image::createFromMemory(memory.data(), memory.size()).value();
+            CHECK(image.getSize() == sf::Vector2u(24, 24));
+            CHECK(image.getPixelsPtr() != nullptr);
+            CHECK(image.getPixel({0, 0}) == sf::Color::Green);
+            CHECK(image.getPixel({23, 23}) == sf::Color::Green);
+        }
+    }
+
+    SECTION("createFromStream()")
+    {
+        auto       stream = sf::FileInputStream::create("Graphics/sfml-logo-big.png").value();
+        const auto image  = sf::Image::createFromStream(stream).value();
         CHECK(image.getSize() == sf::Vector2u(1001, 304));
         CHECK(image.getPixelsPtr() != nullptr);
         CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
@@ -232,7 +426,7 @@ TEST_CASE("[Graphics] sf::Image")
 
             // Cannot test JPEG encoding due to it triggering UB in stbiw__jpg_writeBits
 
-            const auto loadedImage = sf::Image::loadFromFile(filename).value();
+            const auto loadedImage = sf::Image::createFromFile(filename).value();
             CHECK(loadedImage.getSize() == sf::Vector2u(256, 256));
             CHECK(loadedImage.getPixelsPtr() != nullptr);
 

--- a/test/Graphics/Render.test.cpp
+++ b/test/Graphics/Render.test.cpp
@@ -12,9 +12,7 @@ TEST_CASE("[Graphics] Render Tests", runDisplayTests())
 {
     SECTION("Stencil Tests")
     {
-        auto renderTexture = sf::RenderTexture::create({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */})
-                                 .value();
-
+        sf::RenderTexture renderTexture({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */});
         renderTexture.clear(sf::Color::Red, 127);
 
         sf::RectangleShape shape1({100, 100});

--- a/test/Graphics/RenderTexture.test.cpp
+++ b/test/Graphics/RenderTexture.test.cpp
@@ -9,11 +9,18 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(!std::is_default_constructible_v<sf::RenderTexture>);
         STATIC_CHECK(!std::is_copy_constructible_v<sf::RenderTexture>);
         STATIC_CHECK(!std::is_copy_assignable_v<sf::RenderTexture>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::RenderTexture>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::RenderTexture>);
+    }
+
+    SECTION("Construction")
+    {
+        const sf::RenderTexture renderTexture;
+        CHECK(!renderTexture.isSmooth());
+        CHECK(!renderTexture.isRepeated());
+        CHECK(renderTexture.getSize() == sf::Vector2u(0, 0));
     }
 
     SECTION("create()")
@@ -35,6 +42,21 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
         CHECK(!texture.isSrgb());
         CHECK(!texture.isRepeated());
         CHECK(texture.getNativeHandle() != 0);
+    }
+
+    SECTION("resize()")
+    {
+        sf::RenderTexture renderTexture;
+        CHECK(!renderTexture.resize({1'000'000, 1'000'000}));
+        CHECK(renderTexture.resize({480, 360}));
+        CHECK(!renderTexture.isSmooth());
+        CHECK(!renderTexture.isRepeated());
+        CHECK(renderTexture.getSize() == sf::Vector2u(480, 360));
+        CHECK(!renderTexture.isSrgb());
+        CHECK(renderTexture.resize({360, 480}));
+        CHECK(renderTexture.getSize() == sf::Vector2u(360, 480));
+        CHECK(renderTexture.resize({100, 100}, sf::ContextSettings{8 /* depthBits */, 0 /* stencilBits */}));
+        CHECK(renderTexture.resize({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */}));
     }
 
     SECTION("getMaximumAntialiasingLevel()")

--- a/test/Graphics/RenderTexture.test.cpp
+++ b/test/Graphics/RenderTexture.test.cpp
@@ -17,20 +17,45 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
 
     SECTION("Construction")
     {
-        const sf::RenderTexture renderTexture;
-        CHECK(!renderTexture.isSmooth());
-        CHECK(!renderTexture.isRepeated());
-        CHECK(renderTexture.getSize() == sf::Vector2u(0, 0));
+        SECTION("Default constructor")
+        {
+            const sf::RenderTexture renderTexture;
+            CHECK(!renderTexture.isSmooth());
+            CHECK(!renderTexture.isRepeated());
+            CHECK(renderTexture.getSize() == sf::Vector2u(0, 0));
+        }
+
+        SECTION("2 parameter constructor")
+        {
+            CHECK_THROWS_AS(sf::RenderTexture({1'000'000, 1'000'000}), std::runtime_error);
+
+            CHECK_NOTHROW(sf::RenderTexture({100, 100}, sf::ContextSettings{8 /* depthBits */, 0 /* stencilBits */}));
+            CHECK_NOTHROW(sf::RenderTexture({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */}));
+
+            const sf::RenderTexture renderTexture({360, 480});
+            CHECK(renderTexture.getSize() == sf::Vector2u(360, 480));
+            CHECK(!renderTexture.isSmooth());
+            CHECK(!renderTexture.isRepeated());
+            CHECK(!renderTexture.isSrgb());
+
+            const auto& texture = renderTexture.getTexture();
+            CHECK(texture.getSize() == sf::Vector2u(360, 480));
+            CHECK(!texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() != 0);
+        }
     }
 
-    SECTION("create()")
+    SECTION("resize()")
     {
-        CHECK(!sf::RenderTexture::create({1'000'000, 1'000'000}));
+        sf::RenderTexture renderTexture;
+        CHECK(!renderTexture.resize({1'000'000, 1'000'000}));
 
-        CHECK(sf::RenderTexture::create({100, 100}, sf::ContextSettings{8 /* depthBits */, 0 /* stencilBits */}));
-        CHECK(sf::RenderTexture::create({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */}));
+        CHECK(renderTexture.resize({100, 100}, sf::ContextSettings{8 /* depthBits */, 0 /* stencilBits */}));
+        CHECK(renderTexture.resize({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */}));
 
-        const auto renderTexture = sf::RenderTexture::create({360, 480}).value();
+        REQUIRE(renderTexture.resize({360, 480}));
         CHECK(renderTexture.getSize() == sf::Vector2u(360, 480));
         CHECK(!renderTexture.isSmooth());
         CHECK(!renderTexture.isRepeated());
@@ -66,27 +91,27 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
 
     SECTION("Set/get smooth")
     {
-        auto renderTexture = sf::RenderTexture::create({64, 64}).value();
+        sf::RenderTexture renderTexture({64, 64});
         renderTexture.setSmooth(true);
         CHECK(renderTexture.isSmooth());
     }
 
     SECTION("Set/get repeated")
     {
-        auto renderTexture = sf::RenderTexture::create({64, 64}).value();
+        sf::RenderTexture renderTexture({64, 64});
         renderTexture.setRepeated(true);
         CHECK(renderTexture.isRepeated());
     }
 
     SECTION("generateMipmap()")
     {
-        auto renderTexture = sf::RenderTexture::create({64, 64}).value();
+        sf::RenderTexture renderTexture({64, 64});
         CHECK(renderTexture.generateMipmap());
     }
 
     SECTION("setActive()")
     {
-        auto renderTexture = sf::RenderTexture::create({64, 64}).value();
+        sf::RenderTexture renderTexture({64, 64});
         CHECK(renderTexture.setActive());
         CHECK(renderTexture.setActive(false));
         CHECK(renderTexture.setActive(true));
@@ -94,7 +119,7 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
 
     SECTION("getTexture()")
     {
-        const auto renderTexture = sf::RenderTexture::create({64, 64}).value();
+        const sf::RenderTexture renderTexture({64, 64});
         CHECK(renderTexture.getTexture().getSize() == sf::Vector2u(64, 64));
     }
 }

--- a/test/Graphics/RenderWindow.test.cpp
+++ b/test/Graphics/RenderWindow.test.cpp
@@ -75,7 +75,7 @@ TEST_CASE("[Graphics] sf::RenderWindow", runDisplayTests())
                                 sf::ContextSettings{});
         REQUIRE(window.getSize() == sf::Vector2u(256, 256));
 
-        auto texture = sf::Texture::create(window.getSize()).value();
+        sf::Texture texture(window.getSize());
 
         window.clear(sf::Color::Red);
         texture.update(window);

--- a/test/Graphics/Shape.test.cpp
+++ b/test/Graphics/Shape.test.cpp
@@ -66,8 +66,8 @@ TEST_CASE("[Graphics] sf::Shape", runDisplayTests())
 
     SECTION("Set/get texture")
     {
-        const auto    texture = sf::Texture::create({64, 64}).value();
-        TriangleShape triangleShape({});
+        const sf::Texture texture(sf::Vector2u(64, 64));
+        TriangleShape     triangleShape({});
         triangleShape.setTexture(&texture, true);
         CHECK(triangleShape.getTexture() == &texture);
     }

--- a/test/Graphics/Sprite.test.cpp
+++ b/test/Graphics/Sprite.test.cpp
@@ -22,7 +22,7 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Sprite>);
     }
 
-    const auto texture = sf::Texture::create({64, 64}).value();
+    const sf::Texture texture(sf::Vector2u(64, 64));
 
     SECTION("Construction")
     {
@@ -60,7 +60,7 @@ TEST_CASE("[Graphics] sf::Sprite", runDisplayTests())
     SECTION("Set/get texture")
     {
         sf::Sprite        sprite(texture);
-        const sf::Texture otherTexture = sf::Texture::create({64, 64}).value();
+        const sf::Texture otherTexture(sf::Vector2u(64, 64));
         sprite.setTexture(otherTexture);
         CHECK(&sprite.getTexture() == &otherTexture);
     }

--- a/test/Graphics/Text.test.cpp
+++ b/test/Graphics/Text.test.cpp
@@ -21,7 +21,7 @@ TEST_CASE("[Graphics] sf::Text", runDisplayTests())
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Text>);
     }
 
-    const auto font = sf::Font::openFromFile("Graphics/tuffy.ttf").value();
+    const auto font = sf::Font::createFromFile("Graphics/tuffy.ttf").value();
 
     SECTION("Construction")
     {
@@ -87,7 +87,7 @@ TEST_CASE("[Graphics] sf::Text", runDisplayTests())
     SECTION("Set/get font")
     {
         sf::Text   text(font);
-        const auto otherFont = sf::Font::openFromFile("Graphics/tuffy.ttf").value();
+        const auto otherFont = sf::Font::createFromFile("Graphics/tuffy.ttf").value();
         text.setFont(otherFont);
         CHECK(&text.getFont() == &otherFont);
     }

--- a/test/Graphics/Text.test.cpp
+++ b/test/Graphics/Text.test.cpp
@@ -21,7 +21,7 @@ TEST_CASE("[Graphics] sf::Text", runDisplayTests())
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Text>);
     }
 
-    const auto font = sf::Font::createFromFile("Graphics/tuffy.ttf").value();
+    const sf::Font font("Graphics/tuffy.ttf");
 
     SECTION("Construction")
     {
@@ -86,8 +86,8 @@ TEST_CASE("[Graphics] sf::Text", runDisplayTests())
 
     SECTION("Set/get font")
     {
-        sf::Text   text(font);
-        const auto otherFont = sf::Font::createFromFile("Graphics/tuffy.ttf").value();
+        sf::Text       text(font);
+        const sf::Font otherFont("Graphics/tuffy.ttf");
         text.setFont(otherFont);
         CHECK(&text.getFont() == &otherFont);
     }

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -15,7 +15,6 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(!std::is_default_constructible_v<sf::Texture>);
         STATIC_CHECK(std::is_copy_constructible_v<sf::Texture>);
         STATIC_CHECK(std::is_copy_assignable_v<sf::Texture>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Texture>);
@@ -23,7 +22,43 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         STATIC_CHECK(std::is_nothrow_swappable_v<sf::Texture>);
     }
 
+    SECTION("Construction")
+    {
+        const sf::Texture texture;
+        CHECK(texture.getSize() == sf::Vector2u());
+        CHECK(!texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() == 0);
+    }
+
     SECTION("Move semantics")
+    {
+        SECTION("Construction")
+        {
+            sf::Texture       movedTexture;
+            const sf::Texture texture = std::move(movedTexture);
+            CHECK(texture.getSize() == sf::Vector2u());
+            CHECK(!texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() == 0);
+        }
+
+        SECTION("Assignment")
+        {
+            sf::Texture movedTexture;
+            sf::Texture texture;
+            texture = std::move(movedTexture);
+            CHECK(texture.getSize() == sf::Vector2u());
+            CHECK(!texture.isSmooth());
+            CHECK(!texture.isSrgb());
+            CHECK(!texture.isRepeated());
+            CHECK(texture.getNativeHandle() == 0);
+        }
+    }
+
+    SECTION("Move semantics (create)")
     {
         SECTION("Construction")
         {
@@ -72,9 +107,35 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         }
     }
 
+    SECTION("resize()")
+    {
+        sf::Texture texture;
+
+        SECTION("At least one zero dimension")
+        {
+            CHECK(!texture.resize({}));
+            CHECK(!texture.resize({0, 1}));
+            CHECK(!texture.resize({1, 0}));
+        }
+
+        SECTION("Valid size")
+        {
+            CHECK(texture.resize({100, 100}));
+            CHECK(texture.getSize() == sf::Vector2u(100, 100));
+            CHECK(texture.getNativeHandle() != 0);
+        }
+
+        SECTION("Too large")
+        {
+            CHECK(!texture.resize({100'000, 100'000}));
+            CHECK(!texture.resize({1'000'000, 1'000'000}));
+        }
+    }
+
     SECTION("loadFromFile()")
     {
-        const auto texture = sf::Texture::loadFromFile("Graphics/sfml-logo-big.png").value();
+        sf::Texture texture;
+        REQUIRE(texture.loadFromFile("Graphics/sfml-logo-big.png"));
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());
         CHECK(!texture.isSrgb());
@@ -84,8 +145,9 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 
     SECTION("loadFromMemory()")
     {
-        const auto memory  = loadIntoMemory("Graphics/sfml-logo-big.png");
-        const auto texture = sf::Texture::loadFromMemory(memory.data(), memory.size()).value();
+        const auto  memory = loadIntoMemory("Graphics/sfml-logo-big.png");
+        sf::Texture texture;
+        REQUIRE(texture.loadFromMemory(memory.data(), memory.size()));
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());
         CHECK(!texture.isSrgb());
@@ -95,8 +157,10 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 
     SECTION("loadFromStream()")
     {
-        auto       stream  = sf::FileInputStream::open("Graphics/sfml-logo-big.png").value();
-        const auto texture = sf::Texture::loadFromStream(stream).value();
+        sf::Texture         texture;
+        sf::FileInputStream stream;
+        REQUIRE(stream.open("Graphics/sfml-logo-big.png"));
+        REQUIRE(texture.loadFromStream(stream));
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());
         CHECK(!texture.isSrgb());
@@ -106,27 +170,97 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 
     SECTION("loadFromImage()")
     {
+        SECTION("Empty image")
+        {
+            const sf::Image image;
+            sf::Texture     texture;
+            REQUIRE(!texture.loadFromImage(image));
+            REQUIRE(!texture.loadFromImage(image, false, {{0, 0}, {1, 1}}));
+        }
+
+        SECTION("Subarea of image")
+        {
+            sf::Image image;
+            image.resize(sf::Vector2u(10, 15));
+            sf::Texture texture;
+
+            SECTION("Non-truncated area")
+            {
+                REQUIRE(texture.loadFromImage(image, false, {{0, 0}, {5, 10}}));
+                CHECK(texture.getSize() == sf::Vector2u(5, 10));
+            }
+
+            SECTION("Truncated area (negative position)")
+            {
+                REQUIRE(texture.loadFromImage(image, false, {{-5, -5}, {4, 8}}));
+                CHECK(texture.getSize() == sf::Vector2u(4, 8));
+            }
+
+            SECTION("Truncated area (width/height too big)")
+            {
+                REQUIRE(texture.loadFromImage(image, false, {{5, 5}, {12, 18}}));
+                CHECK(texture.getSize() == sf::Vector2u(5, 10));
+            }
+
+            CHECK(texture.getNativeHandle() != 0);
+        }
+    }
+
+    SECTION("createFromFile()")
+    {
+        const auto texture = sf::Texture::createFromFile("Graphics/sfml-logo-big.png").value();
+        CHECK(texture.getSize() == sf::Vector2u(1001, 304));
+        CHECK(!texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() != 0);
+    }
+
+    SECTION("createFromMemory()")
+    {
+        const auto memory  = loadIntoMemory("Graphics/sfml-logo-big.png");
+        const auto texture = sf::Texture::createFromMemory(memory.data(), memory.size()).value();
+        CHECK(texture.getSize() == sf::Vector2u(1001, 304));
+        CHECK(!texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() != 0);
+    }
+
+    SECTION("createFromStream()")
+    {
+        auto       stream  = sf::FileInputStream::create("Graphics/sfml-logo-big.png").value();
+        const auto texture = sf::Texture::createFromStream(stream).value();
+        CHECK(texture.getSize() == sf::Vector2u(1001, 304));
+        CHECK(!texture.isSmooth());
+        CHECK(!texture.isSrgb());
+        CHECK(!texture.isRepeated());
+        CHECK(texture.getNativeHandle() != 0);
+    }
+
+    SECTION("createFromImage()")
+    {
         SECTION("Subarea of image")
         {
             const sf::Image image(sf::Vector2u(10, 15));
 
             SECTION("Non-truncated area")
             {
-                const auto texture = sf::Texture::loadFromImage(image, false, {{0, 0}, {5, 10}}).value();
+                const auto texture = sf::Texture::createFromImage(image, false, {{0, 0}, {5, 10}}).value();
                 CHECK(texture.getSize() == sf::Vector2u(5, 10));
                 CHECK(texture.getNativeHandle() != 0);
             }
 
             SECTION("Truncated area (negative position)")
             {
-                const auto texture = sf::Texture::loadFromImage(image, false, {{-5, -5}, {4, 8}}).value();
+                const auto texture = sf::Texture::createFromImage(image, false, {{-5, -5}, {4, 8}}).value();
                 CHECK(texture.getSize() == sf::Vector2u(4, 8));
                 CHECK(texture.getNativeHandle() != 0);
             }
 
             SECTION("Truncated area (width/height too big)")
             {
-                const auto texture = sf::Texture::loadFromImage(image, false, {{5, 5}, {12, 18}}).value();
+                const auto texture = sf::Texture::createFromImage(image, false, {{5, 5}, {12, 18}}).value();
                 CHECK(texture.getSize() == sf::Vector2u(5, 10));
                 CHECK(texture.getNativeHandle() != 0);
             }

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -72,24 +72,38 @@ TEST_CASE("[System] sf::FileInputStream")
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::FileInputStream>);
     }
 
-    SECTION("Default constructor")
-    {
-        sf::FileInputStream fileInputStream;
-        CHECK(fileInputStream.read(nullptr, 0) == std::nullopt);
-        CHECK(fileInputStream.seek(0) == std::nullopt);
-        CHECK(fileInputStream.tell() == std::nullopt);
-        CHECK(fileInputStream.getSize() == std::nullopt);
-    }
-
     const TemporaryFile temporaryFile("Hello world");
     char                buffer[32];
+
+    SECTION("Construction")
+    {
+        SECTION("Default constructor")
+        {
+            sf::FileInputStream fileInputStream;
+            CHECK(fileInputStream.read(nullptr, 0) == std::nullopt);
+            CHECK(fileInputStream.seek(0) == std::nullopt);
+            CHECK(fileInputStream.tell() == std::nullopt);
+            CHECK(fileInputStream.getSize() == std::nullopt);
+        }
+
+        SECTION("File path constructor")
+        {
+            sf::FileInputStream fileInputStream(temporaryFile.getPath());
+            CHECK(fileInputStream.read(buffer, 5) == 5);
+            CHECK(fileInputStream.tell() == 5);
+            CHECK(fileInputStream.getSize() == 11);
+            CHECK(std::string_view(buffer, 5) == "Hello"sv);
+            CHECK(fileInputStream.seek(6) == 6);
+            CHECK(fileInputStream.tell() == 6);
+        }
+    }
 
     SECTION("Move semantics")
     {
         SECTION("Move constructor")
         {
-            auto                movedFileInputStream = sf::FileInputStream::create(temporaryFile.getPath()).value();
-            sf::FileInputStream fileInputStream      = std::move(movedFileInputStream);
+            sf::FileInputStream movedFileInputStream(temporaryFile.getPath());
+            sf::FileInputStream fileInputStream = std::move(movedFileInputStream);
             CHECK(fileInputStream.read(buffer, 6) == 6);
             CHECK(fileInputStream.tell() == 6);
             CHECK(fileInputStream.getSize() == 11);
@@ -98,10 +112,10 @@ TEST_CASE("[System] sf::FileInputStream")
 
         SECTION("Move assignment")
         {
-            auto                movedFileInputStream = sf::FileInputStream::create(temporaryFile.getPath()).value();
+            sf::FileInputStream movedFileInputStream(temporaryFile.getPath());
             const TemporaryFile temporaryFile2("Hello world the sequel");
-            auto                fileInputStream = sf::FileInputStream::create(temporaryFile2.getPath()).value();
-            fileInputStream                     = std::move(movedFileInputStream);
+            sf::FileInputStream fileInputStream(temporaryFile2.getPath());
+            fileInputStream = std::move(movedFileInputStream);
             CHECK(fileInputStream.read(buffer, 6) == 6);
             CHECK(fileInputStream.tell() == 6);
             CHECK(fileInputStream.getSize() == 11);
@@ -123,7 +137,7 @@ TEST_CASE("[System] sf::FileInputStream")
 
     SECTION("Temporary file stream create")
     {
-        auto fileInputStream = sf::FileInputStream::create(temporaryFile.getPath()).value();
+        sf::FileInputStream fileInputStream(temporaryFile.getPath());
         CHECK(fileInputStream.read(buffer, 5) == 5);
         CHECK(fileInputStream.tell() == 5);
         CHECK(fileInputStream.getSize() == 11);

--- a/test/System/MemoryInputStream.test.cpp
+++ b/test/System/MemoryInputStream.test.cpp
@@ -18,8 +18,17 @@ TEST_CASE("[System] sf::MemoryInputStream")
 
     using namespace std::literals::string_view_literals;
 
-    SECTION("open()")
+    SECTION("Construction")
     {
+        SECTION("Null data")
+        {
+            sf::MemoryInputStream memoryInputStream(nullptr, 0);
+            CHECK(memoryInputStream.read(nullptr, 0) == std::nullopt);
+            CHECK(memoryInputStream.seek(0) == std::nullopt);
+            CHECK(memoryInputStream.tell() == std::nullopt);
+            CHECK(memoryInputStream.getSize() == std::nullopt);
+        }
+
         static constexpr auto input = "hello world"sv;
 
         SECTION("Zero length")

--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -17,6 +17,37 @@ TEST_CASE("[Window] sf::Cursor", runDisplayTests())
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Cursor>);
     }
 
+    SECTION("Constructor")
+    {
+        SECTION("Pixels")
+        {
+            static constexpr std::array<std::uint8_t, 4> pixels{};
+
+            CHECK_THROWS_AS(sf::Cursor(nullptr, {}, {}), std::runtime_error);
+            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {0, 1}, {}), std::runtime_error);
+            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {1, 0}, {}), std::runtime_error);
+            CHECK_NOTHROW(sf::Cursor(pixels.data(), {1, 1}, {}));
+        }
+
+        SECTION("System")
+        {
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::Hand));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeHorizontal));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeVertical));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeLeft));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeRight));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeTop));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeBottom));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeTopLeft));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeTopRight));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeBottomLeft));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::SizeBottomRight));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::Cross));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::Help));
+            CHECK_NOTHROW(sf::Cursor(sf::Cursor::Type::NotAllowed));
+        }
+    }
+
     SECTION("loadFromPixels()")
     {
         static constexpr std::array<std::uint8_t, 4> pixels{};

--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -21,27 +21,27 @@ TEST_CASE("[Window] sf::Cursor", runDisplayTests())
     {
         static constexpr std::array<std::uint8_t, 4> pixels{};
 
-        CHECK(!sf::Cursor::loadFromPixels(nullptr, {}, {}));
-        CHECK(!sf::Cursor::loadFromPixels(pixels.data(), {0, 1}, {}));
-        CHECK(!sf::Cursor::loadFromPixels(pixels.data(), {1, 0}, {}));
-        CHECK(sf::Cursor::loadFromPixels(pixels.data(), {1, 1}, {}));
+        CHECK(!sf::Cursor::createFromPixels(nullptr, {}, {}));
+        CHECK(!sf::Cursor::createFromPixels(pixels.data(), {0, 1}, {}));
+        CHECK(!sf::Cursor::createFromPixels(pixels.data(), {1, 0}, {}));
+        CHECK(sf::Cursor::createFromPixels(pixels.data(), {1, 1}, {}));
     }
 
     SECTION("loadFromSystem()")
     {
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::Hand));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeHorizontal));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeVertical));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeLeft));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeRight));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeTop));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeBottom));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeTopLeft));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeTopRight));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeBottomLeft));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::SizeBottomRight));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::Cross));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::Help));
-        CHECK(sf::Cursor::loadFromSystem(sf::Cursor::Type::NotAllowed));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Hand));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeHorizontal));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeVertical));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeLeft));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeRight));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTop));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottom));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTopLeft));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTopRight));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottomLeft));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottomRight));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Cross));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Help));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::NotAllowed));
     }
 }

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -26,16 +26,16 @@ int main()
     sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 
     // Set the Icon
-    const auto icon = sf::Image::loadFromFile(resourcePath() / "icon.png").value();
+    const sf::Image icon(resourcePath() / "icon.png");
     window.setIcon(icon);
 
     // Load a sprite to display
-    const auto texture = sf::Texture::loadFromFile(resourcePath() / "background.jpg").value();
-    sf::Sprite sprite(texture);
+    const sf::Texture texture(resourcePath() / "background.jpg");
+    sf::Sprite        sprite(texture);
 
     // Create a graphical text to display
-    const auto font = sf::Font::openFromFile(resourcePath() / "tuffy.ttf").value();
-    sf::Text   text(font, "Hello SFML", 50);
+    const sf::Font font(resourcePath() / "tuffy.ttf");
+    sf::Text       text(font, "Hello SFML", 50);
     text.setFillColor(sf::Color::Black);
 
     // Load a music to play

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -24,16 +24,16 @@ int main()
     sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 
     // Set the Icon
-    const auto icon = sf::Image::loadFromFile("icon.png").value();
+    const sf::Image icon("icon.png");
     window.setIcon(icon);
 
     // Load a sprite to display
-    const auto texture = sf::Texture::loadFromFile("background.jpg").value();
-    sf::Sprite sprite(texture);
+    const sf::Texture texture("background.jpg");
+    sf::Sprite        sprite(texture);
 
     // Create a graphical text to display
-    const auto font = sf::Font::openFromFile("tuffy.ttf").value();
-    sf::Text   text(font, "Hello SFML", 50);
+    const sf::Font font("tuffy.ttf");
+    sf::Text       text(font, "Hello SFML", 50);
     text.setFillColor(sf::Color::Black);
 
     // Load a music to play


### PR DESCRIPTION
This change does several things:
- Reimplements default constructors for types whose use in default state was never really problematic (e.g. caused UB)
- Attempts to provide a documented definition of the valid state of a default constructed object
- Renames several `create` methods to `resize` since this is technically what they are actually used for from a user perspective
- ~~Renames the factory functions to `createFromXYZ` since this better conveys that they create new objects instead of operate on existing ones~~
- Reimplements `loadFromXYZ`/`openFromXYZ` methods in order to allow efficient object recycling after construction
- Adds throwing variants of constructors that take the same parameters as the factory or equivalent `loadFromXYZ`/`openFromXYZ` methods

I know... this is going to be another involved discussion, but it had to happen.

It has become obvious to me that we underestimated the impact that only providing factory methods would have on existing codebases. The factory methods are in no way a drop-in replacement for the old functionality and would force users to rewrite larger portions of their code than they might be comfortable with. Certain usage patterns that they have established over a long time might not be implementable using only factory methods. Only having access to factory methods also means that the only way they can construct instances of their own types that contain unwrapped SFML objects as members is by calling `.value()` within the initializer list and ending up having to handle exceptions (`std::bad_optional_access`) anyway. This basically forces the user to wrap their own objects in `optional`s and write factory functions for them as well in order to properly handle failure to load a resource. I don't feel good about SFML's API having such a "viral" nature.

```cpp
struct MyStruct
{
    // How do you handle load failure here without exception handling? You can't...
    MyStruct() : texture(sf::Texture::loadFromFile(...).value())
    {
    }
    sf::Texture texture;
}

struct MyViralStruct
{
    // The only way to support initializer list initialization is by storing an optional in my own types
    // This would mean I would have to check whether it is valid every time I access it
    MyStruct() : texture(sf::Texture::loadFromFile(...))
    {
    }
    std::optional<sf::Texture> texture;
}

struct MyOtherViralStruct
{
    // Another way of solving this problem is by calling the factory outside and moving in
    MyStruct(sf::Texture&& tex) : texture(tex)
    {
    }
    sf::Texture texture;
}

// Now resource loading can only take place outside the struct/class and error handling as well

// MyOtherViralStruct makeStruct() // Nope, would require exceptions
// {
//     auto tex = sf::Texture::loadFromFile(...);
//     return MyOtherViralStruct(std::move(tex.value()));
// }

std::optional<MyOtherViralStruct> maybeMakeStruct()
{
    auto tex = sf::Texture::loadFromFile(...);
    if (tex)
        return std::make_optional<MyOtherViralStruct>(std::move(*tex));
    return std::nullopt;
}
```
If anyone has been paying attention, the last example is exactly how the Shader example ended up having to be rewritten in order to make use of the new factory methods. This is a very high impact change and as I already said above, nobody is going to be able to sell it as a drop-in replacement. Not everybody is willing to pay for additional safety at any cost. The examples above should also make it obvious that the alternatives forced upon the user will end up making their code noticeably more complex than what it would have been when using the old API. This is not only annoying for experienced users trying to get work done but will also significantly degrade the experience of beginners just trying to get their first object-oriented project through the door.

Also, the lack of non-factory `loadFromXYZ`/`openFromXYZ` methods means the only way to reload a resource is by moving a newly created one on top of the older one, which is very inefficient, performance-wise and memory-usage-wise.

In addition to providing throwing constructor variants of the factory methods (equivalent to #3134), this change also reimplements the default constructors and `loadFromXYZ`/`openFromXYZ` methods. The factory methods were renamed to `createFromXYZ` to avoid name clashes and because create better reflects that they create new objects instead of operate on existing ones.

The initial motivation of converting the `loadFromXYZ`/`openFromXYZ` methods to factory methods was as a follow-up to the error handling discussions. In retrospect, I think that too little was discussed about the actual implementation and consequences of applying the mechanical transformation to all of the affected APIs.

In my opinion, a discussion should have been had about what constitutes an "invalid object state" before the factory conversion was performed. As far as I can tell, using most of the default constructed objects affected by this change never really resulted in any undefined behaviour if the user didn't load anything into them before using them. What was lacking was a documented definition of the state an object would be in after it had been default constructed. Many users might have already known this and taken it into account over the years. For me, an object that is fully usable after default construction without causing any undefined behaviour also has to be considered fully initialized, thus providing default constructors and `loadFromXYZ`/`openFromXYZ` methods was never really two-phase initialization in a formal sense.

One might question what sense it makes to operate on "empty" objects, and you can make the argument that the library has to prevent this from happening, but if we are to follow the example of the C++ standard library, operations on "empty ranges" (i.e. where both `first` and `last` iterators are equal) are perfectly legal and don't trigger any asserts or other diagnostic warnings. Empty containers make just as much sense as "empty" SFML objects. If C++ doesn't force us to create new containers just to assign values to an existing one then neither should SFML. It just doesn't feel natural and might come across as overreaching our domain of responsibility. Sure... performing anything on empty objects will often times be the result of a programming error somewhere, but these are logic errors and that's why we still rely on humans to program and use debuggers to find these kinds of mistakes.

The 3 forms of object construction that this change provides are targeted at 3 different user groups:
- Default construction + `loadFromXYZ`/`openFromXYZ` for legacy projects and users who have their own established frameworks set up around them
- Factory methods for new projects that prefer them over throwing constructors (might not want exceptions)
- Throwing constructors for new projects that prefer unwrapped objects and don't mind exceptions

Regardless of whether the default constructors still exist or not, providing `loadFromXYZ`/`openFromXYZ` methods still provides reload functionality even for newer projects that use throwing constructors or factory methods. Because their implementation is used as the common base for both the throwing constructors and factory methods it wouldn't make sense not to offer them since the code is already there.

The examples and documentation text have not been changed and still reference the factory methods although it might need to be discussed whether throwing constructors should be mentioned as well. Default construction is deliberately not mentioned because it is not recommended for newer projects.

As with #3134 the same applies here, if we add support for our own differentiated exceptions, the user will have finer grained control over how they might want to handle them. The `std::runtime_error`s can be seen as place holders until we establish if and what kind of exceptions we want to support.

Closes #3134
Resolves #3120
@danieljpetersen might be interested in this.