### PR TITLE
Specify `sf::Image`'s save format via a scoped enumeration

### DIFF
--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -36,7 +36,6 @@
 
 #include <filesystem>
 #include <optional>
-#include <string_view>
 #include <vector>
 
 #include <cstddef>
@@ -54,6 +53,18 @@ class InputStream;
 class SFML_GRAPHICS_API Image
 {
 public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Supported formats for saving
+    ///
+    ////////////////////////////////////////////////////////////
+    enum class SaveFormat
+    {
+        BMP,
+        TGA,
+        PNG,
+        JPG
+    };
+
     ////////////////////////////////////////////////////////////
     /// \brief Default constructor
     ///
@@ -220,13 +231,14 @@ public:
     /// if it already exists. This function fails if the image is empty.
     ///
     /// \param filename Path of the file to save
+    /// \param format   Encoding format to use
     ///
     /// \return True if saving was successful
     ///
     /// \see saveToMemory, loadFromFile
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool saveToFile(const std::filesystem::path& filename) const;
+    [[nodiscard]] bool saveToFile(const std::filesystem::path& filename, SaveFormat format) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Save the image to a buffer in memory
@@ -244,7 +256,7 @@ public:
     /// \see saveToFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::optional<std::vector<std::uint8_t>> saveToMemory(std::string_view format) const;
+    [[nodiscard]] std::optional<std::vector<std::uint8_t>> saveToMemory(SaveFormat format) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size (width and height) of the image

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -317,44 +317,34 @@ bool Image::loadFromStream(InputStream& stream)
 
 
 ////////////////////////////////////////////////////////////
-bool Image::saveToFile(const std::filesystem::path& filename) const
+bool Image::saveToFile(const std::filesystem::path& filename, SaveFormat format) const
 {
     // Make sure the image is not empty
     if (!m_pixels.empty() && m_size.x > 0 && m_size.y > 0)
     {
-        // Deduce the image type from its extension
+        const Vector2i convertedSize = Vector2i(m_size);
 
-        // Extract the extension
-        const std::filesystem::path extension     = filename.extension();
-        const Vector2i              convertedSize = Vector2i(m_size);
-
-        if (extension == ".bmp")
+        switch (format)
         {
-            // BMP format
-            if (stbi_write_bmp(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return true;
-        }
-        else if (extension == ".tga")
-        {
-            // TGA format
-            if (stbi_write_tga(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return true;
-        }
-        else if (extension == ".png")
-        {
-            // PNG format
-            if (stbi_write_png(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
-                return true;
-        }
-        else if (extension == ".jpg" || extension == ".jpeg")
-        {
-            // JPG format
-            if (stbi_write_jpg(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
-                return true;
-        }
-        else
-        {
-            err() << "Image file extension " << extension << " not supported\n";
+            case SaveFormat::BMP:
+                if (stbi_write_bmp(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+                    return true;
+                break;
+            case SaveFormat::TGA:
+                if (stbi_write_tga(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+                    return true;
+                break;
+            case SaveFormat::PNG:
+                if (stbi_write_png(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
+                    return true;
+                break;
+            case SaveFormat::JPG:
+                if (stbi_write_jpg(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
+                    return true;
+                break;
+            default:
+                assert(false && "Invalid format enumeration provided");
+                return false;
         }
     }
 
@@ -364,44 +354,39 @@ bool Image::saveToFile(const std::filesystem::path& filename) const
 
 
 ////////////////////////////////////////////////////////////
-std::optional<std::vector<std::uint8_t>> Image::saveToMemory(std::string_view format) const
+std::optional<std::vector<std::uint8_t>> Image::saveToMemory(SaveFormat format) const
 {
     // Make sure the image is not empty
     if (!m_pixels.empty() && m_size.x > 0 && m_size.y > 0)
     {
-        // Choose function based on format
-        const std::string specified     = toLower(std::string(format));
-        const Vector2i    convertedSize = Vector2i(m_size);
-
+        const Vector2i            convertedSize = Vector2i(m_size);
         std::vector<std::uint8_t> buffer;
 
-        if (specified == "bmp")
+        switch (format)
         {
-            // BMP format
-            if (stbi_write_bmp_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return buffer;
-        }
-        else if (specified == "tga")
-        {
-            // TGA format
-            if (stbi_write_tga_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return buffer;
-        }
-        else if (specified == "png")
-        {
-            // PNG format
-            if (stbi_write_png_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
-                return buffer;
-        }
-        else if (specified == "jpg" || specified == "jpeg")
-        {
-            // JPG format
-            if (stbi_write_jpg_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
-                return buffer;
+            case SaveFormat::BMP:
+                if (stbi_write_bmp_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+                    return buffer;
+                break;
+            case SaveFormat::TGA:
+                if (stbi_write_tga_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+                    return buffer;
+                break;
+            case SaveFormat::PNG:
+                if (stbi_write_png_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
+                    return buffer;
+                break;
+            case SaveFormat::JPG:
+                if (stbi_write_jpg_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
+                    return buffer;
+                break;
+            default:
+                assert(false && "Invalid format enumeration provided");
+                return std::nullopt;
         }
     }
 
-    err() << "Failed to save image with format " << std::quoted(format) << std::endl;
+    err() << "Failed to save image" << std::endl;
     return std::nullopt;
 }
 


### PR DESCRIPTION
## Description

Closes #3157 

The rationale in Vittorio's issue lays out the value case for this change so I won't repeat that.

The one place this PR differs from Vittorio's issue is that I chose to not change the return type of `sf::Image::saveToMemory` since the `stbi_write_` functions are prone to fail and to avoid having to make bigger changes to `sf::image`. This PR does not aim to change what we deem a valid image nor change the semantics of `sf::Image::Image`. Such a change can be discussed in a separate PR like #3152.

---

We have one other `saveToFile` function in `sf::SoundBuffer::saveToFile` but that function seems unfit for such a change since it supported an open set of file formats rather than the closed set of formats that `sf::Image::saveToFile` supports.