### PR TITLE
change glCheck macro to be usable as an expression

### DIFF
--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -430,9 +430,7 @@ bool RenderTextureImplFBO::createFrameBuffer()
     glCheck(GLEXT_glFramebufferTexture2D(GLEXT_GL_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_textureId, 0));
 
     // A final check, just to be sure...
-    GLenum status = 0;
-    glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
-    if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
+    if (glCheck(GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER)) != GLEXT_GL_FRAMEBUFFER_COMPLETE)
     {
         glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
         err() << "Impossible to create render texture (failed to link the target texture to the frame buffer)" << std::endl;
@@ -486,8 +484,7 @@ bool RenderTextureImplFBO::createFrameBuffer()
         }
 
         // A final check, just to be sure...
-        glCheck(status = GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER));
-        if (status != GLEXT_GL_FRAMEBUFFER_COMPLETE)
+        if (glCheck(GLEXT_glCheckFramebufferStatus(GLEXT_GL_FRAMEBUFFER)) != GLEXT_GL_FRAMEBUFFER_COMPLETE)
         {
             glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_FRAMEBUFFER, 0));
             err() << "Impossible to create render texture (failed to link the render buffers to the multisample frame "

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -185,7 +185,7 @@ struct Shader::UniformBinder
         if (currentProgram)
         {
             // Enable program object
-            glCheck(savedProgram = GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
+            savedProgram = glCheck(GLEXT_glGetHandle(GLEXT_GL_PROGRAM_OBJECT));
             if (currentProgram != savedProgram)
                 glCheck(GLEXT_glUseProgramObject(currentProgram));
 
@@ -865,17 +865,15 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
     }
 
     // Create the program
-    GLEXT_GLhandle shaderProgram{};
-    glCheck(shaderProgram = GLEXT_glCreateProgramObject());
+    const GLEXT_GLhandle shaderProgram = glCheck(GLEXT_glCreateProgramObject());
 
     // Create the vertex shader if needed
     if (!vertexShaderCode.empty())
     {
         // Create and compile the shader
-        GLEXT_GLhandle vertexShader{};
-        glCheck(vertexShader = GLEXT_glCreateShaderObject(GLEXT_GL_VERTEX_SHADER));
-        const GLcharARB* sourceCode       = vertexShaderCode.data();
-        const auto       sourceCodeLength = static_cast<GLint>(vertexShaderCode.length());
+        const GLEXT_GLhandle vertexShader     = glCheck(GLEXT_glCreateShaderObject(GLEXT_GL_VERTEX_SHADER));
+        const GLcharARB*     sourceCode       = vertexShaderCode.data();
+        const auto           sourceCodeLength = static_cast<GLint>(vertexShaderCode.length());
         glCheck(GLEXT_glShaderSource(vertexShader, 1, &sourceCode, &sourceCodeLength));
         glCheck(GLEXT_glCompileShader(vertexShader));
 
@@ -929,10 +927,9 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
     if (!fragmentShaderCode.empty())
     {
         // Create and compile the shader
-        GLEXT_GLhandle fragmentShader{};
-        glCheck(fragmentShader = GLEXT_glCreateShaderObject(GLEXT_GL_FRAGMENT_SHADER));
-        const GLcharARB* sourceCode       = fragmentShaderCode.data();
-        const auto       sourceCodeLength = static_cast<GLint>(fragmentShaderCode.length());
+        const GLEXT_GLhandle fragmentShader   = glCheck(GLEXT_glCreateShaderObject(GLEXT_GL_FRAGMENT_SHADER));
+        const GLcharARB*     sourceCode       = fragmentShaderCode.data();
+        const auto           sourceCodeLength = static_cast<GLint>(fragmentShaderCode.length());
         glCheck(GLEXT_glShaderSource(fragmentShader, 1, &sourceCode, &sourceCodeLength));
         glCheck(GLEXT_glCompileShader(fragmentShader));
 

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -648,11 +648,9 @@ void Texture::update(const Texture& texture, Vector2u dest)
             GLEXT_glFramebufferTexture2D(GLEXT_GL_DRAW_FRAMEBUFFER, GLEXT_GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0));
 
         // A final check, just to be sure...
-        GLenum sourceStatus = 0;
-        glCheck(sourceStatus = GLEXT_glCheckFramebufferStatus(GLEXT_GL_READ_FRAMEBUFFER));
+        const GLenum sourceStatus = glCheck(GLEXT_glCheckFramebufferStatus(GLEXT_GL_READ_FRAMEBUFFER));
 
-        GLenum destStatus = 0;
-        glCheck(destStatus = GLEXT_glCheckFramebufferStatus(GLEXT_GL_DRAW_FRAMEBUFFER));
+        const GLenum destStatus = glCheck(GLEXT_glCheckFramebufferStatus(GLEXT_GL_DRAW_FRAMEBUFFER));
 
         if ((sourceStatus == GLEXT_GL_FRAMEBUFFER_COMPLETE) && (destStatus == GLEXT_GL_FRAMEBUFFER_COMPLETE))
         {

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -236,23 +236,19 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
                                nullptr,
                                VertexBufferImpl::usageToGlEnum(m_usage)));
 
-    void* destination = nullptr;
-    glCheck(destination = GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_WRITE_ONLY));
+    void* const destination = glCheck(GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_WRITE_ONLY));
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, vertexBuffer.m_buffer));
 
-    void* source = nullptr;
-    glCheck(source = GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_READ_ONLY));
+    const void* const source = glCheck(GLEXT_glMapBuffer(GLEXT_GL_ARRAY_BUFFER, GLEXT_GL_READ_ONLY));
 
     std::memcpy(destination, source, sizeof(Vertex) * vertexBuffer.m_size);
 
-    GLboolean sourceResult = GL_FALSE;
-    glCheck(sourceResult = GLEXT_glUnmapBuffer(GLEXT_GL_ARRAY_BUFFER));
+    const GLboolean sourceResult = glCheck(GLEXT_glUnmapBuffer(GLEXT_GL_ARRAY_BUFFER));
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, m_buffer));
 
-    GLboolean destinationResult = GL_FALSE;
-    glCheck(destinationResult = GLEXT_glUnmapBuffer(GLEXT_GL_ARRAY_BUFFER));
+    const GLboolean destinationResult = glCheck(GLEXT_glUnmapBuffer(GLEXT_GL_ARRAY_BUFFER));
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, 0));
 

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -42,7 +42,7 @@ bool eglCheckError(const std::filesystem::path& file, unsigned int line, std::st
 {
     const auto logError = [&](const char* error, const char* description)
     {
-        err() << "An internal EGL call failed in " << file.filename() << " (" << line << ") : "
+        err() << "An internal EGL call failed in " << file.filename() << "(" << line << ")."
               << "\nExpression:\n   " << expression << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
 


### PR DESCRIPTION
this change allows [e]glCheck macros to be usable as expressions which makes writing code more natural example

```cpp
GLEXT_GLhandle shaderProgram{};
glCheck(shaderProgram = GLEXT_glCreateProgramObject());
```
into the more natural (and bonus it is const!) ((bonus 2 it can use auto!))
```cpp
const GLEXT_GLhandle shaderProgram = glCheck(GLEXT_glCreateProgramObject());
```