### PR TITLE
Treat Doxygen warnings as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,3 +428,23 @@ jobs:
 
     - name: Test
       run: ctest --test-dir build --output-on-failure
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install Linux Dependencies
+      run: sudo apt-get update && sudo apt-get install xorg-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev xvfb fluxbox && sudo apt-get remove -y libasound2
+
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen graphviz
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure
+      run: cmake -B build -DSFML_BUILD_DOC=ON
+
+    - name: Build Doxygen Site
+      run: cmake --build build --target doc

--- a/doc/doxyfile.in
+++ b/doc/doxyfile.in
@@ -924,7 +924,7 @@ WARN_IF_UNDOC_ENUM_VAL = NO
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -462,7 +462,7 @@ constexpr Time& operator%=(Time& left, Time right);
 /// seconds, milliseconds or microseconds. It also works the
 /// other way round: you can read a time value as either
 /// a number of seconds, milliseconds or microseconds. It
-/// even interoperates with the <chrono> header. You can
+/// even interoperates with the `<chrono>` header. You can
 /// construct an sf::Time from a chrono::duration and read
 /// any sf::Time as a chrono::duration.
 ///


### PR DESCRIPTION
## Description

Closes #2716

This will help ensure our docs maintain a higher level of quality and don't regress going forward. There was only 1 warning remaining so I fixed that in this PR so that CI passes.