### PR TITLE
Use imported target for openal to simplify copying dll's

### DIFF
--- a/cmake/Modules/FindOpenAL.cmake
+++ b/cmake/Modules/FindOpenAL.cmake
@@ -1,0 +1,134 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindOpenAL
+----------
+
+Finds Open Audio Library (OpenAL).
+
+Projects using this module should use ``#include "al.h"`` to include the OpenAL
+header file, **not** ``#include <AL/al.h>``.  The reason for this is that the
+latter is not entirely portable.  Windows/Creative Labs does not by default put
+their headers in ``AL/`` and macOS uses the convention ``<OpenAL/al.h>``.
+
+Hints
+^^^^^
+
+Environment variable ``$OPENALDIR`` can be used to set the prefix of OpenAL
+installation to be found.
+
+By default on macOS, system framework is search first.  In other words,
+OpenAL is searched in the following order:
+
+1. System framework: ``/System/Library/Frameworks``, whose priority can be
+   changed via setting the :variable:`CMAKE_FIND_FRAMEWORK` variable.
+2. Environment variable ``$OPENALDIR``.
+3. System paths.
+4. User-compiled framework: ``~/Library/Frameworks``.
+5. Manually compiled framework: ``/Library/Frameworks``.
+6. Add-on package: ``/opt``.
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+.. versionadded:: 3.25
+
+This module defines the :prop_tgt:`IMPORTED` target:
+
+``OpenAL::OpenAL``
+  The OpenAL library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``OPENAL_FOUND``
+  If false, do not try to link to OpenAL
+``OPENAL_INCLUDE_DIR``
+  OpenAL include directory
+``OPENAL_LIBRARY``
+  Path to the OpenAL library
+``OPENAL_VERSION_STRING``
+  Human-readable string containing the version of OpenAL
+#]=======================================================================]
+
+# For Windows, Creative Labs seems to have added a registry key for their
+# OpenAL 1.1 installer. I have added that key to the list of search paths,
+# however, the key looks like it could be a little fragile depending on
+# if they decide to change the 1.00.0000 number for bug fix releases.
+# Also, they seem to have laid down groundwork for multiple library platforms
+# which puts the library in an extra subdirectory. Currently there is only
+# Win32 and I have hardcoded that here. This may need to be adjusted as
+# platforms are introduced.
+# The OpenAL 1.0 installer doesn't seem to have a useful key I can use.
+# I do not know if the Nvidia OpenAL SDK has a registry key.
+
+find_path(OPENAL_INCLUDE_DIR al.h
+  HINTS
+    ENV OPENALDIR
+  PATHS
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /opt
+    [HKEY_LOCAL_MACHINE\\SOFTWARE\\Creative\ Labs\\OpenAL\ 1.1\ Software\ Development\ Kit\\1.00.0000;InstallDir]
+  PATH_SUFFIXES include/AL include/OpenAL include AL OpenAL
+  )
+
+find_library(OPENAL_LIBRARY
+  NAMES OpenAL al openal OpenAL32
+  HINTS
+    ENV OPENALDIR
+  PATHS
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /opt
+    [HKEY_LOCAL_MACHINE\\SOFTWARE\\Creative\ Labs\\OpenAL\ 1.1\ Software\ Development\ Kit\\1.00.0000;InstallDir]
+  PATH_SUFFIXES libx32 lib64 lib libs64 libs
+  )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  OpenAL
+  REQUIRED_VARS OPENAL_LIBRARY OPENAL_INCLUDE_DIR
+  VERSION_VAR OPENAL_VERSION_STRING
+  )
+
+mark_as_advanced(OPENAL_LIBRARY OPENAL_INCLUDE_DIR)
+
+if(OPENAL_INCLUDE_DIR AND OPENAL_LIBRARY)
+  if(NOT TARGET OpenAL::OpenAL)
+    if(EXISTS "${OPENAL_LIBRARY}")
+      if(WIN32)
+        get_filename_component(OPENAL_PATH ${OPENAL_LIBRARY} DIRECTORY)
+        add_library(OpenAL::OpenAL SHARED IMPORTED)
+        if (ARCH_x86)
+          set(DLL_PATH "${OPENAL_PATH}/../../bin/x86/openal32.dll")
+        elseif(ARCH_X64)
+          set(DLL_PATH "${OPENAL_PATH}/../../bin/x64/openal32.dll")
+        else()
+          set(DLL_PATH "${OPENAL_PATH}/../../bin/ARM64/openal32.dll")
+        endif()
+        set_target_properties(OpenAL::OpenAL PROPERTIES
+          IMPORTED_LOCATION "${DLL_PATH}"
+          IMPORTED_IMPLIB "${OPENAL_LIBRARY}")
+      elseif(APPLE)
+          find_file(OPENAL_FULL_PATH OpenAL ${OPENAL_LIBRARY})
+          add_library(OpenAL::OpenAL SHARED IMPORTED)
+          set_target_properties(OpenAL::OpenAL PROPERTIES
+            IMPORTED_LOCATION "${OPENAL_FULL_PATH}")
+      else()
+        add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
+        set_target_properties(OpenAL::OpenAL PROPERTIES
+          IMPORTED_LOCATION "${OPENAL_LIBRARY}")
+      endif()
+    else()
+      add_library(OpenAL::OpenAL INTERFACE IMPORTED)
+      set_target_properties(OpenAL::OpenAL PROPERTIES
+        IMPORTED_LIBNAME "${OPENAL_LIBRARY}")
+    endif()
+    set_target_properties(OpenAL::OpenAL PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${OPENAL_INCLUDE_DIR}")
+  endif()
+endif()

--- a/cmake/Modules/FindOpenAL.cmake
+++ b/cmake/Modules/FindOpenAL.cmake
@@ -114,7 +114,7 @@ if(OPENAL_INCLUDE_DIR AND OPENAL_LIBRARY)
           IMPORTED_LOCATION "${DLL_PATH}"
           IMPORTED_IMPLIB "${OPENAL_LIBRARY}")
       elseif(APPLE)
-          find_file(OPENAL_FULL_PATH OpenAL ${OPENAL_LIBRARY})
+          find_file(OPENAL_FULL_PATH OpenAL OpenAL.tbd PATHS ${OPENAL_LIBRARY} REQUIRED)
           add_library(OpenAL::OpenAL SHARED IMPORTED)
           set_target_properties(OpenAL::OpenAL PROPERTIES
             IMPORTED_LOCATION "${OPENAL_FULL_PATH}")

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -68,7 +68,7 @@ elseif(SFML_OS_ANDROID)
 endif()
 
 # find external libraries
-sfml_find_package(OpenAL INCLUDE "OPENAL_INCLUDE_DIR" LINK "OPENAL_LIBRARY")
+find_package(OpenAL REQUIRED)
 sfml_find_package(VORBIS INCLUDE "VORBIS_INCLUDE_DIRS" LINK "VORBIS_LIBRARIES")
 sfml_find_package(FLAC INCLUDE "FLAC_INCLUDE_DIR" LINK "FLAC_LIBRARY")
 
@@ -81,7 +81,7 @@ sfml_add_library(sfml-audio
                  SOURCES ${SRC} ${CODECS_SRC})
 
 # setup dependencies
-target_link_libraries(sfml-audio PRIVATE OpenAL)
+target_link_libraries(sfml-audio PRIVATE OpenAL::OpenAL)
 
 # minimp3 sources
 target_include_directories(sfml-audio SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/minimp3")


### PR DESCRIPTION
One of the big problems people face (although now solved with openal Replaced for SFML3) is copying required dlls to the required location. A common and convenient way to do this is with the `TARGET_RUNTIME_DLLS` generator expression which works great for SFML dlls but not for openAL as it's not an imported target

Cmake's built-in module for finding openal creates an imported target but doesn't set the `IMPORTED_LOCATION` property, there's an issue for that here: https://gitlab.kitware.com/cmake/cmake/-/issues/24033. It's unlikely to be fixed any time soon there, as they have to consider that the dll next to the lib isn't guaranteed to be a match, however for SFML we bundle these dependencies so we can guarantee that

So this change adds a lightly modified copy of cmake's find module which sets the IMPORTED_LOCATION appropriately and also handles the different arch variations

the `sfml_find_package` macro doesn't really work with existing targets so I've just reverted to using the standard one which I believe is fine in this case - this all goes away for SFML 3 anyway so don't think we need to be too precious about it