### PR TITLE
Run format before any other build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ defaults:
 jobs:
   build:
     name: ${{ matrix.platform.name }} ${{ matrix.config.name }} ${{ matrix.type.name }}
+    needs: format
     runs-on: ${{ matrix.platform.os }}
 
     env:
@@ -338,6 +339,7 @@ jobs:
 
   tidy:
     name: Analyzing on ${{ matrix.platform.name }}
+    needs: format
     runs-on: ${{ matrix.platform.os }}
 
     strategy:
@@ -386,6 +388,7 @@ jobs:
 
   sanitize:
     name: Sanitizing on ${{ matrix.platform.name }}
+    needs: format
     runs-on: ${{ matrix.platform.os }}
 
     strategy:
@@ -432,6 +435,7 @@ jobs:
 
   docs:
     name: Documentation
+    needs: format
     runs-on: macos-14
 
     steps:


### PR DESCRIPTION
# Description

Checking formatting takes a really short time compared to all of the other jobs. It would make sense to run that first before proceeding with builds.

# How to test

Check the resulting job graph, for example [this one](https://github.com/SFML/SFML/actions/runs/11196163182?pr=3273).