### PR TITLE
Rename Vector2 & Vector3 functions to better fit the naming convention

### DIFF
--- a/doc/migration.md
+++ b/doc/migration.md
@@ -54,7 +54,7 @@ Take `sf::Transformable::setPosition(float, float)` for example.
 The two parameters combine to represent a position in world space.
 
 SFML 3 takes all of the APIs with pairs of parameters like `(float, float)` or `(unsigned int, unsigned int)` and converts them to their corresponding `sf::Vector2<T>` type like `sf::Vector2f` or `sf::Vector2u` to make the interface more expressive and composable.
-This transition is often as simple as wrapping the two adjacement parameters with braces to construct the vector.
+This transition is often as simple as wrapping the two adjacent parameters with braces to construct the vector.
 
 v2:
 ```cpp
@@ -353,31 +353,31 @@ const sf::SoundBuffer soundBuffer("sound.wav");
 
 `sf::Vector2<T>` and `sf::Vector3<T>` gained a number of new functions for performing common mathematic operations on vectors.
 
-| `sf::Vector2<T>` Function    | Description                              |
-| ---------------------------- | ---------------------------------------- |
-| `Vector2(T, sf::Angle)`      | Construct from polar coordinates         |
-| `length()`                   | Get length                               |
-| `lengthSq()`                 | Get length squared                       |
-| `normalized()`               | Get vector normalized to unit circle     |
-| `angleTo(sf::Vector2)`       | Get angle to another vector              |
-| `angle()`                    | Get angle from X axis                    |
-| `rotatedBy(sf::Angle)`       | Get vector rotated by a given angle      |
-| `projectedOnto(sf::Vector2)` | Get vector projected onto another vector |
-| `perpendicular()`            | Get perpendicular vector                 |
-| `dot(sf::Vector2)`           | Get dot product                          |
-| `cross(sf::Vector2)`         | Get Z component of cross product         |
-| `cwiseMul(sf::Vector2)`      | Get component-wise multiple              |
-| `cwiseDiv(sf::Vector2)`      | Get component-wise divisor               |
+| `sf::Vector2<T>` Function       | Description                              |
+| ------------------------------- | ---------------------------------------- |
+| `Vector2(T, sf::Angle)`         | Construct from polar coordinates         |
+| `length()`                      | Get length                               |
+| `lengthSquared()`               | Get length squared                       |
+| `normalized()`                  | Get vector normalized to unit circle     |
+| `angleTo(sf::Vector2)`          | Get angle to another vector              |
+| `angle()`                       | Get angle from X axis                    |
+| `rotatedBy(sf::Angle)`          | Get vector rotated by a given angle      |
+| `projectedOnto(sf::Vector2)`    | Get vector projected onto another vector |
+| `perpendicular()`               | Get perpendicular vector                 |
+| `dot(sf::Vector2)`              | Get dot product                          |
+| `cross(sf::Vector2)`            | Get Z component of cross product         |
+| `componentWiseMul(sf::Vector2)` | Get component-wise multiple              |
+| `componentWiseDiv(sf::Vector2)` | Get component-wise divisor               |
 
-| `sf::Vector3<T>` Function | Description                           |
-| ------------------------- | ------------------------------------- |
-| `length()`                | Get length                            |
-| `lengthSq()`              | Get length squared                    |
-| `normalized()`            | Get vector normalized to unit circle  |
-| `dot(sf::Vector3)`        | Get dot product                       |
-| `cross(sf::Vector3)`      | Get cross product                     |
-| `cwiseMul(sf::Vector3)`   | Get component-wise multiple           |
-| `cwiseDiv(sf::Vector3)`   | Get component-wise divisor            |
+| `sf::Vector3<T>` Function       | Description                           |
+| ------------------------------- | ------------------------------------- |
+| `length()`                      | Get length                            |
+| `lengthSquared()`               | Get length squared                    |
+| `normalized()`                  | Get vector normalized to unit circle  |
+| `dot(sf::Vector3)`              | Get dot product                       |
+| `cross(sf::Vector3)`            | Get cross product                     |
+| `componentWiseMul(sf::Vector3)` | Get component-wise multiple           |
+| `componentWiseDiv(sf::Vector3)` | Get component-wise divisor            |
 
 ## Threading Primitives
 

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -487,7 +487,8 @@ int main()
         if (Effect* currentEffect = effects[current])
         {
             // Update the current example
-            const auto [x, y] = sf::Vector2f(sf::Mouse::getPosition(window)).cwiseDiv(sf::Vector2f(window.getSize()));
+            const auto [x,
+                        y] = sf::Vector2f(sf::Mouse::getPosition(window)).componentWiseDiv(sf::Vector2f(window.getSize()));
             currentEffect->update(clock.getElapsedTime().asSeconds(), x, y);
 
             // Clear the window

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -1213,7 +1213,7 @@ int main()
         }
 
         // Update the current example
-        const auto [x, y] = sf::Vector2f(sf::Mouse::getPosition(window)).cwiseDiv(sf::Vector2f(window.getSize()));
+        const auto [x, y] = sf::Vector2f(sf::Mouse::getPosition(window)).componentWiseDiv(sf::Vector2f(window.getSize()));
         effects[current]->update(clock.getElapsedTime().asSeconds(), x, y);
 
         // Clear the window

--- a/include/SFML/System/Vector2.hpp
+++ b/include/SFML/System/Vector2.hpp
@@ -90,7 +90,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Length of the vector <i><b>(floating-point)</b></i>.
     ///
-    /// If you are not interested in the actual length, but only in comparisons, consider using lengthSq().
+    /// If you are not interested in the actual length, but only in comparisons, consider using lengthSquared().
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] SFML_SYSTEM_API T length() const;
@@ -101,7 +101,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr T lengthSq() const;
+    [[nodiscard]] constexpr T lengthSquared() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -189,7 +189,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr Vector2 cwiseMul(Vector2 rhs) const;
+    [[nodiscard]] constexpr Vector2 componentWiseMul(Vector2 rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -201,7 +201,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr Vector2 cwiseDiv(Vector2 rhs) const;
+    [[nodiscard]] constexpr Vector2 componentWiseDiv(Vector2 rhs) const;
 
 
     ////////////////////////////////////////////////////////////

--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -56,7 +56,7 @@ constexpr Vector2<T>::Vector2(Vector2<U> vector) : x(static_cast<T>(vector.x)), 
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr T Vector2<T>::lengthSq() const
+constexpr T Vector2<T>::lengthSquared() const
 {
     return dot(*this);
 }
@@ -88,7 +88,7 @@ constexpr T Vector2<T>::cross(Vector2<T> rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> Vector2<T>::cwiseMul(Vector2<T> rhs) const
+constexpr Vector2<T> Vector2<T>::componentWiseMul(Vector2<T> rhs) const
 {
     return Vector2<T>(x * rhs.x, y * rhs.y);
 }
@@ -96,10 +96,10 @@ constexpr Vector2<T> Vector2<T>::cwiseMul(Vector2<T> rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector2<T> Vector2<T>::cwiseDiv(Vector2<T> rhs) const
+constexpr Vector2<T> Vector2<T>::componentWiseDiv(Vector2<T> rhs) const
 {
-    assert(rhs.x != 0 && "Vector2::cwiseDiv() cannot divide by 0");
-    assert(rhs.y != 0 && "Vector2::cwiseDiv() cannot divide by 0");
+    assert(rhs.x != 0 && "Vector2::componentWiseDiv() cannot divide by 0");
+    assert(rhs.y != 0 && "Vector2::componentWiseDiv() cannot divide by 0");
     return Vector2<T>(x / rhs.x, y / rhs.y);
 }
 

--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -73,7 +73,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Length of the vector <i><b>(floating-point)</b></i>.
     ///
-    /// If you are not interested in the actual length, but only in comparisons, consider using lengthSq().
+    /// If you are not interested in the actual length, but only in comparisons, consider using lengthSquared().
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] SFML_SYSTEM_API T length() const;
@@ -84,7 +84,7 @@ public:
     /// Suitable for comparisons, more efficient than length().
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr T lengthSq() const;
+    [[nodiscard]] constexpr T lengthSquared() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Vector with same direction but length 1 <i><b>(floating-point)</b></i>.
@@ -115,7 +115,7 @@ public:
     /// This operation is also known as the Hadamard or Schur product.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr Vector3 cwiseMul(const Vector3& rhs) const;
+    [[nodiscard]] constexpr Vector3 componentWiseMul(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Component-wise division of \c *this and \c rhs.
@@ -127,7 +127,7 @@ public:
     /// \pre Neither component of \c rhs is zero.
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] constexpr Vector3 cwiseDiv(const Vector3& rhs) const;
+    [[nodiscard]] constexpr Vector3 componentWiseDiv(const Vector3& rhs) const;
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -59,7 +59,7 @@ z(static_cast<T>(vector.z))
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr T Vector3<T>::lengthSq() const
+constexpr T Vector3<T>::lengthSquared() const
 {
     return dot(*this);
 }
@@ -83,7 +83,7 @@ constexpr Vector3<T> Vector3<T>::cross(const Vector3<T>& rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector3<T> Vector3<T>::cwiseMul(const Vector3<T>& rhs) const
+constexpr Vector3<T> Vector3<T>::componentWiseMul(const Vector3<T>& rhs) const
 {
     return Vector3<T>(x * rhs.x, y * rhs.y, z * rhs.z);
 }
@@ -91,11 +91,11 @@ constexpr Vector3<T> Vector3<T>::cwiseMul(const Vector3<T>& rhs) const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-constexpr Vector3<T> Vector3<T>::cwiseDiv(const Vector3<T>& rhs) const
+constexpr Vector3<T> Vector3<T>::componentWiseDiv(const Vector3<T>& rhs) const
 {
-    assert(rhs.x != 0 && "Vector3::cwiseDiv() cannot divide by 0");
-    assert(rhs.y != 0 && "Vector3::cwiseDiv() cannot divide by 0");
-    assert(rhs.z != 0 && "Vector3::cwiseDiv() cannot divide by 0");
+    assert(rhs.x != 0 && "Vector3::componentWiseDiv() cannot divide by 0");
+    assert(rhs.y != 0 && "Vector3::componentWiseDiv() cannot divide by 0");
+    assert(rhs.z != 0 && "Vector3::componentWiseDiv() cannot divide by 0");
     return Vector3<T>(x / rhs.x, y / rhs.y, z / rhs.z);
 }
 

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -306,9 +306,10 @@ Vector2f RenderTarget::mapPixelToCoords(Vector2i point) const
 Vector2f RenderTarget::mapPixelToCoords(Vector2i point, const View& view) const
 {
     // First, convert from viewport coordinates to homogeneous coordinates
-    const FloatRect viewport   = FloatRect(getViewport(view));
-    const Vector2f  normalized = Vector2f(-1, 1) +
-                                Vector2f(2, -2).cwiseMul(Vector2f(point) - viewport.position).cwiseDiv(viewport.size);
+    const FloatRect viewport = FloatRect(getViewport(view));
+    const Vector2f
+        normalized = Vector2f(-1, 1) +
+                     Vector2f(2, -2).componentWiseMul(Vector2f(point) - viewport.position).componentWiseDiv(viewport.size);
 
     // Then transform by the inverse of the view matrix
     return view.getInverseTransform().transformPoint(normalized);
@@ -330,8 +331,9 @@ Vector2i RenderTarget::mapCoordsToPixel(Vector2f point, const View& view) const
 
     // Then convert to viewport coordinates
     const FloatRect viewport = FloatRect(getViewport(view));
-    return Vector2i((normalized.cwiseMul({1, -1}) + sf::Vector2f(1, 1)).cwiseDiv({2, 2}).cwiseMul(viewport.size) +
-                    viewport.position);
+    return Vector2i(
+        (normalized.componentWiseMul({1, -1}) + sf::Vector2f(1, 1)).componentWiseDiv({2, 2}).componentWiseMul(viewport.size) +
+        viewport.position);
 }
 
 

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -271,8 +271,8 @@ void Shape::updateTexCoords()
 
     for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
     {
-        const Vector2f ratio    = (m_vertices[i].position - m_insideBounds.position).cwiseDiv(safeInsideSize);
-        m_vertices[i].texCoords = convertedTextureRect.position + convertedTextureRect.size.cwiseMul(ratio);
+        const Vector2f ratio    = (m_vertices[i].position - m_insideBounds.position).componentWiseDiv(safeInsideSize);
+        m_vertices[i].texCoords = convertedTextureRect.position + convertedTextureRect.size.componentWiseMul(ratio);
     }
 }
 

--- a/src/SFML/System/Vector2.cpp
+++ b/src/SFML/System/Vector2.cpp
@@ -88,7 +88,7 @@ Vector2<T> Vector2<T>::projectedOnto(Vector2<T> axis) const
     static_assert(std::is_floating_point_v<T>, "Vector2::projectedOnto() is only supported for floating point types");
 
     assert(axis != Vector2<T>() && "Vector2::projectedOnto() cannot project onto a zero vector");
-    return dot(axis) / axis.lengthSq() * axis;
+    return dot(axis) / axis.lengthSquared() * axis;
 }
 
 

--- a/test/System/Vector2.test.cpp
+++ b/test/System/Vector2.test.cpp
@@ -254,13 +254,13 @@ TEMPLATE_TEST_CASE("[System] sf::Vector2", "", int, float)
         constexpr sf::Vector2f v(2.4f, 3.0f);
 
         CHECK(v.length() == Approx(3.84187f));
-        CHECK(v.lengthSq() == Approx(14.7599650969f));
+        CHECK(v.lengthSquared() == Approx(14.7599650969f));
         CHECK(v.normalized() == Approx(sf::Vector2f(0.624695f, 0.780869f)));
 
         constexpr sf::Vector2f w(-0.7f, -2.2f);
 
         CHECK(w.length() == Approx(2.30868f));
-        CHECK(w.lengthSq() == Approx(5.3300033f));
+        CHECK(w.lengthSquared() == Approx(5.3300033f));
         CHECK(w.normalized() == Approx(sf::Vector2f(-0.303204f, -0.952926f)));
     }
 
@@ -304,10 +304,10 @@ TEMPLATE_TEST_CASE("[System] sf::Vector2", "", int, float)
         CHECK(v.cross(w) == Approx(-3.18f));
         CHECK(w.cross(v) == Approx(+3.18f));
 
-        CHECK(v.cwiseMul(w) == Approx(sf::Vector2f(-1.68f, -6.6f)));
-        CHECK(w.cwiseMul(v) == Approx(sf::Vector2f(-1.68f, -6.6f)));
-        CHECK(v.cwiseDiv(w) == Approx(sf::Vector2f(-3.428571f, -1.363636f)));
-        CHECK(w.cwiseDiv(v) == Approx(sf::Vector2f(-0.291666f, -0.733333f)));
+        CHECK(v.componentWiseMul(w) == Approx(sf::Vector2f(-1.68f, -6.6f)));
+        CHECK(w.componentWiseMul(v) == Approx(sf::Vector2f(-1.68f, -6.6f)));
+        CHECK(v.componentWiseDiv(w) == Approx(sf::Vector2f(-3.428571f, -1.363636f)));
+        CHECK(w.componentWiseDiv(v) == Approx(sf::Vector2f(-0.291666f, -0.733333f)));
     }
 
     SECTION("Projection")
@@ -334,12 +334,12 @@ TEMPLATE_TEST_CASE("[System] sf::Vector2", "", int, float)
         STATIC_CHECK(v.y == 2);
         STATIC_CHECK(v + w == sf::Vector2<TestType>(3, -4));
 
-        STATIC_CHECK(v.lengthSq() == 5);
+        STATIC_CHECK(v.lengthSquared() == 5);
         STATIC_CHECK(v.perpendicular() == sf::Vector2<TestType>(-2, 1));
 
         STATIC_CHECK(v.dot(w) == -10);
         STATIC_CHECK(v.cross(w) == -10);
-        STATIC_CHECK(v.cwiseMul(w) == sf::Vector2<TestType>(2, -12));
-        STATIC_CHECK(w.cwiseDiv(v) == sf::Vector2<TestType>(2, -3));
+        STATIC_CHECK(v.componentWiseMul(w) == sf::Vector2<TestType>(2, -12));
+        STATIC_CHECK(w.componentWiseDiv(v) == sf::Vector2<TestType>(2, -3));
     }
 }

--- a/test/System/Vector3.test.cpp
+++ b/test/System/Vector3.test.cpp
@@ -211,7 +211,7 @@ TEMPLATE_TEST_CASE("[System] sf::Vector3", "", int, float)
         constexpr sf::Vector3f v(2.4f, 3.0f, 5.2f);
 
         CHECK(v.length() == Approx(6.46529f));
-        CHECK(v.lengthSq() == Approx(41.79997f));
+        CHECK(v.lengthSquared() == Approx(41.79997f));
         CHECK(v.normalized() == Approx(sf::Vector3f(0.37121f, 0.46401f, 0.80429f)));
     }
 
@@ -226,9 +226,9 @@ TEMPLATE_TEST_CASE("[System] sf::Vector3", "", int, float)
         CHECK(v.cross(w) == Approx(sf::Vector3f(-2.96f, 7.88f, -3.18f)));
         CHECK(w.cross(v) == Approx(sf::Vector3f(2.96f, -7.88f, 3.18f)));
 
-        CHECK(v.cwiseMul(w) == Approx(sf::Vector3f(-1.68f, -6.6f, -24.96f)));
-        CHECK(w.cwiseMul(v) == Approx(sf::Vector3f(-1.68f, -6.6f, -24.96f)));
-        CHECK(v.cwiseDiv(w) == Approx(sf::Vector3f(-3.428571f, -1.363636f, -1.0833333f)));
-        CHECK(w.cwiseDiv(v) == Approx(sf::Vector3f(-0.291666f, -0.733333f, -0.9230769f)));
+        CHECK(v.componentWiseMul(w) == Approx(sf::Vector3f(-1.68f, -6.6f, -24.96f)));
+        CHECK(w.componentWiseMul(v) == Approx(sf::Vector3f(-1.68f, -6.6f, -24.96f)));
+        CHECK(v.componentWiseDiv(w) == Approx(sf::Vector3f(-3.428571f, -1.363636f, -1.0833333f)));
+        CHECK(w.componentWiseDiv(v) == Approx(sf::Vector3f(-0.291666f, -0.733333f, -0.9230769f)));
     }
 }


### PR DESCRIPTION
## Description

When implementing the new Vector operations, we didn't really discuss the function naming and the abbreviations seemed to go a bit against the common naming convention in SFML.

I've currently picked the following renames:
- `lengthSq` to `lengthSquared`: Switching it around to `squaredLength` would make it harder to discover and doesn't provide more meaning that `lengthSquared`.
- `cwiseMul` to `componentWiseMul`: `cwise` was quite confusing, as one could also think of "clock-wise". `Mul` might be an acceptable abbreviation, as it represents an operation in itself and `Multiplication` would be quite a bit longer.
- `cwiseDiv` to `componentWiseDiv`: The same reasons as above.

Feel free to make additional suggestions.

Closes #3183 

## How to test this PR?

CI with tests should pass