### PR TITLE
Require that `sf::WindowBase::handleEvents` receives at least one argument

### DIFF
--- a/include/SFML/Window/WindowBase.inl
+++ b/include/SFML/Window/WindowBase.inl
@@ -57,6 +57,8 @@ struct DelayOverloadResolution
 template <typename... Ts>
 void WindowBase::handleEvents(Ts&&... handlers) // NOLINT(cppcoreguidelines-missing-std-forward)
 {
+    static_assert(sizeof...(Ts) > 0, "Must provide at least one handler");
+
     // Disable misc-const-correctness for this line since clang-tidy
     // complains about it even though the code would become uncompilable
 

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -203,9 +203,6 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
     {
         sf::WindowBase windowBase(sf::VideoMode({360, 240}), "WindowBase Tests");
 
-        // Should compile if user provides nothing
-        windowBase.handleEvents();
-
         // Should compile if user provides only a specific handler
         windowBase.handleEvents([](const sf::Event::Closed&) {});
 


### PR DESCRIPTION
## Description

The fact that `handleEvents` previously allowed for zero arguments was probably just an oversight due to how variadic functions implicitly allow for calling them with zero arguments. It's probably a bug to call `handleEvents` with no callbacks. If users just want to dump all active events then I'd rather they provide a lambda which matches all events and does nothing with them.