### PR TITLE
Make macos scaling for Desktop and Fullscreen Modes consistent

### DIFF
--- a/src/SFML/Window/OSX/SFWindowController.mm
+++ b/src/SFML/Window/OSX/SFWindowController.mm
@@ -181,7 +181,6 @@
 {
     // Create a screen-sized window on the main display
     sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
-    sf::priv::scaleInWidthHeight(desktop, nil);
     NSRect windowRect = NSMakeRect(0, 0, desktop.width, desktop.height);
     m_window = [[SFWindow alloc] initWithContentRect:windowRect
                                            styleMask:NSBorderlessWindowMask
@@ -448,7 +447,6 @@
         // Special case when fullscreen: only resize the opengl view
         // and make sure the requested size is not bigger than the window.
         sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
-        sf::priv::scaleInWidthHeight(desktop, nil);
 
         width = std::min(width, desktop.width);
         height = std::min(height, desktop.height);

--- a/src/SFML/Window/OSX/cg_sf_conversion.mm
+++ b/src/SFML/Window/OSX/cg_sf_conversion.mm
@@ -97,7 +97,9 @@ VideoMode convertCGModeToSFMode(CGDisplayModeRef cgmode)
     // [1]: "APIs for Supporting High Resolution" > "Additions and Changes for OS X v10.8"
     // https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/APIs/APIs.html#//apple_ref/doc/uid/TP40012302-CH5-SW27
     const Vector2u size = Vector2u(Vector2<size_t>(CGDisplayModeGetPixelWidth(cgmode), CGDisplayModeGetPixelHeight(cgmode)));
-    return VideoMode(size.x, size.y, static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
+    VideoMode mode(size.x, size.y, static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
+    scaleInWidthHeight(mode, nil);
+    return mode;
 }
 
 } // namespace priv

--- a/src/SFML/Window/OSX/cg_sf_conversion.mm
+++ b/src/SFML/Window/OSX/cg_sf_conversion.mm
@@ -28,6 +28,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/OSX/cg_sf_conversion.hpp>
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Vector2.hpp>
 
 #import <SFML/Window/OSX/Scaling.h>
 
@@ -95,11 +96,9 @@ VideoMode convertCGModeToSFMode(CGDisplayModeRef cgmode)
     //
     // [1]: "APIs for Supporting High Resolution" > "Additions and Changes for OS X v10.8"
     // https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/APIs/APIs.html#//apple_ref/doc/uid/TP40012302-CH5-SW27
-    VideoMode mode(static_cast<unsigned int>(CGDisplayModeGetWidth(cgmode)), static_cast<unsigned int>(CGDisplayModeGetHeight(cgmode)), static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
-    scaleOutWidthHeight(mode, nil);
-    return mode;
+    const Vector2u size = Vector2u(Vector2<size_t>(CGDisplayModeGetPixelWidth(cgmode), CGDisplayModeGetPixelHeight(cgmode)));
+    return VideoMode(size.x, size.y, static_cast<unsigned int>(modeBitsPerPixel(cgmode)));
 }
 
 } // namespace priv
 } // namespace sf
-


### PR DESCRIPTION
## Description

This PR aims at fixing the issue of no valid Fullscreen Mode being reported on MacOS, or buggy Fullscreen Modes bigger than the actual screen size getting returned.
Basically, before this PR getFullscreenModes was using the natural getDesktopMode size.
But when the actual fullscreen canvas was created, said getDesktopMode size was being scaled down depending on the screen's DPI. That same transformation was not being applied to the Fullscreen Modes. So in HiDPI mode in #3151 , you'd get Fullscreen Modes bigger than the canvas, meaning you'd end up with stuff being displayed outside the visible monitor.

This PR applies the same factor to both getDesktopMode and the available Fullscreen Modes from the beginning. So they're properly compared, and the actual amount of available pixels is reported to the library user.

The original problem (#2300 ) was the following: To account for the separate getDesktopMode scaling down, the desktop mode was getting scaled up during the initial acquisition. This was because the original code was using CGDisplayModeGetWidth and not CGDisplayModeGetPixelWidth, which means it was getting the scaled down size.
The problem is that that same code was also being applied to the Fullscreen Modes, for which CGDisplayModeGetWidth  already returned the properly scaled size. So you'd end up with giant invalid Fullscreen Modes, which would be bigger than the Desktop Mode.
#3151 switches to CGDisplayModeGetPixelWidth, which returns the sizes scaled by the same factor (1.0 from my tests) for both.
In synthesis, the original problem was the following:
For Desktop Mode: CGDisplayModeGetWidth = 0.5x -> *2 = 1.0 (then, later 1.0 *0.5 = 0.5)
For Fullscreen Modes: CGDisplayModeGetWidth = 1.0x -> *2 = 2.0... 2.0 > 1.0! Not valid!

This PR is related to https://github.com/SFML/SFML/pull/3151 and https://github.com/SFML/SFML/issues/2300 
Should also be applied to the branch macos_fullscreen

## Tasks

-   [X] Tested on macOS

## How to test this PR?

Make a small program that you can set to fullscreen, with something written inside of it to make sure it's not displaying stuff outside the visible monitor. Make it print the available resolutions to the console as well, to make sure they're properly reported.
Test in both HiDPI mode and normal DPI mode.