### PR TITLE
Remove unnecessary friend declarations

### DIFF
--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -110,10 +110,6 @@ public:
     static const Time Zero; //!< Predefined "zero" time value
 
 private:
-    friend constexpr Time seconds(float);
-    friend constexpr Time milliseconds(std::int32_t);
-    friend constexpr Time microseconds(std::int64_t);
-
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
These functions do not access any private internals they do not need to be `friend`ed