### PR TITLE
Fix event handling stack corruption on msvc

### DIFF
--- a/include/SFML/Window/WindowBase.inl
+++ b/include/SFML/Window/WindowBase.inl
@@ -39,6 +39,9 @@ template <typename... Ts>
 struct OverloadSet : Ts...
 {
     using Ts::operator()...;
+#if defined(_MSC_VER) && !defined(__clang__)
+    unsigned char dummy; // Dummy variable to ensure that this struct is not empty thus avoiding a crash due to an MSVC bug
+#endif
 };
 template <typename... Ts>
 OverloadSet(Ts...) -> OverloadSet<Ts...>;


### PR DESCRIPTION
A fix to stack corruption due to incorrect compiler behavior from MSVC that it will never fix due to backward compatability

Compile with MSVC (in debug mode) run examples/event_handling and press Enter until you switch to Overload it will instantly crash saying stack corruption around variable overloadSet in src/WindowBase.inl this commit is to fix this bug by making sure no base classes are empty in the sf::priv::OverloadSet for MSVC only since MSVC does not do the optimizations correctly (even with __declspec(empty_bases) which was made to do so )but leaves Clang/GCC/Intel Compiler alone since they do it correctly.

this fix only applies to MSVC by checking against [Intel](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2023-1/additional-predefined-macros.html) and Clang-CL predfined macro _MSC_VER.

[godbolt showing off the bug not the crash though](https://godbolt.org/z/7j5WMWfW9) 

[Microsoft Article about Layout of classes](https://devblogs.microsoft.com/cppblog/optimizing-the-layout-of-empty-base-classes-in-vs2015-update-2-3/)

[Bug report on MSVC about it](https://developercommunity.visualstudio.com/t/address-of-empty-base-class-is-wrong-c-bad-code-ge/322444)

