### PR TITLE
Fix `island` example freeze when submitting work too quickly

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -398,7 +398,7 @@ void generateTerrain(sf::Vertex* buffer)
         {
             const std::lock_guard lock(workQueueMutex);
 
-            if (workQueue.empty())
+            if (pendingWorkCount == 0u)
                 break;
         }
 


### PR DESCRIPTION
As the title says, if you run the `island` example and keep pressing Enter in quick succession, the example would get stuck prior to this PR.