### PR TITLE
Define default constructor in headers when possible

### DIFF
--- a/include/SFML/Graphics/Color.hpp
+++ b/include/SFML/Graphics/Color.hpp
@@ -48,7 +48,7 @@ public:
     /// sf::Color(0, 0, 0, 255).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Color();
+    constexpr Color() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the color from its 4 RGBA components

--- a/include/SFML/Graphics/Color.inl
+++ b/include/SFML/Graphics/Color.inl
@@ -31,10 +31,6 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-constexpr Color::Color() = default;
-
-
-////////////////////////////////////////////////////////////
 constexpr Color::Color(std::uint8_t red, std::uint8_t green, std::uint8_t blue, std::uint8_t alpha) :
 r(red),
 g(green),

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -49,7 +49,7 @@ public:
     /// Rect({0, 0}, {0, 0})).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Rect();
+    constexpr Rect() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the rectangle from position and size

--- a/include/SFML/Graphics/Rect.inl
+++ b/include/SFML/Graphics/Rect.inl
@@ -32,11 +32,6 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Rect<T>::Rect() = default;
-
-
-////////////////////////////////////////////////////////////
-template <typename T>
 constexpr Rect<T>::Rect(const Vector2<T>& thePosition, const Vector2<T>& theSize) : position(thePosition), size(theSize)
 {
 }

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -53,7 +53,7 @@ public:
     /// Creates an identity transform (a transform that does nothing).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Transform();
+    constexpr Transform() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct a transform from a 3x3 matrix

--- a/include/SFML/Graphics/Transform.inl
+++ b/include/SFML/Graphics/Transform.inl
@@ -35,10 +35,6 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-constexpr Transform::Transform() = default;
-
-
-////////////////////////////////////////////////////////////
 // clang-format off
 constexpr Transform::Transform(float a00, float a01, float a02,
                                float a10, float a11, float a12,

--- a/include/SFML/System/Angle.hpp
+++ b/include/SFML/System/Angle.hpp
@@ -45,7 +45,7 @@ public:
     /// Sets the angle value to zero.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Angle();
+    constexpr Angle() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Return the angle's value in degrees

--- a/include/SFML/System/Angle.inl
+++ b/include/SFML/System/Angle.inl
@@ -45,11 +45,6 @@ constexpr float positiveRemainder(float a, float b)
 }
 } // namespace priv
 
-
-////////////////////////////////////////////////////////////
-constexpr Angle::Angle() = default;
-
-
 ////////////////////////////////////////////////////////////
 constexpr float Angle::asDegrees() const
 {

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -49,7 +49,7 @@ public:
     /// Sets the time value to zero.
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Time();
+    constexpr Time() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct from std::chrono::duration

--- a/include/SFML/System/Time.inl
+++ b/include/SFML/System/Time.inl
@@ -35,10 +35,6 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-constexpr Time::Time() = default;
-
-
-////////////////////////////////////////////////////////////
 template <typename Rep, typename Period>
 constexpr Time::Time(const std::chrono::duration<Rep, Period>& duration) : m_microseconds(duration)
 {

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -46,7 +46,7 @@ public:
     /// Creates a Vector2(0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector2();
+    constexpr Vector2() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from cartesian coordinates

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -33,11 +33,6 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-template <typename T>
-constexpr Vector2<T>::Vector2() = default;
-
-
-////////////////////////////////////////////////////////////
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -44,7 +44,7 @@ public:
     /// Creates a Vector3(0, 0, 0).
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector3();
+    constexpr Vector3() = default;
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the vector from its coordinates

--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -33,11 +33,6 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-template <typename T>
-constexpr Vector3<T>::Vector3() = default;
-
-
-////////////////////////////////////////////////////////////
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"


### PR DESCRIPTION
## Description

Putting the `= default` in the header file like other files do and not in the `.inl` implementation files for consistency