### PR TITLE
Added setPosition overloads for Transformable and RenderWindow alignm…

### DIFF
--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -31,9 +31,30 @@
 #include <SFML/Graphics/Export.hpp>
 #include <SFML/Graphics/Transform.hpp>
 
+#include "RenderWindow.hpp"
+
 
 namespace sf
 {
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enum representing alignment points on an object
+    ///
+    /// Defines locations like corners and center for alignment.
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Location {
+        TopLeft,    ///< Top-left corner
+        TopMid,     ///< Top center
+        TopRight,   ///< Top-right corner
+        MidLeft,    ///< Middle left
+        MidMid,     ///< Center
+        MidRight,   ///< Middle right
+        BottomLeft, ///< Bottom-left corner
+        BottomMid,  ///< Bottom center
+        BottomRight ///< Bottom-right corner
+    };
+
 ////////////////////////////////////////////////////////////
 /// \brief Decomposed transform defined by a position, a rotation and a scale
 ///
@@ -82,6 +103,43 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     void setPosition(const Vector2f& position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the position of the object relative to another transformable
+    ///
+    /// This function completely overwrites the previous position of the object.
+    /// The position is set based on the specified origin point of the current object
+    /// and the reference origin point of the provided transformable object.
+    /// For example, you can align the top-left corner of the current object with
+    /// the center of the reference transformable.
+    ///
+    /// \param origin Location on this object to be aligned (e.g., TopLeft, MidMid)
+    /// \param refOrigin Location on the reference transformable to align with
+    /// \param transformableRef The reference transformable to align this object with
+    ///
+    /// \see move, getPosition, Location
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPosition(Location origin, Location refOrigin, sf::Transformable& transformableRef);
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the position of the object relative to a window
+    ///
+    /// This function completely overwrites the previous position of the object.
+    /// The position is set based on the specified origin point of the current object
+    /// and the reference origin point of the provided render window.
+    /// For example, you can align the top-left corner of the object with the center
+    /// of the render window.
+    ///
+    /// \param origin Location on this object to be aligned (e.g., TopLeft, MidMid)
+    /// \param refOrigin Location in the render window to align the object with
+    /// \param windowRef The render window to align this object with
+    ///
+    /// \see move, getPosition, Location
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPosition(Location origin, Location refOrigin, const sf::RenderWindow& windowRef);
 
     ////////////////////////////////////////////////////////////
     /// \brief set the orientation of the object

--- a/src/SFML/Graphics/Transformable.cpp
+++ b/src/SFML/Graphics/Transformable.cpp
@@ -26,6 +26,9 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Transformable.hpp>
+#include "SFML/Graphics/Shape.hpp"
+#include "SFML/Graphics/Sprite.hpp"
+#include "SFML/Graphics/Text.hpp"
 #include <cmath>
 
 
@@ -65,6 +68,125 @@ void Transformable::setPosition(float x, float y)
 void Transformable::setPosition(const Vector2f& position)
 {
     setPosition(position.x, position.y);
+}
+
+
+////////////////////////////////////////////////////////////
+void sf::Transformable::setPosition(Location origin, Location refOrigin, sf::Transformable& transformableRef) {
+    // Get the current positions of both transformables
+    sf::Vector2f position = this->getPosition();
+    sf::Vector2f refPosition = transformableRef.getPosition();
+
+    // Placeholder for sizes. Since sf::Transformable doesn't provide size, we assume zero size here.
+    sf::Vector2f thisSize(0.f, 0.f);
+    sf::Vector2f refSize(0.f, 0.f);
+
+    // Check if the current object is of a type that provides bounds (like sf::Sprite, sf::Text, etc.)
+    if (const sf::Sprite* sprite = dynamic_cast<const sf::Sprite*>(this)) {
+        thisSize = sf::Vector2f(sprite->getGlobalBounds().width, sprite->getGlobalBounds().height);
+    } else if (const sf::Text* text = dynamic_cast<const sf::Text*>(this)) {
+        thisSize = sf::Vector2f(text->getGlobalBounds().width, text->getGlobalBounds().height);
+    } else if (const sf::Shape* shape = dynamic_cast<const sf::Shape*>(this)) {
+        thisSize = sf::Vector2f(shape->getGlobalBounds().width, shape->getGlobalBounds().height);
+    }
+
+    // Do the same for the reference transformable
+    if (const sf::Sprite* sprite = dynamic_cast<const sf::Sprite*>(&transformableRef)) {
+        refSize = sf::Vector2f(sprite->getGlobalBounds().width, sprite->getGlobalBounds().height);
+    } else if (const sf::Text* text = dynamic_cast<const sf::Text*>(&transformableRef)) {
+        refSize = sf::Vector2f(text->getGlobalBounds().width, text->getGlobalBounds().height);
+    } else if (const sf::Shape* shape = dynamic_cast<const sf::Shape*>(&transformableRef)) {
+        refSize = sf::Vector2f(shape->getGlobalBounds().width, shape->getGlobalBounds().height);
+    }
+
+    // These will hold the offsets for the desired locations
+    sf::Vector2f offsetOrigin;
+    sf::Vector2f offsetRefOrigin;
+
+    // Determine the position for the origin based on the `origin` parameter (this transformable)
+    switch (origin) {
+        case TopLeft:      offsetOrigin = sf::Vector2f(0.f, 0.f); break;
+        case TopMid:       offsetOrigin = sf::Vector2f(thisSize.x / 2.f, 0.f); break;
+        case TopRight:     offsetOrigin = sf::Vector2f(thisSize.x, 0.f); break;
+        case MidLeft:      offsetOrigin = sf::Vector2f(0.f, thisSize.y / 2.f); break;
+        case MidMid:       offsetOrigin = sf::Vector2f(thisSize.x / 2.f, thisSize.y / 2.f); break;
+        case MidRight:     offsetOrigin = sf::Vector2f(thisSize.x, thisSize.y / 2.f); break;
+        case BottomLeft:   offsetOrigin = sf::Vector2f(0.f, thisSize.y); break;
+        case BottomMid:    offsetOrigin = sf::Vector2f(thisSize.x / 2.f, thisSize.y); break;
+        case BottomRight:  offsetOrigin = sf::Vector2f(thisSize.x, thisSize.y); break;
+    }
+
+    // Determine the position for the reference origin based on the `refOrigin` parameter (reference transformable)
+    switch (refOrigin) {
+        case TopLeft:      offsetRefOrigin = sf::Vector2f(0.f, 0.f); break;
+        case TopMid:       offsetRefOrigin = sf::Vector2f(refSize.x / 2.f, 0.f); break;
+        case TopRight:     offsetRefOrigin = sf::Vector2f(refSize.x, 0.f); break;
+        case MidLeft:      offsetRefOrigin = sf::Vector2f(0.f, refSize.y / 2.f); break;
+        case MidMid:       offsetRefOrigin = sf::Vector2f(refSize.x / 2.f, refSize.y / 2.f); break;
+        case MidRight:     offsetRefOrigin = sf::Vector2f(refSize.x, refSize.y / 2.f); break;
+        case BottomLeft:   offsetRefOrigin = sf::Vector2f(0.f, refSize.y); break;
+        case BottomMid:    offsetRefOrigin = sf::Vector2f(refSize.x / 2.f, refSize.y); break;
+        case BottomRight:  offsetRefOrigin = sf::Vector2f(refSize.x, refSize.y); break;
+    }
+
+    // Set the new position of the calling transformable based on the offset positions
+    this->setPosition(refPosition + offsetRefOrigin - offsetOrigin);
+}
+
+
+////////////////////////////////////////////////////////////
+void sf::Transformable::setPosition(Location origin, Location refOrigin, const sf::RenderWindow& windowRef) {
+    // Get the current position of this transformable
+    sf::Vector2f position = this->getPosition();
+
+    // Placeholder for the size of the transformable (since sf::Transformable doesn't provide size)
+    sf::Vector2f thisSize(0.f, 0.f);
+
+    // Check if the current object is of a type that provides bounds (like sf::Sprite, sf::Text, etc.)
+    if (const sf::Sprite* sprite = dynamic_cast<const sf::Sprite*>(this)) {
+        thisSize = sf::Vector2f(sprite->getGlobalBounds().width, sprite->getGlobalBounds().height);
+    } else if (const sf::Text* text = dynamic_cast<const sf::Text*>(this)) {
+        thisSize = sf::Vector2f(text->getGlobalBounds().width, text->getGlobalBounds().height);
+    } else if (const sf::Shape* shape = dynamic_cast<const sf::Shape*>(this)) {
+        thisSize = sf::Vector2f(shape->getGlobalBounds().width, shape->getGlobalBounds().height);
+    }
+
+    // Get the size of the window
+    sf::Vector2u windowSize = windowRef.getSize();
+    sf::Vector2f refSize(static_cast<float>(windowSize.x), static_cast<float>(windowSize.y));
+
+    // These will hold the offsets for the desired locations
+    sf::Vector2f offsetOrigin;
+    sf::Vector2f offsetRefOrigin;
+
+    // Determine the position for the origin based on the `origin` parameter (this transformable)
+    switch (origin) {
+        case TopLeft:      offsetOrigin = sf::Vector2f(0.f, 0.f); break;
+        case TopMid:       offsetOrigin = sf::Vector2f(thisSize.x / 2.f, 0.f); break;
+        case TopRight:     offsetOrigin = sf::Vector2f(thisSize.x, 0.f); break;
+        case MidLeft:      offsetOrigin = sf::Vector2f(0.f, thisSize.y / 2.f); break;
+        case MidMid:       offsetOrigin = sf::Vector2f(thisSize.x / 2.f, thisSize.y / 2.f); break;
+        case MidRight:     offsetOrigin = sf::Vector2f(thisSize.x, thisSize.y / 2.f); break;
+        case BottomLeft:   offsetOrigin = sf::Vector2f(0.f, thisSize.y); break;
+        case BottomMid:    offsetOrigin = sf::Vector2f(thisSize.x / 2.f, thisSize.y); break;
+        case BottomRight:  offsetOrigin = sf::Vector2f(thisSize.x, thisSize.y); break;
+    }
+
+    // Determine the position for the reference origin based on the `refOrigin` parameter (the window)
+    switch (refOrigin) {
+        case TopLeft:      offsetRefOrigin = sf::Vector2f(0.f, 0.f); break;
+        case TopMid:       offsetRefOrigin = sf::Vector2f(refSize.x / 2.f, 0.f); break;
+        case TopRight:     offsetRefOrigin = sf::Vector2f(refSize.x, 0.f); break;
+        case MidLeft:      offsetRefOrigin = sf::Vector2f(0.f, refSize.y / 2.f); break;
+        case MidMid:       offsetRefOrigin = sf::Vector2f(refSize.x / 2.f, refSize.y / 2.f); break;
+        case MidRight:     offsetRefOrigin = sf::Vector2f(refSize.x, refSize.y / 2.f); break;
+        case BottomLeft:   offsetRefOrigin = sf::Vector2f(0.f, refSize.y); break;
+        case BottomMid:    offsetRefOrigin = sf::Vector2f(refSize.x / 2.f, refSize.y); break;
+        case BottomRight:  offsetRefOrigin = sf::Vector2f(refSize.x, refSize.y); break;
+    }
+
+    // Set the new position of the calling transformable based on the offset positions
+    this->setPosition(offsetRefOrigin - offsetOrigin);
 }
 
 


### PR DESCRIPTION
## Description
This PR introduces an enum Location and new overide setPosition functions that allows easier alignment and positioning of SFML transformables. The changes allow users to set a transformable's position relative to a specific origin (e.g., TopLeft, MidMid, BottomRight) and align it to another transformable or render window. 

Closes #3259

```cpp
    #include <SFML/Graphics.hpp>

    int main()
    {
        sf::RenderWindow window(sf::VideoMode(800, 600), "Positioning Test");
        window.setFramerateLimit(60);
    
        // Create a shape and text
        sf::RectangleShape shape(sf::Vector2f(200, 100));
        shape.setFillColor(sf::Color::Green);
        sf::Text text;
        sf::Font font;
        font.loadFromFile("arial.ttf");
        text.setFont(font);
        text.setString("Centered Text");
    
        // Set positions using the new Location enum
        shape.setPosition(MidMid, MidMid, window);  // Shape centered in window
        text.setPosition(MidMid, MidMid, shape);    // Text centered in shape
    
        while (window.isOpen())
        {
            sf::Event event;
            while (window.pollEvent(event))
            {
                if (event.type == sf::Event::Closed)
                    window.close();
            }
    
            window.clear();
            window.draw(shape);
            window.draw(text);
            window.display();
        }
    }
```