### PR TITLE
Remove useless attributes from implementation files

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -662,7 +662,7 @@ Out Utf<32>::toUtf32(In begin, In end, Out output)
 
 ////////////////////////////////////////////////////////////
 template <typename In>
-std::uint32_t Utf<32>::decodeAnsi(In input, [[maybe_unused]] const std::locale& locale)
+std::uint32_t Utf<32>::decodeAnsi(In input,const std::locale& locale)
 {
     // Get the facet of the locale which deals with character conversion
     const auto& facet = std::use_facet<std::ctype<wchar_t>>(locale);
@@ -688,7 +688,7 @@ std::uint32_t Utf<32>::decodeWide(In input)
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<32>::encodeAnsi(std::uint32_t codepoint, Out output, char replacement, [[maybe_unused]] const std::locale& locale)
+Out Utf<32>::encodeAnsi(std::uint32_t codepoint, Out output, char replacement,const std::locale& locale)
 {
     // Get the facet of the locale which deals with character conversion
     const auto& facet = std::use_facet<std::ctype<wchar_t>>(locale);

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -662,7 +662,7 @@ Out Utf<32>::toUtf32(In begin, In end, Out output)
 
 ////////////////////////////////////////////////////////////
 template <typename In>
-std::uint32_t Utf<32>::decodeAnsi(In input,const std::locale& locale)
+std::uint32_t Utf<32>::decodeAnsi(In input, const std::locale& locale)
 {
     // Get the facet of the locale which deals with character conversion
     const auto& facet = std::use_facet<std::ctype<wchar_t>>(locale);
@@ -688,7 +688,7 @@ std::uint32_t Utf<32>::decodeWide(In input)
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<32>::encodeAnsi(std::uint32_t codepoint, Out output, char replacement,const std::locale& locale)
+Out Utf<32>::encodeAnsi(std::uint32_t codepoint, Out output, char replacement, const std::locale& locale)
 {
     // Get the facet of the locale which deals with character conversion
     const auto& facet = std::use_facet<std::ctype<wchar_t>>(locale);

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -376,7 +376,7 @@ void Image::createMaskFromColor(const Color& color, std::uint8_t alpha)
 
 
 ////////////////////////////////////////////////////////////
-[[nodiscard]] bool Image::copy(const Image& source, Vector2u dest, const IntRect& sourceRect, bool applyAlpha)
+bool Image::copy(const Image& source, Vector2u dest, const IntRect& sourceRect, bool applyAlpha)
 {
     // Make sure that both images are valid
     if (source.m_size.x == 0 || source.m_size.y == 0 || m_size.x == 0 || m_size.y == 0)


### PR DESCRIPTION
Remove reduntant / useless attributes

`[[maybe_used]]` on unconditionally always used variables

`[[nodiscard]]` on function definitions (they are only needed in *declarations*)