### PR TITLE
Fixed broken joystick axis mappings under Linux

### DIFF
--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -525,7 +525,7 @@ bool JoystickImpl::open(unsigned int index)
         if (m_file >= 0)
         {
             // Retrieve the axes mapping
-            ioctl(m_file, JSIOCGAXMAP, m_mapping);
+            ioctl(m_file, JSIOCGAXMAP, m_mapping.data());
 
             // Get info
             m_identification.name = getJoystickName(index);


### PR DESCRIPTION
## Description

Fixes broken joystick axis mappings on Linux. Without the change ioctl returns -1 and errno is set to INVALID_ADDRESS

This PR is related to the issue #3166 

## Tasks

-   [X] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Just run the Joystick example and look at the output for each axis.
