### PR TITLE
chore: update catch2 from 3.6.0 to 3.7.0

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
 set(CATCH_CONFIG_NO_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT ON CACHE BOOL "")
 FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.6.0
+    GIT_TAG v3.7.0
     GIT_SHALLOW ON)
 FetchContent_MakeAvailable(Catch2)
 include(Catch)


### PR DESCRIPTION
## Description
Updates `catch2` from `3.6.0` to `3.7.0`.

<!-- Please describe your pull request. -->

This PR is not related to any issues I could find.

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run the tests, expected to pass.