### PR TITLE
Use more correct iterator comparison operator

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -168,7 +168,7 @@ template <typename In>
 std::size_t Utf<8>::count(In begin, In end)
 {
     std::size_t length = 0;
-    while (begin < end)
+    while (begin != end)
     {
         begin = next(begin, end);
         ++length;
@@ -182,7 +182,7 @@ std::size_t Utf<8>::count(In begin, In end)
 template <typename In, typename Out>
 Out Utf<8>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
-    while (begin < end)
+    while (begin != end)
     {
         const std::uint32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
         output                        = encode(codepoint, output);
@@ -196,7 +196,7 @@ Out Utf<8>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 template <typename In, typename Out>
 Out Utf<8>::fromWide(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = Utf<32>::decodeWide(*begin++);
         output                  = encode(codepoint, output);
@@ -212,7 +212,7 @@ Out Utf<8>::fromLatin1(In begin, In end, Out output)
 {
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
-    while (begin < end)
+    while (begin != end)
         output = encode(*begin++, output);
 
     return output;
@@ -223,7 +223,7 @@ Out Utf<8>::fromLatin1(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<8>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -238,7 +238,7 @@ Out Utf<8>::toAnsi(In begin, In end, Out output, char replacement, const std::lo
 template <typename In, typename Out>
 Out Utf<8>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -255,7 +255,7 @@ Out Utf<8>::toLatin1(In begin, In end, Out output, char replacement)
 {
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -278,7 +278,7 @@ Out Utf<8>::toUtf8(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<8>::toUtf16(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -293,7 +293,7 @@ Out Utf<8>::toUtf16(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<8>::toUtf32(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -313,7 +313,7 @@ In Utf<16>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replac
     // If it's a surrogate pair, first convert to a single UTF-32 character
     if ((first >= 0xD800) && (first <= 0xDBFF))
     {
-        if (begin < end)
+        if (begin != end)
         {
             const std::uint32_t second = *begin++;
             if ((second >= 0xDC00) && (second <= 0xDFFF))
@@ -395,7 +395,7 @@ template <typename In>
 std::size_t Utf<16>::count(In begin, In end)
 {
     std::size_t length = 0;
-    while (begin < end)
+    while (begin != end)
     {
         begin = next(begin, end);
         ++length;
@@ -409,7 +409,7 @@ std::size_t Utf<16>::count(In begin, In end)
 template <typename In, typename Out>
 Out Utf<16>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
         output                  = encode(codepoint, output);
@@ -423,7 +423,7 @@ Out Utf<16>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 template <typename In, typename Out>
 Out Utf<16>::fromWide(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = Utf<32>::decodeWide(*begin++);
         output                  = encode(codepoint, output);
@@ -447,7 +447,7 @@ Out Utf<16>::fromLatin1(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<16>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -462,7 +462,7 @@ Out Utf<16>::toAnsi(In begin, In end, Out output, char replacement, const std::l
 template <typename In, typename Out>
 Out Utf<16>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -479,7 +479,7 @@ Out Utf<16>::toLatin1(In begin, In end, Out output, char replacement)
 {
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
-    while (begin < end)
+    while (begin != end)
     {
         *output++ = *begin < 256 ? static_cast<char>(*begin) : replacement;
         ++begin;
@@ -493,7 +493,7 @@ Out Utf<16>::toLatin1(In begin, In end, Out output, char replacement)
 template <typename In, typename Out>
 Out Utf<16>::toUtf8(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -516,7 +516,7 @@ Out Utf<16>::toUtf16(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<16>::toUtf32(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
     {
         std::uint32_t codepoint = 0;
         begin                   = decode(begin, end, codepoint);
@@ -565,7 +565,7 @@ std::size_t Utf<32>::count(In begin, In end)
 template <typename In, typename Out>
 Out Utf<32>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
-    while (begin < end)
+    while (begin != end)
         *output++ = decodeAnsi(*begin++, locale);
 
     return output;
@@ -576,7 +576,7 @@ Out Utf<32>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 template <typename In, typename Out>
 Out Utf<32>::fromWide(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
         *output++ = decodeWide(*begin++);
 
     return output;
@@ -597,7 +597,7 @@ Out Utf<32>::fromLatin1(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<32>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
 {
-    while (begin < end)
+    while (begin != end)
         output = encodeAnsi(*begin++, output, replacement, locale);
 
     return output;
@@ -608,7 +608,7 @@ Out Utf<32>::toAnsi(In begin, In end, Out output, char replacement, const std::l
 template <typename In, typename Out>
 Out Utf<32>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
-    while (begin < end)
+    while (begin != end)
         output = encodeWide(*begin++, output, replacement);
 
     return output;
@@ -621,7 +621,7 @@ Out Utf<32>::toLatin1(In begin, In end, Out output, char replacement)
 {
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
-    while (begin < end)
+    while (begin != end)
     {
         *output++ = *begin < 256 ? static_cast<char>(*begin) : replacement;
         ++begin;
@@ -635,7 +635,7 @@ Out Utf<32>::toLatin1(In begin, In end, Out output, char replacement)
 template <typename In, typename Out>
 Out Utf<32>::toUtf8(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
         output = Utf<8>::encode(*begin++, output);
 
     return output;
@@ -645,7 +645,7 @@ Out Utf<32>::toUtf8(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<32>::toUtf16(In begin, In end, Out output)
 {
-    while (begin < end)
+    while (begin != end)
         output = Utf<16>::encode(*begin++, output);
 
     return output;

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -146,7 +146,7 @@ void Image::resize(Vector2u size, Color color)
         // Fill it with the specified color
         std::uint8_t* ptr = newPixels.data();
         std::uint8_t* end = ptr + newPixels.size();
-        while (ptr < end)
+        while (ptr != end)
         {
             *ptr++ = color.r;
             *ptr++ = color.g;
@@ -424,7 +424,7 @@ void Image::createMaskFromColor(Color color, std::uint8_t alpha)
         // Replace the alpha of the pixels that match the transparent color
         std::uint8_t* ptr = m_pixels.data();
         std::uint8_t* end = ptr + m_pixels.size();
-        while (ptr < end)
+        while (ptr != end)
         {
             if ((ptr[0] == color.r) && (ptr[1] == color.g) && (ptr[2] == color.b) && (ptr[3] == color.a))
                 ptr[3] = alpha;


### PR DESCRIPTION
Switching the iterator comparison operator used lowers the requirement for iterators from *RandomAccessIterators* 
to *ForwardIterators*, which is a benefit. It is also more accurate; instead of saying "if `begin` is less than the end, stop." it states "if `begin` is not equal to end, stop."

Additionally, the old '<' did not protect us from undefined behavior because it is undefined to compare two iterators relationally that are not:

1. past the end
2. within the array
