### PR TITLE
Fix event handling overloadSet stack corruption on MSVC compiler

### DIFF
--- a/examples/event_handling/EventHandling.cpp
+++ b/examples/event_handling/EventHandling.cpp
@@ -1,7 +1,12 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-#include <SFML/Graphics.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Font.hpp>
+#include <SFML/Graphics/Text.hpp>
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Window/Event.hpp>
+#include <SFML/System/Vector2.hpp>
 
 #include <vector>
 

--- a/include/SFML/Window/WindowBase.inl
+++ b/include/SFML/Window/WindowBase.inl
@@ -29,7 +29,7 @@
 #include <SFML/Window/WindowBase.hpp> // NOLINT(misc-header-include-cycle)
 
 #include <utility>
-
+#include <type_traits>
 
 namespace sf
 {
@@ -45,7 +45,7 @@ struct NotEmpty : T
 {
     using T::T;
     template<typename U>
-    NotEmpty(U&& u) : T(static_cast<U&&>(u))
+    NotEmpty(U&& u) : T(std::forward<U>(u))
     {}
 
     char for_making_this_not_empty;
@@ -56,7 +56,7 @@ struct NotEmpty<T,false> : T
 {
     using T::T;
     template <typename U>
-    NotEmpty(U&& u) : T(static_cast<U&&>(u))
+    NotEmpty(U&& u) : T(std::forward<U>(u))
     {
     }
 };

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -30,6 +30,7 @@
 #include <SFML/System/Err.hpp>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Utils.hpp>
+
 #ifdef SFML_SYSTEM_ANDROID
 #include <SFML/System/Android/Activity.hpp>
 #include <SFML/System/Android/ResourceStream.hpp>
@@ -48,10 +49,27 @@
 
 #include <cassert>
 #include <cstring>
-
+#include <cctype>
 
 namespace
 {
+
+bool caseless_equal(std::string_view a, std::string_view b)
+{
+    const auto alen = a.length();
+    if (alen != b.length())
+        return false;
+
+    for (std::size_t i = 0; i < alen; ++i)
+    {
+        if (std::tolower(static_cast<unsigned char>(a[i])) !=
+            std::tolower(static_cast<unsigned char>(b[i])))
+            return false;
+    }
+    return true;
+}
+
+
 // stb_image callbacks that operate on a sf::InputStream
 int read(void* user, char* data, int size)
 {
@@ -96,63 +114,40 @@ using StbPtr = std::unique_ptr<stbi_uc, StbDeleter>;
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-Image::Image(Vector2u size, const Color& color)
+Image::Image(Vector2u size, const Color& color) :
+m_size(size),
+m_pixels(static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) * 4)
 {
-    if (size.x && size.y)
-    {
-        // Create a new pixel buffer first for exception safety's sake
-        std::vector<std::uint8_t> newPixels(static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y) * 4);
-
-        // Fill it with the specified color
-        std::uint8_t* ptr = newPixels.data();
-        std::uint8_t* end = ptr + newPixels.size();
-        while (ptr < end)
-        {
-            *ptr++ = color.r;
-            *ptr++ = color.g;
-            *ptr++ = color.b;
-            *ptr++ = color.a;
-        }
-
-        // Commit the new pixel buffer
-        m_pixels.swap(newPixels);
-
-        // Assign the new size
-        m_size = size;
-    }
-    else
-    {
-        // Dump the pixel buffer
-        std::vector<std::uint8_t>().swap(m_pixels);
-
-        // Assign the new size
+    // not sure if this is intended
+    // but I will keep compliance with the previous implementation
+    if (size.x == 0 || size.y == 0)
         m_size = {};
+
+    // Fill it with the specified color
+    std::uint8_t* ptr = m_pixels.data();
+    std::uint8_t* end = ptr + m_pixels.size();
+    while (ptr != end)
+    {
+        *ptr++ = color.r;
+        *ptr++ = color.g;
+        *ptr++ = color.b;
+        *ptr++ = color.a;
     }
 }
 
 
 ////////////////////////////////////////////////////////////
-Image::Image(Vector2u size, const std::uint8_t* pixels)
+Image::Image(Vector2u size, const std::uint8_t* pixels) : m_size(size)
 {
-    if (pixels && size.x && size.y)
-    {
-        // Create a new pixel buffer first for exception safety's sake
-        std::vector<std::uint8_t> newPixels(pixels, pixels + size.x * size.y * 4);
-
-        // Commit the new pixel buffer
-        m_pixels.swap(newPixels);
-
-        // Assign the new size
-        m_size = size;
-    }
-    else
-    {
-        // Dump the pixel buffer
-        std::vector<std::uint8_t>().swap(m_pixels);
-
-        // Assign the new size
+    // not sure if this is intended
+    // but I will keep compliance with the previous implementation
+    if (size.x == 0 || size.y == 0)
         m_size = {};
-    }
+
+    if (!pixels)
+        return;
+
+    m_pixels.assign(pixels, pixels + (size.x * size.y * 4));
 }
 
 
@@ -182,9 +177,7 @@ std::optional<Image> Image::loadFromFile(const std::filesystem::path& filename)
     const auto ptr      = StbPtr(stbi_load(filename.string().c_str(), &width, &height, &channels, STBI_rgb_alpha));
 
     if (ptr)
-    {
         return Image(Vector2u(Vector2i(width, height)), {ptr.get(), ptr.get() + width * height * 4});
-    }
 
 
     // Error, failed to load the image
@@ -199,28 +192,24 @@ std::optional<Image> Image::loadFromFile(const std::filesystem::path& filename)
 std::optional<Image> Image::loadFromMemory(const void* data, std::size_t size)
 {
     // Check input parameters
-    if (data && size)
+    if (!data || size == 0)
     {
-        // Load the image and get a pointer to the pixels in memory
-        int         width    = 0;
-        int         height   = 0;
-        int         channels = 0;
-        const auto* buffer   = static_cast<const unsigned char*>(data);
-        const auto  ptr      = StbPtr(
-            stbi_load_from_memory(buffer, static_cast<int>(size), &width, &height, &channels, STBI_rgb_alpha));
-
-        if (ptr)
-        {
-            return Image(Vector2u(Vector2i(width, height)), {ptr.get(), ptr.get() + width * height * 4});
-        }
-
-        // Error, failed to load the image
-        err() << "Failed to load image from memory. Reason: " << stbi_failure_reason() << std::endl;
-
+        err() << "Failed to load image from memory, no data provided (was null) or size was 0" << std::endl;
         return std::nullopt;
     }
 
-    err() << "Failed to load image from memory, no data provided" << std::endl;
+    // Load the image and get a pointer to the pixels in memory
+    Vector2i     dim;
+    int          channels = 0;
+    const auto*  buffer   = static_cast<const unsigned char*>(data);
+    const StbPtr ptr(stbi_load_from_memory(buffer, static_cast<int>(size), &dim.x, &dim.y, &channels, STBI_rgb_alpha));
+
+    // apply RVO if possible (via passkey)
+    if (ptr)
+        return Image(Vector2u(dim), {ptr.get(), ptr.get() + dim.x * dim.y * 4});
+
+    // Error, failed to load the image
+    err() << "Failed to load image from memory. Reason: " << stbi_failure_reason() << std::endl;
     return std::nullopt;
 }
 
@@ -242,15 +231,12 @@ std::optional<Image> Image::loadFromStream(InputStream& stream)
     callbacks.eof  = eof;
 
     // Load the image and get a pointer to the pixels in memory
-    int        width    = 0;
-    int        height   = 0;
+    Vector2i   dim;
     int        channels = 0;
-    const auto ptr = StbPtr(stbi_load_from_callbacks(&callbacks, &stream, &width, &height, &channels, STBI_rgb_alpha));
+    const auto ptr = StbPtr(stbi_load_from_callbacks(&callbacks, &stream, &dim.x, &dim.y, &channels, STBI_rgb_alpha));
 
     if (ptr)
-    {
-        return Image(Vector2u(Vector2i(width, height)), {ptr.get(), ptr.get() + width * height * 4});
-    }
+        return Image(Vector2u(dim), {ptr.get(), ptr.get() + dim.x * dim.y * 4});
 
     // Error, failed to load the image
     err() << "Failed to load image from stream. Reason: " << stbi_failure_reason() << std::endl;
@@ -263,45 +249,46 @@ std::optional<Image> Image::loadFromStream(InputStream& stream)
 bool Image::saveToFile(const std::filesystem::path& filename) const
 {
     // Make sure the image is not empty
-    if (!m_pixels.empty() && m_size.x > 0 && m_size.y > 0)
+    if (m_pixels.empty() || m_size.x == 0 || m_size.y == 0)
     {
-        // Deduce the image type from its extension
-
-        // Extract the extension
-        const std::filesystem::path extension     = filename.extension();
-        const Vector2i              convertedSize = Vector2i(m_size);
-
-        if (extension == ".bmp")
-        {
-            // BMP format
-            if (stbi_write_bmp(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return true;
-        }
-        else if (extension == ".tga")
-        {
-            // TGA format
-            if (stbi_write_tga(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return true;
-        }
-        else if (extension == ".png")
-        {
-            // PNG format
-            if (stbi_write_png(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
-                return true;
-        }
-        else if (extension == ".jpg" || extension == ".jpeg")
-        {
-            // JPG format
-            if (stbi_write_jpg(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
-                return true;
-        }
-        else
-        {
-            err() << "Image file extension " << extension << " not supported\n";
-        }
+        err() << "Failed to save empty image\n" << formatDebugPathInfo(filename) << std::endl;
+        return false;
     }
 
-    err() << "Failed to save image\n" << formatDebugPathInfo(filename) << std::endl;
+    // Deduce the image type from its extension
+
+    // Extract the extension
+    const std::filesystem::path extension     = filename.extension();
+    const Vector2i              convertedSize = Vector2i(m_size);
+
+    if (extension == ".bmp")
+    {
+        // BMP format
+        if (stbi_write_bmp(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+            return true;
+    }
+    else if (extension == ".tga")
+    {
+        // TGA format
+        if (stbi_write_tga(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+            return true;
+    }
+    else if (extension == ".png")
+    {
+        // PNG format
+        if (stbi_write_png(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
+            return true;
+    }
+    else if (extension == ".jpg" || extension == ".jpeg")
+    {
+        // JPG format
+        if (stbi_write_jpg(filename.string().c_str(), convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
+            return true;
+    }
+    else
+    {
+        err() << "Image file extension " << extension << " not supported\n";
+    }
     return false;
 }
 
@@ -310,41 +297,41 @@ bool Image::saveToFile(const std::filesystem::path& filename) const
 std::optional<std::vector<std::uint8_t>> Image::saveToMemory(std::string_view format) const
 {
     // Make sure the image is not empty
-    if (!m_pixels.empty() && m_size.x > 0 && m_size.y > 0)
+    if (m_pixels.empty() || m_size.x == 0 || m_size.y == 0)
     {
-        // Choose function based on format
-        const std::string specified     = toLower(std::string(format));
-        const Vector2i    convertedSize = Vector2i(m_size);
-
-        std::vector<std::uint8_t> buffer;
-
-        if (specified == "bmp")
-        {
-            // BMP format
-            if (stbi_write_bmp_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return buffer;
-        }
-        else if (specified == "tga")
-        {
-            // TGA format
-            if (stbi_write_tga_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
-                return buffer;
-        }
-        else if (specified == "png")
-        {
-            // PNG format
-            if (stbi_write_png_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
-                return buffer;
-        }
-        else if (specified == "jpg" || specified == "jpeg")
-        {
-            // JPG format
-            if (stbi_write_jpg_to_func(bufferFromCallback, &buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
-                return buffer;
-        }
+        err() << "Failed to save image with format " << std::quoted(format) << std::endl;
+        return std::nullopt;
     }
 
-    err() << "Failed to save image with format " << std::quoted(format) << std::endl;
+    // Choose function based on format
+    const Vector2i convertedSize = Vector2i(m_size);
+
+    std::optional<std::vector<std::uint8_t>> buffer(std::in_place);
+
+    if (caseless_equal(format, "bmp"))
+    {
+        // BMP format
+        if (stbi_write_bmp_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+            return buffer;
+    }
+    else if (caseless_equal(format, "tga"))
+    {
+        // TGA format
+        if (stbi_write_tga_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data()))
+            return buffer;
+    }
+    else if (caseless_equal(format, "png"))
+    {
+        // PNG format
+        if (stbi_write_png_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 0))
+            return buffer;
+    }
+    else if (caseless_equal(format, "jpg") || caseless_equal(format, "jpeg"))
+    {
+        // JPG format
+        if (stbi_write_jpg_to_func(bufferFromCallback, &*buffer, convertedSize.x, convertedSize.y, 4, m_pixels.data(), 90))
+            return buffer;
+    }
     return std::nullopt;
 }
 
@@ -360,23 +347,29 @@ Vector2u Image::getSize() const
 void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
 {
     // Make sure that the image is not empty
-    if (!m_pixels.empty())
+    if (m_pixels.empty())
+        return;
+
+    // Replace the alpha of the pixels that match the transparent color
+    std::uint8_t* ptr = m_pixels.data();
+    std::uint8_t* end = ptr + m_pixels.size();
+    while (ptr != end)
     {
-        // Replace the alpha of the pixels that match the transparent color
-        std::uint8_t* ptr = m_pixels.data();
-        std::uint8_t* end = ptr + m_pixels.size();
-        while (ptr < end)
-        {
-            if ((ptr[0] == color.r) && (ptr[1] == color.g) && (ptr[2] == color.b) && (ptr[3] == color.a))
-                ptr[3] = alpha;
-            ptr += 4;
-        }
+        // this could be replaced by
+        // std::memcpy(ptr,&color,4) == 0
+        // which I personally find it clearer
+        // and the assembely shows it is faster but I am not doing it for that
+        // https://godbolt.org/z/Tf6jEfs9Y
+        // if you use -fno-builtin it will be slower
+        if ((ptr[0] == color.r) && (ptr[1] == color.g) && (ptr[2] == color.b) && (ptr[3] == color.a))
+            ptr[3] = alpha;
+        ptr += 4;
     }
 }
 
 
 ////////////////////////////////////////////////////////////
-[[nodiscard]] bool Image::copy(const Image& source, Vector2u dest, const IntRect& sourceRect, bool applyAlpha)
+bool Image::copy(const Image& source, Vector2u dest, const IntRect& sourceRect, bool applyAlpha)
 {
     // Make sure that both images are valid
     if (source.m_size.x == 0 || source.m_size.y == 0 || m_size.x == 0 || m_size.y == 0)
@@ -386,9 +379,13 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
     if (sourceRect.position.x < 0 || sourceRect.position.y < 0 || sourceRect.size.x < 0 || sourceRect.size.y < 0)
         return false;
 
+    // Make sure the destination position is within this image bounds
+    if (m_size.x <= dest.x || m_size.y <= dest.y)
+        return false;
+
     Rect<unsigned int> srcRect(sourceRect);
 
-    // Use the whole source image as srcRect if the provided source rectangle is empty
+    // Use the whole source image as srcRect if the provided source rectangle has either x or y equal zero
     if (srcRect.size.x == 0 || srcRect.size.y == 0)
     {
         srcRect = Rect<unsigned int>({0, 0}, source.m_size);
@@ -402,20 +399,16 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
             return false;
     }
 
-    // Make sure the destination position is within this image bounds
-    if (m_size.x <= dest.x || m_size.y <= dest.y)
-        return false;
-
     // Then find the valid size of the destination rectangle
     const Vector2u dstSize(std::min(m_size.x - dest.x, srcRect.size.x), std::min(m_size.y - dest.y, srcRect.size.y));
 
     // Precompute as much as possible
-    const std::size_t  pitch     = static_cast<std::size_t>(dstSize.x) * 4;
+    const auto  pitch     = static_cast<std::size_t>(dstSize.x) * 4;
     const unsigned int srcStride = source.m_size.x * 4;
     const unsigned int dstStride = m_size.x * 4;
 
     const std::uint8_t* srcPixels = source.m_pixels.data() + (srcRect.position.x + srcRect.position.y * source.m_size.x) * 4;
-    std::uint8_t*       dstPixels = m_pixels.data() + (dest.x + dest.y * m_size.x) * 4;
+    std::uint8_t* dstPixels = m_pixels.data() + (dest.x + dest.y * m_size.x) * 4;
 
     // Copy the pixels
     if (applyAlpha)
@@ -436,7 +429,7 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
 
                 dst[3] = outAlpha;
 
-                if (outAlpha)
+                if (outAlpha != 0)
                     for (int k = 0; k < 3; k++)
                         dst[k] = static_cast<std::uint8_t>((src[k] * srcAlpha + dst[k] * (outAlpha - srcAlpha)) / outAlpha);
                 else
@@ -469,7 +462,10 @@ void Image::setPixel(Vector2u coords, const Color& color)
     assert(coords.x < m_size.x && "Image::setPixel() x coordinate is out of bounds");
     assert(coords.y < m_size.y && "Image::setPixel() y coordinate is out of bounds");
 
-    const auto    index = (coords.x + coords.y * m_size.x) * 4;
+    const auto index = (coords.x + coords.y * m_size.x) * 4;
+    // can use std::memcpy here
+    // std::memcpy(&m_pixels[index],&color,4);
+    // which should be fine iirc
     std::uint8_t* pixel = &m_pixels[index];
     *pixel++            = color.r;
     *pixel++            = color.g;
@@ -494,9 +490,7 @@ Color Image::getPixel(Vector2u coords) const
 const std::uint8_t* Image::getPixelsPtr() const
 {
     if (!m_pixels.empty())
-    {
         return m_pixels.data();
-    }
 
     err() << "Trying to access the pixels of an empty image" << std::endl;
     return nullptr;
@@ -506,23 +500,21 @@ const std::uint8_t* Image::getPixelsPtr() const
 ////////////////////////////////////////////////////////////
 void Image::flipHorizontally()
 {
-    if (!m_pixels.empty())
+    if (m_pixels.empty())
+        return;
+
+    const std::size_t rowSize = m_size.x * 4;
+
+    for (std::size_t y = 0; y < m_size.y; ++y)
     {
-        const std::size_t rowSize = m_size.x * 4;
+        auto left  = m_pixels.data() + y * rowSize;
+        auto right = m_pixels.data() + ((y + 1) * rowSize - 4);
 
-        for (std::size_t y = 0; y < m_size.y; ++y)
+        for (std::size_t x = 0; x < m_size.x / 2; ++x)
         {
-            auto left = m_pixels.begin() + static_cast<std::vector<std::uint8_t>::iterator::difference_type>(y * rowSize);
-            auto right = m_pixels.begin() +
-                         static_cast<std::vector<std::uint8_t>::iterator::difference_type>((y + 1) * rowSize - 4);
-
-            for (std::size_t x = 0; x < m_size.x / 2; ++x)
-            {
-                std::swap_ranges(left, left + 4, right);
-
-                left += 4;
-                right -= 4;
-            }
+            std::swap_ranges(left, left + 4, right);
+            left += 4;
+            right -= 4;
         }
     }
 }
@@ -531,20 +523,20 @@ void Image::flipHorizontally()
 ////////////////////////////////////////////////////////////
 void Image::flipVertically()
 {
-    if (!m_pixels.empty())
+    if (m_pixels.empty())
+        return;
+
+    const auto rowSize = m_size.x * 4;
+
+    auto top    = m_pixels.data();
+    auto bottom = (m_pixels.data() + m_pixels.size()) - rowSize;
+
+    for (std::size_t y = 0; y < m_size.y / 2; ++y)
     {
-        const auto rowSize = static_cast<std::vector<std::uint8_t>::iterator::difference_type>(m_size.x * 4);
+        std::swap_ranges(top, top + rowSize, bottom);
 
-        auto top    = m_pixels.begin();
-        auto bottom = m_pixels.end() - rowSize;
-
-        for (std::size_t y = 0; y < m_size.y / 2; ++y)
-        {
-            std::swap_ranges(top, top + rowSize, bottom);
-
-            top += rowSize;
-            bottom -= rowSize;
-        }
+        top += rowSize;
+        bottom -= rowSize;
     }
 }
 


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Before you create the pull request, we ask you to check the follow boxes. (For small changes not everything needs to ticked, but the more the better!)

-   [N] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [Y] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [Y] Have you provided some example/test code for your changes?
-->

## Description

<!-- Please describe your pull request. -->

A fix to stack corruption due to incorrect compiler behavior from MSVC that it will never fix due to backward compatability

This PR is related to the issue #



## Tasks

-   [N] Tested on Linux
-   [Y] Tested on Windows
-   [N] Tested on macOS
-   [N] Tested on iOS
-   [N] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->
Compile with MSVC (in debug mode) run examples/event_handling and press Enter until you switch to Overload it will instantly crash saying stack corruption around variable overloadSet in src/WindowBase.inl this commit is to fix this bug by making sure no base classes are empty in the sf::priv::OverloadSet for MSVC only since MSVC does not do the optimizations correctly but leaves Clang/GCC alone.
