### PR TITLE
Avoid unnecessary assignment in `Text::findCharacterPos`

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -312,9 +312,7 @@ Vector2f Text::findCharacterPos(std::size_t index) const
     }
 
     // Transform the position to global coordinates
-    position = getTransform().transformPoint(position);
-
-    return position;
+    return getTransform().transformPoint(position);
 }
 
 


### PR DESCRIPTION
Minor stylistical thing but I was confused by this assignment when reading the code and had to do a double-take (i.e. *"is there something I am missing? Why is this not being returned directly?"*) so I think it also aids readability.