### PR TITLE
Add window create functions without style specifier

### DIFF
--- a/include/SFML/Window/Window.hpp
+++ b/include/SFML/Window/Window.hpp
@@ -180,9 +180,8 @@ public:
     /// If \a `state` is `State::Fullscreen`, then \a `mode` must be
     /// a valid video mode.
     ///
-    /// The last parameter is an optional structure specifying
-    /// advanced OpenGL context settings such as anti-aliasing,
-    /// depth-buffer bits, etc.
+    /// The last parameter is a structure specifying advanced OpenGL
+    /// context settings such as anti-aliasing, depth-buffer bits, etc.
     ///
     /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
     /// \param title    Title of the window
@@ -192,6 +191,38 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     virtual void create(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create (or recreate) the window
+    ///
+    /// If the window was already created, it closes it first.
+    /// If \a `state` is `State::Fullscreen`, then \a `mode` must be
+    /// a valid video mode.
+    ///
+    /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title    Title of the window
+    /// \param state    %Window state
+    ///
+    ////////////////////////////////////////////////////////////
+    void create(VideoMode mode, const String& title, State state) override;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create (or recreate) the window
+    ///
+    /// If the window was already created, it closes it first.
+    /// If \a `state` is `State::Fullscreen`, then \a `mode` must be
+    /// a valid video mode.
+    ///
+    /// The last parameter is a structure specifying advanced OpenGL
+    /// context settings such as anti-aliasing, depth-buffer bits, etc.
+    ///
+    /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title    Title of the window
+    /// \param state    %Window state
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void create(VideoMode mode, const String& title, State state, const ContextSettings& settings);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create (or recreate) the window from an existing control

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -158,6 +158,20 @@ public:
     virtual void create(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Create (or recreate) the window
+    ///
+    /// If the window was already created, it closes it first.
+    /// If \a `state` is `State::Fullscreen`, then \a `mode` must be
+    /// a valid video mode.
+    ///
+    /// \param mode  Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title Title of the window
+    /// \param state %Window state
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void create(VideoMode mode, const String& title, State state);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Create (or recreate) the window from an existing control
     ///
     /// \param handle Platform-specific handle of the control

--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -96,6 +96,20 @@ void Window::create(VideoMode mode, const String& title, std::uint32_t style, St
 
 
 ////////////////////////////////////////////////////////////
+void Window::create(VideoMode mode, const String& title, State state)
+{
+    Window::create(mode, title, sf::Style::Default, state, ContextSettings{});
+}
+
+
+////////////////////////////////////////////////////////////
+void Window::create(VideoMode mode, const String& title, State state, const ContextSettings& settings)
+{
+    Window::create(mode, title, sf::Style::Default, state, settings);
+}
+
+
+////////////////////////////////////////////////////////////
 void Window::create(WindowHandle handle)
 {
     Window::create(handle, ContextSettings{});

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -103,6 +103,13 @@ void WindowBase::create(VideoMode mode, const String& title, std::uint32_t style
 
 
 ////////////////////////////////////////////////////////////
+void WindowBase::create(VideoMode mode, const String& title, State state)
+{
+    create(mode, title, Style::Default, state);
+}
+
+
+////////////////////////////////////////////////////////////
 void WindowBase::create(WindowHandle handle)
 {
     // Recreate the window implementation

--- a/test/Window/Window.test.cpp
+++ b/test/Window/Window.test.cpp
@@ -128,11 +128,43 @@ TEST_CASE("[Window] sf::Window", runDisplayTests())
             CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
         }
 
-        SECTION("Mode, title, style, and context settings")
+        SECTION("Mode, title, style, and state")
+        {
+            window.create(sf::VideoMode({240, 360}), "Window Tests", sf::Style::Resize, sf::State::Windowed);
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(240, 360));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
+        }
+
+        SECTION("Mode, title, style, state, and context settings")
         {
             window.create(sf::VideoMode({240, 360}),
                           "Window Tests",
                           sf::Style::Resize,
+                          sf::State::Windowed,
+                          sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antiAliasingLevel */ 1});
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(240, 360));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().depthBits >= 1);
+            CHECK(window.getSettings().stencilBits >= 1);
+            CHECK(window.getSettings().antiAliasingLevel >= 1);
+        }
+
+        SECTION("Mode, title, and state")
+        {
+            window.create(sf::VideoMode({240, 360}), "Window Tests", sf::State::Windowed);
+            CHECK(window.isOpen());
+            CHECK(window.getSize() == sf::Vector2u(240, 360));
+            CHECK(window.getNativeHandle() != sf::WindowHandle());
+            CHECK(window.getSettings().attributeFlags == sf::ContextSettings::Default);
+        }
+
+        SECTION("Mode, title, state, and context settings")
+        {
+            window.create(sf::VideoMode({240, 360}),
+                          "Window Tests",
                           sf::State::Windowed,
                           sf::ContextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antiAliasingLevel */ 1});
             CHECK(window.isOpen());

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -88,6 +88,14 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
             CHECK(windowBase.getNativeHandle() != sf::WindowHandle());
         }
 
+        SECTION("Mode, title, and state")
+        {
+            windowBase.create(sf::VideoMode({240, 360}), "WindowBase Tests", sf::State::Windowed);
+            CHECK(windowBase.isOpen());
+            CHECK(windowBase.getSize() == sf::Vector2u(240, 360));
+            CHECK(windowBase.getNativeHandle() != sf::WindowHandle());
+        }
+
         SECTION("Mode, title, style, and state")
         {
             windowBase.create(sf::VideoMode({240, 360}), "WindowBase Tests", sf::Style::Resize, sf::State::Windowed);


### PR DESCRIPTION
## Description

There were currently window constructor overloads that only take an `sf::State`, but the equivalent `create()` functions were missing.

This PR fixes #3227 

```diff
 WindowBase();
 WindowBase(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed);
 WindowBase(VideoMode mode, const String& title, State state);
 explicit WindowBase(WindowHandle handle);
 
 virtual void create(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed);
+virtual void create(VideoMode mode, const String& title, State state);
 virtual void create(WindowHandle handle);
 
 Window();
 Window(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed, const ContextSettings& settings = {});
 Window(VideoMode mode, const String& title, State state, const ContextSettings& settings = {});
 explicit Window(WindowHandle handle, const ContextSettings& settings = {});
 
 void create(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed) override;
 virtual void create(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings);
+void create(VideoMode mode, const String& title, State state) override;
+virtual void create(VideoMode mode, const String& title, State state, const ContextSettings& settings);
 void create(WindowHandle handle) override;
 virtual void create(WindowHandle handle, const ContextSettings& settings);
 
 RenderWindow() = default;
 RenderWindow(VideoMode mode, const String& title, std::uint32_t style = Style::Default, State state = State::Windowed, const ContextSettings& settings = {});
 RenderWindow(VideoMode mode, const String& title, State state, const ContextSettings& settings = {});
 explicit RenderWindow(WindowHandle handle, const ContextSettings& settings = {});
```

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window;
    window.setFramerateLimit(60);

    window.create(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example", sf::State::Fullscreen);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        window.clear();
        window.display();
    }
}
```
