### PR TITLE
Add the missing ChannelMap to the example code

### DIFF
--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -346,11 +346,11 @@ private:
 ///     {
 ///         // Open the source and get audio settings
 ///         ...
-///         unsigned int channelCount = ...;
-///         unsigned int sampleRate = ...;
+///         unsigned int channelCount = 2; // Stereo
+///         unsigned int sampleRate = 44100; // 44100 Hz
 ///
 ///         // Initialize the stream -- important!
-///         initialize(channelCount, sampleRate);
+///         initialize(channelCount, sampleRate, {sf::SoundChannel::FrontLeft, sf::SoundChannel::FrontRight});
 ///         return true;
 ///     }
 ///


### PR DESCRIPTION
## Description

The ChannelMap was missing in the SoundStream example code.

I also checked other places and could find anything else. OuputSoundFile has the example correctly updated.

This PR fixes #3226

## How to test this PR?

Generate the docs, check if it's displayed correctly and optionally compile the code to verify.