### PR TITLE
Stop running tests that sometimes hang indefinitely

### DIFF
--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -196,7 +196,10 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
         windowBase.setMinimumSize(sf::Vector2u(200, 300));
     }
 
-    SECTION("handleEvents()")
+    // Test for compilation but do not run. This code sometimes hangs indefinitely
+    // when running on the BuildBot CI pipeline. Because it contains no
+    // assertions we have nothing to gain by running it anyways
+    (void)[]
     {
         sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests");
 
@@ -211,5 +214,5 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
 
         // Should compile if user provides both a specific handler and a catch-all
         windowBase.handleEvents([](const sf::Event::Closed&) {}, [](const auto&) {});
-    }
+    };
 }


### PR DESCRIPTION
## Description

Tests originally added in #3154 but contain no assertions so running them isn't necessary.

To test compilation without running this code I put it into a temporary, unnamed lambda that never gets invoked. 

[Here's an example of these tests timing out.](https://ci.sfml-dev.org/#/builders/14/builds/1143)