### PR TITLE
Fix white square problem in OpenGL example

### DIFF
--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -221,6 +221,9 @@ int main()
                         // We simply reload the texture to disable mipmapping
                         texture = sf::Texture::loadFromFile(resourcesDir() / "logo.png").value();
 
+                        // Rebind the texture
+                        sf::Texture::bind(&texture);
+
                         mipmapEnabled = false;
                     }
                     else if (texture.generateMipmap())


### PR DESCRIPTION
## Description

_Thanks to @vittorioromeo for spotting this one within the GL example!_

When the OpenGL example is ran, and the texture mip map toggle key (return) is pressed, the cube becomes fully white (see below screenshot). This reproduces only on master, and is not an issue in 2.6.1.

This is because within the example the texture is loaded from disk, then bound 

![image](https://github.com/user-attachments/assets/1c5ac124-f733-40c4-86cf-809df9685723)


https://github.com/SFML/SFML/blob/master/examples/opengl/OpenGL.cpp#L126

but then when we reload the texture we call the constructor which destroys the old texture and invalidates its ID

https://github.com/SFML/SFML/blob/master/examples/opengl/OpenGL.cpp#L222
https://github.com/SFML/SFML/blob/master/src/SFML/Graphics/Texture.cpp#L144

now the bound state will be refering to an unused texture ID. This was not an issue in 2.6.x as calling `.loadFromFile()` on a texture instance that has been loaded into previously would cause its ID to be reused. 

https://github.com/SFML/SFML/blob/2.6.x/src/SFML/Graphics/Texture.cpp#L163

The solution is to call `sf::Texture::bind()` whenever we've reloaded the texture from disk.

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?


Run OpenGL example, and try toggling mip map on/off with the return key. Before this fix the white square shown above will appear, after the fix the texture will show correctly:

![image](https://github.com/user-attachments/assets/155ae28c-8f21-41ca-92aa-9a2d46439820)
