### PR TITLE
Modernize memory management of Core Foundation pointers

### DIFF
--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/JoystickImpl.hpp>
 #include <SFML/Window/Keyboard.hpp>
+#include <SFML/Window/macOS/Utils.hpp>
 
 #include <IOKit/hid/IOHIDDevice.h>
 #include <IOKit/hid/IOHIDManager.h>
@@ -40,7 +41,7 @@
 namespace sf::priv
 {
 
-using IOHIDElements = std::vector<IOHIDElementRef>;
+using IOHIDElements = std::vector<CFPtr<IOHIDElementRef>>;
 
 ////////////////////////////////////////////////////////////
 class HIDInputManager
@@ -81,7 +82,7 @@ public:
     /// \return a retained CFDictionaryRef
     ///
     ////////////////////////////////////////////////////////////
-    static CFDictionaryRef copyDevicesMask(std::uint32_t page, std::uint32_t usage);
+    static CFPtr<CFDictionaryRef> copyDevicesMask(std::uint32_t page, std::uint32_t usage);
 
     ////////////////////////////////////////////////////////////
     /// \brief Try to convert a character into a SFML key code
@@ -210,10 +211,10 @@ private:
     ///
     /// \param page  HID page like kHIDPage_GenericDesktop
     /// \param usage HID usage page like kHIDUsage_GD_Keyboard or kHIDUsage_GD_Mouse
-    /// \return a retained, non-empty CFSetRef of IOHIDDeviceRef or `nullptr`
+    /// \return a retained, non-empty __CFSet pointer of IOHIDDeviceRef or `nullptr`
     ///
     ////////////////////////////////////////////////////////////
-    CFSetRef copyDevices(std::uint32_t page, std::uint32_t usage);
+    CFPtr<CFSetRef> copyDevices(std::uint32_t page, std::uint32_t usage);
 
     ////////////////////////////////////////////////////////////
     /// \brief Check if a key is pressed
@@ -253,8 +254,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    IOHIDManagerRef m_manager{};         ///< Underlying HID Manager
-    bool            m_keysInitialized{}; ///< Has initializeKeyboard been called at least once?
+    CFPtr<IOHIDManagerRef> m_manager;           ///< Underlying HID Manager
+    bool                   m_keysInitialized{}; ///< Has initializeKeyboard been called at least once?
     EnumArray<Keyboard::Scancode, IOHIDElements, Keyboard::ScancodeCount> m_keys; ///< All the keys on any connected keyboard
     EnumArray<Keyboard::Key, Keyboard::Scancode, Keyboard::KeyCount> m_keyToScancodeMapping{}; ///< Mapping from Key to Scancode
     EnumArray<Keyboard::Scancode, Keyboard::Key, Keyboard::ScancodeCount> m_scancodeToKeyMapping{}; ///< Mapping from Scancode to Key

--- a/src/SFML/Window/macOS/HIDJoystickManager.cpp
+++ b/src/SFML/Window/macOS/HIDJoystickManager.cpp
@@ -61,10 +61,9 @@ unsigned int HIDJoystickManager::getJoystickCount()
 
 
 ////////////////////////////////////////////////////////////
-CFSetRef HIDJoystickManager::copyJoysticks()
+CFPtr<CFSetRef> HIDJoystickManager::copyJoysticks()
 {
-    CFSetRef devices = IOHIDManagerCopyDevices(m_manager);
-    return devices;
+    return CFPtr<CFSetRef>(IOHIDManagerCopyDevices(m_manager));
 }
 
 
@@ -73,17 +72,15 @@ HIDJoystickManager::HIDJoystickManager()
 {
     m_manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
 
-    CFDictionaryRef mask0 = HIDInputManager::copyDevicesMask(kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
+    const auto mask0 = HIDInputManager::copyDevicesMask(kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
 
-    CFDictionaryRef mask1 = HIDInputManager::copyDevicesMask(kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
+    const auto mask1 = HIDInputManager::copyDevicesMask(kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
 
-    std::array maskArray = {mask0, mask1};
-    CFArrayRef mask = CFArrayCreate(nullptr, reinterpret_cast<const void**>(maskArray.data()), maskArray.size(), nullptr);
+    std::array maskArray = {mask0.get(), mask1.get()};
+    const auto mask      = CFPtr<CFArrayRef>(
+        CFArrayCreate(nullptr, reinterpret_cast<const void**>(maskArray.data()), maskArray.size(), nullptr));
 
-    IOHIDManagerSetDeviceMatchingMultiple(m_manager, mask);
-    CFRelease(mask);
-    CFRelease(mask1);
-    CFRelease(mask0);
+    IOHIDManagerSetDeviceMatchingMultiple(m_manager, mask.get());
 
 
     IOHIDManagerRegisterDeviceMatchingCallback(m_manager, pluggedIn, this);

--- a/src/SFML/Window/macOS/HIDJoystickManager.hpp
+++ b/src/SFML/Window/macOS/HIDJoystickManager.hpp
@@ -63,10 +63,10 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Copy the devices associated with this HID manager
     ///
-    /// \return a retained CFSetRef of IOHIDDeviceRef or `nullptr`
+    /// \return a retained __CFSet pointer of IOHIDDeviceRef or `nullptr`
     ///
     ////////////////////////////////////////////////////////////
-    CFSetRef copyJoysticks();
+    CFPtr<CFSetRef> copyJoysticks();
 
 private:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/macOS/JoystickImpl.cpp
+++ b/src/SFML/Window/macOS/JoystickImpl.cpp
@@ -131,15 +131,15 @@ bool JoystickImpl::isConnected(unsigned int index)
         if (connectedCount > openedCount)
         {
             // Get all devices
-            CFSetRef devices = HIDJoystickManager::getInstance().copyJoysticks();
+            const auto devices = CFPtr<CFSetRef>(HIDJoystickManager::getInstance().copyJoysticks());
 
             if (devices != nullptr)
             {
-                const CFIndex size = CFSetGetCount(devices);
+                const CFIndex size = CFSetGetCount(devices.get());
                 if (size > 0)
                 {
                     std::vector<CFTypeRef> array(static_cast<std::size_t>(size)); // array of IOHIDDeviceRef
-                    CFSetGetValues(devices, array.data());
+                    CFSetGetValues(devices.get(), array.data());
 
                     // If there exists a device d s.t. there is no j s.t.
                     // m_locationIDs[j] == d's location then we have a new device.
@@ -165,8 +165,6 @@ bool JoystickImpl::isConnected(unsigned int index)
                         }
                     }
                 }
-
-                CFRelease(devices);
             }
         }
     }
@@ -184,14 +182,14 @@ bool JoystickImpl::open(unsigned int index)
     const Location deviceLoc = m_locationIDs[index]; // The device we need to load
 
     // Get all devices
-    CFSetRef devices = HIDJoystickManager::getInstance().copyJoysticks();
+    const auto devices = HIDJoystickManager::getInstance().copyJoysticks();
     if (devices == nullptr)
         return false;
 
     // Get a usable copy of the joysticks devices.
-    const CFIndex          joysticksCount = CFSetGetCount(devices);
+    const CFIndex          joysticksCount = CFSetGetCount(devices.get());
     std::vector<CFTypeRef> devicesArray(static_cast<std::size_t>(joysticksCount));
-    CFSetGetValues(devices, devicesArray.data());
+    CFSetGetValues(devices.get(), devicesArray.data());
 
     // Get the desired joystick.
     IOHIDDeviceRef self = nil;
@@ -203,33 +201,28 @@ bool JoystickImpl::open(unsigned int index)
     }
 
     if (self == nil)
-    {
-        CFRelease(devices);
         return false;
-    }
 
     m_identification.name      = getDeviceString(self, CFSTR(kIOHIDProductKey), m_index);
     m_identification.vendorId  = getDeviceUint(self, CFSTR(kIOHIDVendorIDKey), m_index);
     m_identification.productId = getDeviceUint(self, CFSTR(kIOHIDProductIDKey), m_index);
 
     // Get a list of all elements attached to the device.
-    CFArrayRef elements = IOHIDDeviceCopyMatchingElements(self, nullptr, kIOHIDOptionsTypeNone);
+    const auto elements = CFPtr<CFArrayRef>(IOHIDDeviceCopyMatchingElements(self, nullptr, kIOHIDOptionsTypeNone));
 
     if (elements == nullptr)
-    {
-        CFRelease(devices);
         return false;
-    }
 
     // Go through all connected elements.
-    const CFIndex elementsCount = CFArrayGetCount(elements);
+    const CFIndex elementsCount = CFArrayGetCount(elements.get());
     for (int i = 0; i < elementsCount; ++i)
     {
-        auto* element = static_cast<IOHIDElementRef>(const_cast<void*>(CFArrayGetValueAtIndex(elements, i)));
-        switch (IOHIDElementGetUsagePage(element))
+        auto element = std::shared_ptr(CFPtr<IOHIDElementRef>(
+            static_cast<IOHIDElementRef>(const_cast<void*>(CFArrayGetValueAtIndex(elements.get(), i)))));
+        switch (IOHIDElementGetUsagePage(element.get()))
         {
             case kHIDPage_GenericDesktop:
-                switch (IOHIDElementGetUsage(element))
+                switch (IOHIDElementGetUsage(element.get()))
                 {
                     case kHIDUsage_GD_X:
                         m_axis[Joystick::Axis::X] = element;
@@ -262,8 +255,8 @@ bool JoystickImpl::open(unsigned int index)
                         // We assume this model here as well. Hence, with 4 switches and intermediate
                         // positions we have 8 values (0-7) plus the "null" state (8).
                         {
-                            const CFIndex min = IOHIDElementGetLogicalMin(element);
-                            const CFIndex max = IOHIDElementGetLogicalMax(element);
+                            const CFIndex min = IOHIDElementGetLogicalMin(element.get());
+                            const CFIndex max = IOHIDElementGetLogicalMax(element.get());
 
                             if (min != 0 || max != 7)
                             {
@@ -282,18 +275,18 @@ bool JoystickImpl::open(unsigned int index)
                         // We assume a game pad is an application collection, meaning it doesn't hold
                         // any values per say. They kind of "emit" the joystick's usages.
                         // See §3.4.3 Usage Types (Collection) of HUT v1.12
-                        if (IOHIDElementGetCollectionType(element) != kIOHIDElementCollectionTypeApplication)
+                        if (IOHIDElementGetCollectionType(element.get()) != kIOHIDElementCollectionTypeApplication)
                         {
                             err() << std::hex << "Gamepage (vendor/product id: 0x" << m_identification.vendorId << "/0x"
                                   << m_identification.productId << ") is not an CA but a 0x"
-                                  << IOHIDElementGetCollectionType(element) << std::dec << std::endl;
+                                  << IOHIDElementGetCollectionType(element.get()) << std::dec << std::endl;
                         }
                         break;
 
                     default:
 #ifdef SFML_DEBUG
                         err() << "Unexpected usage for element of Page Generic Desktop: 0x" << std::hex
-                              << IOHIDElementGetUsage(element) << std::dec << std::endl;
+                              << IOHIDElementGetUsage(element.get()) << std::dec << std::endl;
 #endif
                         break;
                 }
@@ -314,24 +307,7 @@ bool JoystickImpl::open(unsigned int index)
     // HID Usage (assigned by manufacturer and/or a driver).
     std::sort(m_buttons.begin(),
               m_buttons.end(),
-              [](IOHIDElementRef b1, IOHIDElementRef b2) { return IOHIDElementGetUsage(b1) < IOHIDElementGetUsage(b2); });
-
-    // Retain all these objects for personal use
-    for (IOHIDElementRef iohidElementRef : m_buttons)
-        CFRetain(iohidElementRef);
-
-    for (const auto& [axis, iohidElementRef] : m_axis)
-        CFRetain(iohidElementRef);
-
-    if (m_hat != nullptr)
-        CFRetain(m_hat);
-
-    // Note: we didn't retain element in the switch because we might have multiple
-    // Axis X (for example) and we want to keep only the last one. To prevent
-    // leaking we retain objects 'only' now.
-
-    CFRelease(devices);
-    CFRelease(elements);
+              [](auto b1, auto b2) { return IOHIDElementGetUsage(b1.get()) < IOHIDElementGetUsage(b2.get()); });
 
     return true;
 }
@@ -342,20 +318,9 @@ void JoystickImpl::close()
 {
     const AutoreleasePool pool;
 
-    for (IOHIDElementRef iohidElementRef : m_buttons)
-        CFRelease(iohidElementRef);
-
     m_buttons.clear();
-
-    for (const auto& [axis, iohidElementRef] : m_axis)
-        CFRelease(iohidElementRef);
-
     m_axis.clear();
-
-    if (m_hat != nullptr)
-        CFRelease(m_hat);
-
-    m_hat = nullptr;
+    m_hat.reset();
 
     // And we unregister this joystick
     m_locationIDs[m_index] = 0;
@@ -405,14 +370,14 @@ JoystickState JoystickImpl::update()
     const Location selfLoc = m_locationIDs[m_index];
 
     // Get all devices
-    CFSetRef devices = HIDJoystickManager::getInstance().copyJoysticks();
+    auto devices = HIDJoystickManager::getInstance().copyJoysticks();
     if (devices == nullptr)
         return disconnectedState;
 
     // Get a usable copy of the joysticks devices.
-    const CFIndex          joysticksCount = CFSetGetCount(devices);
+    const CFIndex          joysticksCount = CFSetGetCount(devices.get());
     std::vector<CFTypeRef> devicesArray(static_cast<std::size_t>(joysticksCount));
-    CFSetGetValues(devices, devicesArray.data());
+    CFSetGetValues(devices.get(), devicesArray.data());
 
     // Search for it
     bool found = false;
@@ -423,19 +388,15 @@ JoystickState JoystickImpl::update()
             found = true;
     }
 
-    // Release unused stuff
-    CFRelease(devices);
-
     // If not found we consider it disconnected
     if (!found)
         return disconnectedState;
 
     // Update buttons' state
-    unsigned int i = 0;
-    for (auto it = m_buttons.begin(); it != m_buttons.end(); ++it, ++i)
+    for (std::size_t i = 0; i < m_buttons.size(); ++i)
     {
         IOHIDValueRef value = nil;
-        IOHIDDeviceGetValue(IOHIDElementGetDevice(*it), *it, &value);
+        IOHIDDeviceGetValue(IOHIDElementGetDevice(m_buttons[i].get()), m_buttons[i].get(), &value);
 
         // Check for plug out.
         if (!value)
@@ -451,7 +412,7 @@ JoystickState JoystickImpl::update()
     for (const auto& [axis, iohidElementRef] : m_axis)
     {
         IOHIDValueRef value = nil;
-        IOHIDDeviceGetValue(IOHIDElementGetDevice(iohidElementRef), iohidElementRef, &value);
+        IOHIDDeviceGetValue(IOHIDElementGetDevice(iohidElementRef.get()), iohidElementRef.get(), &value);
 
         // Check for plug out.
         if (!value)
@@ -469,8 +430,8 @@ JoystickState JoystickImpl::update()
         // This method might not be very accurate (the "0 position" can be
         // slightly shift with some device) but we don't care because most
         // of devices are so sensitive that this is not relevant.
-        const auto   physicalMax   = static_cast<double>(IOHIDElementGetPhysicalMax(iohidElementRef));
-        const auto   physicalMin   = static_cast<double>(IOHIDElementGetPhysicalMin(iohidElementRef));
+        const auto   physicalMax   = static_cast<double>(IOHIDElementGetPhysicalMax(iohidElementRef.get()));
+        const auto   physicalMin   = static_cast<double>(IOHIDElementGetPhysicalMin(iohidElementRef.get()));
         const double scaledMin     = -100;
         const double scaledMax     = 100;
         const double physicalValue = IOHIDValueGetScaledValue(value, kIOHIDValueScaleTypePhysical);
@@ -488,7 +449,7 @@ JoystickState JoystickImpl::update()
     if (m_hat != nullptr)
     {
         IOHIDValueRef value = nil;
-        IOHIDDeviceGetValue(IOHIDElementGetDevice(m_hat), m_hat, &value);
+        IOHIDDeviceGetValue(IOHIDElementGetDevice(m_hat.get()), m_hat.get(), &value);
 
         // Check for plug out.
         if (!value)

--- a/src/SFML/Window/macOS/JoystickImpl.hpp
+++ b/src/SFML/Window/macOS/JoystickImpl.hpp
@@ -70,14 +70,14 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     using Location      = long;
-    using AxisMap       = std::unordered_map<Joystick::Axis, IOHIDElementRef>;
-    using ButtonsVector = std::vector<IOHIDElementRef>;
+    using AxisMap       = std::unordered_map<Joystick::Axis, std::shared_ptr<__IOHIDElement>>;
+    using ButtonsVector = std::vector<std::shared_ptr<__IOHIDElement>>;
 
-    AxisMap                  m_axis;           ///< Axes (but not POV/Hat) of the joystick
-    IOHIDElementRef          m_hat{};          ///< POV/Hat axis of the joystick
-    ButtonsVector            m_buttons;        ///< Buttons of the joystick
-    unsigned int             m_index{};        ///< SFML index
-    Joystick::Identification m_identification; ///< Joystick identification
+    AxisMap                         m_axis;           ///< Axes (but not POV/Hat) of the joystick
+    std::shared_ptr<__IOHIDElement> m_hat;            ///< POV/Hat axis of the joystick
+    ButtonsVector                   m_buttons;        ///< Buttons of the joystick
+    unsigned int                    m_index{};        ///< SFML index
+    Joystick::Identification        m_identification; ///< Joystick identification
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     static inline std::array<Location, Joystick::Count> m_locationIDs{}; ///< Global Joystick register

--- a/src/SFML/Window/macOS/Utils.hpp
+++ b/src/SFML/Window/macOS/Utils.hpp
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2025 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <memory>
+#include <type_traits>
+
+
+namespace sf::priv
+{
+////////////////////////////////////////////////////////////
+/// \brief Class for freeing Core Foundation pointers
+///
+////////////////////////////////////////////////////////////
+struct CFDeleter
+{
+    template <typename T>
+    void operator()(T* data) const
+    {
+        CFRelease(data);
+    }
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Class template for wrapping owning raw pointers from Core Foundation
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+using CFPtr = std::unique_ptr<std::remove_pointer_t<T>, CFDeleter>;
+} // namespace sf::priv

--- a/src/SFML/Window/macOS/VideoModeImpl.cpp
+++ b/src/SFML/Window/macOS/VideoModeImpl.cpp
@@ -27,6 +27,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/VideoModeImpl.hpp>
+#include <SFML/Window/macOS/Utils.hpp>
 #include <SFML/Window/macOS/cg_sf_conversion.hpp>
 
 #include <SFML/System/Err.hpp>
@@ -41,7 +42,7 @@ namespace sf::priv
 std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
 {
     // Retrieve all modes available for main screen only.
-    CFArrayRef cgmodes = CGDisplayCopyAllDisplayModes(CGMainDisplayID(), nullptr);
+    const auto cgmodes = CFPtr<CFArrayRef>(CGDisplayCopyAllDisplayModes(CGMainDisplayID(), nullptr));
 
     if (cgmodes == nullptr)
     {
@@ -53,10 +54,10 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     std::vector<VideoMode> modes   = {desktop};
 
     // Loop on each mode and convert it into a sf::VideoMode object.
-    const CFIndex modesCount = CFArrayGetCount(cgmodes);
+    const CFIndex modesCount = CFArrayGetCount(cgmodes.get());
     for (CFIndex i = 0; i < modesCount; ++i)
     {
-        auto* cgmode = static_cast<CGDisplayModeRef>(const_cast<void*>(CFArrayGetValueAtIndex(cgmodes, i)));
+        auto* cgmode = static_cast<CGDisplayModeRef>(const_cast<void*>(CFArrayGetValueAtIndex(cgmodes.get(), i)));
 
         const VideoMode mode = convertCGModeToSFMode(cgmode);
 
@@ -68,9 +69,6 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
         if (std::find(modes.begin(), modes.end(), mode) == modes.end())
             modes.push_back(mode);
     }
-
-    // Clean up memory.
-    CFRelease(cgmodes);
 
     return modes;
 }

--- a/src/SFML/Window/macOS/cg_sf_conversion.mm
+++ b/src/SFML/Window/macOS/cg_sf_conversion.mm
@@ -27,6 +27,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #import <SFML/Window/macOS/Scaling.h>
+#include <SFML/Window/macOS/Utils.hpp>
 #include <SFML/Window/macOS/cg_sf_conversion.hpp>
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -37,21 +38,16 @@ namespace sf::priv
 ////////////////////////////////////////////////////////////
 unsigned int modeBitsPerPixel(CGDisplayModeRef mode)
 {
-    unsigned int bpp = 0; // no match
-
     // Compare encoding.
-    CFStringRef pixEnc = CGDisplayModeCopyPixelEncoding(mode);
-    if (CFStringCompare(pixEnc, CFSTR(IO32BitDirectPixels), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
-        bpp = 32;
-    else if (CFStringCompare(pixEnc, CFSTR(IO16BitDirectPixels), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
-        bpp = 16;
-    else if (CFStringCompare(pixEnc, CFSTR(IO8BitIndexedPixels), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
-        bpp = 8;
+    const auto pixEnc = CFPtr<CFStringRef>(CGDisplayModeCopyPixelEncoding(mode));
+    if (CFStringCompare(pixEnc.get(), CFSTR(IO32BitDirectPixels), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+        return 32;
+    if (CFStringCompare(pixEnc.get(), CFSTR(IO16BitDirectPixels), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+        return 16;
+    if (CFStringCompare(pixEnc.get(), CFSTR(IO8BitIndexedPixels), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+        return 8;
 
-    // Clean up memory.
-    CFRelease(pixEnc);
-
-    return bpp;
+    return 0;
 }
 
 


### PR DESCRIPTION
## Description

Follows the same pattern as https://github.com/SFML/SFML/pull/2540, https://github.com/SFML/SFML/pull/2759, https://github.com/SFML/SFML/pull/2801, and https://github.com/SFML/SFML/pull/3149. 

Core Foundation pointers are used in a slightly more complicated way than in the previously cited PRs. In some cases `CFRetain` is called on a given pointer. I don't entirely understand how retains and releases work in the Apple Objective-C world so I chose not to touch pointers which are retained.

I believe this fixes a memory leak here:

https://github.com/SFML/SFML/blob/5eb57ae5f103947ab5ff4ad244d9c3fb640a3422/src/SFML/Window/macOS/HIDInputManager.mm#L771-L776

If `underlying` is non-null and `CFArrayGetCount(underlying)` returns zero then we exit the function without releasing `underlying`. This PR's new RAII-based approach guarantees that `underlying` gets freed.

---

Edit: I tried improving upon the pointers that did use `CFRetain` now that I better understand what retains and releases are. I'm still not entirely what I wrote is correct so this PR will have to sit for a bit longer before I'm ready to mark it as ready for review.