### PR TITLE
Change Spelling of Anti-Aliasing

### DIFF
--- a/doc/migration.md
+++ b/doc/migration.md
@@ -414,6 +414,13 @@ SFML 3 removes all of the deprecated APIs in SFML 2.
 This is not a drop-in replacement but rather will require refactoring your code to work with a new geometry.
 One viable option is to use `sf::PrimitiveType::Triangles` where two adjacent triangles join to form what was previously one quad.
 
+## Anti-Aliasing Renamed
+
+SFML 3 capitalizes the `A` of `aliasing` for all the APIs.
+
+* `sf::RenderTexture::getMaximumAntialiasingLevel()` becomes `sf::RenderTexture::getMaximumAntiAliasingLevel()`
+* `sf::ContextSettings::antialiasingLevel` becomes `sf::ContextSettings::antiAliasingLevel`
+
 ## Other Minor Changes
 
 SFML 3 includes various smaller changes that ought to be mentioned.

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -137,7 +137,7 @@ public:
     /// \return The maximum anti-aliasing level supported by the system
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static unsigned int getMaximumAntialiasingLevel();
+    [[nodiscard]] static unsigned int getMaximumAntiAliasingLevel();
 
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable texture smoothing

--- a/include/SFML/Window/ContextSettings.hpp
+++ b/include/SFML/Window/ContextSettings.hpp
@@ -54,7 +54,7 @@ struct ContextSettings
     ////////////////////////////////////////////////////////////
     unsigned int  depthBits{};                        //!< Bits of the depth buffer
     unsigned int  stencilBits{};                      //!< Bits of the stencil buffer
-    unsigned int  antialiasingLevel{};                //!< Level of antialiasing
+    unsigned int  antiAliasingLevel{};                //!< Level of anti-aliasing
     unsigned int  majorVersion{1};                    //!< Major number of the context version to create
     unsigned int  minorVersion{1};                    //!< Minor number of the context version to create
     std::uint32_t attributeFlags{Attribute::Default}; //!< The attribute flags to create the context with
@@ -80,7 +80,7 @@ struct ContextSettings
 /// of bits per pixel requested for the (respectively) depth
 /// and stencil buffers.
 ///
-/// antialiasingLevel represents the requested number of
+/// antiAliasingLevel represents the requested number of
 /// multisampling levels for anti-aliasing.
 ///
 /// majorVersion and minorVersion define the version of the

--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -75,7 +75,7 @@ public:
     /// must be a valid video mode.
     ///
     /// The last parameter is an optional structure specifying
-    /// advanced OpenGL context settings such as antialiasing,
+    /// advanced OpenGL context settings such as anti-aliasing,
     /// depth-buffer bits, etc.
     ///
     /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)

--- a/src/SFML/Graphics/RenderTexture.cpp
+++ b/src/SFML/Graphics/RenderTexture.cpp
@@ -106,14 +106,14 @@ bool RenderTexture::resize(Vector2u size, const ContextSettings& settings)
 
 
 ////////////////////////////////////////////////////////////
-unsigned int RenderTexture::getMaximumAntialiasingLevel()
+unsigned int RenderTexture::getMaximumAntiAliasingLevel()
 {
     if (priv::RenderTextureImplFBO::isAvailable())
     {
-        return priv::RenderTextureImplFBO::getMaximumAntialiasingLevel();
+        return priv::RenderTextureImplFBO::getMaximumAntiAliasingLevel();
     }
 
-    return priv::RenderTextureImplDefault::getMaximumAntialiasingLevel();
+    return priv::RenderTextureImplDefault::getMaximumAntiAliasingLevel();
 }
 
 

--- a/src/SFML/Graphics/RenderTextureImplDefault.cpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.cpp
@@ -47,7 +47,7 @@ RenderTextureImplDefault::~RenderTextureImplDefault() = default;
 
 
 ////////////////////////////////////////////////////////////
-unsigned int RenderTextureImplDefault::getMaximumAntialiasingLevel()
+unsigned int RenderTextureImplDefault::getMaximumAntiAliasingLevel()
 {
     // If the system is so old that it doesn't support FBOs, chances are it is
     // also using either a software renderer or some CPU emulated support for AA

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -69,7 +69,7 @@ public:
     /// \return The maximum anti-aliasing level supported by the system
     ///
     ////////////////////////////////////////////////////////////
-    static unsigned int getMaximumAntialiasingLevel();
+    static unsigned int getMaximumAntiAliasingLevel();
 
 private:
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -114,7 +114,7 @@ bool RenderTextureImplFBO::isAvailable()
 
 
 ////////////////////////////////////////////////////////////
-unsigned int RenderTextureImplFBO::getMaximumAntialiasingLevel()
+unsigned int RenderTextureImplFBO::getMaximumAntiAliasingLevel()
 {
 #ifdef SFML_OPENGL_ES
 
@@ -150,7 +150,7 @@ bool RenderTextureImplFBO::create(Vector2u size, unsigned int textureId, const C
         // Make sure that extensions are initialized
         ensureExtensionsInit();
 
-        if (settings.antialiasingLevel && !(GLEXT_framebuffer_multisample && GLEXT_framebuffer_blit))
+        if (settings.antiAliasingLevel && !(GLEXT_framebuffer_multisample && GLEXT_framebuffer_blit))
             return false;
 
         m_sRgb = settings.sRgbCapable && GL_EXT_texture_sRGB;
@@ -158,22 +158,22 @@ bool RenderTextureImplFBO::create(Vector2u size, unsigned int textureId, const C
 #ifndef SFML_OPENGL_ES
 
         // Check if the requested anti-aliasing level is supported
-        if (settings.antialiasingLevel)
+        if (settings.antiAliasingLevel)
         {
             GLint samples = 0;
             glCheck(glGetIntegerv(GLEXT_GL_MAX_SAMPLES, &samples));
 
-            if (settings.antialiasingLevel > static_cast<unsigned int>(samples))
+            if (settings.antiAliasingLevel > static_cast<unsigned int>(samples))
             {
                 err() << "Impossible to create render texture (unsupported anti-aliasing level)"
-                      << " Requested: " << settings.antialiasingLevel << " Maximum supported: " << samples << std::endl;
+                      << " Requested: " << settings.antiAliasingLevel << " Maximum supported: " << samples << std::endl;
                 return false;
             }
         }
 
 #endif
 
-        if (!settings.antialiasingLevel)
+        if (!settings.antiAliasingLevel)
         {
             // Create the depth/stencil buffer if requested
             if (settings.stencilBits && settings.depthBits)
@@ -261,7 +261,7 @@ bool RenderTextureImplFBO::create(Vector2u size, unsigned int textureId, const C
             }
             glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_colorBuffer));
             glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER,
-                                                           static_cast<GLsizei>(settings.antialiasingLevel),
+                                                           static_cast<GLsizei>(settings.antiAliasingLevel),
                                                            m_sRgb ? GL_SRGB8_ALPHA8_EXT : GL_RGBA,
                                                            static_cast<GLsizei>(size.x),
                                                            static_cast<GLsizei>(size.y)));
@@ -281,7 +281,7 @@ bool RenderTextureImplFBO::create(Vector2u size, unsigned int textureId, const C
                 }
                 glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
                 glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER,
-                                                               static_cast<GLsizei>(settings.antialiasingLevel),
+                                                               static_cast<GLsizei>(settings.antiAliasingLevel),
                                                                GLEXT_GL_DEPTH24_STENCIL8,
                                                                static_cast<GLsizei>(size.x),
                                                                static_cast<GLsizei>(size.y)));
@@ -303,7 +303,7 @@ bool RenderTextureImplFBO::create(Vector2u size, unsigned int textureId, const C
                 }
                 glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
                 glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER,
-                                                               static_cast<GLsizei>(settings.antialiasingLevel),
+                                                               static_cast<GLsizei>(settings.antiAliasingLevel),
                                                                GLEXT_GL_DEPTH_COMPONENT,
                                                                static_cast<GLsizei>(size.x),
                                                                static_cast<GLsizei>(size.y)));
@@ -325,7 +325,7 @@ bool RenderTextureImplFBO::create(Vector2u size, unsigned int textureId, const C
                 }
                 glCheck(GLEXT_glBindRenderbuffer(GLEXT_GL_RENDERBUFFER, m_depthStencilBuffer));
                 glCheck(GLEXT_glRenderbufferStorageMultisample(GLEXT_GL_RENDERBUFFER,
-                                                               static_cast<GLsizei>(settings.antialiasingLevel),
+                                                               static_cast<GLsizei>(settings.antiAliasingLevel),
                                                                GLEXT_GL_STENCIL_INDEX8,
                                                                static_cast<GLsizei>(size.x),
                                                                static_cast<GLsizei>(size.y)));

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -80,7 +80,7 @@ public:
     /// \return The maximum anti-aliasing level supported by the system
     ///
     ////////////////////////////////////////////////////////////
-    static unsigned int getMaximumAntialiasingLevel();
+    static unsigned int getMaximumAntiAliasingLevel();
 
     ////////////////////////////////////////////////////////////
     /// \brief Unbind the currently bound FBO

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -764,7 +764,7 @@ EGLConfig DRMContext::getBestConfig(EGLDisplay display, unsigned int bitsPerPixe
       EGL_STENCIL_SIZE,
       static_cast<EGLint>(settings.stencilBits),
       EGL_SAMPLE_BUFFERS,
-      static_cast<EGLint>(settings.antialiasingLevel),
+      static_cast<EGLint>(settings.antiAliasingLevel),
       EGL_BLUE_SIZE,
       8,
       EGL_GREEN_SIZE,
@@ -808,7 +808,7 @@ void DRMContext::updateSettings()
     m_settings.stencilBits = static_cast<unsigned int>(tmp);
 
     eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_SAMPLES, &tmp));
-    m_settings.antialiasingLevel = static_cast<unsigned int>(tmp);
+    m_settings.antiAliasingLevel = static_cast<unsigned int>(tmp);
 
     m_settings.majorVersion   = 1;
     m_settings.minorVersion   = 1;

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -376,7 +376,7 @@ void EglContext::updateSettings()
     m_settings.attributeFlags    = ContextSettings::Default;
     m_settings.depthBits         = 0;
     m_settings.stencilBits       = 0;
-    m_settings.antialiasingLevel = 0;
+    m_settings.antiAliasingLevel = 0;
 
     EGLBoolean result = EGL_FALSE;
     EGLint     tmp    = 0;
@@ -399,7 +399,7 @@ void EglContext::updateSettings()
         eglCheck(result = eglGetConfigAttrib(m_display, m_config, EGL_SAMPLES, &tmp));
 
         if (result != EGL_FALSE)
-            m_settings.antialiasingLevel = static_cast<unsigned int>(tmp);
+            m_settings.antiAliasingLevel = static_cast<unsigned int>(tmp);
     }
 }
 

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -596,7 +596,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, co
         // Re-create our shared context as a core context
         const ContextSettings sharedSettings{/* depthBits */ 0,
                                              /* stencilBits */ 0,
-                                             /* antialiasingLevel */ 0,
+                                             /* antiAliasingLevel */ 0,
                                              settings.majorVersion,
                                              settings.minorVersion,
                                              settings.attributeFlags};
@@ -645,7 +645,7 @@ std::unique_ptr<GlContext> GlContext::create(const ContextSettings& settings, Ve
         // Re-create our shared context as a core context
         const ContextSettings sharedSettings{/* depthBits */ 0,
                                              /* stencilBits */ 0,
-                                             /* antialiasingLevel */ 0,
+                                             /* antiAliasingLevel */ 0,
                                              settings.majorVersion,
                                              settings.minorVersion,
                                              settings.attributeFlags};
@@ -810,23 +810,23 @@ int GlContext::evaluateFormat(
     int                    colorBits,
     int                    depthBits,
     int                    stencilBits,
-    int                    antialiasing,
+    int                    antiAliasing,
     bool                   accelerated,
     bool                   sRgb)
 {
     int colorDiff        = static_cast<int>(bitsPerPixel) - colorBits;
     int depthDiff        = static_cast<int>(settings.depthBits) - depthBits;
     int stencilDiff      = static_cast<int>(settings.stencilBits) - stencilBits;
-    int antialiasingDiff = static_cast<int>(settings.antialiasingLevel) - antialiasing;
+    int antiAliasingDiff = static_cast<int>(settings.antiAliasingLevel) - antiAliasing;
 
     // Weight sub-scores so that better settings don't score equally as bad as worse settings
     colorDiff *= ((colorDiff > 0) ? 100000 : 1);
     depthDiff *= ((depthDiff > 0) ? 100000 : 1);
     stencilDiff *= ((stencilDiff > 0) ? 100000 : 1);
-    antialiasingDiff *= ((antialiasingDiff > 0) ? 100000 : 1);
+    antiAliasingDiff *= ((antiAliasingDiff > 0) ? 100000 : 1);
 
     // Aggregate the scores
-    int score = std::abs(colorDiff) + std::abs(depthDiff) + std::abs(stencilDiff) + std::abs(antialiasingDiff);
+    int score = std::abs(colorDiff) + std::abs(depthDiff) + std::abs(stencilDiff) + std::abs(antiAliasingDiff);
 
     // If the user wants an sRGB capable format, try really hard to get one
     if (settings.sRgbCapable && !sRgb)
@@ -1021,13 +1021,13 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
     }
 
     // Enable anti-aliasing if requested by the user and supported
-    if ((requestedSettings.antialiasingLevel > 0) && (m_settings.antialiasingLevel > 0))
+    if ((requestedSettings.antiAliasingLevel > 0) && (m_settings.antiAliasingLevel > 0))
     {
         glEnableFunc(GL_MULTISAMPLE);
     }
     else
     {
-        m_settings.antialiasingLevel = 0;
+        m_settings.antiAliasingLevel = 0;
     }
 
     // Enable sRGB if requested by the user and supported
@@ -1058,19 +1058,19 @@ void GlContext::checkSettings(const ContextSettings& requestedSettings) const
 
     if ((m_settings.attributeFlags != requestedSettings.attributeFlags) || (version < requestedVersion) ||
         (m_settings.stencilBits < requestedSettings.stencilBits) ||
-        (m_settings.antialiasingLevel < requestedSettings.antialiasingLevel) ||
+        (m_settings.antiAliasingLevel < requestedSettings.antiAliasingLevel) ||
         (m_settings.depthBits < requestedSettings.depthBits) || (!m_settings.sRgbCapable && requestedSettings.sRgbCapable))
     {
         err() << "Warning: The created OpenGL context does not fully meet the settings that were requested" << '\n'
               << "Requested: version = " << requestedSettings.majorVersion << "." << requestedSettings.minorVersion
               << " ; depth bits = " << requestedSettings.depthBits << " ; stencil bits = " << requestedSettings.stencilBits
-              << " ; AA level = " << requestedSettings.antialiasingLevel << std::boolalpha
+              << " ; AA level = " << requestedSettings.antiAliasingLevel << std::boolalpha
               << " ; core = " << ((requestedSettings.attributeFlags & ContextSettings::Core) != 0)
               << " ; debug = " << ((requestedSettings.attributeFlags & ContextSettings::Debug) != 0)
               << " ; sRGB = " << requestedSettings.sRgbCapable << std::noboolalpha << '\n'
               << "Created: version = " << m_settings.majorVersion << "." << m_settings.minorVersion
               << " ; depth bits = " << m_settings.depthBits << " ; stencil bits = " << m_settings.stencilBits
-              << " ; AA level = " << m_settings.antialiasingLevel << std::boolalpha
+              << " ; AA level = " << m_settings.antiAliasingLevel << std::boolalpha
               << " ; core = " << ((m_settings.attributeFlags & ContextSettings::Core) != 0)
               << " ; debug = " << ((m_settings.attributeFlags & ContextSettings::Debug) != 0)
               << " ; sRGB = " << m_settings.sRgbCapable << std::noboolalpha << std::endl;

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -273,7 +273,7 @@ protected:
     /// \param colorBits    Color bits of the configuration to evaluate
     /// \param depthBits    Depth bits of the configuration to evaluate
     /// \param stencilBits  Stencil bits of the configuration to evaluate
-    /// \param antialiasing Antialiasing level of the configuration to evaluate
+    /// \param antiAliasing Anti-aliasing level of the configuration to evaluate
     /// \param accelerated  Whether the pixel format is hardware accelerated
     /// \param sRgb         Whether the pixel format is sRGB capable
     ///
@@ -285,7 +285,7 @@ protected:
                               int                    colorBits,
                               int                    depthBits,
                               int                    stencilBits,
-                              int                    antialiasing,
+                              int                    antiAliasing,
                               bool                   accelerated,
                               bool                   sRgb);
 

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -421,7 +421,7 @@ void GlxContext::updateSettingsFromVisualInfo(XVisualInfo* visualInfo)
 
     m_settings.depthBits         = static_cast<unsigned int>(depth);
     m_settings.stencilBits       = static_cast<unsigned int>(stencil);
-    m_settings.antialiasingLevel = multiSampling ? static_cast<unsigned int>(samples) : 0;
+    m_settings.antiAliasingLevel = multiSampling ? static_cast<unsigned int>(samples) : 0;
     m_settings.sRgbCapable       = (sRgb == True);
 }
 

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -266,7 +266,7 @@ int WglContext::selectBestPixelFormat(HDC deviceContext, unsigned int bitsPerPix
         unsigned int bitsPerPixel{};
         unsigned int depthBits{};
         unsigned int stencilBits{};
-        unsigned int antialiasingLevel{};
+        unsigned int antiAliasingLevel{};
         bool         pbuffer{};
         int          bestFormat{};
     };
@@ -282,7 +282,7 @@ int WglContext::selectBestPixelFormat(HDC deviceContext, unsigned int bitsPerPix
         for (const auto& entry : pixelFormatCache)
         {
             if (bitsPerPixel == entry.bitsPerPixel && settings.depthBits == entry.depthBits &&
-                settings.stencilBits == entry.stencilBits && settings.antialiasingLevel == entry.antialiasingLevel &&
+                settings.stencilBits == entry.stencilBits && settings.antiAliasingLevel == entry.antiAliasingLevel &&
                 pbuffer == entry.pbuffer)
                 return entry.bestFormat;
         }
@@ -429,7 +429,7 @@ int WglContext::selectBestPixelFormat(HDC deviceContext, unsigned int bitsPerPix
         const std::lock_guard lock(cacheMutex);
 
         pixelFormatCache.emplace_back(
-            PixelFormatCacheEntry{bitsPerPixel, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, pbuffer, bestFormat});
+            PixelFormatCacheEntry{bitsPerPixel, settings.depthBits, settings.stencilBits, settings.antiAliasingLevel, pbuffer, bestFormat});
     }
 
     return bestFormat;
@@ -524,18 +524,18 @@ void WglContext::updateSettingsFromPixelFormat()
             if (wglGetPixelFormatAttribivARB(m_deviceContext, format, PFD_MAIN_PLANE, 2, sampleAttributes, sampleValues) ==
                 TRUE)
             {
-                m_settings.antialiasingLevel = static_cast<unsigned int>(sampleValues[0] ? sampleValues[1] : 0);
+                m_settings.antiAliasingLevel = static_cast<unsigned int>(sampleValues[0] ? sampleValues[1] : 0);
             }
             else
             {
                 err() << "Failed to retrieve pixel format multisampling information: " << getErrorString(GetLastError())
                       << std::endl;
-                m_settings.antialiasingLevel = 0;
+                m_settings.antiAliasingLevel = 0;
             }
         }
         else
         {
-            m_settings.antialiasingLevel = 0;
+            m_settings.antiAliasingLevel = 0;
         }
 
         if (SF_GLAD_WGL_ARB_framebuffer_sRGB || SF_GLAD_WGL_EXT_framebuffer_sRGB)
@@ -564,7 +564,7 @@ void WglContext::updateSettingsFromPixelFormat()
     {
         m_settings.depthBits         = actualFormat.cDepthBits;
         m_settings.stencilBits       = actualFormat.cStencilBits;
-        m_settings.antialiasingLevel = 0;
+        m_settings.antiAliasingLevel = 0;
     }
 }
 

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -130,7 +130,7 @@ void Window::close()
 ////////////////////////////////////////////////////////////
 const ContextSettings& Window::getSettings() const
 {
-    static constexpr ContextSettings empty{/* depthBits */ 0, /* stencilBits */ 0, /* antialiasingLevel */ 0};
+    static constexpr ContextSettings empty{/* depthBits */ 0, /* stencilBits */ 0, /* antiAliasingLevel */ 0};
 
     return m_context ? m_context->getSettings() : empty;
 }

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -91,7 +91,7 @@ void WindowBase::create(VideoMode mode, const String& title, std::uint32_t style
                                       state,
                                       ContextSettings{/* depthBits */ 0,
                                                       /* stencilBits */ 0,
-                                                      /* antialiasingLevel */ 0,
+                                                      /* antiAliasingLevel */ 0,
                                                       /* majorVersion */ 0,
                                                       /* minorVersion */ 0,
                                                       /* attributeFlags */ 0xFFFFFFFF,

--- a/src/SFML/Window/macOS/SFContext.mm
+++ b/src/SFML/Window/macOS/SFContext.mm
@@ -47,7 +47,7 @@ SFContext::SFContext(SFContext* shared)
     // Create the context
     createContext(shared,
                   VideoMode::getDesktopMode().bitsPerPixel,
-                  ContextSettings{0 /* depthBits */, 0 /* stencilBits */, 0 /* antialiasingLevel */});
+                  ContextSettings{0 /* depthBits */, 0 /* stencilBits */, 0 /* antiAliasingLevel */});
 }
 
 
@@ -180,7 +180,7 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
     attrs.push_back(NSOpenGLPFAStencilSize);
     attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(m_settings.stencilBits));
 
-    if (m_settings.antialiasingLevel > 0)
+    if (m_settings.antiAliasingLevel > 0)
     {
         /*
          * Antialiasing techniques are described in the
@@ -202,7 +202,7 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
 
         // Antialiasing level
         attrs.push_back(NSOpenGLPFASamples);
-        attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(m_settings.antialiasingLevel));
+        attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(m_settings.antiAliasingLevel));
 
         // No software renderer - only hardware renderer
         attrs.push_back(NSOpenGLPFAAccelerated);

--- a/test/Graphics/RenderTexture.test.cpp
+++ b/test/Graphics/RenderTexture.test.cpp
@@ -87,9 +87,9 @@ TEST_CASE("[Graphics] sf::RenderTexture", runDisplayTests())
         CHECK(renderTexture.resize({100, 100}, sf::ContextSettings{0 /* depthBits */, 8 /* stencilBits */}));
     }
 
-    SECTION("getMaximumAntialiasingLevel()")
+    SECTION("getMaximumAntiAliasingLevel()")
     {
-        CHECK(sf::RenderTexture::getMaximumAntialiasingLevel() <= 64);
+        CHECK(sf::RenderTexture::getMaximumAntiAliasingLevel() <= 64);
     }
 
     SECTION("Set/get smooth")

--- a/test/Window/ContextSettings.test.cpp
+++ b/test/Window/ContextSettings.test.cpp
@@ -21,7 +21,7 @@ TEST_CASE("[Window] sf::ContextSettings")
             constexpr sf::ContextSettings contextSettings;
             STATIC_CHECK(contextSettings.depthBits == 0);
             STATIC_CHECK(contextSettings.stencilBits == 0);
-            STATIC_CHECK(contextSettings.antialiasingLevel == 0);
+            STATIC_CHECK(contextSettings.antiAliasingLevel == 0);
             STATIC_CHECK(contextSettings.majorVersion == 1);
             STATIC_CHECK(contextSettings.minorVersion == 1);
             STATIC_CHECK(contextSettings.attributeFlags == sf::ContextSettings::Default);
@@ -33,7 +33,7 @@ TEST_CASE("[Window] sf::ContextSettings")
             constexpr sf::ContextSettings contextSettings{1, 1, 2, 3, 5, sf::ContextSettings::Core, true};
             STATIC_CHECK(contextSettings.depthBits == 1);
             STATIC_CHECK(contextSettings.stencilBits == 1);
-            STATIC_CHECK(contextSettings.antialiasingLevel == 2);
+            STATIC_CHECK(contextSettings.antiAliasingLevel == 2);
             STATIC_CHECK(contextSettings.majorVersion == 3);
             STATIC_CHECK(contextSettings.minorVersion == 5);
             STATIC_CHECK(contextSettings.attributeFlags == sf::ContextSettings::Core);

--- a/test/Window/Window.test.cpp
+++ b/test/Window/Window.test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.getNativeHandle() == sf::WindowHandle());
             CHECK(window.getSettings().depthBits == 0);
             CHECK(window.getSettings().stencilBits == 0);
-            CHECK(window.getSettings().antialiasingLevel == 0);
+            CHECK(window.getSettings().antiAliasingLevel == 0);
             CHECK(window.getSettings().majorVersion == 1);
             CHECK(window.getSettings().minorVersion == 1);
             CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
@@ -73,13 +73,13 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
                                     "Window Tests",
                                     sf::Style::Resize,
                                     sf::State::Windowed,
-                                    sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antialiasingLevel */ 1});
+                                    sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antiAliasingLevel */ 1});
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(360, 240));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
             CHECK(window.getSettings().depthBits >= 1);
             CHECK(window.getSettings().stencilBits >= 1);
-            CHECK(window.getSettings().antialiasingLevel >= 1);
+            CHECK(window.getSettings().antiAliasingLevel >= 1);
         }
 
         SECTION("Mode, title, and state")
@@ -96,13 +96,13 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             const sf::Window window(sf::VideoMode({360, 240}),
                                     "Window Tests",
                                     sf::State::Windowed,
-                                    sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antialiasingLevel */ 1});
+                                    sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antiAliasingLevel */ 1});
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(360, 240));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
             CHECK(window.getSettings().depthBits >= 1);
             CHECK(window.getSettings().stencilBits >= 1);
-            CHECK(window.getSettings().antialiasingLevel >= 1);
+            CHECK(window.getSettings().antiAliasingLevel >= 1);
         }
     }
 
@@ -134,13 +134,13 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
                           "Window Tests",
                           sf::Style::Resize,
                           sf::State::Windowed,
-                          sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antialiasingLevel */ 1});
+                          sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antiAliasingLevel */ 1});
             CHECK(window.isOpen());
             CHECK(window.getSize() == sf::Vector2u(240, 360));
             CHECK(window.getNativeHandle() != sf::WindowHandle());
             CHECK(window.getSettings().depthBits >= 1);
             CHECK(window.getSettings().stencilBits >= 1);
-            CHECK(window.getSettings().antialiasingLevel >= 1);
+            CHECK(window.getSettings().antiAliasingLevel >= 1);
         }
     }
 }


### PR DESCRIPTION
## Description

While going over the API docs in the past and again today, I was bothered by the IMHO odd spelling of anti-aliasing in our APIs. As such, I decided to suggest a change.

* `sf::RenderTexture::getMaximumAntialiasingLevel()` becomes `sf::RenderTexture::getMaximumAntiAliasingLevel()`
* `sf::ContextSettings::antialiasingLevel` becomes `sf::ContextSettings::antiAliasingLevel`

## How to test this PR?

This is a question of preference, no testing needed.