### PR TITLE
Fix more outdated references to Mac OS X

### DIFF
--- a/include/SFML/Graphics/RenderWindow.hpp
+++ b/include/SFML/Graphics/RenderWindow.hpp
@@ -120,7 +120,7 @@ public:
     /// parameters for a regular usage of the graphics module.
     ///
     /// \param handle   Platform-specific handle of the control (\a HWND on
-    ///                 Windows, \a %Window on Linux/FreeBSD, \a NSWindow on OS X)
+    ///                 Windows, \a %Window on Linux/FreeBSD, \a NSWindow on macOS)
     /// \param settings Additional settings for the underlying OpenGL context
     ///
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/ContextSettings.hpp
+++ b/include/SFML/Window/ContextSettings.hpp
@@ -106,13 +106,13 @@ struct ContextSettings
 /// system, this might be required for advanced OpenGL debugging.
 /// OpenGL debugging is disabled by default.
 ///
-/// <b>Special Note for OS X:</b>
+/// <b>Special Note for macOS:</b>
 /// Apple only supports choosing between either a legacy context
 /// (OpenGL 2.1) or a core context (OpenGL version depends on the
 /// operating system version but is at least 3.2). Compatibility
 /// contexts are not supported. Further information is available on the
 /// <a href="https://developer.apple.com/opengl/capabilities/index.html">
-/// OpenGL Capabilities Tables</a> page. OS X also currently does
+/// OpenGL Capabilities Tables</a> page. macOS also currently does
 /// not support debug contexts.
 ///
 /// Please note that these values are only a hint.

--- a/src/SFML/Window/macOS/SFContext.mm
+++ b/src/SFML/Window/macOS/SFContext.mm
@@ -246,7 +246,7 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
 
     attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(0)); // end of array
 
-    // All OS X pixel formats are sRGB capable
+    // All macOS pixel formats are sRGB capable
     m_settings.sRgbCapable = true;
 
     // Create the pixel format.

--- a/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
+++ b/tools/xcode/templates/SFML/SFML App.xctemplate/main.cpp
@@ -5,7 +5,7 @@
 // This code will work only if you selected window, graphics and audio.
 //
 // Note that the "Run Script" build phase will copy the required frameworks
-// or dylibs to your application bundle so you can execute it on any OS X
+// or dylibs to your application bundle so you can execute it on any macOS
 // computer.
 //
 // Your resource files (images, sounds, fonts, ...) are also copied to your


### PR DESCRIPTION
## Description

See https://github.com/SFML/SFML/pull/2626

These instances of "OS X" must have slipped past whatever regex I used to write #2626.