### PR TITLE
Remove redunant clear

### DIFF
--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -258,7 +258,6 @@ std::uint64_t InputSoundFile::read(std::int16_t* samples, std::uint64_t maxCount
 void InputSoundFile::close()
 {
     *this = {};
-    m_channelMap.clear();
 }
 
 


### PR DESCRIPTION
remove an unnecessary clear in InputSoundFile::close

the `*this = {}` will already clear the vector destroying all of its contents