### PR TITLE
Throw custom `sf::Exception` type

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -35,6 +35,7 @@ function(set_target_warnings target)
             /wd4068 # disable warnings about unknown pragmas (e.g. #pragma GCC)
             /wd4505 # disable warnings about unused functions that might be platform-specific
             /wd4800 # disable warnings regarding implicit conversions to bool
+            /wd4275 # disable warnings about exporting non DLL-interface classes
         )
     endif()
 

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -73,7 +73,7 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \throws `std::runtime_error` if opening the file was unsuccessful
+    /// \throws `sf::Exception` if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile(const std::filesystem::path& filename);
@@ -87,7 +87,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `std::runtime_error` if opening the file was unsuccessful
+    /// \throws `sf::Exception` if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile(const void* data, std::size_t sizeInBytes);
@@ -100,7 +100,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `std::runtime_error` if opening the file was unsuccessful
+    /// \throws `sf::Exception` if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile(InputStream& stream);

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -88,7 +88,7 @@ public:
     ///
     /// \param filename Path of the music file to open
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see openFromMemory, openFromStream
     ///
@@ -111,7 +111,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromStream
     ///
@@ -132,7 +132,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromMemory
     ///

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -67,7 +67,7 @@ public:
     /// \param channelCount Number of channels in the sound
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \throws `std::runtime_error` if the file could not be opened successfully
+    /// \throws `sf::Exception` if the file could not be opened successfully
     ///
     ////////////////////////////////////////////////////////////
     OutputSoundFile(const std::filesystem::path&     filename,

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -79,7 +79,7 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
     ///
@@ -95,7 +95,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromStream, loadFromSamples
     ///
@@ -110,7 +110,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromSamples
     ///
@@ -128,7 +128,7 @@ public:
     /// \param sampleRate   Sample rate (number of samples to play per second)
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, saveToFile
     ///

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -95,7 +95,7 @@ public:
     ///
     /// \param filename Path of the font file to open
     ///
-    /// \throws `std::runtime_error` if opening was unsuccessful
+    /// \throws `sf::Exception` if opening was unsuccessful
     ///
     /// \see openFromFile, openFromMemory, openFromStream
     ///
@@ -116,7 +116,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromMemory, openFromStream
     ///
@@ -138,7 +138,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see openFromFile, openFromMemory, openFromStream
     ///

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -96,7 +96,7 @@ public:
     ///
     /// \param filename Path of the image file to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -113,7 +113,7 @@ public:
     /// \param data Pointer to the file data in memory
     /// \param size Size of the data to load, in bytes
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -129,7 +129,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -77,7 +77,7 @@ public:
     /// \param size     Width and height of the render-texture
     /// \param settings Additional settings for the underlying OpenGL texture and context
     ///
-    /// \throws `std::runtime_error` if creation was unsuccessful
+    /// \throws `sf::Exception` if creation was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     RenderTexture(Vector2u size, const ContextSettings& settings = {});

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -139,7 +139,7 @@ public:
     /// \param filename Path of the vertex, geometry or fragment shader file to load
     /// \param type     Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -160,7 +160,7 @@ public:
     /// \param vertexShaderFilename   Path of the vertex shader file to load
     /// \param fragmentShaderFilename Path of the fragment shader file to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -182,7 +182,7 @@ public:
     /// \param geometryShaderFilename Path of the geometry shader file to load
     /// \param fragmentShaderFilename Path of the fragment shader file to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -204,7 +204,7 @@ public:
     /// \param shader String containing the source code of the shader
     /// \param type   Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -225,7 +225,7 @@ public:
     /// \param vertexShader   String containing the source code of the vertex shader
     /// \param fragmentShader String containing the source code of the fragment shader
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -247,7 +247,7 @@ public:
     /// \param geometryShader String containing the source code of the geometry shader
     /// \param fragmentShader String containing the source code of the fragment shader
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -267,7 +267,7 @@ public:
     /// \param stream Source stream to read from
     /// \param type   Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -288,7 +288,7 @@ public:
     /// \param vertexShaderStream   Source stream to read the vertex shader from
     /// \param fragmentShaderStream Source stream to read the fragment shader from
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///
@@ -310,7 +310,7 @@ public:
     /// \param geometryShaderStream Source stream to read the geometry shader from
     /// \param fragmentShaderStream Source stream to read the fragment shader from
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream
     ///

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -106,7 +106,7 @@ public:
     /// \param filename Path of the image file to load
     /// \param sRgb     True to enable sRGB conversion, false to disable it
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -129,7 +129,7 @@ public:
     /// \param sRgb     True to enable sRGB conversion, false to disable it
     /// \param area     Area of the image to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -146,7 +146,7 @@ public:
     /// \param size Size of the data to load, in bytes
     /// \param sRgb True to enable sRGB conversion, false to disable it
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -170,7 +170,7 @@ public:
     /// \param sRgb True to enable sRGB conversion, false to disable it
     /// \param area Area of the image to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -186,7 +186,7 @@ public:
     /// \param stream Source stream to read from
     /// \param sRgb   True to enable sRGB conversion, false to disable it
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -209,7 +209,7 @@ public:
     /// \param sRgb   True to enable sRGB conversion, false to disable it
     /// \param area   Area of the image to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -225,7 +225,7 @@ public:
     /// \param image Image to load into the texture
     /// \param sRgb  True to enable sRGB conversion, false to disable it
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -247,7 +247,7 @@ public:
     /// \param sRgb  True to enable sRGB conversion, false to disable it
     /// \param area  Area of the image to load
     ///
-    /// \throws `std::runtime_error` if loading was unsuccessful
+    /// \throws `sf::Exception` if loading was unsuccessful
     ///
     /// \see loadFromFile, loadFromMemory, loadFromStream, loadFromImage
     ///
@@ -260,7 +260,7 @@ public:
     /// \param size Width and height of the texture
     /// \param sRgb True to enable sRGB conversion, false to disable it
     ///
-    /// \throws `std::runtime_error` if construction was unsuccessful
+    /// \throws `sf::Exception` if construction was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     explicit Texture(Vector2u size, bool sRgb = false);

--- a/include/SFML/System/Exception.hpp
+++ b/include/SFML/System/Exception.hpp
@@ -27,29 +27,26 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
 
-#include <SFML/Config.hpp>
-
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
-#include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
+#include <stdexcept>
 
 
+namespace sf
+{
 ////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
+/// \brief Library-specific exception type
 ///
 ////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API Exception : public std::runtime_error
+{
+public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct with message
+    ///
+    /// \param message Exception message
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Exception(const std::string& message);
+};
+} // namespace sf

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -100,7 +100,7 @@ public:
     ///
     /// \param filename Name of the file to open
     ///
-    /// \throws `std::runtime_error` on error
+    /// \throws `sf::Exception` on error
     ///
     ////////////////////////////////////////////////////////////
     explicit FileInputStream(const std::filesystem::path& filename);

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -171,7 +171,7 @@ public:
     /// \param size    Width and height of the image
     /// \param hotspot (x,y) location of the hotspot
     ///
-    /// \throws `std::runtime_error` if the cursor could not be constructed
+    /// \throws `sf::Exception` if the cursor could not be constructed
     ///
     ////////////////////////////////////////////////////////////
     Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
@@ -186,7 +186,7 @@ public:
     ///
     /// \param type Native system cursor type
     ///
-    /// \throws `std::runtime_error` if the corresponding cursor
+    /// \throws `sf::Exception` if the corresponding cursor
     ///         is not natively supported by the operating
     ///         system
     ///

--- a/src/SFML/Audio/InputSoundFile.cpp
+++ b/src/SFML/Audio/InputSoundFile.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Audio/SoundFileReader.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/MemoryInputStream.hpp>
@@ -70,7 +71,7 @@ void InputSoundFile::StreamDeleter::operator()(InputStream* ptr) const
 InputSoundFile::InputSoundFile(const std::filesystem::path& filename)
 {
     if (!openFromFile(filename))
-        throw std::runtime_error("Failed to open input sound file");
+        throw sf::Exception("Failed to open input sound file");
 }
 
 
@@ -78,7 +79,7 @@ InputSoundFile::InputSoundFile(const std::filesystem::path& filename)
 InputSoundFile::InputSoundFile(const void* data, std::size_t sizeInBytes)
 {
     if (!openFromMemory(data, sizeInBytes))
-        throw std::runtime_error("Failed to open input sound file from memory");
+        throw sf::Exception("Failed to open input sound file from memory");
 }
 
 
@@ -86,7 +87,7 @@ InputSoundFile::InputSoundFile(const void* data, std::size_t sizeInBytes)
 InputSoundFile::InputSoundFile(InputStream& stream)
 {
     if (!openFromStream(stream))
-        throw std::runtime_error("Failed to open input sound file from stream");
+        throw sf::Exception("Failed to open input sound file from stream");
 }
 
 

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Audio/Music.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/Time.hpp>
 
 #include <algorithm>
@@ -68,7 +69,7 @@ Music::Music() : m_impl(std::make_unique<Impl>())
 Music::Music(const std::filesystem::path& filename) : Music()
 {
     if (!openFromFile(filename))
-        throw std::runtime_error("Failed to open music from file");
+        throw sf::Exception("Failed to open music from file");
 }
 
 
@@ -76,7 +77,7 @@ Music::Music(const std::filesystem::path& filename) : Music()
 Music::Music(const void* data, std::size_t sizeInBytes) : Music()
 {
     if (!openFromMemory(data, sizeInBytes))
-        throw std::runtime_error("Failed to open music from memory");
+        throw sf::Exception("Failed to open music from memory");
 }
 
 
@@ -84,7 +85,7 @@ Music::Music(const void* data, std::size_t sizeInBytes) : Music()
 Music::Music(InputStream& stream) : Music()
 {
     if (!openFromStream(stream))
-        throw std::runtime_error("Failed to open music from stream");
+        throw sf::Exception("Failed to open music from stream");
 }
 
 

--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Audio/SoundFileWriter.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 
 #include <cassert>
 
@@ -43,7 +44,7 @@ OutputSoundFile::OutputSoundFile(const std::filesystem::path&     filename,
                                  const std::vector<SoundChannel>& channelMap)
 {
     if (!openFromFile(filename, sampleRate, channelCount, channelMap))
-        throw std::runtime_error("Failed to open output sound file");
+        throw sf::Exception("Failed to open output sound file");
 }
 
 

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -31,6 +31,7 @@
 #include <SFML/Audio/SoundBuffer.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 
 #include <exception>
 #include <ostream>
@@ -43,7 +44,7 @@ namespace sf
 SoundBuffer::SoundBuffer(const std::filesystem::path& filename)
 {
     if (!loadFromFile(filename))
-        throw std::runtime_error("Failed to open sound buffer from file");
+        throw sf::Exception("Failed to open sound buffer from file");
 }
 
 
@@ -51,7 +52,7 @@ SoundBuffer::SoundBuffer(const std::filesystem::path& filename)
 SoundBuffer::SoundBuffer(const void* data, std::size_t sizeInBytes)
 {
     if (!loadFromMemory(data, sizeInBytes))
-        throw std::runtime_error("Failed to open sound buffer from memory");
+        throw sf::Exception("Failed to open sound buffer from memory");
 }
 
 
@@ -59,7 +60,7 @@ SoundBuffer::SoundBuffer(const void* data, std::size_t sizeInBytes)
 SoundBuffer::SoundBuffer(InputStream& stream)
 {
     if (!loadFromStream(stream))
-        throw std::runtime_error("Failed to open sound buffer from stream");
+        throw sf::Exception("Failed to open sound buffer from stream");
 }
 
 
@@ -71,7 +72,7 @@ SoundBuffer::SoundBuffer(const std::int16_t*              samples,
                          const std::vector<SoundChannel>& channelMap)
 {
     if (!loadFromSamples(samples, sampleCount, channelCount, sampleRate, channelMap))
-        throw std::runtime_error("Failed to open sound buffer from samples");
+        throw sf::Exception("Failed to open sound buffer from samples");
 }
 
 

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -32,6 +32,7 @@
 #include <SFML/System/Android/ResourceStream.hpp>
 #endif
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Utils.hpp>
 
@@ -124,7 +125,7 @@ struct Font::FontHandles
 Font::Font(const std::filesystem::path& filename)
 {
     if (!openFromFile(filename))
-        throw std::runtime_error("Failed to open font from file");
+        throw sf::Exception("Failed to open font from file");
 }
 
 
@@ -132,7 +133,7 @@ Font::Font(const std::filesystem::path& filename)
 Font::Font(const void* data, std::size_t sizeInBytes)
 {
     if (!openFromMemory(data, sizeInBytes))
-        throw std::runtime_error("Failed to open font from memory");
+        throw sf::Exception("Failed to open font from memory");
 }
 
 
@@ -140,7 +141,7 @@ Font::Font(const void* data, std::size_t sizeInBytes)
 Font::Font(InputStream& stream)
 {
     if (!openFromStream(stream))
-        throw std::runtime_error("Failed to open font from stream");
+        throw sf::Exception("Failed to open font from stream");
 }
 
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Graphics/Image.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Utils.hpp>
 #ifdef SFML_SYSTEM_ANDROID
@@ -113,7 +114,7 @@ Image::Image(Vector2u size, const std::uint8_t* pixels)
 Image::Image(const std::filesystem::path& filename)
 {
     if (!loadFromFile(filename))
-        throw std::runtime_error("Failed to open image from file");
+        throw sf::Exception("Failed to open image from file");
 }
 
 
@@ -121,7 +122,7 @@ Image::Image(const std::filesystem::path& filename)
 Image::Image(const void* data, std::size_t size)
 {
     if (!loadFromMemory(data, size))
-        throw std::runtime_error("Failed to open image from memory");
+        throw sf::Exception("Failed to open image from memory");
 }
 
 
@@ -129,7 +130,7 @@ Image::Image(const void* data, std::size_t size)
 Image::Image(InputStream& stream)
 {
     if (!loadFromStream(stream))
-        throw std::runtime_error("Failed to open image from stream");
+        throw sf::Exception("Failed to open image from stream");
 }
 
 

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -30,6 +30,7 @@
 #include <SFML/Graphics/RenderTextureImplFBO.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 
 #include <memory>
 #include <ostream>
@@ -47,7 +48,7 @@ RenderTexture::RenderTexture() = default;
 RenderTexture::RenderTexture(Vector2u size, const ContextSettings& settings)
 {
     if (!resize(size, settings))
-        throw std::runtime_error("Failed to create render texture");
+        throw sf::Exception("Failed to create render texture");
 }
 
 

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -34,6 +34,7 @@
 #include <SFML/Window/GlResource.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Utils.hpp>
 #include <SFML/System/Vector2.hpp>
@@ -227,7 +228,7 @@ struct Shader::UniformBinder
 Shader::Shader(const std::filesystem::path& filename, Type type)
 {
     if (!loadFromFile(filename, type))
-        throw std::runtime_error("Failed to load shader from file");
+        throw sf::Exception("Failed to load shader from file");
 }
 
 
@@ -235,7 +236,7 @@ Shader::Shader(const std::filesystem::path& filename, Type type)
 Shader::Shader(const std::filesystem::path& vertexShaderFilename, const std::filesystem::path& fragmentShaderFilename)
 {
     if (!loadFromFile(vertexShaderFilename, fragmentShaderFilename))
-        throw std::runtime_error("Failed to load shader from files");
+        throw sf::Exception("Failed to load shader from files");
 }
 
 
@@ -245,7 +246,7 @@ Shader::Shader(const std::filesystem::path& vertexShaderFilename,
                const std::filesystem::path& fragmentShaderFilename)
 {
     if (!loadFromFile(vertexShaderFilename, geometryShaderFilename, fragmentShaderFilename))
-        throw std::runtime_error("Failed to load shader from files");
+        throw sf::Exception("Failed to load shader from files");
 }
 
 
@@ -253,7 +254,7 @@ Shader::Shader(const std::filesystem::path& vertexShaderFilename,
 Shader::Shader(std::string_view shader, Type type)
 {
     if (!loadFromMemory(shader, type))
-        throw std::runtime_error("Failed to load shader from memory");
+        throw sf::Exception("Failed to load shader from memory");
 }
 
 
@@ -261,7 +262,7 @@ Shader::Shader(std::string_view shader, Type type)
 Shader::Shader(std::string_view vertexShader, std::string_view fragmentShader)
 {
     if (!loadFromMemory(vertexShader, fragmentShader))
-        throw std::runtime_error("Failed to load shader from memory");
+        throw sf::Exception("Failed to load shader from memory");
 }
 
 
@@ -269,7 +270,7 @@ Shader::Shader(std::string_view vertexShader, std::string_view fragmentShader)
 Shader::Shader(std::string_view vertexShader, std::string_view geometryShader, std::string_view fragmentShader)
 {
     if (!loadFromMemory(vertexShader, geometryShader, fragmentShader))
-        throw std::runtime_error("Failed to load shader from memory");
+        throw sf::Exception("Failed to load shader from memory");
 }
 
 
@@ -277,7 +278,7 @@ Shader::Shader(std::string_view vertexShader, std::string_view geometryShader, s
 Shader::Shader(InputStream& stream, Type type)
 {
     if (!loadFromStream(stream, type))
-        throw std::runtime_error("Failed to load shader from stream");
+        throw sf::Exception("Failed to load shader from stream");
 }
 
 
@@ -285,7 +286,7 @@ Shader::Shader(InputStream& stream, Type type)
 Shader::Shader(InputStream& vertexShaderStream, InputStream& fragmentShaderStream)
 {
     if (!loadFromStream(vertexShaderStream, fragmentShaderStream))
-        throw std::runtime_error("Failed to load shader from streams");
+        throw sf::Exception("Failed to load shader from streams");
 }
 
 
@@ -293,7 +294,7 @@ Shader::Shader(InputStream& vertexShaderStream, InputStream& fragmentShaderStrea
 Shader::Shader(InputStream& vertexShaderStream, InputStream& geometryShaderStream, InputStream& fragmentShaderStream)
 {
     if (!loadFromStream(vertexShaderStream, geometryShaderStream, fragmentShaderStream))
-        throw std::runtime_error("Failed to load shader from streams");
+        throw sf::Exception("Failed to load shader from streams");
 }
 
 
@@ -1039,7 +1040,7 @@ namespace sf
 ////////////////////////////////////////////////////////////
 Shader::Shader(const std::filesystem::path& /* filename */, Type /* type */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
@@ -1047,7 +1048,7 @@ Shader::Shader(const std::filesystem::path& /* filename */, Type /* type */)
 Shader::Shader(const std::filesystem::path& /* vertexShaderFilename */,
                const std::filesystem::path& /* fragmentShaderFilename */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
@@ -1056,42 +1057,42 @@ Shader::Shader(const std::filesystem::path& /* vertexShaderFilename */,
                const std::filesystem::path& /* geometryShaderFilename */,
                const std::filesystem::path& /* fragmentShaderFilename */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
 ////////////////////////////////////////////////////////////
 Shader::Shader(std::string_view /* shader */, Type /* type */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
 ////////////////////////////////////////////////////////////
 Shader::Shader(std::string_view /* vertexShader */, std::string_view /* fragmentShader */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
 ////////////////////////////////////////////////////////////
 Shader::Shader(std::string_view /* vertexShader */, std::string_view /* geometryShader */, std::string_view /* fragmentShader */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
 ////////////////////////////////////////////////////////////
 Shader::Shader(InputStream& /* stream */, Type /* type */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
 ////////////////////////////////////////////////////////////
 Shader::Shader(InputStream& /* vertexShaderStream */, InputStream& /* fragmentShaderStream */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 
@@ -1100,7 +1101,7 @@ Shader::Shader(InputStream& /* vertexShaderStream */,
                InputStream& /* geometryShaderStream */,
                InputStream& /* fragmentShaderStream */)
 {
-    throw std::runtime_error("Shaders are not supported with OpenGL ES 1");
+    throw sf::Exception("Shaders are not supported with OpenGL ES 1");
 }
 
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -35,6 +35,7 @@
 #include <SFML/Window/Window.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 
 #include <algorithm>
 #include <array>
@@ -75,7 +76,7 @@ Texture::Texture() : m_cacheId(TextureImpl::getUniqueId())
 Texture::Texture(const std::filesystem::path& filename, bool sRgb) : Texture()
 {
     if (!loadFromFile(filename, sRgb))
-        throw std::runtime_error("Failed to load texture from file");
+        throw sf::Exception("Failed to load texture from file");
 }
 
 
@@ -83,7 +84,7 @@ Texture::Texture(const std::filesystem::path& filename, bool sRgb) : Texture()
 Texture::Texture(const std::filesystem::path& filename, bool sRgb, const IntRect& area) : Texture()
 {
     if (!loadFromFile(filename, sRgb, area))
-        throw std::runtime_error("Failed to load texture from file");
+        throw sf::Exception("Failed to load texture from file");
 }
 
 
@@ -91,7 +92,7 @@ Texture::Texture(const std::filesystem::path& filename, bool sRgb, const IntRect
 Texture::Texture(const void* data, std::size_t size, bool sRgb) : Texture()
 {
     if (!loadFromMemory(data, size, sRgb))
-        throw std::runtime_error("Failed to load texture from memory");
+        throw sf::Exception("Failed to load texture from memory");
 }
 
 
@@ -99,7 +100,7 @@ Texture::Texture(const void* data, std::size_t size, bool sRgb) : Texture()
 Texture::Texture(const void* data, std::size_t size, bool sRgb, const IntRect& area) : Texture()
 {
     if (!loadFromMemory(data, size, sRgb, area))
-        throw std::runtime_error("Failed to load texture from memory");
+        throw sf::Exception("Failed to load texture from memory");
 }
 
 
@@ -107,7 +108,7 @@ Texture::Texture(const void* data, std::size_t size, bool sRgb, const IntRect& a
 Texture::Texture(InputStream& stream, bool sRgb) : Texture()
 {
     if (!loadFromStream(stream, sRgb))
-        throw std::runtime_error("Failed to load texture from stream");
+        throw sf::Exception("Failed to load texture from stream");
 }
 
 
@@ -115,7 +116,7 @@ Texture::Texture(InputStream& stream, bool sRgb) : Texture()
 Texture::Texture(InputStream& stream, bool sRgb, const IntRect& area) : Texture()
 {
     if (!loadFromStream(stream, sRgb, area))
-        throw std::runtime_error("Failed to load texture from stream");
+        throw sf::Exception("Failed to load texture from stream");
 }
 
 
@@ -123,7 +124,7 @@ Texture::Texture(InputStream& stream, bool sRgb, const IntRect& area) : Texture(
 Texture::Texture(const Image& image, bool sRgb) : Texture()
 {
     if (!loadFromImage(image, sRgb))
-        throw std::runtime_error("Failed to load texture from image");
+        throw sf::Exception("Failed to load texture from image");
 }
 
 
@@ -131,7 +132,7 @@ Texture::Texture(const Image& image, bool sRgb) : Texture()
 Texture::Texture(const Image& image, bool sRgb, const IntRect& area) : Texture()
 {
     if (!loadFromImage(image, sRgb, area))
-        throw std::runtime_error("Failed to load texture from image");
+        throw sf::Exception("Failed to load texture from image");
 }
 
 
@@ -139,7 +140,7 @@ Texture::Texture(const Image& image, bool sRgb, const IntRect& area) : Texture()
 Texture::Texture(Vector2u size, bool sRgb) : Texture()
 {
     if (!resize(size, sRgb))
-        throw std::runtime_error("Failed to create texture");
+        throw sf::Exception("Failed to create texture");
 }
 
 

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -10,6 +10,8 @@ set(SRC
     ${SRCROOT}/EnumArray.hpp
     ${SRCROOT}/Err.cpp
     ${INCROOT}/Err.hpp
+    ${SRCROOT}/Exception.cpp
+    ${INCROOT}/Exception.hpp
     ${INCROOT}/Export.hpp
     ${INCROOT}/InputStream.hpp
     ${INCROOT}/NativeActivity.hpp

--- a/src/SFML/System/Exception.cpp
+++ b/src/SFML/System/Exception.cpp
@@ -22,34 +22,17 @@
 //
 ////////////////////////////////////////////////////////////
 
-#pragma once
-
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-
-#include <SFML/Config.hpp>
-
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
 #include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
 
 
+namespace sf
+{
 ////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
-///
-////////////////////////////////////////////////////////////
+Exception::Exception(const std::string& message) : std::runtime_error(message)
+{
+}
+
+} // namespace sf

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 #ifdef SFML_SYSTEM_ANDROID
 #include <SFML/System/Android/Activity.hpp>
@@ -51,7 +52,7 @@ FileInputStream::FileInputStream() = default;
 FileInputStream::FileInputStream(const std::filesystem::path& filename)
 {
     if (!open(filename))
-        throw std::runtime_error("Failed to open file input stream");
+        throw sf::Exception("Failed to open file input stream");
 }
 
 

--- a/src/SFML/Window/Cursor.cpp
+++ b/src/SFML/Window/Cursor.cpp
@@ -29,6 +29,7 @@
 #include <SFML/Window/CursorImpl.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/Vector2.hpp>
 
 #include <memory>
@@ -47,10 +48,10 @@ Cursor::Cursor() : m_impl(std::make_unique<priv::CursorImpl>())
 Cursor::Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot) : Cursor()
 {
     if ((pixels == nullptr) || (size.x == 0) || (size.y == 0))
-        throw std::runtime_error("Failed to create cursor from pixels (invalid arguments)");
+        throw sf::Exception("Failed to create cursor from pixels (invalid arguments)");
 
     if (!m_impl->loadFromPixels(pixels, size, hotspot))
-        throw std::runtime_error("Failed to create cursor from pixels");
+        throw sf::Exception("Failed to create cursor from pixels");
 }
 
 
@@ -58,7 +59,7 @@ Cursor::Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot) : Cu
 Cursor::Cursor(Type type) : Cursor()
 {
     if (!m_impl->loadFromSystem(type))
-        throw std::runtime_error("Failed to create cursor from type");
+        throw sf::Exception("Failed to create cursor from type");
 }
 
 

--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Audio/InputSoundFile.hpp>
 
 // Other 1st party headers
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 #include <SFML/System/Time.hpp>
 
@@ -36,7 +37,7 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("Invalid file")
         {
-            CHECK_THROWS_AS(sf::InputSoundFile("does/not/exist.wav"), std::runtime_error);
+            CHECK_THROWS_AS(sf::InputSoundFile("does/not/exist.wav"), sf::Exception);
         }
 
         SECTION("Valid file")

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Audio/Music.hpp>
 
 // Other 1st party headers
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -52,7 +53,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
         {
             SECTION("Invalid file")
             {
-                CHECK_THROWS_AS(sf::Music("does/not/exist.wav"), std::runtime_error);
+                CHECK_THROWS_AS(sf::Music("does/not/exist.wav"), sf::Exception);
             }
 
             SECTION("Valid file")
@@ -76,7 +77,7 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
             SECTION("Invalid buffer")
             {
-                CHECK_THROWS_AS(sf::Music(memory.data(), memory.size()), std::runtime_error);
+                CHECK_THROWS_AS(sf::Music(memory.data(), memory.size()), sf::Exception);
             }
 
             SECTION("Valid buffer")

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Audio/SoundBuffer.hpp>
 
 // Other 1st party headers
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -38,7 +39,7 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
         {
             SECTION("Invalid filename")
             {
-                CHECK_THROWS_AS(sf::SoundBuffer("does/not/exist.wav"), std::runtime_error);
+                CHECK_THROWS_AS(sf::SoundBuffer("does/not/exist.wav"), sf::Exception);
             }
 
             SECTION("Valid file")
@@ -57,7 +58,7 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
             SECTION("Invalid memory")
             {
                 constexpr std::array<std::byte, 5> memory{};
-                CHECK_THROWS_AS(sf::SoundBuffer(memory.data(), memory.size()), std::runtime_error);
+                CHECK_THROWS_AS(sf::SoundBuffer(memory.data(), memory.size()), sf::Exception);
             }
 
             SECTION("Valid memory")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SYSTEM_SRC
     System/Clock.test.cpp
     System/Config.test.cpp
     System/Err.test.cpp
+    System/Exception.test.cpp
     System/FileInputStream.test.cpp
     System/MemoryInputStream.test.cpp
     System/Sleep.test.cpp

--- a/test/Graphics/Font.test.cpp
+++ b/test/Graphics/Font.test.cpp
@@ -1,7 +1,9 @@
 #include <SFML/Graphics/Font.hpp>
-#include <SFML/Graphics/Texture.hpp>
 
 // Other 1st party headers
+#include <SFML/Graphics/Texture.hpp>
+
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -38,7 +40,7 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
         {
             SECTION("Invalid filename")
             {
-                CHECK_THROWS_AS(sf::Font("does/not/exist.ttf"), std::runtime_error);
+                CHECK_THROWS_AS(sf::Font("does/not/exist.ttf"), sf::Exception);
             }
 
             SECTION("Successful load")
@@ -72,9 +74,9 @@ TEST_CASE("[Graphics] sf::Font", runDisplayTests())
         {
             SECTION("Invalid data and size")
             {
-                CHECK_THROWS_AS(sf::Font(nullptr, 1), std::runtime_error);
+                CHECK_THROWS_AS(sf::Font(nullptr, 1), sf::Exception);
                 const std::byte testByte{0xCD};
-                CHECK_THROWS_AS(sf::Font(&testByte, 0), std::runtime_error);
+                CHECK_THROWS_AS(sf::Font(&testByte, 0), sf::Exception);
             }
 
             SECTION("Successful load")

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Graphics/Image.hpp>
 
 // Other 1st party headers
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -32,8 +33,8 @@ TEST_CASE("[Graphics] sf::Image")
         {
             SECTION("Invalid file")
             {
-                CHECK_THROWS_AS(sf::Image("."), std::runtime_error);
-                CHECK_THROWS_AS(sf::Image("this/does/not/exist.jpg"), std::runtime_error);
+                CHECK_THROWS_AS(sf::Image("."), sf::Exception);
+                CHECK_THROWS_AS(sf::Image("this/does/not/exist.jpg"), sf::Exception);
             }
 
             SECTION("Successful load")
@@ -89,13 +90,13 @@ TEST_CASE("[Graphics] sf::Image")
         {
             SECTION("Invalid pointer")
             {
-                CHECK_THROWS_AS(sf::Image(nullptr, 1), std::runtime_error);
+                CHECK_THROWS_AS(sf::Image(nullptr, 1), sf::Exception);
             }
 
             SECTION("Invalid size")
             {
                 const std::byte testByte{0xAB};
-                CHECK_THROWS_AS(sf::Image(&testByte, 0), std::runtime_error);
+                CHECK_THROWS_AS(sf::Image(&testByte, 0), sf::Exception);
             }
 
             SECTION("Failed load")
@@ -112,7 +113,7 @@ TEST_CASE("[Graphics] sf::Image")
                     memory = {1, 2, 3, 4};
                 }
 
-                CHECK_THROWS_AS(sf::Image(memory.data(), memory.size()), std::runtime_error);
+                CHECK_THROWS_AS(sf::Image(memory.data(), memory.size()), sf::Exception);
             }
 
             SECTION("Successful load")

--- a/test/Graphics/RenderTexture.test.cpp
+++ b/test/Graphics/RenderTexture.test.cpp
@@ -1,5 +1,8 @@
 #include <SFML/Graphics/RenderTexture.hpp>
 
+// Other 1st party headers
+#include <SFML/System/Exception.hpp>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <WindowUtil.hpp>
@@ -27,7 +30,7 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
 
         SECTION("2 parameter constructor")
         {
-            CHECK_THROWS_AS(sf::RenderTexture({1'000'000, 1'000'000}), std::runtime_error);
+            CHECK_THROWS_AS(sf::RenderTexture({1'000'000, 1'000'000}), sf::Exception);
 
             CHECK_NOTHROW(sf::RenderTexture({100, 100}, sf::ContextSettings{8 /* depthBits */, 0 /* stencilBits */}));
             CHECK_NOTHROW(sf::RenderTexture({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */}));

--- a/test/Graphics/Shader.test.cpp
+++ b/test/Graphics/Shader.test.cpp
@@ -1,6 +1,7 @@
 #include <SFML/Graphics/Shader.hpp>
 
 // Other 1st party headers
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -147,14 +148,14 @@ TEST_CASE("[Graphics] sf::Shader (Dummy Implementation)", skipShaderDummyTests()
 
     SECTION("Construct from memory")
     {
-        CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), sf::Shader::Type::Vertex), std::runtime_error);
-        CHECK_THROWS_AS(sf::Shader(std::string_view(geometrySource), sf::Shader::Type::Geometry), std::runtime_error);
-        CHECK_THROWS_AS(sf::Shader(std::string_view(fragmentSource), sf::Shader::Type::Fragment), std::runtime_error);
-        CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), std::string_view(fragmentSource)), std::runtime_error);
+        CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), sf::Shader::Type::Vertex), sf::Exception);
+        CHECK_THROWS_AS(sf::Shader(std::string_view(geometrySource), sf::Shader::Type::Geometry), sf::Exception);
+        CHECK_THROWS_AS(sf::Shader(std::string_view(fragmentSource), sf::Shader::Type::Fragment), sf::Exception);
+        CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), std::string_view(fragmentSource)), sf::Exception);
         CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource),
                                    std::string_view(geometrySource),
                                    std::string_view(fragmentSource)),
-                        std::runtime_error);
+                        sf::Exception);
     }
 
     SECTION("loadFromMemory()")
@@ -191,7 +192,7 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
             SECTION("One shader")
             {
                 CHECK_THROWS_AS(sf::Shader(std::filesystem::path("does-not-exist.vert"), sf::Shader::Type::Vertex),
-                                std::runtime_error);
+                                sf::Exception);
 
                 if (sf::Shader::isAvailable())
                 {
@@ -203,9 +204,9 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                 else
                 {
                     CHECK_THROWS_AS(sf::Shader(std::filesystem::path("Graphics/shader.vert"), sf::Shader::Type::Vertex),
-                                    std::runtime_error);
+                                    sf::Exception);
                     CHECK_THROWS_AS(sf::Shader(std::filesystem::path("Graphics/shader.frag"), sf::Shader::Type::Fragment),
-                                    std::runtime_error);
+                                    sf::Exception);
                 }
             }
 
@@ -213,10 +214,10 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
             {
                 CHECK_THROWS_AS(sf::Shader(std::filesystem::path("does-not-exist.vert"),
                                            std::filesystem::path("Graphics/shader.frag")),
-                                std::runtime_error);
+                                sf::Exception);
                 CHECK_THROWS_AS(sf::Shader(std::filesystem::path("Graphics/shader.vert"),
                                            std::filesystem::path("does-not-exist.frag")),
-                                std::runtime_error);
+                                sf::Exception);
 
                 if (sf::Shader::isAvailable())
                 {
@@ -228,7 +229,7 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                 {
                     CHECK_THROWS_AS(sf::Shader(std::filesystem::path("Graphics/shader.vert"),
                                                std::filesystem::path("Graphics/shader.frag")),
-                                    std::runtime_error);
+                                    sf::Exception);
                 }
             }
 
@@ -237,15 +238,15 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                 CHECK_THROWS_AS(sf::Shader(std::filesystem::path("does-not-exist.vert"),
                                            std::filesystem::path("Graphics/shader.geom"),
                                            std::filesystem::path("Graphics/shader.frag")),
-                                std::runtime_error);
+                                sf::Exception);
                 CHECK_THROWS_AS(sf::Shader(std::filesystem::path("Graphics/shader.vert"),
                                            std::filesystem::path("does-not-exist.geom"),
                                            std::filesystem::path("Graphics/shader.frag")),
-                                std::runtime_error);
+                                sf::Exception);
                 CHECK_THROWS_AS(sf::Shader(std::filesystem::path("Graphics/shader.vert"),
                                            std::filesystem::path("Graphics/shader.geom"),
                                            std::filesystem::path("does-not-exist.frag")),
-                                std::runtime_error);
+                                sf::Exception);
 
                 if (sf::Shader::isGeometryAvailable())
                 {
@@ -259,7 +260,7 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                     CHECK_THROWS_AS(sf::Shader(std::filesystem::path("Graphics/shader.vert"),
                                                std::filesystem::path("Graphics/shader.geom"),
                                                std::filesystem::path("Graphics/shader.frag")),
-                                    std::runtime_error);
+                                    sf::Exception);
                 }
             }
         }
@@ -269,20 +270,16 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
             if (sf::Shader::isAvailable())
             {
                 CHECK(sf::Shader(std::string_view(vertexSource), sf::Shader::Type::Vertex).getNativeHandle() != 0);
-                CHECK_THROWS_AS(sf::Shader(std::string_view(geometrySource), sf::Shader::Type::Geometry),
-                                std::runtime_error);
+                CHECK_THROWS_AS(sf::Shader(std::string_view(geometrySource), sf::Shader::Type::Geometry), sf::Exception);
                 CHECK(sf::Shader(std::string_view(fragmentSource), sf::Shader::Type::Fragment).getNativeHandle() != 0);
                 CHECK(sf::Shader(std::string_view(vertexSource), std::string_view(fragmentSource)).getNativeHandle() != 0);
             }
             else
             {
-                CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), sf::Shader::Type::Vertex), std::runtime_error);
-                CHECK_THROWS_AS(sf::Shader(std::string_view(geometrySource), sf::Shader::Type::Geometry),
-                                std::runtime_error);
-                CHECK_THROWS_AS(sf::Shader(std::string_view(fragmentSource), sf::Shader::Type::Fragment),
-                                std::runtime_error);
-                CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), std::string_view(fragmentSource)),
-                                std::runtime_error);
+                CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), sf::Shader::Type::Vertex), sf::Exception);
+                CHECK_THROWS_AS(sf::Shader(std::string_view(geometrySource), sf::Shader::Type::Geometry), sf::Exception);
+                CHECK_THROWS_AS(sf::Shader(std::string_view(fragmentSource), sf::Shader::Type::Fragment), sf::Exception);
+                CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource), std::string_view(fragmentSource)), sf::Exception);
             }
 
             if (sf::Shader::isGeometryAvailable())
@@ -295,7 +292,7 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                 CHECK_THROWS_AS(sf::Shader(std::string_view(vertexSource),
                                            std::string_view(geometrySource),
                                            std::string_view(fragmentSource)),
-                                std::runtime_error);
+                                sf::Exception);
             }
         }
 
@@ -309,7 +306,7 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
 
             SECTION("One shader")
             {
-                CHECK_THROWS_AS(sf::Shader(emptyStream, sf::Shader::Type::Vertex), std::runtime_error);
+                CHECK_THROWS_AS(sf::Shader(emptyStream, sf::Shader::Type::Vertex), sf::Exception);
 
                 if (sf::Shader::isAvailable())
                 {
@@ -318,15 +315,15 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                 }
                 else
                 {
-                    CHECK_THROWS_AS(sf::Shader(vertexShaderStream, sf::Shader::Type::Vertex), std::runtime_error);
-                    CHECK_THROWS_AS(sf::Shader(fragmentShaderStream, sf::Shader::Type::Fragment), std::runtime_error);
+                    CHECK_THROWS_AS(sf::Shader(vertexShaderStream, sf::Shader::Type::Vertex), sf::Exception);
+                    CHECK_THROWS_AS(sf::Shader(fragmentShaderStream, sf::Shader::Type::Fragment), sf::Exception);
                 }
             }
 
             SECTION("Two shaders")
             {
-                CHECK_THROWS_AS(sf::Shader(emptyStream, fragmentShaderStream), std::runtime_error);
-                CHECK_THROWS_AS(sf::Shader(vertexShaderStream, emptyStream), std::runtime_error);
+                CHECK_THROWS_AS(sf::Shader(emptyStream, fragmentShaderStream), sf::Exception);
+                CHECK_THROWS_AS(sf::Shader(vertexShaderStream, emptyStream), sf::Exception);
 
                 if (sf::Shader::isAvailable())
                 {
@@ -334,15 +331,15 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                 }
                 else
                 {
-                    CHECK_THROWS_AS(sf::Shader(vertexShaderStream, fragmentShaderStream), std::runtime_error);
+                    CHECK_THROWS_AS(sf::Shader(vertexShaderStream, fragmentShaderStream), sf::Exception);
                 }
             }
 
             SECTION("Three shaders")
             {
-                CHECK_THROWS_AS(sf::Shader(emptyStream, geometryShaderStream, fragmentShaderStream), std::runtime_error);
-                CHECK_THROWS_AS(sf::Shader(vertexShaderStream, emptyStream, fragmentShaderStream), std::runtime_error);
-                CHECK_THROWS_AS(sf::Shader(vertexShaderStream, geometryShaderStream, emptyStream), std::runtime_error);
+                CHECK_THROWS_AS(sf::Shader(emptyStream, geometryShaderStream, fragmentShaderStream), sf::Exception);
+                CHECK_THROWS_AS(sf::Shader(vertexShaderStream, emptyStream, fragmentShaderStream), sf::Exception);
+                CHECK_THROWS_AS(sf::Shader(vertexShaderStream, geometryShaderStream, emptyStream), sf::Exception);
 
                 if (sf::Shader::isGeometryAvailable())
                 {
@@ -351,7 +348,7 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
                 else
                 {
                     CHECK_THROWS_AS(sf::Shader(vertexShaderStream, geometryShaderStream, fragmentShaderStream),
-                                    std::runtime_error);
+                                    sf::Exception);
                 }
             }
         }

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -3,6 +3,7 @@
 // Other 1st party headers
 #include <SFML/Graphics/Image.hpp>
 
+#include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -38,9 +39,9 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         {
             SECTION("At least one zero dimension")
             {
-                CHECK_THROWS_AS(sf::Texture(sf::Vector2u()), std::runtime_error);
-                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(0, 1)), std::runtime_error);
-                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(1, 0)), std::runtime_error);
+                CHECK_THROWS_AS(sf::Texture(sf::Vector2u()), sf::Exception);
+                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(0, 1)), sf::Exception);
+                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(1, 0)), sf::Exception);
             }
 
             SECTION("Valid size")
@@ -52,8 +53,8 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
 
             SECTION("Too large")
             {
-                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(100'000, 100'000)), std::runtime_error);
-                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(1'000'000, 1'000'000)), std::runtime_error);
+                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(100'000, 100'000)), sf::Exception);
+                CHECK_THROWS_AS(sf::Texture(sf::Vector2u(1'000'000, 1'000'000)), sf::Exception);
             }
         }
 

--- a/test/System/Exception.test.cpp
+++ b/test/System/Exception.test.cpp
@@ -1,0 +1,21 @@
+#include <SFML/System/Exception.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("[System] sf::Exception")
+{
+    SECTION("Type traits")
+    {
+        STATIC_CHECK(std::is_copy_constructible_v<sf::Exception>);
+        STATIC_CHECK(std::is_copy_assignable_v<sf::Exception>);
+        STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Exception>);
+        STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Exception>);
+        STATIC_CHECK(std::is_base_of_v<std::runtime_error, sf::Exception>);
+    }
+
+    SECTION("Construction")
+    {
+        const sf::Exception exception("Oops");
+        CHECK(exception.what() == std::string("Oops"));
+    }
+}

--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -1,5 +1,8 @@
 #include <SFML/Window/Cursor.hpp>
 
+// Other 1st party headers
+#include <SFML/System/Exception.hpp>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <WindowUtil.hpp>
@@ -23,9 +26,9 @@ TEST_CASE("[Window] sf::Cursor", runDisplayTests())
         {
             static constexpr std::array<std::uint8_t, 4> pixels{};
 
-            CHECK_THROWS_AS(sf::Cursor(nullptr, {}, {}), std::runtime_error);
-            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {0, 1}, {}), std::runtime_error);
-            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {1, 0}, {}), std::runtime_error);
+            CHECK_THROWS_AS(sf::Cursor(nullptr, {}, {}), sf::Exception);
+            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {0, 1}, {}), sf::Exception);
+            CHECK_THROWS_AS(sf::Cursor(pixels.data(), {1, 0}, {}), sf::Exception);
             CHECK_NOTHROW(sf::Cursor(pixels.data(), {1, 1}, {}));
         }
 


### PR DESCRIPTION
## Description

It seems wise to throw a custom exception type for a few minor reasons.

1. Allows users to disambiguate exceptions from SFML code from other sources
2. Gives us an abstraction upon which to add more functionality later. Perhaps in a future version we'll want to add something with `std::source_location` to this or maybe `std::stacktrace`.