### PR TITLE
Proof-of-concept `sf::Texture` "recycling" API

### DIFF
--- a/doc/mainpage.hpp
+++ b/doc/mainpage.hpp
@@ -21,7 +21,7 @@
 ///     sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML window");
 ///
 ///     // Load a sprite to display
-///     const auto texture = sf::Texture::loadFromFile("cute_image.jpg").value();
+///     const auto texture = sf::Texture::createFromFile("cute_image.jpg").value();
 ///     sf::Sprite sprite(texture);
 ///
 ///     // Create a graphical text to display

--- a/examples/android/app/src/main/jni/main.cpp
+++ b/examples/android/app/src/main/jni/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
     sf::RenderWindow window(screen, "");
     window.setFramerateLimit(30);
 
-    const auto texture = sf::Texture::loadFromFile("image.png").value();
+    const auto texture = sf::Texture::createFromFile("image.png").value();
 
     sf::Sprite image(texture);
     image.setPosition(sf::Vector2f(screen.size) / 2.f);

--- a/examples/cocoa/CocoaAppDelegate.mm
+++ b/examples/cocoa/CocoaAppDelegate.mm
@@ -54,7 +54,7 @@ struct SFMLmainWindow
     sf::RenderWindow      renderWindow;
     sf::Font              font{sf::Font::openFromFile(resPath / "tuffy.ttf").value()};
     sf::Text              text{font};
-    sf::Texture           logo{sf::Texture::loadFromFile(resPath / "logo.png").value()};
+    sf::Texture           logo{sf::Texture::createFromFile(resPath / "logo.png").value()};
     sf::Sprite            sprite{logo};
     sf::Color             background{sf::Color::Blue};
 };

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -58,7 +58,7 @@ int main()
         window.setMaximumSize(sf::Vector2u(1200, 900));
 
         // Create a sprite for the background
-        const auto       backgroundTexture = sf::Texture::loadFromFile(resourcesDir() / "background.jpg", sRgb).value();
+        const auto       backgroundTexture = sf::Texture::createFromFile(resourcesDir() / "background.jpg", sRgb).value();
         const sf::Sprite background(backgroundTexture);
 
         // Create some text to draw on top of our OpenGL object
@@ -75,7 +75,7 @@ int main()
         mipmapInstructions.setPosition({200.f, 550.f});
 
         // Load a texture to apply to our 3D cube
-        auto texture = sf::Texture::loadFromFile(resourcesDir() / "logo.png").value();
+        auto texture = sf::Texture::createFromFile(resourcesDir() / "logo.png").value();
 
         // Attempt to generate a mipmap for our cube texture
         // We don't check the return value here since
@@ -219,7 +219,7 @@ int main()
                     if (mipmapEnabled)
                     {
                         // We simply reload the texture to disable mipmapping
-                        texture = sf::Texture::loadFromFile(resourcesDir() / "logo.png").value();
+                        texture = sf::Texture::createFromFile(resourcesDir() / "logo.png").value();
 
                         mipmapEnabled = false;
                     }

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -278,7 +278,7 @@ private:
 ////////////////////////////////////////////////////////////
 std::optional<Pixelate> tryLoadPixelate()
 {
-    auto texture = sf::Texture::loadFromFile("resources/background.jpg");
+    auto texture = sf::Texture::createFromFile("resources/background.jpg");
     if (!texture.has_value())
         return std::nullopt;
 
@@ -317,14 +317,14 @@ std::optional<Edge> tryLoadEdge()
     surface->setSmooth(true);
 
     // Load the background texture
-    auto backgroundTexture = sf::Texture::loadFromFile("resources/sfml.png");
+    auto backgroundTexture = sf::Texture::createFromFile("resources/sfml.png");
     if (!backgroundTexture.has_value())
         return std::nullopt;
 
     backgroundTexture->setSmooth(true);
 
     // Load the entity texture
-    auto entityTexture = sf::Texture::loadFromFile("resources/devices.png");
+    auto entityTexture = sf::Texture::createFromFile("resources/devices.png");
     if (!entityTexture.has_value())
         return std::nullopt;
 
@@ -350,7 +350,7 @@ std::optional<Geometry> tryLoadGeometry()
         return std::nullopt;
 
     // Load the logo texture
-    auto logoTexture = sf::Texture::loadFromFile("resources/logo.png");
+    auto logoTexture = sf::Texture::createFromFile("resources/logo.png");
     if (!logoTexture.has_value())
         return std::nullopt;
 
@@ -418,7 +418,7 @@ int main()
     std::size_t current = 0;
 
     // Create the messages background
-    const auto textBackgroundTexture = sf::Texture::loadFromFile("resources/text-background.png").value();
+    const auto textBackgroundTexture = sf::Texture::createFromFile("resources/text-background.png").value();
     sf::Sprite textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -1106,7 +1106,7 @@ int main()
     effects[current]->start();
 
     // Create the messages background
-    const auto textBackgroundTexture = sf::Texture::loadFromFile(resourcesDir() / "text-background.png").value();
+    const auto textBackgroundTexture = sf::Texture::createFromFile(resourcesDir() / "text-background.png").value();
     sf::Sprite textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -53,7 +53,7 @@ int main()
     sf::Sound  ballSound(ballSoundBuffer);
 
     // Create the SFML logo texture:
-    const auto sfmlLogoTexture = sf::Texture::loadFromFile(resourcesDir() / "sfml_logo.png").value();
+    const auto sfmlLogoTexture = sf::Texture::createFromFile(resourcesDir() / "sfml_logo.png").value();
     sf::Sprite sfmlLogo(sfmlLogoTexture);
     sfmlLogo.setPosition({170.f, 50.f});
 

--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -111,8 +111,8 @@ int main()
     sf::RenderWindow sfmlView2(view2);
 
     // Load some textures to display
-    const auto texture1 = sf::Texture::loadFromFile("resources/image1.jpg").value();
-    const auto texture2 = sf::Texture::loadFromFile("resources/image2.jpg").value();
+    const auto texture1 = sf::Texture::createFromFile("resources/image1.jpg").value();
+    const auto texture2 = sf::Texture::createFromFile("resources/image2.jpg").value();
     sf::Sprite sprite1(texture1);
     sf::Sprite sprite2(texture2);
     sprite1.setOrigin(sf::Vector2f(texture1.getSize()) / 2.f);

--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -266,7 +266,7 @@ private:
 /// sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML OpenGL");
 ///
 /// // Create a sprite and a text to display
-/// const auto texture = sf::Texture::loadFromFile("circle.png").value();
+/// const auto texture = sf::Texture::createFromFile("circle.png").value();
 /// sf::Sprite sprite(texture);
 /// const auto font = sf::Font::openFromFile("arial.ttf").value();
 /// sf::Text text(font);

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -261,7 +261,7 @@ private:
 /// Usage example:
 /// \code
 /// // Load a texture
-/// const auto texture = sf::Texture::loadFromFile("texture.png").value();
+/// const auto texture = sf::Texture::createFromFile("texture.png").value();
 ///
 /// // Create a sprite
 /// sf::Sprite sprite(texture);

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -100,6 +100,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static std::optional<Texture> create(const Vector2u& size, bool sRgb = false);
+    [[nodiscard]] bool                          recreate(const Vector2u& size, bool sRgb = false);
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a file on disk
@@ -124,9 +125,11 @@ public:
     /// \see loadFromMemory, loadFromStream, loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromFile(const std::filesystem::path& filename,
-                                                             bool                         sRgb = false,
-                                                             const IntRect&               area = {});
+    [[nodiscard]] static std::optional<Texture> createFromFile(const std::filesystem::path& filename,
+                                                               bool                         sRgb = false,
+                                                               const IntRect&               area = {});
+    [[nodiscard]] bool recreateFromFile(const std::filesystem::path& filename, bool sRgb = false, const IntRect& area = {});
+
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a file in memory
@@ -152,11 +155,12 @@ public:
     /// \see loadFromFile, loadFromStream, loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromMemory(
+    [[nodiscard]] static std::optional<Texture> createFromMemory(
         const void*    data,
         std::size_t    size,
         bool           sRgb = false,
         const IntRect& area = {});
+    [[nodiscard]] bool recreateFromMemory(const void* data, std::size_t size, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from a custom stream
@@ -181,7 +185,10 @@ public:
     /// \see loadFromFile, loadFromMemory, loadFromImage
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromStream(InputStream& stream, bool sRgb = false, const IntRect& area = {});
+    [[nodiscard]] static std::optional<Texture> createFromStream(InputStream&   stream,
+                                                                 bool           sRgb = false,
+                                                                 const IntRect& area = {});
+    [[nodiscard]] bool recreateFromStream(InputStream& stream, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Load the texture from an image
@@ -206,7 +213,8 @@ public:
     /// \see loadFromFile, loadFromMemory
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<Texture> loadFromImage(const Image& image, bool sRgb = false, const IntRect& area = {});
+    [[nodiscard]] static std::optional<Texture> createFromImage(const Image& image, bool sRgb = false, const IntRect& area = {});
+    [[nodiscard]] bool recreateFromImage(const Image& image, bool sRgb = false, const IntRect& area = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the size of the texture
@@ -630,7 +638,7 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// However, if you want to perform some modifications on the pixels
 /// before creating the final texture, you can load your file to a
 /// sf::Image, do whatever you need with the pixels, and then call
-/// Texture::loadFromImage.
+/// Texture::createFromImage.
 ///
 /// Since they live in the graphics card memory, the pixels of a texture
 /// cannot be accessed without a slow copy first. And they cannot be
@@ -662,7 +670,7 @@ SFML_GRAPHICS_API void swap(Texture& left, Texture& right) noexcept;
 /// // drawing a sprite
 ///
 /// // Load a texture from a file
-/// const auto texture = sf::Texture::loadFromFile("texture.png").value();
+/// const auto texture = sf::Texture::createFromFile("texture.png").value();
 ///
 /// // Assign it to a sprite
 /// sf::Sprite sprite(texture);

--- a/include/SFML/System/InputStream.hpp
+++ b/include/SFML/System/InputStream.hpp
@@ -142,7 +142,7 @@ public:
 ///     // Handle error...
 /// }
 ///
-/// const auto texture = sf::Texture::loadFromStream(stream).value();
+/// const auto texture = sf::Texture::createFromStream(stream).value();
 ///
 /// // musics...
 /// sf::Music music;

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -750,7 +750,7 @@ std::optional<Font::Page> Font::Page::create(bool smooth)
             image.setPixel({x, y}, Color::White);
 
     // Create the texture
-    auto texture = sf::Texture::loadFromImage(image);
+    auto texture = sf::Texture::createFromImage(image);
     if (!texture)
     {
         err() << "Failed to load font page texture" << std::endl;

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -74,7 +74,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 
     SECTION("loadFromFile()")
     {
-        const auto texture = sf::Texture::loadFromFile("Graphics/sfml-logo-big.png").value();
+        const auto texture = sf::Texture::createFromFile("Graphics/sfml-logo-big.png").value();
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());
         CHECK(!texture.isSrgb());
@@ -85,7 +85,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
     SECTION("loadFromMemory()")
     {
         const auto memory  = loadIntoMemory("Graphics/sfml-logo-big.png");
-        const auto texture = sf::Texture::loadFromMemory(memory.data(), memory.size()).value();
+        const auto texture = sf::Texture::createFromMemory(memory.data(), memory.size()).value();
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());
         CHECK(!texture.isSrgb());
@@ -96,7 +96,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
     SECTION("loadFromStream()")
     {
         auto       stream  = sf::FileInputStream::open("Graphics/sfml-logo-big.png").value();
-        const auto texture = sf::Texture::loadFromStream(stream).value();
+        const auto texture = sf::Texture::createFromStream(stream).value();
         CHECK(texture.getSize() == sf::Vector2u(1001, 304));
         CHECK(!texture.isSmooth());
         CHECK(!texture.isSrgb());
@@ -112,21 +112,21 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 
             SECTION("Non-truncated area")
             {
-                const auto texture = sf::Texture::loadFromImage(image, false, {{0, 0}, {5, 10}}).value();
+                const auto texture = sf::Texture::createFromImage(image, false, {{0, 0}, {5, 10}}).value();
                 CHECK(texture.getSize() == sf::Vector2u(5, 10));
                 CHECK(texture.getNativeHandle() != 0);
             }
 
             SECTION("Truncated area (negative position)")
             {
-                const auto texture = sf::Texture::loadFromImage(image, false, {{-5, -5}, {4, 8}}).value();
+                const auto texture = sf::Texture::createFromImage(image, false, {{-5, -5}, {4, 8}}).value();
                 CHECK(texture.getSize() == sf::Vector2u(4, 8));
                 CHECK(texture.getNativeHandle() != 0);
             }
 
             SECTION("Truncated area (width/height too big)")
             {
-                const auto texture = sf::Texture::loadFromImage(image, false, {{5, 5}, {12, 18}}).value();
+                const auto texture = sf::Texture::createFromImage(image, false, {{5, 5}, {12, 18}}).value();
                 CHECK(texture.getSize() == sf::Vector2u(5, 10));
                 CHECK(texture.getNativeHandle() != 0);
             }

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -30,7 +30,7 @@ int main()
     window.setIcon(icon);
 
     // Load a sprite to display
-    const auto texture = sf::Texture::loadFromFile(resourcePath() / "background.jpg").value();
+    const auto texture = sf::Texture::createFromFile(resourcePath() / "background.jpg").value();
     sf::Sprite sprite(texture);
 
     // Create a graphical text to display

--- a/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML CLT.xctemplate/main.cpp
@@ -28,7 +28,7 @@ int main()
     window.setIcon(icon);
 
     // Load a sprite to display
-    const auto texture = sf::Texture::loadFromFile("background.jpg").value();
+    const auto texture = sf::Texture::createFromFile("background.jpg").value();
     sf::Sprite sprite(texture);
 
     // Create a graphical text to display


### PR DESCRIPTION
@binary1248's #3152 allows for "efficient object recycling after construction". 

Such feature can coexist with `std::optional`-based factory construction, and can coexist with the principle of having SFML objects always in a valid state. This PR is a proof-of-concept for that, only for `sf::Texture`.

Changes:

- Renamed factory functions to `createFromXXX`
- Added a recycling function for every factory function, named `recreateFromXXX`
- Factory functions are implemented in terms of recycling functions

I'm still not convinced that this is worthwhile doing, but it's definitely worth exploring. The advantage of "recycling" compared to assignment is that internal handles/buffers can be reused. In other words:

```cpp
auto t0 = sf::Texture::createFromFile("somepath").value();
t0 = sf::Texture::createFromFile("somepath").value(); 
    // Semantically correct, simple, but cannot reuse resources such as GL texture
    // handle, or internal containers (will need to be reallocated and moved)
    
auto t1 = sf::Texture::createFromFile("somepath").value();
if (!t1.recreateFromFile("somepath")) { /* ... */ }
    // Allows internal resources to be reused (e.g. no need to create a new GL 
    // texture, internal containers can be cleared instead of being reallocated)
```

Reasons why I am not convinced this is worthwhile doing:
1. Increases the surface area of SFML objects API
2. Somewhat increases complexity of SFML object implementation
3. Users now have to consciously choose between `operator=` or `.recreateFromXXX`
4. No evidence that recycling is meaningful/useful in any real application

Point (4) is the most important. If a program's performance bottleneck is texture loading, image creation, font loading, soundbuffer loading, and so on... there's something severely wrong. 

These things should not be done on a per-frame basis, resources should be loaded sparingly and only when needed. 

Furthermore, the overhead of using the file system to read an image file is going to be much larger than the one for calling `glGenTextures` or allocating a `std::vector<std::uint8_t>` for an image's pixels.

Therefore, I think that `operator=` is good enough in most cases, even if not optimal, but I can be convinced otherwise if provided with compelling evidence.