### PR TITLE
Add missing OpenAL name

### DIFF
--- a/cmake/Modules/FindOpenAL.cmake
+++ b/cmake/Modules/FindOpenAL.cmake
@@ -77,7 +77,7 @@ find_path(OPENAL_INCLUDE_DIR al.h
   )
 
 find_library(OPENAL_LIBRARY
-  NAMES OpenAL al openal OpenAL32
+  NAMES OpenAL al openal OpenAL32 openal32
   HINTS
     ENV OPENALDIR
   PATHS


### PR DESCRIPTION
-   [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?

## Description

Adds one more name to look for when finding the openal library.
This name was previously included, but it wasn't included in b60b7b4fcbecdc02a670c7d00e4e4828ba2ade35 .
This broke mingw cross-platform compilation from Linux to Windows.

## Tasks

-   [X] Tested on Linux
-   [X] Tested on Windows

## How to test this PR?

Just compile the cmake template and check if it all works.