### PR TITLE
Fix Regex for SFML_USE_STATIC_STD_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if(SFML_OS_WINDOWS)
         foreach(flag
                 CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
                 CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            string(REGEX REPLACE "/MD|/MDd|/MT|/MTd" "" ${flag} "${${flag}}")
+            string(REGEX REPLACE "/MDd|/MD|/MTd|/MT" "" ${flag} "${${flag}}")
         endforeach()
         add_compile_options(/MT$<$<CONFIG:Debug>:d>)
     endif()


### PR DESCRIPTION
## Description

Regex would match with the short string first and then not consider the longer version.
Swapping it around will make it work.

Originally added in #3131

## Tasks

-   [x] Tested on Windows

## How to test this PR?

Build SFML as static lib with static runtime