### PR TITLE
Use lazy loading for keyboard scancodes on macos (backport)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 -   [Windows] Close the clipboard if we fail to empty it (#3043)
 -   [Android] Remove use of deprecated `ALooper_pollAll` (#3181, #3189)
 -   [macOS] Fix how macOS fullscreen video modes are detected (#2300, #3151)
+-   [macOS] Prevent unnecessary macOS input monitoring permission prompts (#2843, #3235)
 
 ### Graphics
 

--- a/src/SFML/Window/OSX/HIDInputManager.hpp
+++ b/src/SFML/Window/OSX/HIDInputManager.hpp
@@ -281,6 +281,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     IOHIDManagerRef    m_manager;                                             ///< Underlying HID Manager
+    bool               m_keysInitialized;                                     ///< Has initializeKeyboard been called at least once?
     IOHIDElements      m_keys[Keyboard::Scan::ScancodeCount];                 ///< All the keys on any connected keyboard
     Keyboard::Scancode m_keyToScancodeMapping[Keyboard::KeyCount];            ///< Mapping from Key to Scancode
     Keyboard::Key      m_scancodeToKeyMapping[Keyboard::Scan::ScancodeCount]; ///< Mapping from Scancode to Key


### PR DESCRIPTION
## Description

Backport of #3232 for 2.6.x.
To test (I will in a few minutes/hours... Or if you guys are faster, feel free to do it in the meantime).

## Tasks

-   [ ] Tested on macOS

## How to test this PR?

Try running a simple program on macos (like the Island example) which uses events for keyboard inputs.
You should not see any permission request popup.

Then, try running another program on macos which uses isKeyPressed.
After confirming input monitoring is allowed through the popup, you should be able to use isKeyPressed just fine.

(Same as #3232 )