### PR TITLE
pass sf::IpAddress by value

### DIFF
--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -30,7 +30,7 @@ public:
     /// \param port Port of the remote host
     ///
     ////////////////////////////////////////////////////////////
-    NetworkRecorder(const sf::IpAddress& host, unsigned short port) : m_host(host), m_port(port)
+    NetworkRecorder(sf::IpAddress host, unsigned short port) : m_host(host), m_port(port)
     {
     }
 

--- a/include/SFML/Network/Ftp.hpp
+++ b/include/SFML/Network/Ftp.hpp
@@ -290,7 +290,7 @@ public:
     /// \see disconnect
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Response connect(const IpAddress& server, unsigned short port = 21, Time timeout = Time::Zero);
+    [[nodiscard]] Response connect(IpAddress server, unsigned short port = 21, Time timeout = Time::Zero);
 
     ////////////////////////////////////////////////////////////
     /// \brief Close the connection with the server

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -171,7 +171,7 @@ public:
     // NOLINTEND(readability-identifier-naming)
 
 private:
-    friend SFML_NETWORK_API bool operator<(const IpAddress& left, const IpAddress& right);
+    friend SFML_NETWORK_API bool operator<(IpAddress left, IpAddress right);
 
     ////////////////////////////////////////////////////////////
     // Member data
@@ -188,7 +188,7 @@ private:
 /// \return True if both addresses are equal
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] SFML_NETWORK_API bool operator==(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator==(IpAddress left, IpAddress right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of != operator to compare two IP addresses
@@ -199,7 +199,7 @@ private:
 /// \return True if both addresses are different
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] SFML_NETWORK_API bool operator!=(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator!=(IpAddress left, IpAddress right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of < operator to compare two IP addresses
@@ -210,7 +210,7 @@ private:
 /// \return True if \a left is lesser than \a right
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] SFML_NETWORK_API bool operator<(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator<(IpAddress left, IpAddress right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of > operator to compare two IP addresses
@@ -221,7 +221,7 @@ private:
 /// \return True if \a left is greater than \a right
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] SFML_NETWORK_API bool operator>(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator>(IpAddress left, IpAddress right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of <= operator to compare two IP addresses
@@ -232,7 +232,7 @@ private:
 /// \return True if \a left is lesser or equal than \a right
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] SFML_NETWORK_API bool operator<=(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator<=(IpAddress left, IpAddress right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of >= operator to compare two IP addresses
@@ -243,7 +243,7 @@ private:
 /// \return True if \a left is greater or equal than \a right
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] SFML_NETWORK_API bool operator>=(const IpAddress& left, const IpAddress& right);
+[[nodiscard]] SFML_NETWORK_API bool operator>=(IpAddress left, IpAddress right);
 
 ////////////////////////////////////////////////////////////
 /// \brief Overload of >> operator to extract an IP address from an input stream
@@ -265,7 +265,7 @@ SFML_NETWORK_API std::istream& operator>>(std::istream& stream, std::optional<Ip
 /// \return Reference to the output stream
 ///
 ////////////////////////////////////////////////////////////
-SFML_NETWORK_API std::ostream& operator<<(std::ostream& stream, const IpAddress& address);
+SFML_NETWORK_API std::ostream& operator<<(std::ostream& stream, IpAddress address);
 
 } // namespace sf
 

--- a/include/SFML/Network/TcpListener.hpp
+++ b/include/SFML/Network/TcpListener.hpp
@@ -85,7 +85,7 @@ public:
     /// \see accept, close
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Status listen(unsigned short port, const IpAddress& address = IpAddress::Any);
+    [[nodiscard]] Status listen(unsigned short port, IpAddress address = IpAddress::Any);
 
     ////////////////////////////////////////////////////////////
     /// \brief Stop listening and close the socket

--- a/include/SFML/Network/TcpSocket.hpp
+++ b/include/SFML/Network/TcpSocket.hpp
@@ -115,7 +115,7 @@ public:
     /// \see disconnect
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Status connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout = Time::Zero);
+    [[nodiscard]] Status connect(IpAddress remoteAddress, unsigned short remotePort, Time timeout = Time::Zero);
 
     ////////////////////////////////////////////////////////////
     /// \brief Disconnect the socket from its remote peer

--- a/include/SFML/Network/UdpSocket.hpp
+++ b/include/SFML/Network/UdpSocket.hpp
@@ -97,7 +97,7 @@ public:
     /// \see unbind, getLocalPort
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Status bind(unsigned short port, const IpAddress& address = IpAddress::Any);
+    [[nodiscard]] Status bind(unsigned short port, IpAddress address = IpAddress::Any);
 
     ////////////////////////////////////////////////////////////
     /// \brief Unbind the socket from the local port to which it is bound
@@ -130,7 +130,7 @@ public:
     /// \see receive
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Status send(const void* data, std::size_t size, const IpAddress& remoteAddress, unsigned short remotePort);
+    [[nodiscard]] Status send(const void* data, std::size_t size, IpAddress remoteAddress, unsigned short remotePort);
 
     ////////////////////////////////////////////////////////////
     /// \brief Receive raw data from a remote peer
@@ -175,7 +175,7 @@ public:
     /// \see receive
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Status send(Packet& packet, const IpAddress& remoteAddress, unsigned short remotePort);
+    [[nodiscard]] Status send(Packet& packet, IpAddress remoteAddress, unsigned short remotePort);
 
     ////////////////////////////////////////////////////////////
     /// \brief Receive a formatted packet of data from a remote peer

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -158,7 +158,7 @@ Ftp::~Ftp()
 
 
 ////////////////////////////////////////////////////////////
-Ftp::Response Ftp::connect(const IpAddress& server, unsigned short port, Time timeout)
+Ftp::Response Ftp::connect(IpAddress server, unsigned short port, Time timeout)
 {
     // Connect to the server
     if (m_commandSocket.connect(server, port, timeout) != Socket::Status::Done)

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -190,42 +190,42 @@ std::optional<IpAddress> IpAddress::getPublicAddress(Time timeout)
 
 
 ////////////////////////////////////////////////////////////
-bool operator==(const IpAddress& left, const IpAddress& right)
+bool operator==(IpAddress left, IpAddress right)
 {
     return !(left < right) && !(right < left);
 }
 
 
 ////////////////////////////////////////////////////////////
-bool operator!=(const IpAddress& left, const IpAddress& right)
+bool operator!=(IpAddress left, IpAddress right)
 {
     return !(left == right);
 }
 
 
 ////////////////////////////////////////////////////////////
-bool operator<(const IpAddress& left, const IpAddress& right)
+bool operator<(IpAddress left, IpAddress right)
 {
     return left.m_address < right.m_address;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool operator>(const IpAddress& left, const IpAddress& right)
+bool operator>(IpAddress left, IpAddress right)
 {
     return right < left;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool operator<=(const IpAddress& left, const IpAddress& right)
+bool operator<=(IpAddress left, IpAddress right)
 {
     return !(right < left);
 }
 
 
 ////////////////////////////////////////////////////////////
-bool operator>=(const IpAddress& left, const IpAddress& right)
+bool operator>=(IpAddress left, IpAddress right)
 {
     return !(left < right);
 }
@@ -243,7 +243,7 @@ std::istream& operator>>(std::istream& stream, std::optional<IpAddress>& address
 
 
 ////////////////////////////////////////////////////////////
-std::ostream& operator<<(std::ostream& stream, const IpAddress& address)
+std::ostream& operator<<(std::ostream& stream, IpAddress address)
 {
     return stream << address.toString();
 }

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -62,7 +62,7 @@ unsigned short TcpListener::getLocalPort() const
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status TcpListener::listen(unsigned short port, const IpAddress& address)
+Socket::Status TcpListener::listen(unsigned short port, IpAddress address)
 {
     // Close the socket if it is already bound
     close();

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -119,7 +119,7 @@ unsigned short TcpSocket::getRemotePort() const
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status TcpSocket::connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout)
+Socket::Status TcpSocket::connect(IpAddress remoteAddress, unsigned short remotePort, Time timeout)
 {
     // Disconnect the socket if it is already connected
     disconnect();

--- a/src/SFML/Network/UdpSocket.cpp
+++ b/src/SFML/Network/UdpSocket.cpp
@@ -65,7 +65,7 @@ unsigned short UdpSocket::getLocalPort() const
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status UdpSocket::bind(unsigned short port, const IpAddress& address)
+Socket::Status UdpSocket::bind(unsigned short port, IpAddress address)
 {
     // Close the socket if it is already bound
     close();
@@ -98,7 +98,7 @@ void UdpSocket::unbind()
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status UdpSocket::send(const void* data, std::size_t size, const IpAddress& remoteAddress, unsigned short remotePort)
+Socket::Status UdpSocket::send(const void* data, std::size_t size, IpAddress remoteAddress, unsigned short remotePort)
 {
     // Create the internal socket if it doesn't exist
     create();
@@ -183,7 +183,7 @@ Socket::Status UdpSocket::receive(void*                     data,
 
 
 ////////////////////////////////////////////////////////////
-Socket::Status UdpSocket::send(Packet& packet, const IpAddress& remoteAddress, unsigned short remotePort)
+Socket::Status UdpSocket::send(Packet& packet, IpAddress remoteAddress, unsigned short remotePort)
 {
     // UDP is a datagram-oriented protocol (as opposed to TCP which is a stream protocol).
     // Sending one datagram is almost safe: it may be lost but if it's received, then its data

--- a/test/Network/IpAddress.test.cpp
+++ b/test/Network/IpAddress.test.cpp
@@ -17,6 +17,7 @@ TEST_CASE("[Network] sf::IpAddress")
         STATIC_CHECK(std::is_copy_assignable_v<sf::IpAddress>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::IpAddress>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::IpAddress>);
+        STATIC_CHECK(std::is_trivially_copyable_v<sf::IpAddress>);
     }
 
     SECTION("Construction")


### PR DESCRIPTION
Continues the work of https://github.com/SFML/SFML/issues/3047.


`sf::IpAddress` is a wrapper around a `std::uint32_t` which is 4 bytes and the class itself is trivial to copy, thus preferred to pass by value.