### PR TITLE
Revert to LLVM 18 until we can upgrade to macOS 14 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,8 +348,8 @@ jobs:
         - { name: Linux,           os: ubuntu-24.04 }
         - { name: Linux DRM,       os: ubuntu-24.04, flags: -DSFML_USE_DRM=ON }
         - { name: Linux OpenGL ES, os: ubuntu-24.04, flags: -DSFML_OPENGL_ES=ON }
-        - { name: macOS,           os: macos-12 }
-        - { name: iOS,             os: macos-12,     flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
+        - { name: macOS,           os: macos-13 }
+        - { name: iOS,             os: macos-13,     flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
         - { name: Android,         os: ubuntu-24.04, flags: -DCMAKE_ANDROID_ARCH_ABI=x86_64 -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=21 -DCMAKE_ANDROID_NDK=$ANDROID_NDK -DCMAKE_ANDROID_STL_TYPE=c++_shared }
 
     steps:
@@ -375,8 +375,8 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew update
-        brew install llvm || true
-        echo /usr/local/opt/llvm/bin >> $GITHUB_PATH
+        brew install llvm@18 || true
+        echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
 
     - name: Configure
       run: cmake --preset dev -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_UNITY_BUILD=ON ${{matrix.platform.flags}}


### PR DESCRIPTION
## Description

This fixes the problem where CI was building LLVM from source which takes a _long_ time. If you use LLVM 18 on macOS 12, Homebrew still has to build it from source but if we bump that up to macOS 13 then Homebrew can use a prebuilt version. 