### PR TITLE
delegate to operator equals in operator not equals

### DIFF
--- a/include/SFML/System/Vector2.inl
+++ b/include/SFML/System/Vector2.inl
@@ -210,7 +210,7 @@ constexpr bool operator==(Vector2<T> left, Vector2<T> right)
 template <typename T>
 constexpr bool operator!=(Vector2<T> left, Vector2<T> right)
 {
-    return (left.x != right.x) || (left.y != right.y);
+    return !(left == right);
 }
 
 

--- a/include/SFML/System/Vector3.inl
+++ b/include/SFML/System/Vector3.inl
@@ -210,7 +210,7 @@ constexpr bool operator==(const Vector3<T>& left, const Vector3<T>& right)
 template <typename T>
 constexpr bool operator!=(const Vector3<T>& left, const Vector3<T>& right)
 {
-    return (left.x != right.x) || (left.y != right.y) || (left.z != right.z);
+    return !(left == right);
 }
 
 } // namespace sf


### PR DESCRIPTION
all other `operator!=` implementations did this except these two.



~~cannot wait for C++20~~