### PR TITLE
Extend the migration guide regarding the sf::Text constructor change

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -425,6 +425,7 @@ SFML 3 capitalizes the `A` of `aliasing` for all the APIs.
 
 SFML 3 includes various smaller changes that ought to be mentioned.
 
+* Changed the parameter order of the `sf::Text` constructor, so that the provided font is always the first parameter
 * Reverted to default value of CMake's `BUILD_SHARED_LIBS` which means SFML now builds static libraries by default
 * Changed `sf::String` interface to use `std::u16string` and `std::u32string`
 * Removed `sf::ContextSettings` constructor in favor of aggregate initialization


### PR DESCRIPTION
## Description

Just noticed this small change and thought it was still worth mentioning.

```cpp
auto text = sf::Text{"Hello World", font};
```
vs
```cpp
auto test = sf::Text{font, "Hello World"};
```