### PR TITLE
Prevent reading from an uninitialized character buffer

### DIFF
--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -40,6 +40,7 @@
 #include <SFML/System/Vector2.hpp>
 #include <SFML/System/Vector3.hpp>
 
+#include <array>
 #include <fstream>
 #include <iomanip>
 #include <ostream>
@@ -882,9 +883,9 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
         glCheck(GLEXT_glGetObjectParameteriv(vertexShader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
         if (success == GL_FALSE)
         {
-            char log[1024];
-            glCheck(GLEXT_glGetInfoLog(vertexShader, sizeof(log), nullptr, log));
-            err() << "Failed to compile vertex shader:" << '\n' << log << std::endl;
+            std::array<char, 1024> log{};
+            glCheck(GLEXT_glGetInfoLog(vertexShader, sizeof(log), nullptr, log.data()));
+            err() << "Failed to compile vertex shader:" << '\n' << log.data() << std::endl;
             glCheck(GLEXT_glDeleteObject(vertexShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
             return false;
@@ -910,9 +911,9 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
         glCheck(GLEXT_glGetObjectParameteriv(geometryShader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
         if (success == GL_FALSE)
         {
-            char log[1024];
-            glCheck(GLEXT_glGetInfoLog(geometryShader, sizeof(log), nullptr, log));
-            err() << "Failed to compile geometry shader:" << '\n' << log << std::endl;
+            std::array<char, 1024> log{};
+            glCheck(GLEXT_glGetInfoLog(geometryShader, sizeof(log), nullptr, log.data()));
+            err() << "Failed to compile geometry shader:" << '\n' << log.data() << std::endl;
             glCheck(GLEXT_glDeleteObject(geometryShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
             return false;
@@ -938,9 +939,9 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
         glCheck(GLEXT_glGetObjectParameteriv(fragmentShader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
         if (success == GL_FALSE)
         {
-            char log[1024];
-            glCheck(GLEXT_glGetInfoLog(fragmentShader, sizeof(log), nullptr, log));
-            err() << "Failed to compile fragment shader:" << '\n' << log << std::endl;
+            std::array<char, 1024> log{};
+            glCheck(GLEXT_glGetInfoLog(fragmentShader, sizeof(log), nullptr, log.data()));
+            err() << "Failed to compile fragment shader:" << '\n' << log.data() << std::endl;
             glCheck(GLEXT_glDeleteObject(fragmentShader));
             glCheck(GLEXT_glDeleteObject(shaderProgram));
             return false;
@@ -959,9 +960,9 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
     glCheck(GLEXT_glGetObjectParameteriv(shaderProgram, GLEXT_GL_OBJECT_LINK_STATUS, &success));
     if (success == GL_FALSE)
     {
-        char log[1024];
-        glCheck(GLEXT_glGetInfoLog(shaderProgram, sizeof(log), nullptr, log));
-        err() << "Failed to link shader:" << '\n' << log << std::endl;
+        std::array<char, 1024> log{};
+        glCheck(GLEXT_glGetInfoLog(shaderProgram, sizeof(log), nullptr, log.data()));
+        err() << "Failed to link shader:" << '\n' << log.data() << std::endl;
         glCheck(GLEXT_glDeleteObject(shaderProgram));
         return false;
     }


### PR DESCRIPTION
## Description

If `GLEXT_glGetInfoLog` fails then `log` is left unchanged which can lead to a reading from an uninitialized buffer on the following line. Initializing the buffer ensures this never happens. While I was touching this code I elected to switch to `std::array` as well since SFML has made previous efforts to stop using C-style arrays and I wanted to continue that effort.

Coverity caught this in a recent scan
```
/home/buildbot-worker/coverity/build/src/SFML/Graphics/Shader.cpp: 943 in sf::Shader::compile(std::basic_string_view<char, std::char_traits<char>>, std::basic_string_view<char, std::char_traits<char>>, std::basic_string_view<char, std::char_traits<char>>)()
937             GLint success = 0;
938             glCheck(GLEXT_glGetObjectParameteriv(fragmentShader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
939             if (success == GL_FALSE)
940             {
941                 char log[1024];
942                 glCheck(GLEXT_glGetInfoLog(fragmentShader, sizeof(log), nullptr, log));
   CID 420681:    (UNINIT)
   Using uninitialized value "*log" when calling "operator <<". [Note: The source code implementation of the function has been overridden by a builtin model.]
943                 err() << "Failed to compile fragment shader:" << '\n' << log << std::endl;
944                 glCheck(GLEXT_glDeleteObject(fragmentShader));
945                 glCheck(GLEXT_glDeleteObject(shaderProgram));
946                 return false;
947             }
948     
```