### PR TITLE
Pass `sf::Vector2<T>` by value in test code

### DIFF
--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -38,7 +38,7 @@ std::ostream& operator<<(std::ostream& os, Time time)
 }
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const Vector2<T>& vector)
+std::ostream& operator<<(std::ostream& os, Vector2<T> vector)
 {
     setStreamPrecision(os, std::numeric_limits<T>::max_digits10);
     return os << "(" << vector.x << ", " << vector.y << ")";
@@ -51,9 +51,9 @@ std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector)
     return os << "(" << vector.x << ", " << vector.y << ", " << vector.z << ")";
 }
 
-template std::ostream& operator<<(std::ostream&, const Vector2<int>&);
-template std::ostream& operator<<(std::ostream&, const Vector2<unsigned int>&);
-template std::ostream& operator<<(std::ostream&, const Vector2<float>&);
+template std::ostream& operator<<(std::ostream&, Vector2<int>);
+template std::ostream& operator<<(std::ostream&, Vector2<unsigned int>);
+template std::ostream& operator<<(std::ostream&, Vector2<float>);
 
 template std::ostream& operator<<(std::ostream&, const Vector3<int>&);
 template std::ostream& operator<<(std::ostream&, const Vector3<unsigned int>&);
@@ -65,7 +65,7 @@ bool operator==(const float& lhs, const Approx<float>& rhs)
     return lhs == Catch::Approx(rhs.value).margin(1e-5);
 }
 
-bool operator==(const sf::Vector2f& lhs, const Approx<sf::Vector2f>& rhs)
+bool operator==(sf::Vector2f lhs, const Approx<sf::Vector2f>& rhs)
 {
     return (lhs - rhs.value).length() == Approx(0.f);
 }

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -31,7 +31,7 @@ std::ostream& operator<<(std::ostream& os, const String& string);
 std::ostream& operator<<(std::ostream& os, Time time);
 
 template <typename T>
-std::ostream& operator<<(std::ostream& os, const Vector2<T>& vector);
+std::ostream& operator<<(std::ostream& os, Vector2<T> vector);
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector);
@@ -53,7 +53,7 @@ struct Approx
 };
 
 bool operator==(const float& lhs, const Approx<float>& rhs);
-bool operator==(const sf::Vector2<float>& lhs, const Approx<sf::Vector2<float>>& rhs);
+bool operator==(sf::Vector2<float> lhs, const Approx<sf::Vector2<float>>& rhs);
 bool operator==(const sf::Vector3<float>& lhs, const Approx<sf::Vector3<float>>& rhs);
 bool operator==(const sf::Angle& lhs, const Approx<sf::Angle>& rhs);
 


### PR DESCRIPTION
## Description

Cleaning up an oversight from #3047.