### PR TITLE
Update the macOS images for the CI analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,9 +323,6 @@ jobs:
     name: Formatting
     runs-on: ubuntu-22.04
 
-    strategy:
-      fail-fast: false
-
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -348,8 +345,8 @@ jobs:
         - { name: Linux,           os: ubuntu-24.04 }
         - { name: Linux DRM,       os: ubuntu-24.04, flags: -DSFML_USE_DRM=ON }
         - { name: Linux OpenGL ES, os: ubuntu-24.04, flags: -DSFML_OPENGL_ES=ON }
-        - { name: macOS,           os: macos-12 }
-        - { name: iOS,             os: macos-12,     flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
+        - { name: macOS,           os: macos-14 }
+        - { name: iOS,             os: macos-14,     flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
         - { name: Android,         os: ubuntu-24.04, flags: -DCMAKE_ANDROID_ARCH_ABI=x86_64 -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=21 -DCMAKE_ANDROID_NDK=$ANDROID_NDK -DCMAKE_ANDROID_STL_TYPE=c++_shared }
 
     steps:
@@ -375,7 +372,9 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew update
-        brew install llvm || true
+        brew install llvm lld || true
+        ln -s "$(brew --prefix llvm)/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+        ln -s "$(brew --prefix llvm)/bin/run-clang-tidy" "/usr/local/bin/run-clang-tidy"
         echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
 
     - name: Configure
@@ -392,7 +391,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Linux,               os: ubuntu-22.04, flags: }
+        - { name: Linux,               os: ubuntu-22.04 }
         - { name: Linux DRM,           os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_USE_DRM=ON }
         - { name: Linux GCC OpenGL ES, os: ubuntu-22.04, flags: -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_OPENGL_ES=ON }
 


### PR DESCRIPTION
## Description

[It looks like](https://github.com/SFML/SFML/actions/runs/11099776203/job/30834545898) brew on `macos-12` doesn't ship the wanted LLVM version anymore. So each build triggers a complete build of clang and clang-tools, which can take 3+h.

By updating to the `macos-14` image, we should get pre-built binaries again.

## How to test this PR?

The CI Analyzer steps for iOS and macOS shouldn't build LLVM and shouldn't take 2+h.