### PR TITLE
Pass `sf::Color`s by value

### DIFF
--- a/include/SFML/Graphics/Color.hpp
+++ b/include/SFML/Graphics/Color.hpp
@@ -113,7 +113,7 @@ public:
 /// \return True if colors are equal, false if they are different
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr bool operator==(const Color& left, const Color& right);
+[[nodiscard]] constexpr bool operator==(Color left, Color right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Color
@@ -127,7 +127,7 @@ public:
 /// \return True if colors are different, false if they are equal
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr bool operator!=(const Color& left, const Color& right);
+[[nodiscard]] constexpr bool operator!=(Color left, Color right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Color
@@ -142,7 +142,7 @@ public:
 /// \return Result of \a left + \a right
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Color operator+(const Color& left, const Color& right);
+[[nodiscard]] constexpr Color operator+(Color left, Color right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Color
@@ -157,7 +157,7 @@ public:
 /// \return Result of \a left - \a right
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Color operator-(const Color& left, const Color& right);
+[[nodiscard]] constexpr Color operator-(Color left, Color right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Color
@@ -174,7 +174,7 @@ public:
 /// \return Result of \a left * \a right
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] constexpr Color operator*(const Color& left, const Color& right);
+[[nodiscard]] constexpr Color operator*(Color left, Color right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Color
@@ -190,7 +190,7 @@ public:
 /// \return Reference to \a left
 ///
 ////////////////////////////////////////////////////////////
-constexpr Color& operator+=(Color& left, const Color& right);
+constexpr Color& operator+=(Color& left, Color right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Color
@@ -206,7 +206,7 @@ constexpr Color& operator+=(Color& left, const Color& right);
 /// \return Reference to \a left
 ///
 ////////////////////////////////////////////////////////////
-constexpr Color& operator-=(Color& left, const Color& right);
+constexpr Color& operator-=(Color& left, Color right);
 
 ////////////////////////////////////////////////////////////
 /// \relates Color
@@ -224,7 +224,7 @@ constexpr Color& operator-=(Color& left, const Color& right);
 /// \return Reference to \a left
 ///
 ////////////////////////////////////////////////////////////
-constexpr Color& operator*=(Color& left, const Color& right);
+constexpr Color& operator*=(Color& left, Color right);
 
 } // namespace sf
 

--- a/include/SFML/Graphics/Color.inl
+++ b/include/SFML/Graphics/Color.inl
@@ -58,21 +58,21 @@ constexpr std::uint32_t Color::toInteger() const
 
 
 ////////////////////////////////////////////////////////////
-constexpr bool operator==(const Color& left, const Color& right)
+constexpr bool operator==(Color left, Color right)
 {
     return (left.r == right.r) && (left.g == right.g) && (left.b == right.b) && (left.a == right.a);
 }
 
 
 ////////////////////////////////////////////////////////////
-constexpr bool operator!=(const Color& left, const Color& right)
+constexpr bool operator!=(Color left, Color right)
 {
     return !(left == right);
 }
 
 
 ////////////////////////////////////////////////////////////
-constexpr Color operator+(const Color& left, const Color& right)
+constexpr Color operator+(Color left, Color right)
 {
     const auto clampedAdd = [](std::uint8_t lhs, std::uint8_t rhs) -> std::uint8_t
     {
@@ -88,7 +88,7 @@ constexpr Color operator+(const Color& left, const Color& right)
 
 
 ////////////////////////////////////////////////////////////
-constexpr Color operator-(const Color& left, const Color& right)
+constexpr Color operator-(Color left, Color right)
 {
     const auto clampedSub = [](std::uint8_t lhs, std::uint8_t rhs) -> std::uint8_t
     {
@@ -104,7 +104,7 @@ constexpr Color operator-(const Color& left, const Color& right)
 
 
 ////////////////////////////////////////////////////////////
-constexpr Color operator*(const Color& left, const Color& right)
+constexpr Color operator*(Color left, Color right)
 {
     const auto scaledMul = [](std::uint8_t lhs, std::uint8_t rhs) -> std::uint8_t
     {
@@ -117,21 +117,21 @@ constexpr Color operator*(const Color& left, const Color& right)
 
 
 ////////////////////////////////////////////////////////////
-constexpr Color& operator+=(Color& left, const Color& right)
+constexpr Color& operator+=(Color& left, Color right)
 {
     return left = left + right;
 }
 
 
 ////////////////////////////////////////////////////////////
-constexpr Color& operator-=(Color& left, const Color& right)
+constexpr Color& operator-=(Color& left, Color right)
 {
     return left = left - right;
 }
 
 
 ////////////////////////////////////////////////////////////
-constexpr Color& operator*=(Color& left, const Color& right)
+constexpr Color& operator*=(Color& left, Color right)
 {
     return left = left * right;
 }

--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -151,7 +151,7 @@ struct Vector4
     /// \param color Color instance
     ///
     ////////////////////////////////////////////////////////////
-    constexpr Vector4(const Color& color);
+    constexpr Vector4(Color color);
 
     T x{}; //!< 1st component (X) of the 4D vector
     T y{}; //!< 2nd component (Y) of the 4D vector
@@ -162,7 +162,7 @@ struct Vector4
 
 ////////////////////////////////////////////////////////////
 template <>
-constexpr Vector4<float>::Vector4(const Color& color) :
+constexpr Vector4<float>::Vector4(Color color) :
 x(color.r / 255.f),
 y(color.g / 255.f),
 z(color.b / 255.f),
@@ -173,7 +173,7 @@ w(color.a / 255.f)
 
 ////////////////////////////////////////////////////////////
 template <>
-constexpr Vector4<int>::Vector4(const Color& color) : x(color.r), y(color.g), z(color.b), w(color.a)
+constexpr Vector4<int>::Vector4(Color color) : x(color.r), y(color.g), z(color.b), w(color.a)
 {
 }
 

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -61,7 +61,7 @@ public:
     /// \param color Fill color
     ///
     ////////////////////////////////////////////////////////////
-    explicit Image(Vector2u size, const Color& color = Color::Black);
+    explicit Image(Vector2u size, Color color = Color::Black);
 
     ////////////////////////////////////////////////////////////
     /// \brief Construct the image from an array of pixels
@@ -183,7 +183,7 @@ public:
     /// \param alpha Alpha value to assign to transparent pixels
     ///
     ////////////////////////////////////////////////////////////
-    void createMaskFromColor(const Color& color, std::uint8_t alpha = 0);
+    void createMaskFromColor(Color color, std::uint8_t alpha = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy pixels from another image onto this one
@@ -232,7 +232,7 @@ public:
     /// \see getPixel
     ///
     ////////////////////////////////////////////////////////////
-    void setPixel(Vector2u coords, const Color& color);
+    void setPixel(Vector2u coords, Color color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the color of a pixel

--- a/include/SFML/Graphics/RenderTarget.hpp
+++ b/include/SFML/Graphics/RenderTarget.hpp
@@ -101,7 +101,7 @@ public:
     /// \param color Fill color to use to clear the render target
     ///
     ////////////////////////////////////////////////////////////
-    void clear(const Color& color = Color::Black);
+    void clear(Color color = Color::Black);
 
     ////////////////////////////////////////////////////////////
     /// \brief Clear the stencil buffer to a specific value
@@ -124,7 +124,7 @@ public:
     /// \param stencilValue Stencil value to clear to
     ///
     ////////////////////////////////////////////////////////////
-    void clear(const Color& color, StencilValue stencilValue);
+    void clear(Color color, StencilValue stencilValue);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current active view

--- a/include/SFML/Graphics/Shape.hpp
+++ b/include/SFML/Graphics/Shape.hpp
@@ -105,7 +105,7 @@ public:
     /// \see getFillColor, setOutlineColor
     ///
     ////////////////////////////////////////////////////////////
-    void setFillColor(const Color& color);
+    void setFillColor(Color color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the outline color of the shape
@@ -117,7 +117,7 @@ public:
     /// \see getOutlineColor, setFillColor
     ///
     ////////////////////////////////////////////////////////////
-    void setOutlineColor(const Color& color);
+    void setOutlineColor(Color color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the thickness of the shape's outline
@@ -166,7 +166,7 @@ public:
     /// \see setFillColor
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Color& getFillColor() const;
+    [[nodiscard]] Color getFillColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline color of the shape
@@ -176,7 +176,7 @@ public:
     /// \see setOutlineColor
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Color& getOutlineColor() const;
+    [[nodiscard]] Color getOutlineColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline thickness of the shape

--- a/include/SFML/Graphics/Sprite.hpp
+++ b/include/SFML/Graphics/Sprite.hpp
@@ -137,7 +137,7 @@ public:
     /// \see getColor
     ///
     ////////////////////////////////////////////////////////////
-    void setColor(const Color& color);
+    void setColor(Color color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the source texture of the sprite
@@ -170,7 +170,7 @@ public:
     /// \see setColor
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Color& getColor() const;
+    [[nodiscard]] Color getColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the local bounding rectangle of the entity

--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -214,7 +214,7 @@ public:
     /// \see getFillColor
     ///
     ////////////////////////////////////////////////////////////
-    void setFillColor(const Color& color);
+    void setFillColor(Color color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the outline color of the text
@@ -226,7 +226,7 @@ public:
     /// \see getOutlineColor
     ///
     ////////////////////////////////////////////////////////////
-    void setOutlineColor(const Color& color);
+    void setOutlineColor(Color color);
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the thickness of the text's outline
@@ -323,7 +323,7 @@ public:
     /// \see setFillColor
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Color& getFillColor() const;
+    [[nodiscard]] Color getFillColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline color of the text
@@ -333,7 +333,7 @@ public:
     /// \see setOutlineColor
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Color& getOutlineColor() const;
+    [[nodiscard]] Color getOutlineColor() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the outline thickness of the text

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -96,7 +96,7 @@ using StbPtr = std::unique_ptr<stbi_uc, StbDeleter>;
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Image::Image(Vector2u size, const Color& color)
+Image::Image(Vector2u size, Color color)
 {
     if (size.x && size.y)
     {
@@ -357,7 +357,7 @@ Vector2u Image::getSize() const
 
 
 ////////////////////////////////////////////////////////////
-void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
+void Image::createMaskFromColor(Color color, std::uint8_t alpha)
 {
     // Make sure that the image is not empty
     if (!m_pixels.empty())
@@ -464,7 +464,7 @@ bool Image::copy(const Image& source, Vector2u dest, const IntRect& sourceRect, 
 
 
 ////////////////////////////////////////////////////////////
-void Image::setPixel(Vector2u coords, const Color& color)
+void Image::setPixel(Vector2u coords, Color color)
 {
     assert(coords.x < m_size.x && "Image::setPixel() x coordinate is out of bounds");
     assert(coords.y < m_size.y && "Image::setPixel() y coordinate is out of bounds");

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -197,7 +197,7 @@ std::uint32_t stencilFunctionToGlConstant(sf::StencilComparison comparison)
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-void RenderTarget::clear(const Color& color)
+void RenderTarget::clear(Color color)
 {
     if (RenderTargetImpl::isActive(m_id) || setActive(true))
     {
@@ -233,7 +233,7 @@ void RenderTarget::clearStencil(StencilValue stencilValue)
 
 
 ////////////////////////////////////////////////////////////
-void RenderTarget::clear(const Color& color, StencilValue stencilValue)
+void RenderTarget::clear(Color color, StencilValue stencilValue)
 {
     if (RenderTargetImpl::isActive(m_id) || setActive(true))
     {

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -88,7 +88,7 @@ const IntRect& Shape::getTextureRect() const
 
 
 ////////////////////////////////////////////////////////////
-void Shape::setFillColor(const Color& color)
+void Shape::setFillColor(Color color)
 {
     m_fillColor = color;
     updateFillColors();
@@ -96,14 +96,14 @@ void Shape::setFillColor(const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-const Color& Shape::getFillColor() const
+Color Shape::getFillColor() const
 {
     return m_fillColor;
 }
 
 
 ////////////////////////////////////////////////////////////
-void Shape::setOutlineColor(const Color& color)
+void Shape::setOutlineColor(Color color)
 {
     m_outlineColor = color;
     updateOutlineColors();
@@ -111,7 +111,7 @@ void Shape::setOutlineColor(const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-const Color& Shape::getOutlineColor() const
+Color Shape::getOutlineColor() const
 {
     return m_outlineColor;
 }

--- a/src/SFML/Graphics/Sprite.cpp
+++ b/src/SFML/Graphics/Sprite.cpp
@@ -71,7 +71,7 @@ void Sprite::setTextureRect(const IntRect& rectangle)
 
 
 ////////////////////////////////////////////////////////////
-void Sprite::setColor(const Color& color)
+void Sprite::setColor(Color color)
 {
     for (Vertex& vertex : m_vertices)
         vertex.color = color;
@@ -93,7 +93,7 @@ const IntRect& Sprite::getTextureRect() const
 
 
 ////////////////////////////////////////////////////////////
-const Color& Sprite::getColor() const
+Color Sprite::getColor() const
 {
     return m_vertices[0].color;
 }

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -44,7 +44,7 @@ namespace
 void addLine(sf::VertexArray& vertices,
              float            lineLength,
              float            lineTop,
-             const sf::Color& color,
+             sf::Color        color,
              float            offset,
              float            thickness,
              float            outlineThickness = 0)
@@ -61,7 +61,7 @@ void addLine(sf::VertexArray& vertices,
 }
 
 // Add a glyph quad to the vertex array
-void addGlyphQuad(sf::VertexArray& vertices, sf::Vector2f position, const sf::Color& color, const sf::Glyph& glyph, float italicShear)
+void addGlyphQuad(sf::VertexArray& vertices, sf::Vector2f position, sf::Color color, const sf::Glyph& glyph, float italicShear)
 {
     const sf::Vector2f padding(1.f, 1.f);
 
@@ -159,7 +159,7 @@ void Text::setStyle(std::uint32_t style)
 
 
 ////////////////////////////////////////////////////////////
-void Text::setFillColor(const Color& color)
+void Text::setFillColor(Color color)
 {
     if (color != m_fillColor)
     {
@@ -177,7 +177,7 @@ void Text::setFillColor(const Color& color)
 
 
 ////////////////////////////////////////////////////////////
-void Text::setOutlineColor(const Color& color)
+void Text::setOutlineColor(Color color)
 {
     if (color != m_outlineColor)
     {
@@ -248,14 +248,14 @@ std::uint32_t Text::getStyle() const
 
 
 ////////////////////////////////////////////////////////////
-const Color& Text::getFillColor() const
+Color Text::getFillColor() const
 {
     return m_fillColor;
 }
 
 
 ////////////////////////////////////////////////////////////
-const Color& Text::getOutlineColor() const
+Color Text::getOutlineColor() const
 {
     return m_outlineColor;
 }

--- a/test/Graphics/Color.test.cpp
+++ b/test/Graphics/Color.test.cpp
@@ -14,6 +14,7 @@ TEST_CASE("[Graphics] sf::Color")
         STATIC_CHECK(std::is_copy_assignable_v<sf::Color>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Color>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Color>);
+        STATIC_CHECK(std::is_trivially_copyable_v<sf::Color>);
     }
 
     SECTION("Construction")

--- a/test/TestUtilities/GraphicsUtil.cpp
+++ b/test/TestUtilities/GraphicsUtil.cpp
@@ -72,7 +72,7 @@ std::ostream& operator<<(std::ostream& os, const StencilMode& stencilMode)
               << stencilMode.stencilOnly << " )";
 }
 
-std::ostream& operator<<(std::ostream& os, const Color& color)
+std::ostream& operator<<(std::ostream& os, Color color)
 {
     return os << "0x" << std::hex << color.toInteger() << std::dec << " (r=" << int{color.r} << ", g=" << int{color.g}
               << ", b=" << int{color.b} << ", a=" << int{color.a} << ")";

--- a/test/TestUtilities/GraphicsUtil.hpp
+++ b/test/TestUtilities/GraphicsUtil.hpp
@@ -20,7 +20,7 @@ class Rect;
 
 std::ostream& operator<<(std::ostream& os, const BlendMode& blendMode);
 std::ostream& operator<<(std::ostream& os, const StencilMode& stencilMode);
-std::ostream& operator<<(std::ostream& os, const Color& color);
+std::ostream& operator<<(std::ostream& os, Color color);
 std::ostream& operator<<(std::ostream& os, const Transform& transform);
 
 template <typename T>


### PR DESCRIPTION
## Description

Continuation of the work started in #3140. `sf::Color` is only 4 bytes wide so it's advantageous to pass it by value.