### PR TITLE
Replace `swap` with move where appropriate

### DIFF
--- a/src/SFML/Audio/SoundFileReaderFlac.cpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.cpp
@@ -362,13 +362,10 @@ std::uint64_t SoundFileReaderFlac::read(std::int16_t* samples, std::uint64_t max
         if (left > maxCount)
         {
             // There are more leftovers than needed
-            std::copy(m_clientData.leftovers.begin(),
-                      m_clientData.leftovers.begin() + static_cast<std::vector<std::int16_t>::difference_type>(maxCount),
-                      samples);
-            std::vector<std::int16_t> leftovers(m_clientData.leftovers.begin() +
-                                                    static_cast<std::vector<std::int16_t>::difference_type>(maxCount),
-                                                m_clientData.leftovers.end());
-            m_clientData.leftovers.swap(leftovers);
+            const auto signedMaxCount = static_cast<std::vector<std::int16_t>::difference_type>(maxCount);
+            std::copy(m_clientData.leftovers.begin(), m_clientData.leftovers.begin() + signedMaxCount, samples);
+            m_clientData.leftovers = std::vector<std::int16_t>(m_clientData.leftovers.begin() + signedMaxCount,
+                                                               m_clientData.leftovers.end());
             return maxCount;
         }
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -46,6 +46,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <utility>
 
 #include <cassert>
 #include <cstring>
@@ -154,7 +155,7 @@ void Image::resize(Vector2u size, Color color)
         }
 
         // Commit the new pixel buffer
-        m_pixels.swap(newPixels);
+        m_pixels = std::move(newPixels);
 
         // Assign the new size
         m_size = size;
@@ -179,7 +180,7 @@ void Image::resize(Vector2u size, const std::uint8_t* pixels)
         std::vector<std::uint8_t> newPixels(pixels, pixels + size.x * size.y * 4);
 
         // Commit the new pixel buffer
-        m_pixels.swap(newPixels);
+        m_pixels = std::move(newPixels);
 
         // Assign the new size
         m_size = size;


### PR DESCRIPTION
Should not have any effect on behavior -- these swaps seems remnant of C++03-like move semantics emulation.