### PR TITLE
renamed getLoop() to isLooping() and setLoop() to setLooping()

### DIFF
--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -122,7 +122,7 @@ public:
         }
 
         // Set the music to loop
-        m_music.setLoop(true);
+        m_music.setLooping(true);
 
         // Set attenuation to a nice value
         m_music.setAttenuation(0.04f);
@@ -184,7 +184,7 @@ public:
         }
 
         // Set the music to loop
-        m_music.setLoop(true);
+        m_music.setLooping(true);
 
         // We don't care about attenuation in this effect
         m_music.setAttenuation(0.f);
@@ -290,7 +290,7 @@ public:
         }
 
         // Set the music to loop
-        m_music.setLoop(true);
+        m_music.setLooping(true);
 
         // Set attenuation factor
         m_music.setAttenuation(m_attenuation);
@@ -684,7 +684,7 @@ protected:
         }
 
         // Set the music to loop
-        m_music.setLoop(true);
+        m_music.setLooping(true);
 
         // Set attenuation to a nice value
         m_music.setAttenuation(0.0f);

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -366,7 +366,7 @@ private:
 /// music.setPosition({0, 1, 10}); // change its 3D position
 /// music.setPitch(2);             // increase the pitch
 /// music.setVolume(50);           // reduce the volume
-/// music.setLoop(true);           // make it loop
+/// music.setLooping(true);        // make it loop
 ///
 /// // Play it
 /// music.play();

--- a/include/SFML/Audio/Sound.hpp
+++ b/include/SFML/Audio/Sound.hpp
@@ -137,15 +137,15 @@ public:
     ///
     /// If set, the sound will restart from beginning after
     /// reaching the end and so on, until it is stopped or
-    /// setLoop(false) is called.
+    /// setLooping(false) is called.
     /// The default looping state for sound is false.
     ///
     /// \param loop True to play in loop, false to play once
     ///
-    /// \see getLoop
+    /// \see isLooping
     ///
     ////////////////////////////////////////////////////////////
-    void setLoop(bool loop);
+    void setLooping(bool loop);
 
     ////////////////////////////////////////////////////////////
     /// \brief Change the current playing position of the sound
@@ -186,10 +186,10 @@ public:
     ///
     /// \return True if the sound is looping, false otherwise
     ///
-    /// \see setLoop
+    /// \see setLooping
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool getLoop() const;
+    [[nodiscard]] bool isLooping() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current playing position of the sound

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -186,25 +186,25 @@ public:
     ///
     /// If set, the stream will restart from beginning after
     /// reaching the end and so on, until it is stopped or
-    /// setLoop(false) is called.
+    /// setLooping(false) is called.
     /// The default looping state for streams is false.
     ///
     /// \param loop True to play in loop, false to play once
     ///
-    /// \see getLoop
+    /// \see isLooping
     ///
     ////////////////////////////////////////////////////////////
-    void setLoop(bool loop);
+    void setLooping(bool loop);
 
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether or not the stream is in loop mode
     ///
     /// \return True if the stream is looping, false otherwise
     ///
-    /// \see setLoop
+    /// \see setLooping
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool getLoop() const;
+    [[nodiscard]] bool isLooping() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Set the effect processor to be applied to the sound

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -262,7 +262,7 @@ bool Music::onGetData(SoundStream::Chunk& data)
     // If the loop end is enabled and imminent, request less data.
     // This will trip an "onLoop()" call from the underlying SoundStream,
     // and we can then take action.
-    if (getLoop() && (m_impl->loopSpan.length != 0) && (currentOffset <= loopEnd) && (currentOffset + toFill > loopEnd))
+    if (isLooping() && (m_impl->loopSpan.length != 0) && (currentOffset <= loopEnd) && (currentOffset + toFill > loopEnd))
         toFill = static_cast<std::size_t>(loopEnd - currentOffset);
 
     // Fill the chunk parameters
@@ -291,7 +291,8 @@ std::optional<std::uint64_t> Music::onLoop()
     const std::lock_guard lock(m_impl->mutex);
     const std::uint64_t   currentOffset = m_impl->file.getSampleOffset();
 
-    if (getLoop() && (m_impl->loopSpan.length != 0) && (currentOffset == m_impl->loopSpan.offset + m_impl->loopSpan.length))
+    if (isLooping() && (m_impl->loopSpan.length != 0) &&
+        (currentOffset == m_impl->loopSpan.offset + m_impl->loopSpan.length))
     {
         // Looping is enabled, and either we're at the loop end, or we're at the EOF
         // when it's equivalent to the loop end (loop end takes priority). Send us to loop begin
@@ -299,7 +300,7 @@ std::optional<std::uint64_t> Music::onLoop()
         return m_impl->file.getSampleOffset();
     }
 
-    if (getLoop() && (currentOffset >= m_impl->file.getSampleCount()))
+    if (isLooping() && (currentOffset >= m_impl->file.getSampleCount()))
     {
         // If we're at the EOF, reset to 0
         m_impl->file.seek(0);

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -200,7 +200,7 @@ Sound::Sound(const Sound& copy) : SoundSource(copy), m_impl(std::make_unique<Imp
 
     if (copy.m_impl->buffer)
         setBuffer(*copy.m_impl->buffer);
-    setLoop(copy.getLoop());
+    setLooping(copy.isLooping());
 }
 
 
@@ -283,7 +283,7 @@ void Sound::setBuffer(const SoundBuffer& buffer)
 
 
 ////////////////////////////////////////////////////////////
-void Sound::setLoop(bool loop)
+void Sound::setLooping(bool loop)
 {
     ma_sound_set_looping(&m_impl->sound, loop ? MA_TRUE : MA_FALSE);
 }
@@ -319,7 +319,7 @@ const SoundBuffer& Sound::getBuffer() const
 
 
 ////////////////////////////////////////////////////////////
-bool Sound::getLoop() const
+bool Sound::isLooping() const
 {
     return ma_sound_is_looping(&m_impl->sound) == MA_TRUE;
 }
@@ -366,7 +366,7 @@ Sound& Sound::operator=(const Sound& right)
     // Copy the remaining sound attributes
     if (right.m_impl->buffer)
         setBuffer(*right.m_impl->buffer);
-    setLoop(right.getLoop());
+    setLooping(right.isLooping());
 
     return *this;
 }

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -375,14 +375,14 @@ Time SoundStream::getPlayingOffset() const
 
 
 ////////////////////////////////////////////////////////////
-void SoundStream::setLoop(bool loop)
+void SoundStream::setLooping(bool loop)
 {
     ma_sound_set_looping(&m_impl->sound, loop ? MA_TRUE : MA_FALSE);
 }
 
 
 ////////////////////////////////////////////////////////////
-bool SoundStream::getLoop() const
+bool SoundStream::isLooping() const
 {
     return ma_sound_is_looping(&m_impl->sound) == MA_TRUE;
 }

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -45,7 +45,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 0);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
 
         SECTION("File")
@@ -66,7 +66,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
                 CHECK(music.getSampleRate() == 44100);
                 CHECK(music.getStatus() == sf::Music::Status::Stopped);
                 CHECK(music.getPlayingOffset() == sf::Time::Zero);
-                CHECK(!music.getLoop());
+                CHECK(!music.isLooping());
             }
         }
 
@@ -92,7 +92,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
                 CHECK(music.getSampleRate() == 44100);
                 CHECK(music.getStatus() == sf::Music::Status::Stopped);
                 CHECK(music.getPlayingOffset() == sf::Time::Zero);
-                CHECK(!music.getLoop());
+                CHECK(!music.isLooping());
             }
         }
 
@@ -108,7 +108,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 44100);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
     }
 
@@ -127,7 +127,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 0);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
 
         SECTION("Valid file")
@@ -141,7 +141,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 44100);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
     }
 
@@ -161,7 +161,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 0);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
 
         SECTION("Valid buffer")
@@ -176,7 +176,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 44100);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
     }
 
@@ -196,7 +196,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 0);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
 
         SECTION("Valid stream")
@@ -211,7 +211,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
             CHECK(music.getSampleRate() == 44100);
             CHECK(music.getStatus() == sf::Music::Status::Stopped);
             CHECK(music.getPlayingOffset() == sf::Time::Zero);
-            CHECK(!music.getLoop());
+            CHECK(!music.isLooping());
         }
     }
 
@@ -249,6 +249,6 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         CHECK(music.getSampleRate() == 22050);
         CHECK(music.getStatus() == sf::Music::Status::Stopped);
         CHECK(music.getPlayingOffset() == sf::Time::Zero);
-        CHECK(!music.getLoop());
+        CHECK(!music.isLooping());
     }
 }

--- a/test/Audio/Sound.test.cpp
+++ b/test/Audio/Sound.test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
     {
         const sf::Sound sound(soundBuffer);
         CHECK(&sound.getBuffer() == &soundBuffer);
-        CHECK(!sound.getLoop());
+        CHECK(!sound.isLooping());
         CHECK(sound.getPlayingOffset() == sf::Time::Zero);
         CHECK(sound.getStatus() == sf::Sound::Status::Stopped);
     }
@@ -45,7 +45,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
         {
             const sf::Sound soundCopy(sound); // NOLINT(performance-unnecessary-copy-initialization)
             CHECK(&soundCopy.getBuffer() == &soundBuffer);
-            CHECK(!soundCopy.getLoop());
+            CHECK(!soundCopy.isLooping());
             CHECK(soundCopy.getPlayingOffset() == sf::Time::Zero);
             CHECK(soundCopy.getStatus() == sf::Sound::Status::Stopped);
         }
@@ -56,7 +56,7 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
             sf::Sound             soundCopy(otherSoundBuffer);
             soundCopy = sound;
             CHECK(&soundCopy.getBuffer() == &soundBuffer);
-            CHECK(!soundCopy.getLoop());
+            CHECK(!soundCopy.isLooping());
             CHECK(soundCopy.getPlayingOffset() == sf::Time::Zero);
             CHECK(soundCopy.getStatus() == sf::Sound::Status::Stopped);
         }
@@ -73,8 +73,8 @@ TEST_CASE("[Audio] sf::Sound", runAudioDeviceTests())
     SECTION("Set/get loop")
     {
         sf::Sound sound(soundBuffer);
-        sound.setLoop(true);
-        CHECK(sound.getLoop());
+        sound.setLooping(true);
+        CHECK(sound.isLooping());
     }
 
     SECTION("Set/get playing offset")

--- a/test/Audio/SoundStream.test.cpp
+++ b/test/Audio/SoundStream.test.cpp
@@ -47,7 +47,7 @@ TEST_CASE("[Audio] sf::SoundStream", runAudioDeviceTests())
         CHECK(soundStream.getSampleRate() == 0);
         CHECK(soundStream.getStatus() == sf::SoundStream::Status::Stopped);
         CHECK(soundStream.getPlayingOffset() == sf::Time::Zero);
-        CHECK(!soundStream.getLoop());
+        CHECK(!soundStream.isLooping());
     }
 
     SECTION("Set/get playing offset")
@@ -60,7 +60,7 @@ TEST_CASE("[Audio] sf::SoundStream", runAudioDeviceTests())
     SECTION("Set/get loop")
     {
         SoundStream soundStream;
-        soundStream.setLoop(true);
-        CHECK(soundStream.getLoop());
+        soundStream.setLooping(true);
+        CHECK(soundStream.isLooping());
     }
 }


### PR DESCRIPTION
## Description
This PR is related to the issue #3184
https://github.com/SFML/SFML/issues/3184

## Tasks

-   [ ] Tested on Linux
-   [X] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?
Some usage of setLooping() is already present in SoundEffects.cpp example project. Please check this example project. 
