### PR TITLE
Add CapsLock, NumLock and ScrollLock support for Events

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -99,12 +99,15 @@ public:
     ////////////////////////////////////////////////////////////
     struct KeyPressed
     {
-        Keyboard::Key      code{};     //!< Code of the key that has been pressed
-        Keyboard::Scancode scancode{}; //!< Physical code of the key that has been pressed
-        bool               alt{};      //!< Is the Alt key pressed?
-        bool               control{};  //!< Is the Control key pressed?
-        bool               shift{};    //!< Is the Shift key pressed?
-        bool               system{};   //!< Is the System key pressed?
+        Keyboard::Key      code{};       //!< Code of the key that has been pressed
+        Keyboard::Scancode scancode{};   //!< Physical code of the key that has been pressed
+        bool               alt{};        //!< Is the Alt key pressed?
+        bool               control{};    //!< Is the Control key pressed?
+        bool               shift{};      //!< Is the Shift key pressed?
+        bool               system{};     //!< Is the System key pressed?
+        bool               capsLock{};   //!< Is the CapsLock key toggled?
+        bool               numLock{};    //!< Is the NumLock key toggled? (Not supported on macOS)
+        bool               scrollLock{}; //!< Is the ScrollLock key toggled?
     };
 
     ////////////////////////////////////////////////////////////
@@ -113,12 +116,15 @@ public:
     ////////////////////////////////////////////////////////////
     struct KeyReleased
     {
-        Keyboard::Key      code{};     //!< Code of the key that has been released
-        Keyboard::Scancode scancode{}; //!< Physical code of the key that has been released
-        bool               alt{};      //!< Is the Alt key pressed?
-        bool               control{};  //!< Is the Control key pressed?
-        bool               shift{};    //!< Is the Shift key pressed?
-        bool               system{};   //!< Is the System key pressed?
+        Keyboard::Key      code{};       //!< Code of the key that has been released
+        Keyboard::Scancode scancode{};   //!< Physical code of the key that has been released
+        bool               alt{};        //!< Is the Alt key pressed?
+        bool               control{};    //!< Is the Control key pressed?
+        bool               shift{};      //!< Is the Shift key pressed?
+        bool               system{};     //!< Is the System key pressed?
+        bool               capsLock{};   //!< Is the CapsLock key toggled?
+        bool               numLock{};    //!< Is the NumLock key toggled? (Not supported on macOS)
+        bool               scrollLock{}; //!< Is the ScrollLock key toggled?
     };
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -427,10 +427,14 @@ int WindowImplAndroid::processKeyboardKeyEvent(
 {
     const auto forwardKeyEvent = [&](auto keyEvent)
     {
-        keyEvent.code     = key;
-        keyEvent.scancode = scancode;
-        keyEvent.alt      = metakey & AMETA_ALT_ON;
-        keyEvent.shift    = metakey & AMETA_SHIFT_ON;
+        keyEvent.code       = key;
+        keyEvent.scancode   = scancode;
+        keyEvent.alt        = metakey & AMETA_ALT_ON;
+        keyEvent.shift      = metakey & AMETA_SHIFT_ON;
+        keyEvent.system     = metakey & AMETA_SYM_ON;
+        keyEvent.capsLock   = metakey & AMETA_CAPS_LOCK_ON;
+        keyEvent.numLock    = metakey & AMETA_NUM_LOCK_ON;
+        keyEvent.scrollLock = metakey & AMETA_SCROLL_LOCK_ON;
         forwardEvent(keyEvent);
     };
 

--- a/src/SFML/Window/DRM/InputImpl.cpp
+++ b/src/SFML/Window/DRM/InputImpl.cpp
@@ -91,6 +91,18 @@ bool systemDown()
 {
     return keyMap[sf::Keyboard::Key::LSystem] || keyMap[sf::Keyboard::Key::RSystem];
 }
+bool capsLockDown()
+{
+    return false; // TODO: To be implemented, potentially with scancode support
+}
+bool numLockDown()
+{
+    return false; // TODO: To be implemented, potentially with scancode support
+}
+bool scrollLockDown()
+{
+    return false; // TODO: To be implemented, potentially with scancode support
+}
 
 void uninitFileDescriptors()
 {
@@ -408,12 +420,15 @@ std::optional<sf::Event> eventProcess()
 
                     const auto makeKeyEvent = [&](auto keyEvent)
                     {
-                        keyEvent.code     = kb;
-                        keyEvent.scancode = sf::Keyboard::Scan::Unknown; // TODO: not implemented
-                        keyEvent.alt      = altDown();
-                        keyEvent.control  = controlDown();
-                        keyEvent.shift    = shiftDown();
-                        keyEvent.system   = systemDown();
+                        keyEvent.code       = kb;
+                        keyEvent.scancode   = sf::Keyboard::Scan::Unknown; // TODO: not implemented
+                        keyEvent.alt        = altDown();
+                        keyEvent.control    = controlDown();
+                        keyEvent.shift      = shiftDown();
+                        keyEvent.system     = systemDown();
+                        keyEvent.capsLock   = capsLockDown();
+                        keyEvent.numLock    = numLockDown();
+                        keyEvent.scrollLock = scrollLockDown();
                         return keyEvent;
                     };
 

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1936,12 +1936,15 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
             // Fill the event parameters
             // TODO: if modifiers are wrong, use XGetModifierMapping to retrieve the actual modifiers mapping
             Event::KeyPressed event;
-            event.code     = KeyboardImpl::getKeyFromEvent(windowEvent.xkey);
-            event.scancode = KeyboardImpl::getScancodeFromEvent(windowEvent.xkey);
-            event.alt      = windowEvent.xkey.state & Mod1Mask;
-            event.control  = windowEvent.xkey.state & ControlMask;
-            event.shift    = windowEvent.xkey.state & ShiftMask;
-            event.system   = windowEvent.xkey.state & Mod4Mask;
+            event.code       = KeyboardImpl::getKeyFromEvent(windowEvent.xkey);
+            event.scancode   = KeyboardImpl::getScancodeFromEvent(windowEvent.xkey);
+            event.alt        = windowEvent.xkey.state & Mod1Mask;
+            event.control    = windowEvent.xkey.state & ControlMask;
+            event.shift      = windowEvent.xkey.state & ShiftMask;
+            event.system     = windowEvent.xkey.state & Mod4Mask;
+            event.capsLock   = windowEvent.xkey.state & LockMask;
+            event.numLock    = windowEvent.xkey.state & Mod2Mask;
+            event.scrollLock = windowEvent.xkey.state & Mod3Mask;
 
             const bool filtered = XFilterEvent(&windowEvent, None);
 
@@ -2017,12 +2020,15 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
         {
             // Fill the event parameters
             Event::KeyReleased event;
-            event.code     = KeyboardImpl::getKeyFromEvent(windowEvent.xkey);
-            event.scancode = KeyboardImpl::getScancodeFromEvent(windowEvent.xkey);
-            event.alt      = windowEvent.xkey.state & Mod1Mask;
-            event.control  = windowEvent.xkey.state & ControlMask;
-            event.shift    = windowEvent.xkey.state & ShiftMask;
-            event.system   = windowEvent.xkey.state & Mod4Mask;
+            event.code       = KeyboardImpl::getKeyFromEvent(windowEvent.xkey);
+            event.scancode   = KeyboardImpl::getScancodeFromEvent(windowEvent.xkey);
+            event.alt        = windowEvent.xkey.state & Mod1Mask;
+            event.control    = windowEvent.xkey.state & ControlMask;
+            event.shift      = windowEvent.xkey.state & ShiftMask;
+            event.system     = windowEvent.xkey.state & Mod4Mask;
+            event.capsLock   = windowEvent.xkey.state & LockMask;
+            event.numLock    = windowEvent.xkey.state & Mod2Mask;
+            event.scrollLock = windowEvent.xkey.state & Mod3Mask;
             pushEvent(event);
 
             break;

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -887,12 +887,15 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             if (m_keyRepeatEnabled || ((HIWORD(lParam) & KF_REPEAT) == 0))
             {
                 Event::KeyPressed event;
-                event.alt      = HIWORD(GetKeyState(VK_MENU)) != 0;
-                event.control  = HIWORD(GetKeyState(VK_CONTROL)) != 0;
-                event.shift    = HIWORD(GetKeyState(VK_SHIFT)) != 0;
-                event.system   = HIWORD(GetKeyState(VK_LWIN)) || HIWORD(GetKeyState(VK_RWIN));
-                event.code     = virtualKeyCodeToSF(wParam, lParam);
-                event.scancode = toScancode(wParam, lParam);
+                event.alt        = GetKeyState(VK_MENU) & 0x8000;
+                event.control    = GetKeyState(VK_CONTROL) & 0x8000;
+                event.shift      = GetKeyState(VK_SHIFT) & 0x8000;
+                event.system     = GetKeyState(VK_LWIN) & 0x8000 || GetKeyState(VK_RWIN) & 0x8000;
+                event.capsLock   = GetKeyState(VK_CAPITAL) & 0x0001;
+                event.numLock    = GetKeyState(VK_NUMLOCK) & 0x0001;
+                event.scrollLock = GetKeyState(VK_SCROLL) & 0x0001;
+                event.code       = virtualKeyCodeToSF(wParam, lParam);
+                event.scancode   = toScancode(wParam, lParam);
                 pushEvent(event);
             }
             break;
@@ -903,12 +906,15 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         case WM_SYSKEYUP:
         {
             Event::KeyReleased event;
-            event.alt      = HIWORD(GetKeyState(VK_MENU)) != 0;
-            event.control  = HIWORD(GetKeyState(VK_CONTROL)) != 0;
-            event.shift    = HIWORD(GetKeyState(VK_SHIFT)) != 0;
-            event.system   = HIWORD(GetKeyState(VK_LWIN)) || HIWORD(GetKeyState(VK_RWIN));
-            event.code     = virtualKeyCodeToSF(wParam, lParam);
-            event.scancode = toScancode(wParam, lParam);
+            event.alt        = GetKeyState(VK_MENU) & 0x8000;
+            event.control    = GetKeyState(VK_CONTROL) & 0x8000;
+            event.shift      = GetKeyState(VK_SHIFT) & 0x8000;
+            event.system     = GetKeyState(VK_LWIN) & 0x8000 || GetKeyState(VK_RWIN) & 0x8000;
+            event.capsLock   = GetKeyState(VK_CAPITAL) & 0x0001;
+            event.numLock    = GetKeyState(VK_NUMLOCK) & 0x0001;
+            event.scrollLock = GetKeyState(VK_SCROLL) & 0x0001;
+            event.code       = virtualKeyCodeToSF(wParam, lParam);
+            event.scancode   = toScancode(wParam, lParam);
             pushEvent(event);
             break;
         }

--- a/src/SFML/Window/macOS/SFKeyboardModifiersHelper.mm
+++ b/src/SFML/Window/macOS/SFKeyboardModifiersHelper.mm
@@ -63,6 +63,7 @@ struct ModifiersState
     BOOL leftControlWasDown{};
     BOOL rightControlWasDown{};
     BOOL capsLockWasOn{};
+    BOOL numLockWasOn{};
 };
 
 
@@ -151,7 +152,8 @@ void initialiseKeyboardHelper()
     state.rightAlternateWasDown = isKeyMaskActive(modifiers, NSRightAlternateKeyMask);
     state.leftControlWasDown    = isKeyMaskActive(modifiers, NSLeftControlKeyMask);
     state.rightControlWasDown   = isKeyMaskActive(modifiers, NSRightControlKeyMask);
-    state.capsLockWasOn         = isKeyMaskActive(modifiers, NSEventModifierFlagCapsLock);
+    state.capsLockWasOn         = isKeyMaskActive(modifiers, NSAlphaShiftKeyMask);
+    state.numLockWasOn          = isKeyMaskActive(modifiers, NSNumericPadKeyMask);
 
     isStateInitialized = YES;
 }
@@ -161,12 +163,15 @@ void initialiseKeyboardHelper()
 sf::Event::KeyPressed keyPressedEventWithModifiers(NSUInteger modifiers, sf::Keyboard::Key key, sf::Keyboard::Scancode code)
 {
     sf::Event::KeyPressed event;
-    event.code     = key;
-    event.scancode = code;
-    event.alt      = modifiers & NSAlternateKeyMask;
-    event.control  = modifiers & NSControlKeyMask;
-    event.shift    = modifiers & NSShiftKeyMask;
-    event.system   = modifiers & NSCommandKeyMask;
+    event.code       = key;
+    event.scancode   = code;
+    event.alt        = modifiers & NSAlternateKeyMask;
+    event.control    = modifiers & NSControlKeyMask;
+    event.shift      = modifiers & NSShiftKeyMask;
+    event.system     = modifiers & NSCommandKeyMask;
+    event.capsLock   = modifiers & NSAlphaShiftKeyMask;
+    event.numLock    = modifiers & NSNumericPadKeyMask;
+    event.scrollLock = false; // Doesn't exist on macOS
     return event;
 }
 
@@ -175,12 +180,15 @@ sf::Event::KeyPressed keyPressedEventWithModifiers(NSUInteger modifiers, sf::Key
 sf::Event::KeyReleased keyReleasedEventWithModifiers(NSUInteger modifiers, sf::Keyboard::Key key, sf::Keyboard::Scancode code)
 {
     sf::Event::KeyReleased event;
-    event.code     = key;
-    event.scancode = code;
-    event.alt      = modifiers & NSAlternateKeyMask;
-    event.control  = modifiers & NSControlKeyMask;
-    event.shift    = modifiers & NSShiftKeyMask;
-    event.system   = modifiers & NSCommandKeyMask;
+    event.code       = key;
+    event.scancode   = code;
+    event.alt        = modifiers & NSAlternateKeyMask;
+    event.control    = modifiers & NSControlKeyMask;
+    event.shift      = modifiers & NSShiftKeyMask;
+    event.system     = modifiers & NSCommandKeyMask;
+    event.capsLock   = modifiers & NSAlphaShiftKeyMask;
+    event.numLock    = modifiers & NSNumericPadKeyMask;
+    event.scrollLock = false; // Doesn't exist on macOS
     return event;
 }
 
@@ -242,5 +250,13 @@ void handleModifiersChanged(NSUInteger modifiers, sf::priv::WindowImplCocoa& req
                        state.capsLockWasOn,
                        sf::Keyboard::Key::Unknown,
                        sf::Keyboard::Scan::CapsLock,
+                       requester);
+
+    // Handle num lock
+    processOneModifier(modifiers,
+                       NSEventModifierFlagNumericPad,
+                       state.numLockWasOn,
+                       sf::Keyboard::Key::Unknown,
+                       sf::Keyboard::Scan::NumLock,
                        requester);
 }

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -88,7 +88,7 @@ TEST_CASE("[Window] sf::Event")
         const auto& textEntered = *event.getIf<sf::Event::TextEntered>();
         CHECK(textEntered.unicode == 123456);
 
-        event = sf::Event::KeyPressed{sf::Keyboard::Key::C, sf::Keyboard::Scan::C, true, true, true, true};
+        event = sf::Event::KeyPressed{sf::Keyboard::Key::C, sf::Keyboard::Scan::C, true, true, true, true, true, true, true};
         CHECK(event.is<sf::Event::KeyPressed>());
         CHECK(event.getIf<sf::Event::KeyPressed>());
         const auto& keyPressed = *event.getIf<sf::Event::KeyPressed>();
@@ -98,8 +98,11 @@ TEST_CASE("[Window] sf::Event")
         CHECK(keyPressed.control);
         CHECK(keyPressed.shift);
         CHECK(keyPressed.system);
+        CHECK(keyPressed.capsLock);
+        CHECK(keyPressed.numLock);
+        CHECK(keyPressed.scrollLock);
 
-        event = sf::Event::KeyReleased{sf::Keyboard::Key::D, sf::Keyboard::Scan::D, true, true, true, true};
+        event = sf::Event::KeyReleased{sf::Keyboard::Key::D, sf::Keyboard::Scan::D, true, true, true, true, true, true, true};
         CHECK(event.is<sf::Event::KeyReleased>());
         CHECK(event.getIf<sf::Event::KeyReleased>());
         const auto& keyReleased = *event.getIf<sf::Event::KeyReleased>();
@@ -109,6 +112,9 @@ TEST_CASE("[Window] sf::Event")
         CHECK(keyReleased.control);
         CHECK(keyReleased.shift);
         CHECK(keyReleased.system);
+        CHECK(keyReleased.capsLock);
+        CHECK(keyReleased.numLock);
+        CHECK(keyReleased.scrollLock);
 
         event = sf::Event::MouseWheelScrolled{sf::Mouse::Wheel::Horizontal, 3.14f, {4, 5}};
         CHECK(event.is<sf::Event::MouseWheelScrolled>());


### PR DESCRIPTION
## Description

This adds support for getting CapsLock, NumLock and ScrollLock modifier/state information on the events.

If this is accepted, once could also look into adding some functions to `sf::Keyboard`.

This came up as discussion on Discord, which originated from a TGUI issue: https://github.com/texus/TGUI/issues/245

Note: ScrollLock isn't really a concept that macOS has implemented, as such it's always false.

I also looked into the function (Fn) key and while most OS actually has a filter for it, Windows doesn't and since we don't have a Scancode for it, it would be a bit a special case. Additionally, a lot of keyboard firmware won't even trigger as normal key input on the Fn key, so it might not be worth it.

## Tasks

-   [x] Tested on Linux
-   [x] Tested on Windows
-   [x] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    auto window = sf::RenderWindow{ sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example" };
    window.setFramerateLimit(60);

    auto font = sf::Font{ "C:\\Windows\\Fonts\\Arial.ttf" }; // Change me
    auto text = sf::Text{ font };

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
            {
                window.close();
            }
            else if (auto keyPressed = event->getIf<sf::Event::KeyPressed>())
            {
                auto output = std::string{ "Key Pressed: " + sf::Keyboard::getDescription(keyPressed->scancode) };
                output += "\nCapsLock: ";
                output += keyPressed->capsLock ? "true" : "false";
                output += "\nNumLock: ";
                output += keyPressed->numLock ? "true" : "false";
                output += "\nScrollLock: ";
                output += keyPressed->scrollLock ? "true" : "false";
                text.setString(output);
            }
            else if (auto keyReleased = event->getIf<sf::Event::KeyReleased>())
            {
                auto output = std::string{ "Key Released: " + sf::Keyboard::getDescription(keyReleased->scancode) };
                output += "\nCapsLock: ";
                output += keyReleased->capsLock ? "true" : "false";
                output += "\nNumLock: ";
                output += keyReleased->numLock ? "true" : "false";
                output += "\nScrollLock: ";
                output += keyReleased->scrollLock ? "true" : "false";
                text.setString(output);
            }
        }

        window.clear();
        window.draw(text);
        window.display();
    }
}
```
