### PR TITLE
Use lazy loading for keyboard m_keys on macos

### DIFF
--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -286,7 +286,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    IOHIDManagerRef                                                       m_manager{}; ///< Underlying HID Manager
+    IOHIDManagerRef m_manager{};         ///< Underlying HID Manager
+    bool            m_keysInitialized{}; ///< Has initializeKeyboard been called at least once?
     EnumArray<Keyboard::Scancode, IOHIDElements, Keyboard::ScancodeCount> m_keys; ///< All the keys on any connected keyboard
     EnumArray<Keyboard::Key, Keyboard::Scancode, Keyboard::KeyCount> m_keyToScancodeMapping{}; ///< Mapping from Key to Scancode
     EnumArray<Keyboard::Scancode, Keyboard::Key, Keyboard::ScancodeCount> m_scancodeToKeyMapping{}; ///< Mapping from Scancode to Key


### PR DESCRIPTION
## Description

On macos, initializing the keyboard's m_keys (a dictionary to convert scancodes to IOHIDElementRef) has the unfortunate side effect of triggering a request for "input monitor" permissions.
The m_keys dictionary is exclusively used when using isKeyPressed, which is a function that already triggers the input monitor permission request.
This change makes it so initialize_keyboard is only lazily called if isKeyPressed is called.

The benefit of this change is that using keyboard events on macos won't trigger permission requests, anymore (but isKeyPressed still will, like before).
initialize_keyboard is protected by a bool, so there are no risks of calling it more than needed (that is... once).

This PR fixes https://github.com/SFML/SFML/issues/2843

The change should be backported to 2.6.x.

## Tasks

-   [X] Tested on macOS

## How to test this PR?

Try running a simple program on macos (like the Island example) which uses events for keyboard inputs.
You should not see any permission request popup.

Then, try running another program on macos which uses isKeyPressed.
After confirming input monitoring is allowed through the popup, you should be able to use isKeyPressed just fine.