### PR TITLE
Remove unneeded namespace prefix for functions in implementation files

### DIFF
--- a/src/SFML/Window/Joystick.cpp
+++ b/src/SFML/Window/Joystick.cpp
@@ -31,31 +31,31 @@
 #include <cassert>
 
 
-namespace sf
+namespace sf::Joystick
 {
 ////////////////////////////////////////////////////////////
-bool Joystick::isConnected(unsigned int joystick)
+bool isConnected(unsigned int joystick)
 {
     return priv::JoystickManager::getInstance().getState(joystick).connected;
 }
 
 
 ////////////////////////////////////////////////////////////
-unsigned int Joystick::getButtonCount(unsigned int joystick)
+unsigned int getButtonCount(unsigned int joystick)
 {
     return priv::JoystickManager::getInstance().getCapabilities(joystick).buttonCount;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Joystick::hasAxis(unsigned int joystick, Axis axis)
+bool hasAxis(unsigned int joystick, Axis axis)
 {
     return priv::JoystickManager::getInstance().getCapabilities(joystick).axes[axis];
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Joystick::isButtonPressed(unsigned int joystick, unsigned int button)
+bool isButtonPressed(unsigned int joystick, unsigned int button)
 {
     assert(button < Joystick::ButtonCount && "Button must be less than Joystick::ButtonCount");
     return priv::JoystickManager::getInstance().getState(joystick).buttons[button];
@@ -63,23 +63,23 @@ bool Joystick::isButtonPressed(unsigned int joystick, unsigned int button)
 
 
 ////////////////////////////////////////////////////////////
-float Joystick::getAxisPosition(unsigned int joystick, Axis axis)
+float getAxisPosition(unsigned int joystick, Axis axis)
 {
     return priv::JoystickManager::getInstance().getState(joystick).axes[axis];
 }
 
 
 ////////////////////////////////////////////////////////////
-Joystick::Identification Joystick::getIdentification(unsigned int joystick)
+Identification getIdentification(unsigned int joystick)
 {
     return priv::JoystickManager::getInstance().getIdentification(joystick);
 }
 
 
 ////////////////////////////////////////////////////////////
-void Joystick::update()
+void update()
 {
     priv::JoystickManager::getInstance().update();
 }
 
-} // namespace sf
+} // namespace sf::Joystick

--- a/src/SFML/Window/Keyboard.cpp
+++ b/src/SFML/Window/Keyboard.cpp
@@ -31,42 +31,42 @@
 #include <SFML/System/String.hpp>
 
 
-namespace sf
+namespace sf::Keyboard
 {
 ////////////////////////////////////////////////////////////
-bool Keyboard::isKeyPressed(Key key)
+bool isKeyPressed(Key key)
 {
     return priv::InputImpl::isKeyPressed(key);
 }
 
 ////////////////////////////////////////////////////////////
-bool Keyboard::isKeyPressed(Scancode code)
+bool isKeyPressed(Scancode code)
 {
     return priv::InputImpl::isKeyPressed(code);
 }
 
 ////////////////////////////////////////////////////////////
-Keyboard::Key Keyboard::localize(Scancode code)
+Key localize(Scancode code)
 {
     return priv::InputImpl::localize(code);
 }
 
 ////////////////////////////////////////////////////////////
-Keyboard::Scancode Keyboard::delocalize(Key key)
+Scancode delocalize(Key key)
 {
     return priv::InputImpl::delocalize(key);
 }
 
 ////////////////////////////////////////////////////////////
-String Keyboard::getDescription(Scancode code)
+String getDescription(Scancode code)
 {
     return priv::InputImpl::getDescription(code);
 }
 
 ////////////////////////////////////////////////////////////
-void Keyboard::setVirtualKeyboardVisible(bool visible)
+void setVirtualKeyboardVisible(bool visible)
 {
     priv::InputImpl::setVirtualKeyboardVisible(visible);
 }
 
-} // namespace sf
+} // namespace sf::Keyboard

--- a/src/SFML/Window/Mouse.cpp
+++ b/src/SFML/Window/Mouse.cpp
@@ -29,40 +29,40 @@
 #include <SFML/Window/Mouse.hpp>
 
 
-namespace sf
+namespace sf::Mouse
 {
 ////////////////////////////////////////////////////////////
-bool Mouse::isButtonPressed(Button button)
+bool isButtonPressed(Button button)
 {
     return priv::InputImpl::isMouseButtonPressed(button);
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2i Mouse::getPosition()
+Vector2i getPosition()
 {
     return priv::InputImpl::getMousePosition();
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2i Mouse::getPosition(const WindowBase& relativeTo)
+Vector2i getPosition(const WindowBase& relativeTo)
 {
     return priv::InputImpl::getMousePosition(relativeTo);
 }
 
 
 ////////////////////////////////////////////////////////////
-void Mouse::setPosition(Vector2i position)
+void setPosition(Vector2i position)
 {
     priv::InputImpl::setMousePosition(position);
 }
 
 
 ////////////////////////////////////////////////////////////
-void Mouse::setPosition(Vector2i position, const WindowBase& relativeTo)
+void setPosition(Vector2i position, const WindowBase& relativeTo)
 {
     priv::InputImpl::setMousePosition(position, relativeTo);
 }
 
-} // namespace sf
+} // namespace sf::Mouse

--- a/src/SFML/Window/Sensor.cpp
+++ b/src/SFML/Window/Sensor.cpp
@@ -29,25 +29,25 @@
 #include <SFML/Window/SensorManager.hpp>
 
 
-namespace sf
+namespace sf::Sensor
 {
 
 ////////////////////////////////////////////////////////////
-bool Sensor::isAvailable(Type sensor)
+bool isAvailable(Type sensor)
 {
     return priv::SensorManager::getInstance().isAvailable(sensor);
 }
 
 ////////////////////////////////////////////////////////////
-void Sensor::setEnabled(Type sensor, bool enabled)
+void setEnabled(Type sensor, bool enabled)
 {
     priv::SensorManager::getInstance().setEnabled(sensor, enabled);
 }
 
 ////////////////////////////////////////////////////////////
-Vector3f Sensor::getValue(Type sensor)
+Vector3f getValue(Type sensor)
 {
     return priv::SensorManager::getInstance().getValue(sensor);
 }
 
-} // namespace sf
+} // namespace sf::Sensor

--- a/src/SFML/Window/Touch.cpp
+++ b/src/SFML/Window/Touch.cpp
@@ -29,26 +29,26 @@
 #include <SFML/Window/Touch.hpp>
 
 
-namespace sf
+namespace sf::Touch
 {
 ////////////////////////////////////////////////////////////
-bool Touch::isDown(unsigned int finger)
+bool isDown(unsigned int finger)
 {
     return priv::InputImpl::isTouchDown(finger);
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2i Touch::getPosition(unsigned int finger)
+Vector2i getPosition(unsigned int finger)
 {
     return priv::InputImpl::getTouchPosition(finger);
 }
 
 
 ////////////////////////////////////////////////////////////
-Vector2i Touch::getPosition(unsigned int finger, const WindowBase& relativeTo)
+Vector2i getPosition(unsigned int finger, const WindowBase& relativeTo)
 {
     return priv::InputImpl::getTouchPosition(finger, relativeTo);
 }
 
-} // namespace sf
+} // namespace sf::Touch

--- a/src/SFML/Window/Vulkan.cpp
+++ b/src/SFML/Window/Vulkan.cpp
@@ -53,10 +53,10 @@
 #endif
 
 
-namespace sf
+namespace sf::Vulkan
 {
 ////////////////////////////////////////////////////////////
-bool Vulkan::isAvailable([[maybe_unused]] bool requireGraphics)
+bool isAvailable([[maybe_unused]] bool requireGraphics)
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
@@ -71,7 +71,7 @@ bool Vulkan::isAvailable([[maybe_unused]] bool requireGraphics)
 
 
 ////////////////////////////////////////////////////////////
-VulkanFunctionPointer Vulkan::getFunction([[maybe_unused]] const char* name)
+VulkanFunctionPointer getFunction([[maybe_unused]] const char* name)
 {
     assert(name && "Name cannot be a null pointer");
 
@@ -88,7 +88,7 @@ VulkanFunctionPointer Vulkan::getFunction([[maybe_unused]] const char* name)
 
 
 ////////////////////////////////////////////////////////////
-const std::vector<const char*>& Vulkan::getGraphicsRequiredInstanceExtensions()
+const std::vector<const char*>& getGraphicsRequiredInstanceExtensions()
 {
 #if defined(SFML_VULKAN_IMPLEMENTATION_NOT_AVAILABLE)
 
@@ -103,4 +103,4 @@ const std::vector<const char*>& Vulkan::getGraphicsRequiredInstanceExtensions()
 #endif
 }
 
-} // namespace sf
+} // namespace sf::Vulkan


### PR DESCRIPTION
I used nested namespaces from C++17 instead, of having to specify the namespace 
for the function implementation.