### PR TITLE
Reimplement event assertions to loosen constexpr restrictions on event subtypes

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -373,13 +373,13 @@ private:
     // Helper functions
     ////////////////////////////////////////////////////////////
     template <typename T, typename... Ts>
-    [[nodiscard]] static constexpr bool isInParameterPack(const std::variant<Ts...>&)
+    [[nodiscard]] static constexpr bool isInParameterPack(const std::variant<Ts...>*)
     {
         return (std::is_same_v<T, Ts> || ...);
     }
 
     template <typename T>
-    static constexpr bool isEventSubtype = isInParameterPack<T>(decltype(m_data)());
+    static constexpr bool isEventSubtype = isInParameterPack<T>(decltype (&m_data)(nullptr));
 };
 
 } // namespace sf


### PR DESCRIPTION
## Description

The current implementation of these static assertions requires that `std::Event::m_data` be `constexpr` constructible. This transitively requires that all event subtypes are `constexpr` constructible as well. This restrictions currently causes no issues but it means that we cannot add future event subtypes that are not `constexpr` constructible.

To test this out, add a new event subtype containing a `std::string`, add it to `m_data`, then observe compilation fail.