### PR TITLE
Mark standard library types as code in doc strings

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -73,7 +73,7 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \throws std::runtime_error if opening the file was unsuccessful
+    /// \throws `std::runtime_error` if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile(const std::filesystem::path& filename);
@@ -87,7 +87,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws std::runtime_error if opening the file was unsuccessful
+    /// \throws `std::runtime_error` if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile(const void* data, std::size_t sizeInBytes);
@@ -100,7 +100,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws std::runtime_error if opening the file was unsuccessful
+    /// \throws `std::runtime_error` if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile(InputStream& stream);

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -88,7 +88,7 @@ public:
     ///
     /// \param filename Path of the music file to open
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see openFromMemory, openFromStream
     ///
@@ -111,7 +111,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromStream
     ///
@@ -132,7 +132,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromMemory
     ///
@@ -298,7 +298,7 @@ protected:
     /// the seek position for a loop. We then determine whether we are looping on a
     /// loop point or the end-of-file, perform the seek, and return the new position.
     ///
-    /// \return The seek position after looping (or std::nullopt if there's no loop)
+    /// \return The seek position after looping (or `std::nullopt` if there's no loop)
     ///
     ////////////////////////////////////////////////////////////
     std::optional<std::uint64_t> onLoop() override;

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -67,7 +67,7 @@ public:
     /// \param channelCount Number of channels in the sound
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \throws std::runtime_error if the file could not be opened successfully
+    /// \throws `std::runtime_error` if the file could not be opened successfully
     ///
     ////////////////////////////////////////////////////////////
     OutputSoundFile(const std::filesystem::path&     filename,

--- a/include/SFML/Audio/PlaybackDevice.hpp
+++ b/include/SFML/Audio/PlaybackDevice.hpp
@@ -102,7 +102,7 @@ namespace sf::PlaybackDevice
 ////////////////////////////////////////////////////////////
 /// \brief Get the name of the current audio playback device
 ///
-/// \return The name of the current audio playback device or std::nullopt if there is none
+/// \return The name of the current audio playback device or `std::nullopt` if there is none
 ///
 ////////////////////////////////////////////////////////////
 [[nodiscard]] SFML_AUDIO_API std::optional<std::string> getDevice();

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -79,7 +79,7 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
     ///
@@ -95,7 +95,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromStream, loadFromSamples
     ///
@@ -110,7 +110,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromSamples
     ///
@@ -128,7 +128,7 @@ public:
     /// \param sampleRate   Sample rate (number of samples to play per second)
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, saveToFile
     ///

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -280,7 +280,7 @@ protected:
     /// allow implementation of custom loop points. Otherwise,
     /// it just calls onSeek(Time::Zero) and returns 0.
     ///
-    /// \return The seek position after looping (or std::nullopt if there's no loop)
+    /// \return The seek position after looping (or `std::nullopt` if there's no loop)
     ///
     ////////////////////////////////////////////////////////////
     virtual std::optional<std::uint64_t> onLoop();

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -95,7 +95,7 @@ public:
     ///
     /// \param filename Path of the font file to open
     ///
-    /// \throws std::runtime_error if opening was unsuccessful
+    /// \throws `std::runtime_error` if opening was unsuccessful
     ///
     /// \see openFromFile, openFromMemory, openFromStream
     ///
@@ -116,7 +116,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromMemory, openFromStream
     ///
@@ -138,7 +138,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromMemory, openFromStream
     ///

--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -50,7 +50,7 @@ void SFML_GRAPHICS_API copyMatrix(const Transform& source, Matrix<4, 4>& dest);
 ////////////////////////////////////////////////////////////
 /// \brief Copy array-based matrix with given number of elements
 ///
-/// Indirection to std::copy() to avoid inclusion of
+/// Indirection to `std::copy()` to avoid inclusion of
 /// <algorithm> and MSVC's annoying 4996 warning in header
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -96,7 +96,7 @@ public:
     ///
     /// \param filename Path of the image file to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -113,7 +113,7 @@ public:
     /// \param data Pointer to the file data in memory
     /// \param size Size of the data to load, in bytes
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -129,7 +129,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -239,7 +239,7 @@ public:
     /// \param format Encoding format to use
     ///
     /// \return Buffer with encoded data if saving was successful,
-    ///     otherwise std::nullopt
+    ///     otherwise `std::nullopt`
     ///
     /// \see saveToFile, loadFromMemory
     ///

--- a/include/SFML/Graphics/Rect.hpp
+++ b/include/SFML/Graphics/Rect.hpp
@@ -97,7 +97,7 @@ public:
     ///
     /// \param rectangle Rectangle to test
     ///
-    /// \return Intersection rectangle if intersecting, std::nullopt otherwise
+    /// \return Intersection rectangle if intersecting, `std::nullopt` otherwise
     ///
     /// \see contains
     ///

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -77,7 +77,7 @@ public:
     /// \param size     Width and height of the render-texture
     /// \param settings Additional settings for the underlying OpenGL texture and context
     ///
-    /// \throws std::runtime_error if creation was unsuccessful
+    /// \throws `std::runtime_error` if creation was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     RenderTexture(Vector2u size, const ContextSettings& settings = {});

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -139,7 +139,7 @@ public:
     /// \param filename Path of the vertex, geometry or fragment shader file to load
     /// \param type     Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -160,7 +160,7 @@ public:
     /// \param vertexShaderFilename   Path of the vertex shader file to load
     /// \param fragmentShaderFilename Path of the fragment shader file to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -182,7 +182,7 @@ public:
     /// \param geometryShaderFilename Path of the geometry shader file to load
     /// \param fragmentShaderFilename Path of the fragment shader file to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -204,7 +204,7 @@ public:
     /// \param shader String containing the source code of the shader
     /// \param type   Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -225,7 +225,7 @@ public:
     /// \param vertexShader   String containing the source code of the vertex shader
     /// \param fragmentShader String containing the source code of the fragment shader
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -247,7 +247,7 @@ public:
     /// \param geometryShader String containing the source code of the geometry shader
     /// \param fragmentShader String containing the source code of the fragment shader
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -267,7 +267,7 @@ public:
     /// \param stream Source stream to read from
     /// \param type   Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -288,7 +288,7 @@ public:
     /// \param vertexShaderStream   Source stream to read the vertex shader from
     /// \param fragmentShaderStream Source stream to read the fragment shader from
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -310,7 +310,7 @@ public:
     /// \param geometryShaderStream Source stream to read the geometry shader from
     /// \param fragmentShaderStream Source stream to read the fragment shader from
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -106,7 +106,7 @@ public:
     /// \param filename Path of the image file to load
     /// \param sRgb     True to enable sRGB conversion, false to disable it
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -129,7 +129,7 @@ public:
     /// \param sRgb     True to enable sRGB conversion, false to disable it
     /// \param area     Area of the image to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -146,7 +146,7 @@ public:
     /// \param size Size of the data to load, in bytes
     /// \param sRgb True to enable sRGB conversion, false to disable it
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -170,7 +170,7 @@ public:
     /// \param sRgb True to enable sRGB conversion, false to disable it
     /// \param area Area of the image to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -186,7 +186,7 @@ public:
     /// \param stream Source stream to read from
     /// \param sRgb   True to enable sRGB conversion, false to disable it
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -209,7 +209,7 @@ public:
     /// \param sRgb   True to enable sRGB conversion, false to disable it
     /// \param area   Area of the image to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -225,7 +225,7 @@ public:
     /// \param image Image to load into the texture
     /// \param sRgb  True to enable sRGB conversion, false to disable it
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -247,7 +247,7 @@ public:
     /// \param sRgb  True to enable sRGB conversion, false to disable it
     /// \param area  Area of the image to load
     ///
-    /// \throws std::runtime_error if loading was unsuccessful
+    /// \throws `std::runtime_error` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -260,7 +260,7 @@ public:
     /// \param size Width and height of the texture
     /// \param sRgb True to enable sRGB conversion, false to disable it
     ///
-    /// \throws std::runtime_error if construction was unsuccessful
+    /// \throws `std::runtime_error` if construction was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     explicit Texture(Vector2u size, bool sRgb = false);

--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -449,7 +449,7 @@ private:
 /// It is designed to follow the behavior of standard C++ streams,
 /// using operators >> and << to extract and insert data.
 ///
-/// It is recommended to use only fixed-size types (like std::int32_t, etc.),
+/// It is recommended to use only fixed-size types (like `std::int32_t`, etc.),
 /// to avoid possible differences between the sender and the receiver.
 /// Indeed, the native C++ types may have different sizes on two platforms
 /// and your data may be corrupted if that happens.
@@ -485,10 +485,10 @@ private:
 ///
 /// Packets have built-in operator >> and << overloads for
 /// standard types:
-/// \li bool
-/// \li fixed-size integer types (int[8|16|32]_t, uint[8|16|32]_t)
-/// \li floating point numbers (float, double)
-/// \li string types (char*, wchar_t*, std::string, std::wstring, sf::String)
+/// \li `bool`
+/// \li fixed-size integer types (`int[8|16|32]_t`, `uint[8|16|32]_t`)
+/// \li floating point numbers (`float`, `double`)
+/// \li string types (`char*`, `wchar_t*`, `std::string`, `std::wstring`, `sf::String`)
 ///
 /// Like standard streams, it is also possible to define your own
 /// overloads of operators >> and << in order to handle your

--- a/include/SFML/System/Err.hpp
+++ b/include/SFML/System/Err.hpp
@@ -47,17 +47,17 @@ namespace sf
 /// \fn sf::err
 /// \ingroup system
 ///
-/// By default, sf::err() outputs to the same location as std::cerr,
+/// By default, sf::err() outputs to the same location as `std::cerr`,
 /// (-> the stderr descriptor) which is the console if there's
 /// one available.
 ///
-/// It is a standard std::ostream instance, so it supports all the
+/// It is a standard `std::ostream` instance, so it supports all the
 /// insertion operations defined by the STL
 /// (operator <<, manipulators, etc.).
 ///
 /// sf::err() can be redirected to write to another output, independently
-/// of std::cerr, by using the rdbuf() function provided by the
-/// std::ostream class.
+/// of `std::cerr`, by using the `rdbuf()` function provided by the
+/// `std::ostream` class.
 ///
 /// Example:
 /// \code
@@ -72,6 +72,6 @@ namespace sf
 /// sf::err().rdbuf(previous);
 /// \endcode
 ///
-/// \return Reference to std::ostream representing the SFML error stream
+/// \return Reference to `std::ostream` representing the SFML error stream
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -100,7 +100,7 @@ public:
     ///
     /// \param filename Name of the file to open
     ///
-    /// \throws std::runtime_error on error
+    /// \throws `std::runtime_error` on error
     ///
     ////////////////////////////////////////////////////////////
     explicit FileInputStream(const std::filesystem::path& filename);

--- a/include/SFML/System/Sleep.hpp
+++ b/include/SFML/System/Sleep.hpp
@@ -40,7 +40,7 @@ class Time;
 ///
 /// sf::sleep is the best way to block a program or one of its
 /// threads, as it doesn't consume any CPU power. Compared to
-/// the standard std::this_thread::sleep_for function, this
+/// the standard `std::this_thread::sleep_for` function, this
 /// one provides more accurate sleeping time thanks to some
 /// platform-specific tweaks.
 ///

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -41,7 +41,7 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-/// \brief Character traits for std::uint8_t
+/// \brief Character traits for `std::uint8_t`
 ///
 ////////////////////////////////////////////////////////////
 struct SFML_SYSTEM_API U8StringCharTraits
@@ -71,7 +71,7 @@ struct SFML_SYSTEM_API U8StringCharTraits
 };
 
 ////////////////////////////////////////////////////////////
-/// \brief Portable replacement for std::basic_string<std::uint8_t>
+/// \brief Portable replacement for `std::basic_string<std::uint8_t>`
 ///
 /// While all major C++ implementations happen to define this
 /// as of early 2024, this specialization is not strictly speaking
@@ -226,8 +226,8 @@ public:
     /// \brief Create a new sf::String from a UTF-32 encoded string
     ///
     /// This function is provided for consistency, it is equivalent to
-    /// using the constructors that takes a const char32_t* or
-    /// a std::u32string.
+    /// using the constructors that takes a `const char32_t*` or
+    /// a `std::u32string`.
     ///
     /// \param begin Forward iterator to the beginning of the UTF-32 sequence
     /// \param end   Forward iterator to the end of the UTF-32 sequence
@@ -241,7 +241,7 @@ public:
     [[nodiscard]] static String fromUtf32(T begin, T end);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Implicit conversion operator to std::string (ANSI string)
+    /// \brief Implicit conversion operator to `std::string` (ANSI string)
     ///
     /// The current global locale is used for conversion. If you
     /// want to explicitly specify a locale, see toAnsiString.
@@ -258,7 +258,7 @@ public:
     operator std::string() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Implicit conversion operator to std::wstring (wide string)
+    /// \brief Implicit conversion operator to `std::wstring` (wide string)
     ///
     /// Characters that do not fit in the target encoding are
     /// discarded from the returned string.
@@ -678,7 +678,7 @@ private:
 /// \endcode
 ///
 /// sf::String defines the most important functions of the
-/// standard std::string class: removing, random access, iterating,
+/// standard `std::string` class: removing, random access, iterating,
 /// appending, comparing, etc. However it is a simple class
 /// provided for convenience, and you may have to consider using
 /// a more optimized class if your program requires complex string

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -52,7 +52,7 @@ public:
     constexpr Time() = default;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Construct from std::chrono::duration
+    /// \brief Construct from `std::chrono::duration`
     ///
     ////////////////////////////////////////////////////////////
     template <typename Rep, typename Period>
@@ -89,7 +89,7 @@ public:
     [[nodiscard]] constexpr std::int64_t asMicroseconds() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Return the time value as a std::chorono::duration
+    /// \brief Return the time value as a `std::chorono::duration`
     ///
     /// \return Time in microseconds
     ///
@@ -97,7 +97,7 @@ public:
     [[nodiscard]] constexpr std::chrono::microseconds toDuration() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Implicit conversion to std::chrono::duration
+    /// \brief Implicit conversion to `std::chrono::duration`
     ///
     /// \return Duration in microseconds
     ///

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -171,7 +171,7 @@ public:
     /// \param size    Width and height of the image
     /// \param hotspot (x,y) location of the hotspot
     ///
-    /// \throws std::runtime_error if the cursor could not be constructed
+    /// \throws `std::runtime_error` if the cursor could not be constructed
     ///
     ////////////////////////////////////////////////////////////
     Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
@@ -186,7 +186,7 @@ public:
     ///
     /// \param type Native system cursor type
     ///
-    /// \throws std::runtime_error if the corresponding cursor
+    /// \throws `std::runtime_error` if the corresponding cursor
     ///         is not natively supported by the operating
     ///         system
     ///

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -365,7 +365,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
     ///
-    /// Pass std::nullopt to unset the minimum size
+    /// Pass `std::nullopt` to unset the minimum size
     ///
     /// \param minimumSize New minimum size, in pixels
     ///
@@ -375,7 +375,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the maximum window rendering region size
     ///
-    /// Pass std::nullopt to unset the maximum size
+    /// Pass `std::nullopt` to unset the maximum size
     ///
     /// \param maximumSize New maximum size, in pixels
     ///

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -114,7 +114,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
     ///
-    /// Pass std::nullopt to unset the minimum size
+    /// Pass `std::nullopt` to unset the minimum size
     ///
     /// \param minimumSize New minimum size, in pixels
     ///
@@ -124,7 +124,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the maximum window rendering region size
     ///
-    /// Pass std::nullopt to unset the maximum size
+    /// Pass `std::nullopt` to unset the maximum size
     ///
     /// \param maximumSize New maximum size, in pixels
     ///

--- a/src/SFML/Window/DRM/WindowImplDRM.hpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.hpp
@@ -108,7 +108,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
     ///
-    /// Pass std::nullopt to unset the minimum size
+    /// Pass `std::nullopt` to unset the minimum size
     ///
     /// \param minimumSize New minimum size, in pixels
     ///
@@ -118,7 +118,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the maximum window rendering region size
     ///
-    /// Pass std::nullopt to unset the maximum size
+    /// Pass `std::nullopt` to unset the maximum size
     ///
     /// \param maximumSize New maximum size, in pixels
     ///

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -116,7 +116,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
     ///
-    /// Pass std::nullopt to unset the minimum size
+    /// Pass `std::nullopt` to unset the minimum size
     ///
     /// \param minimumSize New minimum size, in pixels
     ///
@@ -126,7 +126,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the maximum window rendering region size
     ///
-    /// Pass std::nullopt to unset the maximum size
+    /// Pass `std::nullopt` to unset the maximum size
     ///
     /// \param maximumSize New maximum size, in pixels
     ///

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -204,7 +204,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
     ///
-    /// Pass std::nullopt to unset the minimum size
+    /// Pass `std::nullopt` to unset the minimum size
     ///
     /// \param minimumSize New minimum size, in pixels
     ///
@@ -214,7 +214,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the maximum window rendering region size
     ///
-    /// Pass std::nullopt to unset the maximum size
+    /// Pass `std::nullopt` to unset the maximum size
     ///
     /// \param maximumSize New maximum size, in pixels
     ///

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -109,7 +109,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
     ///
-    /// Pass std::nullopt to unset the minimum size
+    /// Pass `std::nullopt` to unset the minimum size
     ///
     /// \param minimumSize New minimum size, in pixels
     ///
@@ -119,7 +119,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the maximum window rendering region size
     ///
-    /// Pass std::nullopt to unset the maximum size
+    /// Pass `std::nullopt` to unset the maximum size
     ///
     /// \param maximumSize New maximum size, in pixels
     ///

--- a/src/SFML/Window/macOS/SFOpenGLView+mouse_priv.h
+++ b/src/SFML/Window/macOS/SFOpenGLView+mouse_priv.h
@@ -103,7 +103,7 @@
 ///
 /// \param event a mouse button event
 ///
-/// \return Left, Right, ..., or std::nullopt if the button is unknown
+/// \return Left, Right, ..., or `std::nullopt` if the button is unknown
 ///
 ////////////////////////////////////////////////////////////
 + (std::optional<sf::Mouse::Button>)mouseButtonFromEvent:(NSEvent*)event;

--- a/src/SFML/Window/macOS/WindowImplCocoa.hpp
+++ b/src/SFML/Window/macOS/WindowImplCocoa.hpp
@@ -280,7 +280,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the minimum window rendering region size
     ///
-    /// Pass std::nullopt to unset the minimum size
+    /// Pass `std::nullopt` to unset the minimum size
     ///
     /// \param minimumSize New minimum size, in pixels
     ///
@@ -290,7 +290,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Set the maximum window rendering region size
     ///
-    /// Pass std::nullopt to unset the maximum size
+    /// Pass `std::nullopt` to unset the maximum size
     ///
     /// \param maximumSize New maximum size, in pixels
     ///


### PR DESCRIPTION
## Description

I regex-ed for `/// .* std::[^ ]*` and added backticks. Maybe there are more types that I've missed (e.g. standard types).

Partially solves #3123 

## How to test this PR?

Generate API docs and look at the output.