### PR TITLE
Feature/cppcheck fixes pt1

### DIFF
--- a/examples/X11/X11.cpp
+++ b/examples/X11/X11.cpp
@@ -21,7 +21,7 @@
 /// \return True if operation was successful, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] bool initialize(sf::Window& window)
+[[nodiscard]] bool initialize(const sf::Window& window)
 {
     // Activate the window
     if (!window.setActive())
@@ -73,7 +73,7 @@
 /// \return True if operation was successful, false otherwise
 ///
 ////////////////////////////////////////////////////////////
-[[nodiscard]] bool draw(sf::Window& window, float elapsedTime)
+[[nodiscard]] bool draw(const sf::Window& window, float elapsedTime)
 {
     // Activate the window
     if (!window.setActive())

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -732,8 +732,6 @@ protected:
         float a2{};
         float b1{};
         float b2{};
-        float c0{};
-        float d0{};
     };
 
     using Processing::Processing;

--- a/include/SFML/Network/SocketSelector.hpp
+++ b/include/SFML/Network/SocketSelector.hpp
@@ -100,7 +100,7 @@ public:
     /// \see `remove`, `clear`
     ///
     ////////////////////////////////////////////////////////////
-    void add(Socket& socket);
+    void add(const Socket& socket);
 
     ////////////////////////////////////////////////////////////
     /// \brief Remove a socket from the selector
@@ -113,7 +113,7 @@ public:
     /// \see `add`, `clear`
     ///
     ////////////////////////////////////////////////////////////
-    void remove(Socket& socket);
+    void remove(const Socket& socket);
 
     ////////////////////////////////////////////////////////////
     /// \brief Remove all the sockets stored in the selector
@@ -162,7 +162,7 @@ public:
     /// \see `isReady`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool isReady(Socket& socket) const;
+    [[nodiscard]] bool isReady(const Socket& socket) const;
 
 private:
     struct SocketSelectorImpl;

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -27,6 +27,8 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Utf.hpp> // NOLINT(misc-header-include-cycle)
 
+#include <cassert>
+
 
 ////////////////////////////////////////////////////////////
 // References:
@@ -127,10 +129,10 @@ Out Utf<8>::encode(std::uint32_t input, Out output, std::uint8_t replacement)
         std::size_t bytestoWrite = 1;
 
         // clang-format off
-        if      (input <  0x80)       bytestoWrite = 1;
-        else if (input <  0x800)      bytestoWrite = 2;
-        else if (input <  0x10000)    bytestoWrite = 3;
-        else if (input <= 0x0010FFFF) bytestoWrite = 4;
+        if      (input <  0x80)     {                              bytestoWrite = 1; }
+        else if (input <  0x800)    {                              bytestoWrite = 2; }
+        else if (input <  0x10000)  {                              bytestoWrite = 3; }
+        else                        { assert(input <= 0x0010FFFF); bytestoWrite = 4; }
         // clang-format on
 
         // Extract the bytes to write

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -77,12 +77,11 @@ SoundBuffer::SoundBuffer(const std::int16_t*              samples,
 
 
 ////////////////////////////////////////////////////////////
-SoundBuffer::SoundBuffer(const SoundBuffer& copy)
+SoundBuffer::SoundBuffer(const SoundBuffer& copy) :
+// don't copy the attached sounds
+m_samples(copy.m_samples),
+m_duration(copy.m_duration)
 {
-    // don't copy the attached sounds
-    m_samples  = copy.m_samples;
-    m_duration = copy.m_duration;
-
     // Update the internal buffer with the new samples
     if (!update(copy.getChannelCount(), copy.getSampleRate(), copy.getChannelMap()))
         err() << "Failed to update copy-constructed sound buffer" << std::endl;

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -421,8 +421,9 @@ void SoundRecorder::setChannelCount(unsigned int channelCount)
         {
             m_impl->channelMap = {SoundChannel::Mono};
         }
-        else if (channelCount == 2)
+        else
         {
+            assert(channelCount == 2);
             m_impl->channelMap = {SoundChannel::FrontLeft, SoundChannel::FrontRight};
         }
     }

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -422,8 +422,8 @@ void Image::createMaskFromColor(Color color, std::uint8_t alpha)
     if (!m_pixels.empty())
     {
         // Replace the alpha of the pixels that match the transparent color
-        std::uint8_t* ptr = m_pixels.data();
-        std::uint8_t* end = ptr + m_pixels.size();
+        std::uint8_t*       ptr = m_pixels.data();
+        const std::uint8_t* end = ptr + m_pixels.size();
         while (ptr < end)
         {
             if ((ptr[0] == color.r) && (ptr[1] == color.g) && (ptr[2] == color.b) && (ptr[3] == color.a))

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -305,7 +305,7 @@ void onNativeWindowCreated(ANativeActivity* activity, ANativeWindow* window)
 
     // Wait for the event to be taken into account by SFML
     states.updated = false;
-    while (!(states.updated | states.terminated))
+    while (!(states.updated || states.terminated))
     {
         states.mutex.unlock();
         sf::sleep(sf::milliseconds(10));
@@ -327,7 +327,7 @@ void onNativeWindowDestroyed(ANativeActivity* activity, ANativeWindow* /* window
 
     // Wait for the event to be taken into account by SFML
     states.updated = false;
-    while (!(states.updated | states.terminated))
+    while (!(states.updated || states.terminated))
     {
         states.mutex.unlock();
         sf::sleep(sf::milliseconds(10));
@@ -512,7 +512,7 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
     // Wait for the main thread to be initialized
     states->mutex.lock();
 
-    while (!(states->initialized | states->terminated))
+    while (!(states->initialized || states->terminated))
     {
         states->mutex.unlock();
         sf::sleep(sf::milliseconds(20));

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -606,8 +606,7 @@ void Ftp::DataChannel::receive(std::ostream& stream)
 void Ftp::DataChannel::send(std::istream& stream)
 {
     // Send data
-    char        buffer[1024];
-    std::size_t count = 0;
+    char buffer[1024];
 
     for (;;)
     {
@@ -620,7 +619,7 @@ void Ftp::DataChannel::send(std::istream& stream)
             break;
         }
 
-        count = static_cast<std::size_t>(stream.gcount());
+        const auto count = static_cast<std::size_t>(stream.gcount());
 
         if (count > 0)
         {

--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -88,7 +88,7 @@ SocketSelector& SocketSelector::operator=(SocketSelector&&) noexcept = default;
 
 
 ////////////////////////////////////////////////////////////
-void SocketSelector::add(Socket& socket)
+void SocketSelector::add(const Socket& socket)
 {
     const SocketHandle handle = socket.getNativeHandle();
     if (handle != priv::SocketImpl::invalidSocket())
@@ -130,7 +130,7 @@ void SocketSelector::add(Socket& socket)
 
 
 ////////////////////////////////////////////////////////////
-void SocketSelector::remove(Socket& socket)
+void SocketSelector::remove(const Socket& socket)
 {
     const SocketHandle handle = socket.getNativeHandle();
     if (handle != priv::SocketImpl::invalidSocket())
@@ -187,7 +187,7 @@ bool SocketSelector::wait(Time timeout)
 
 
 ////////////////////////////////////////////////////////////
-bool SocketSelector::isReady(Socket& socket) const
+bool SocketSelector::isReady(const Socket& socket) const
 {
     const SocketHandle handle = socket.getNativeHandle();
     if (handle != priv::SocketImpl::invalidSocket())

--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -445,13 +445,13 @@ void checkInit()
         deviceString = nullptr;
 
     // Use environment variable "SFML_DRM_MODE" (or nullptr if not set)
-    char* modeString = std::getenv("SFML_DRM_MODE");
+    const char* modeString = std::getenv("SFML_DRM_MODE");
 
     // Use environment variable "SFML_DRM_REFRESH" (or 0 if not set)
     // Use in combination with mode to request specific refresh rate for the mode
     // if multiple refresh rates for same mode might be supported
     unsigned int refreshRate   = 0;
-    char*        refreshString = std::getenv("SFML_DRM_REFRESH");
+    const char*  refreshString = std::getenv("SFML_DRM_REFRESH");
 
     if (refreshString)
         refreshRate = static_cast<unsigned int>(atoi(refreshString));
@@ -513,15 +513,13 @@ EGLDisplay getInitializedDisplay()
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-DRMContext::DRMContext(DRMContext* shared)
+DRMContext::DRMContext(DRMContext* shared) :
+// Get the initialized EGL display
+m_display(getInitializedDisplay()),
+// Get the best EGL config matching the default video settings
+m_config(getBestConfig(m_display, VideoMode::getDesktopMode().bitsPerPixel, ContextSettings{}))
 {
     contextCount++;
-
-    // Get the initialized EGL display
-    m_display = getInitializedDisplay();
-
-    // Get the best EGL config matching the default video settings
-    m_config = getBestConfig(m_display, VideoMode::getDesktopMode().bitsPerPixel, ContextSettings{});
     updateSettings();
 
     // Create EGL context
@@ -535,15 +533,13 @@ DRMContext::DRMContext(DRMContext* shared)
 
 
 ////////////////////////////////////////////////////////////
-DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, const WindowImpl& owner, unsigned int bitsPerPixel)
+DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, const WindowImpl& owner, unsigned int bitsPerPixel) :
+// Get the initialized EGL display
+m_display(getInitializedDisplay()),
+// Get the best EGL config matching the requested video settings
+m_config(getBestConfig(m_display, bitsPerPixel, settings))
 {
     contextCount++;
-
-    // Get the initialized EGL display
-    m_display = getInitializedDisplay();
-
-    // Get the best EGL config matching the requested video settings
-    m_config = getBestConfig(m_display, bitsPerPixel, settings);
     updateSettings();
 
     // Create EGL context
@@ -555,15 +551,13 @@ DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, cons
 
 
 ////////////////////////////////////////////////////////////
-DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, Vector2u size)
+DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, Vector2u size) :
+// Get the initialized EGL display
+m_display(getInitializedDisplay()),
+// Get the best EGL config matching the requested video settings
+m_config(getBestConfig(m_display, VideoMode::getDesktopMode().bitsPerPixel, settings))
 {
     contextCount++;
-
-    // Get the initialized EGL display
-    m_display = getInitializedDisplay();
-
-    // Get the best EGL config matching the requested video settings
-    m_config = getBestConfig(m_display, VideoMode::getDesktopMode().bitsPerPixel, settings);
     updateSettings();
 
     // Create EGL context

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -67,7 +67,7 @@ EGLDisplay getInitializedDisplay()
 
     return states.display;
 
-#endif
+#else
 
     static EGLDisplay display = EGL_NO_DISPLAY;
 
@@ -78,6 +78,8 @@ EGLDisplay getInitializedDisplay()
     }
 
     return display;
+
+#endif
 }
 
 

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -74,21 +74,18 @@ void ClipboardImpl::processEvents()
 
 
 ////////////////////////////////////////////////////////////
-ClipboardImpl::ClipboardImpl()
+ClipboardImpl::ClipboardImpl() :
+// Open a connection with the X server
+m_display(openDisplay()),
+// Create a hidden window that will broker our clipboard interactions with X
+m_window(XCreateSimpleWindow(m_display.get(), DefaultRootWindow(m_display.get()), 0, 0, 1, 1, 0, 0, 0)),
+// Get the atoms we need to make use of the clipboard
+m_clipboard(getAtom("CLIPBOARD", false)),
+m_targets(getAtom("TARGETS", false)),
+m_text(getAtom("TEXT", false)),
+m_utf8String(getAtom("UTF8_STRING", true)),
+m_targetProperty(getAtom("SFML_CLIPBOARD_TARGET_PROPERTY", false))
 {
-    // Open a connection with the X server
-    m_display = openDisplay();
-
-    // Get the atoms we need to make use of the clipboard
-    m_clipboard      = getAtom("CLIPBOARD", false);
-    m_targets        = getAtom("TARGETS", false);
-    m_text           = getAtom("TEXT", false);
-    m_utf8String     = getAtom("UTF8_STRING", true);
-    m_targetProperty = getAtom("SFML_CLIPBOARD_TARGET_PROPERTY", false);
-
-    // Create a hidden window that will broker our clipboard interactions with X
-    m_window = XCreateSimpleWindow(m_display.get(), DefaultRootWindow(m_display.get()), 0, 0, 1, 1, 0, 0, 0);
-
     // Register the events we are interested in
     XSelectInput(m_display.get(), m_window, SelectionNotify | SelectionClear | SelectionRequest);
 }

--- a/src/SFML/Window/Unix/ClipboardImpl.hpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.hpp
@@ -135,8 +135,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    ::Window                   m_window{};          ///< X identifier defining our window
     std::shared_ptr<::Display> m_display;           ///< Pointer to the display
+    ::Window                   m_window;            ///< X identifier defining our window
     Atom                       m_clipboard;         ///< X Atom identifying the CLIPBOARD selection
     Atom                       m_targets;           ///< X Atom identifying TARGETS
     Atom                       m_text;              ///< X Atom identifying TEXT

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -343,7 +343,7 @@ bool getEWMHFrameExtents(::Display* disp, ::Window win, long& xFrameExtent, long
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
-        long* extents = reinterpret_cast<long*>(data);
+        const long* extents = reinterpret_cast<long*>(data);
 #pragma GCC diagnostic pop
 
         xFrameExtent = extents[0]; // Left.
@@ -1178,7 +1178,7 @@ void WindowImplX11::requestFocus()
 
     {
         const std::lock_guard lock(allWindowsMutex);
-        for (sf::priv::WindowImplX11* windowPtr : allWindows)
+        for (const sf::priv::WindowImplX11* windowPtr : allWindows)
         {
             if (windowPtr->hasFocus())
             {
@@ -1693,6 +1693,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 XSetICFocus(m_inputContext);
 
             // Grab cursor
+            // TODO: ???
             if (m_cursorGrabbed)
             {
                 // Try multiple times to grab the cursor
@@ -1718,6 +1719,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                     sf::sleep(sf::milliseconds(50));
                 }
 
+                // TODO: ???
                 if (!m_cursorGrabbed)
                     err() << "Failed to grab mouse cursor" << std::endl;
             }

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -1127,7 +1127,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             if ((wParam == DBT_DEVICEARRIVAL) || (wParam == DBT_DEVICEREMOVECOMPLETE))
             {
                 // Some sort of device change has happened, update joystick connections if it is a device interface
-                auto* deviceBroadcastHeader = reinterpret_cast<DEV_BROADCAST_HDR*>(lParam);
+                const auto* deviceBroadcastHeader = reinterpret_cast<DEV_BROADCAST_HDR*>(lParam);
 
                 if (deviceBroadcastHeader && (deviceBroadcastHeader->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE))
                     JoystickImpl::updateConnections();

--- a/test/Network/SocketSelector.test.cpp
+++ b/test/Network/SocketSelector.test.cpp
@@ -17,7 +17,7 @@ TEST_CASE("[Network] sf::SocketSelector")
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::SocketSelector>);
     }
 
-    sf::UdpSocket socket;
+    const sf::UdpSocket socket;
 
     SECTION("Construction")
     {


### PR DESCRIPTION
not applied:
- all "Cppcheck does not need standard library headers to get proper results."
  - bogus
  - no side effects
- all "Consider using an algorithm instead of a raw loop"
  - not always better, also compile-time overhead
- include/SFML/Window/Event.inl:57: warning: (error) Found an exit path from function with non-void return type that has missing return statement
  - protected by static_assert
- include/SFML/Graphics/Rect.inl:35: warning: (style) Function 'Rect < float >' argument 1 names different: declaration 'position' definition 'thePosition'.
  - stylistical
- src/SFML/Graphics/Shader.cpp:334: warning: (error) Reference to local variable returned.
  - bogus
- src/SFML/Graphics/Shader.cpp:322: warning: (style) 'operator=' should return reference to 'this' instance.
  - bogus
- src/SFML/Graphics/Texture.cpp:219: warning: (error) Reference to local variable returned.
  - bogus
- src/SFML/Graphics/Texture.cpp:205: warning: (style) 'operator=' should return reference to 'this' instance.
  - bogus
- src/SFML/System/Vector2.cpp:48: warning: (performance) Function parameter 'rhs' should be passed by const reference.
  - by value is fine for vec2
- src/SFML/System/Vector2.cpp:86: warning: (performance) Function parameter 'axis' should be passed by const reference.
  - by value is fine for vec2
  - 
---

applied:
- examples/X11/X11.cpp:24: warning: (style) Parameter 'window' can be declared as reference to const
- examples/X11/X11.cpp:76: warning: (style) Parameter 'window' can be declared as reference to const
- include/SFML/System/Utf.inl:133: warning: (style) Condition 'input<=0x0010FFFF' is always true
- examples/sound_effects/SoundEffects.cpp:735: warning: (style) struct member 'Coefficients::c0' is never used.
- examples/sound_effects/SoundEffects.cpp:736: warning: (style) struct member 'Coefficients::d0' is never used.
- src/SFML/Audio/SoundBuffer.cpp:83: warning: (performance) Variable 'm_samples' is assigned in constructor body. Consider performing initialization in initialization list.
- src/SFML/Audio/SoundBuffer.cpp:84: warning: (performance) Variable 'm_duration' is assigned in constructor body. Consider performing initialization in initialization list.
- src/SFML/Audio/SoundRecorder.cpp:424: warning: (style) Condition 'channelCount==2' is always true
- src/SFML/Network/SocketSelector.cpp:91: warning: (style) Parameter 'socket' can be declared as reference to const
- src/SFML/Network/SocketSelector.cpp:133: warning: (style) Parameter 'socket' can be declared as reference to const
- src/SFML/Network/SocketSelector.cpp:190: warning: (style) Parameter 'socket' can be declared as reference to const
- src/SFML/Network/Ftp.cpp:610: warning: (style) The scope of the variable 'count' can be reduced.
- src/SFML/Network/Ftp.cpp:610: warning: (style) Variable 'count' is assigned a value that is never used.
- src/SFML/Main/MainAndroid.cpp:308: warning: (style) Boolean expression 'states.updated' is used in bitwise operation. Did you mean '||'?
- src/SFML/Main/MainAndroid.cpp:330: warning: (style) Boolean expression 'states.updated' is used in bitwise operation. Did you mean '||'?
- src/SFML/Main/MainAndroid.cpp:515: warning: (style) Boolean expression 'states->initialized' is used in bitwise operation. Did you mean '||'?
- src/SFML/Window/DRM/DRMContext.cpp:521: warning: (performance) Variable 'm_display' is assigned in constructor body. Consider performing initialization in initialization list.
- src/SFML/Window/DRM/DRMContext.cpp:543: warning: (performance) Variable 'm_display' is assigned in constructor body. Consider performing initialization in initialization list.
- src/SFML/Window/DRM/DRMContext.cpp:563: warning: (performance) Variable 'm_display' is assigned in constructor body. Consider performing initialization in initialization list.
- src/SFML/Window/DRM/DRMContext.cpp:448: warning: (style) Variable 'modeString' can be declared as pointer to const
- src/SFML/Window/DRM/DRMContext.cpp:454: warning: (style) Variable 'refreshString' can be declared as pointer to const
- src/SFML/Graphics/Image.cpp:426: warning: (style) Variable 'end' can be declared as pointer to const
- src/SFML/Window/Unix/ClipboardImpl.cpp:146: warning: (style) Condition '!m_requestResponded' is always true
- src/SFML/Window/Unix/ClipboardImpl.cpp:150: warning: (style) Condition '!m_requestResponded' is always true
- src/SFML/Window/Unix/ClipboardImpl.cpp:80: warning: (performance) Variable 'm_display' is assigned in constructor body. Consider performing initialization in initialization list.
- src/SFML/Window/Win32/WindowImplWin32.cpp:1130: warning: (style) Variable 'deviceBroadcastHeader' can be declared as pointer to const
- src/SFML/Window/Unix/WindowImplX11.cpp:346: warning: (style) Variable 'extents' can be declared as pointer to const
- src/SFML/Window/Unix/WindowImplX11.cpp:1181: warning: (style) Variable 'windowPtr' can be declared as pointer to const
- src/SFML/Window/EglContext.cpp:72: warning: (style) Statements following 'return' will never be executed.
- src/SFML/Window/Android/WindowImplAndroid.cpp:502: warning: (style) Function 'processPointerEvent' argument 2 names different: declaration 'event' definition 'inputEvent'.
- 
---

to review:
- src/SFML/Window/Unix/WindowImplX11.cpp:1721: warning: (style) Condition '!m_cursorGrabbed' is always false

---

There's a few more outstanding ones but I don't want to make the PR too big