### PR TITLE
Make true and false keywords lowercase and monospaced in docs

### DIFF
--- a/src/SFML/Audio/AudioDevice.hpp
+++ b/src/SFML/Audio/AudioDevice.hpp
@@ -82,7 +82,7 @@ public:
     /// and device using the currently selected device name as
     /// returned by sf::PlaybackDevice::getDevice.
     ///
-    /// \return True if reinitialization was successful, false otherwise
+    /// \return `true` if reinitialization was successful, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool reinitialize();
@@ -121,7 +121,7 @@ public:
     ///
     /// \param name The name of the audio playback device
     ///
-    /// \return True, if it was able to set the requested device
+    /// \return `true`, if it was able to set the requested device
     ///
     /// \see getAvailableDevices, getDefaultDevice
     ///
@@ -336,7 +336,7 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Initialize the audio device and engine
     ///
-    /// \return True if initialization was successful, false if it failed
+    /// \return `true` if initialization was successful, `false` if it failed
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool initialize();

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -180,7 +180,7 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
     ////////////////////////////////////////////////////////////
     static constexpr ma_data_source_vtable vtable{read, seek, getFormat, getCursor, getLength, setLooping, 0};
     std::size_t                            cursor{};  //!< The current playing position
-    bool                                   looping{}; //!< True if we are looping the sound
+    bool                                   looping{}; //!< `true` if we are looping the sound
     const SoundBuffer*                     buffer{};  //!< Sound buffer bound to the source
 };
 

--- a/src/SFML/Audio/SoundFileReaderFlac.hpp
+++ b/src/SFML/Audio/SoundFileReaderFlac.hpp
@@ -56,7 +56,7 @@ public:
     ///
     /// \param stream Source stream to check
     ///
-    /// \return True if the file is supported by this reader
+    /// \return `true` if the file is supported by this reader
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(InputStream& stream);

--- a/src/SFML/Audio/SoundFileReaderMp3.hpp
+++ b/src/SFML/Audio/SoundFileReaderMp3.hpp
@@ -67,7 +67,7 @@ public:
     ///
     /// \param stream Source stream to check
     ///
-    /// \return True if the file is supported by this reader
+    /// \return `true` if the file is supported by this reader
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(InputStream& stream);

--- a/src/SFML/Audio/SoundFileReaderOgg.hpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.hpp
@@ -55,7 +55,7 @@ public:
     ///
     /// \param stream Source stream to check
     ///
-    /// \return True if the file is supported by this reader
+    /// \return `true` if the file is supported by this reader
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(InputStream& stream);

--- a/src/SFML/Audio/SoundFileReaderWav.hpp
+++ b/src/SFML/Audio/SoundFileReaderWav.hpp
@@ -55,7 +55,7 @@ public:
     ///
     /// \param stream Source stream to check
     ///
-    /// \return True if the file is supported by this reader
+    /// \return `true` if the file is supported by this reader
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(InputStream& stream);

--- a/src/SFML/Audio/SoundFileWriterFlac.hpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.hpp
@@ -51,7 +51,7 @@ public:
     ///
     /// \param filename Path of the sound file to check
     ///
-    /// \return True if the file can be written by this writer
+    /// \return `true` if the file can be written by this writer
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(const std::filesystem::path& filename);
@@ -64,7 +64,7 @@ public:
     /// \param channelCount Number of channels of the sound
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \return True if the file was successfully opened
+    /// \return `true` if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(const std::filesystem::path&     filename,

--- a/src/SFML/Audio/SoundFileWriterOgg.hpp
+++ b/src/SFML/Audio/SoundFileWriterOgg.hpp
@@ -52,7 +52,7 @@ public:
     ///
     /// \param filename Path of the sound file to check
     ///
-    /// \return True if the file can be written by this writer
+    /// \return `true` if the file can be written by this writer
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(const std::filesystem::path& filename);
@@ -71,7 +71,7 @@ public:
     /// \param channelCount Number of channels of the sound
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \return True if the file was successfully opened
+    /// \return `true` if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(const std::filesystem::path&     filename,

--- a/src/SFML/Audio/SoundFileWriterWav.hpp
+++ b/src/SFML/Audio/SoundFileWriterWav.hpp
@@ -50,7 +50,7 @@ public:
     ///
     /// \param filename Path of the sound file to check
     ///
-    /// \return True if the file can be written by this writer
+    /// \return `true` if the file can be written by this writer
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static bool check(const std::filesystem::path& filename);
@@ -69,7 +69,7 @@ public:
     /// \param channelCount Number of channels of the sound
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \return True if the file was successfully opened
+    /// \return `true` if the file was successfully opened
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(const std::filesystem::path&     filename,

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -218,8 +218,8 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
     unsigned int              channelCount{};            //!< Number of channels (1 = mono, 2 = stereo, ...)
     unsigned int              sampleRate{};              //!< Frequency (samples / second)
     std::vector<SoundChannel> channelMap;                //!< The map of position in sample frame to sound channel
-    bool                      loop{};                    //!< Loop flag (true to loop, false to play once)
-    bool                      streaming{true};           //!< True if we are still streaming samples from the source
+    bool                      loop{};                    //!< Loop flag (`true` to loop, `false` to play once)
+    bool                      streaming{true};           //!< `true` if we are still streaming samples from the source
 };
 
 

--- a/src/SFML/Graphics/RenderTextureImpl.hpp
+++ b/src/SFML/Graphics/RenderTextureImpl.hpp
@@ -75,7 +75,7 @@ public:
     /// \param textureId  OpenGL identifier of the target texture
     /// \param settings   Context settings to create render-texture with
     ///
-    /// \return True if creation has been successful
+    /// \return `true` if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
     virtual bool create(Vector2u size, unsigned int textureId, const ContextSettings& settings) = 0;
@@ -83,9 +83,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering
     ///
-    /// \param active True to activate, false to deactivate
+    /// \param active `true` to activate, `false` to deactivate
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     virtual bool activate(bool active) = 0;
@@ -96,7 +96,7 @@ public:
     /// You can request sRGB encoding for a render-texture
     /// by having the sRgbCapable flag set for the context parameter of create() method
     ///
-    /// \return True if the render-texture use sRGB encoding, false otherwise
+    /// \return `true` if the render-texture use sRGB encoding, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] virtual bool isSrgb() const = 0;

--- a/src/SFML/Graphics/RenderTextureImplDefault.hpp
+++ b/src/SFML/Graphics/RenderTextureImplDefault.hpp
@@ -79,7 +79,7 @@ private:
     /// \param textureId  OpenGL identifier of the target texture
     /// \param settings   Context settings to create render-texture with
     ///
-    /// \return True if creation has been successful
+    /// \return `true` if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
     bool create(Vector2u size, unsigned int textureId, const ContextSettings& settings) override;
@@ -87,9 +87,9 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering
     ///
-    /// \param active True to activate, false to deactivate
+    /// \param active `true` to activate, `false` to deactivate
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     bool activate(bool active) override;
@@ -100,7 +100,7 @@ private:
     /// You can request sRGB encoding for a render-texture
     /// by having the sRgbCapable flag set for the context parameter of create() method
     ///
-    /// \return True if the render-texture use sRGB encoding, false otherwise
+    /// \return `true` if the render-texture use sRGB encoding, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool isSrgb() const override;

--- a/src/SFML/Graphics/RenderTextureImplFBO.hpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.hpp
@@ -69,7 +69,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the system supports FBOs or not
     ///
-    /// \return True if FBO render textures are supported
+    /// \return `true` if FBO render textures are supported
     ///
     ////////////////////////////////////////////////////////////
     static bool isAvailable();
@@ -96,7 +96,7 @@ private:
     /// \param textureId  OpenGL identifier of the target texture
     /// \param settings   Context settings to create render-texture with
     ///
-    /// \return True if creation has been successful
+    /// \return `true` if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
     bool create(Vector2u size, unsigned int textureId, const ContextSettings& settings) override;
@@ -104,7 +104,7 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Create an FBO in the current context
     ///
-    /// \return True if creation has been successful
+    /// \return `true` if creation has been successful
     ///
     ////////////////////////////////////////////////////////////
     bool createFrameBuffer();
@@ -112,9 +112,9 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Activate or deactivate the render texture for rendering
     ///
-    /// \param active True to activate, false to deactivate
+    /// \param active `true` to activate, `false` to deactivate
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     bool activate(bool active) override;
@@ -125,7 +125,7 @@ private:
     /// You can request sRGB encoding for a render-texture
     /// by having the sRgbCapable flag set for the context parameter of create() method
     ///
-    /// \return True if the render-texture use sRGB encoding, false otherwise
+    /// \return `true` if the render-texture use sRGB encoding, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool isSrgb() const override;

--- a/src/SFML/Window/Android/JoystickImpl.hpp
+++ b/src/SFML/Window/Android/JoystickImpl.hpp
@@ -51,7 +51,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -61,7 +61,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);

--- a/src/SFML/Window/Android/SensorImpl.hpp
+++ b/src/SFML/Window/Android/SensorImpl.hpp
@@ -58,7 +58,7 @@ public:
     ///
     /// \param sensor Sensor to check
     ///
-    /// \return True if the sensor is available, false otherwise
+    /// \return `true` if the sensor is available, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isAvailable(Sensor::Type sensor);
@@ -68,7 +68,7 @@ public:
     ///
     /// \param sensor Type of the sensor
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(Sensor::Type sensor);
@@ -90,7 +90,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the sensor
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setEnabled(bool enabled);

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -151,7 +151,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setVisible(bool visible) override;
@@ -159,7 +159,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the mouse cursor
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorVisible(bool visible) override;
@@ -167,7 +167,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Clips or releases the mouse cursor
     ///
-    /// \param grabbed True to enable, false to disable
+    /// \param grabbed `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorGrabbed(bool grabbed) override;
@@ -183,7 +183,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setKeyRepeatEnabled(bool enabled) override;
@@ -198,7 +198,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the window has the input focus
     ///
-    /// \return True if window has focus, false otherwise
+    /// \return `true` if window has focus, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool hasFocus() const override;

--- a/src/SFML/Window/DRM/DRMContext.hpp
+++ b/src/SFML/Window/DRM/DRMContext.hpp
@@ -101,7 +101,7 @@ public:
     ///
     /// \param current Whether to make the context current or no longer current
     ///
-    /// \return True on success, false if any error happened
+    /// \return `true` on success, `false` if any error happened
     ///
     ////////////////////////////////////////////////////////////
     bool makeCurrent(bool current) override;
@@ -120,7 +120,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled: True to enable v-sync, false to deactivate
+    /// \param enabled: `true` to enable v-sync, `false` to deactivate
     ///
     ////////////////////////////////////////////////////////////
     void setVerticalSyncEnabled(bool enabled) override;
@@ -140,7 +140,7 @@ public:
     ///
     /// \param size    Back buffer width and height, in pixels
     /// \param bpp     Pixel depth, in bits per pixel
-    /// \param scanout True to present the surface to the screen
+    /// \param scanout `true` to present the surface to the screen
     ///
     ////////////////////////////////////////////////////////////
     void createSurface(Vector2u size, unsigned int bpp, bool scanout);

--- a/src/SFML/Window/DRM/WindowImplDRM.hpp
+++ b/src/SFML/Window/DRM/WindowImplDRM.hpp
@@ -145,7 +145,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setVisible(bool visible) override;
@@ -153,7 +153,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the mouse cursor
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorVisible(bool visible) override;
@@ -161,7 +161,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Grab or release the mouse cursor
     ///
-    /// \param grabbed True to enable, false to disable
+    /// \param grabbed `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorGrabbed(bool grabbed) override;
@@ -177,7 +177,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setKeyRepeatEnabled(bool enabled) override;
@@ -192,7 +192,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the window has the input focus
     ///
-    /// \return True if window has focus, false otherwise
+    /// \return `true` if window has focus, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool hasFocus() const override;

--- a/src/SFML/Window/EglContext.hpp
+++ b/src/SFML/Window/EglContext.hpp
@@ -96,7 +96,7 @@ public:
     ///
     /// \param current Whether to make the context current or no longer current
     ///
-    /// \return True on success, false if any error happened
+    /// \return `true` on success, `false` if any error happened
     ///
     ////////////////////////////////////////////////////////////
     bool makeCurrent(bool current) override;
@@ -115,7 +115,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled: True to enable v-sync, false to deactivate
+    /// \param enabled: `true` to enable v-sync, `false` to deactivate
     ///
     ////////////////////////////////////////////////////////////
     void setVerticalSyncEnabled(bool enabled) override;

--- a/src/SFML/Window/FreeBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.hpp
@@ -58,7 +58,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -68,7 +68,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -135,7 +135,7 @@ public:
     ///
     /// \param name Name of the extension to check for
     ///
-    /// \return True if available, false if unavailable
+    /// \return `true` if available, `false` if unavailable
     ///
     ////////////////////////////////////////////////////////////
     static bool isExtensionAvailable(std::string_view name);
@@ -208,9 +208,9 @@ public:
     /// Only one context can be active on a thread at a time, thus
     /// the context previously active (if any) automatically gets deactivated.
     ///
-    /// \param active True to activate, false to deactivate
+    /// \param active `true` to activate, `false` to deactivate
     ///
-    /// \return True if operation was successful, false otherwise
+    /// \return `true` if operation was successful, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     bool setActive(bool active);
@@ -229,7 +229,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled True to enable v-sync, false to deactivate
+    /// \param enabled `true` to enable v-sync, `false` to deactivate
     ///
     ////////////////////////////////////////////////////////////
     virtual void setVerticalSyncEnabled(bool enabled) = 0;
@@ -249,7 +249,7 @@ protected:
     ///
     /// \param current Whether to make the context current or no longer current
     ///
-    /// \return True on success, false if any error happened
+    /// \return `true` on success, `false` if any error happened
     ///
     ////////////////////////////////////////////////////////////
     virtual bool makeCurrent(bool current) = 0;

--- a/src/SFML/Window/InputImpl.hpp
+++ b/src/SFML/Window/InputImpl.hpp
@@ -81,7 +81,7 @@ void setVirtualKeyboardVisible(bool visible);
 ///
 /// \param button Button to check
 ///
-/// \return True if the button is pressed, false otherwise
+/// \return `true` if the button is pressed, `false` otherwise
 ///
 ////////////////////////////////////////////////////////////
 bool isMouseButtonPressed(Mouse::Button button);
@@ -141,7 +141,7 @@ void setMousePosition(Vector2i position, const WindowBase& relativeTo);
 ///
 /// \param finger Finger index
 ///
-/// \return True if \a finger is currently touching the screen, false otherwise
+/// \return `true` if \a finger is currently touching the screen, `false` otherwise
 ///
 ////////////////////////////////////////////////////////////
 bool isTouchDown(unsigned int finger);

--- a/src/SFML/Window/NetBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/NetBSD/JoystickImpl.hpp
@@ -59,7 +59,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -69,7 +69,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);

--- a/src/SFML/Window/OpenBSD/JoystickImpl.hpp
+++ b/src/SFML/Window/OpenBSD/JoystickImpl.hpp
@@ -51,7 +51,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -61,7 +61,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);

--- a/src/SFML/Window/SensorManager.hpp
+++ b/src/SFML/Window/SensorManager.hpp
@@ -67,7 +67,7 @@ public:
     ///
     /// \param sensor Sensor to check
     ///
-    /// \return True if the sensor is available, false otherwise
+    /// \return `true` if the sensor is available, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     bool isAvailable(Sensor::Type sensor);
@@ -86,7 +86,7 @@ public:
     ///
     /// \param sensor Sensor to check
     ///
-    /// \return True if the sensor is enabled, false otherwise
+    /// \return `true` if the sensor is enabled, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool isEnabled(Sensor::Type sensor) const;

--- a/src/SFML/Window/Unix/GlxContext.hpp
+++ b/src/SFML/Window/Unix/GlxContext.hpp
@@ -95,7 +95,7 @@ public:
     ///
     /// \param current Whether to make the context current or no longer current
     ///
-    /// \return True on success, false if any error happened
+    /// \return `true` on success, `false` if any error happened
     ///
     ////////////////////////////////////////////////////////////
     bool makeCurrent(bool current) override;
@@ -114,7 +114,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled True to enable v-sync, false to deactivate
+    /// \param enabled `true` to enable v-sync, `false` to deactivate
     ///
     ////////////////////////////////////////////////////////////
     void setVerticalSyncEnabled(bool enabled) override;

--- a/src/SFML/Window/Unix/JoystickImpl.hpp
+++ b/src/SFML/Window/Unix/JoystickImpl.hpp
@@ -56,7 +56,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -66,7 +66,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);

--- a/src/SFML/Window/Unix/SensorImpl.hpp
+++ b/src/SFML/Window/Unix/SensorImpl.hpp
@@ -51,7 +51,7 @@ public:
     ///
     /// \param sensor Sensor to check
     ///
-    /// \return True if the sensor is available, false otherwise
+    /// \return `true` if the sensor is available, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isAvailable(Sensor::Type sensor);
@@ -61,7 +61,7 @@ public:
     ///
     /// \param sensor Type of the sensor
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(Sensor::Type sensor);
@@ -83,7 +83,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the sensor
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setEnabled(bool enabled);

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -153,7 +153,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setVisible(bool visible) override;
@@ -161,7 +161,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the mouse cursor
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorVisible(bool visible) override;
@@ -169,7 +169,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Grab or release the mouse cursor
     ///
-    /// \param grabbed True to enable, false to disable
+    /// \param grabbed `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorGrabbed(bool grabbed) override;
@@ -185,7 +185,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setKeyRepeatEnabled(bool enabled) override;
@@ -200,7 +200,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the window has the input focus
     ///
-    /// \return True if window has focus, false otherwise
+    /// \return `true` if window has focus, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool hasFocus() const override;
@@ -276,7 +276,7 @@ private:
     ///
     /// \param windowEvent Event which has been received
     ///
-    /// \return True if the event was processed, false if it was discarded
+    /// \return `true` if the event was processed, `false` if it was discarded
     ///
     ////////////////////////////////////////////////////////////
     bool processEvent(XEvent& windowEvent);
@@ -284,7 +284,7 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Check if a valid version of XRandR extension is present
     ///
-    /// \return True if a valid XRandR version found, false otherwise
+    /// \return `true` if a valid XRandR version found, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     bool checkXRandR();

--- a/src/SFML/Window/VulkanImpl.hpp
+++ b/src/SFML/Window/VulkanImpl.hpp
@@ -43,12 +43,12 @@ namespace sf::priv::VulkanImpl
 /// any attempt to use Vulkan will fail.
 ///
 /// If only compute is required, set \a requireGraphics
-/// to false to skip checking for the extensions necessary
+/// to `false` to skip checking for the extensions necessary
 /// for graphics rendering.
 ///
 /// \param requireGraphics
 ///
-/// \return True if Vulkan is supported, false otherwise
+/// \return `true` if Vulkan is supported, `false` otherwise
 ///
 ////////////////////////////////////////////////////////////
 [[nodiscard]] bool isAvailable(bool requireGraphics = true);
@@ -79,7 +79,7 @@ namespace sf::priv::VulkanImpl
 /// \param surface      Created surface
 /// \param allocator    Allocator to use
 ///
-/// \return True if surface creation was successful, false otherwise
+/// \return `true` if surface creation was successful, `false` otherwise
 ///
 ////////////////////////////////////////////////////////////
 [[nodiscard]] bool createVulkanSurface(const VkInstance&            instance,

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -60,7 +60,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -84,7 +84,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);
@@ -136,7 +136,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnectedDInput(unsigned int index);
@@ -152,7 +152,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool openDInput(unsigned int index);
@@ -221,7 +221,7 @@ private:
     int m_buttons[Joystick::ButtonCount]{}; //!< Offsets to the bytes containing the button states, -1 if not available
     Joystick::Identification m_identification; //!< Joystick identification
     JoystickState            m_state;          //!< Buffered joystick state
-    bool                     m_buffered{};     //!< true if the device uses buffering, false if the device uses polling
+    bool                     m_buffered{}; //!< `true` if the device uses buffering, `false` if the device uses polling
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/Win32/SensorImpl.hpp
+++ b/src/SFML/Window/Win32/SensorImpl.hpp
@@ -56,7 +56,7 @@ public:
     ///
     /// \param sensor Sensor to check
     ///
-    /// \return True if the sensor is available, false otherwise
+    /// \return `true` if the sensor is available, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isAvailable(Sensor::Type sensor);
@@ -66,7 +66,7 @@ public:
     ///
     /// \param sensor Type of the sensor
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(Sensor::Type sensor);
@@ -88,7 +88,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the sensor
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setEnabled(bool enabled);

--- a/src/SFML/Window/Win32/WglContext.hpp
+++ b/src/SFML/Window/Win32/WglContext.hpp
@@ -100,7 +100,7 @@ public:
     ///
     /// \param current Whether to make the context current or no longer current
     ///
-    /// \return True on success, false if any error happened
+    /// \return `true` on success, `false` if any error happened
     ///
     ////////////////////////////////////////////////////////////
     bool makeCurrent(bool current) override;
@@ -119,7 +119,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled: True to enable v-sync, false to deactivate
+    /// \param enabled: `true` to enable v-sync, `false` to deactivate
     ///
     ////////////////////////////////////////////////////////////
     void setVerticalSyncEnabled(bool enabled) override;

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -137,7 +137,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setVisible(bool visible) override;
@@ -145,7 +145,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the mouse cursor
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorVisible(bool visible) override;
@@ -153,7 +153,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Grab or release the mouse cursor
     ///
-    /// \param grabbed True to enable, false to disable
+    /// \param grabbed `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorGrabbed(bool grabbed) override;
@@ -169,7 +169,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setKeyRepeatEnabled(bool enabled) override;
@@ -184,7 +184,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the window has the input focus
     ///
-    /// \return True if window has focus, false otherwise
+    /// \return `true` if window has focus, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool hasFocus() const override;
@@ -230,7 +230,7 @@ private:
     ////////////////////////////////////////////////////////////
     /// \brief Enables or disables tracking for the mouse cursor leaving the window
     ///
-    /// \param track True to enable, false to disable
+    /// \param track `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setTracking(bool track);
@@ -243,7 +243,7 @@ private:
     /// for example, to release the cursor when switching to
     /// another application.
     ///
-    /// \param grabbed True to enable, false to disable
+    /// \param grabbed `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void grabCursor(bool grabbed);
@@ -277,7 +277,7 @@ private:
     /// \param wParam  First parameter of the message
     /// \param lParam  Second parameter of the message
     ///
-    /// \return True to discard the event after it has been processed
+    /// \return `true` to discard the event after it has been processed
     ///
     ////////////////////////////////////////////////////////////
     static LRESULT CALLBACK globalOnEvent(HWND handle, UINT message, WPARAM wParam, LPARAM lParam);

--- a/src/SFML/Window/WindowImpl.hpp
+++ b/src/SFML/Window/WindowImpl.hpp
@@ -241,7 +241,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     virtual void setVisible(bool visible) = 0;
@@ -249,7 +249,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the mouse cursor
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     virtual void setMouseCursorVisible(bool visible) = 0;
@@ -257,7 +257,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Grab or release the mouse cursor and keeps it from leaving
     ///
-    /// \param grabbed True to enable, false to disable
+    /// \param grabbed `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     virtual void setMouseCursorGrabbed(bool grabbed) = 0;
@@ -273,7 +273,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     virtual void setKeyRepeatEnabled(bool enabled) = 0;
@@ -288,7 +288,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the window has the input focus
     ///
-    /// \return True if window has focus, false otherwise
+    /// \return `true` if window has focus, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] virtual bool hasFocus() const = 0;
@@ -300,7 +300,7 @@ public:
     /// \param surface   Created surface
     /// \param allocator Allocator to use
     ///
-    /// \return True if surface creation was successful, false otherwise
+    /// \return `true` if surface creation was successful, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     bool createVulkanSurface(const VkInstance& instance, VkSurfaceKHR& surface, const VkAllocationCallbacks* allocator) const;

--- a/src/SFML/Window/iOS/EaglContext.hpp
+++ b/src/SFML/Window/iOS/EaglContext.hpp
@@ -122,7 +122,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled: True to enable v-sync, false to deactivate
+    /// \param enabled: `true` to enable v-sync, `false` to deactivate
     ///
     ////////////////////////////////////////////////////////////
     void setVerticalSyncEnabled(bool enabled) override;
@@ -134,7 +134,7 @@ protected:
     ///
     /// \param current Whether to make the context current or no longer current
     ///
-    /// \return True on success, false if any error happened
+    /// \return `true` on success, `false` if any error happened
     ///
     ////////////////////////////////////////////////////////////
     bool makeCurrent(bool current) override;

--- a/src/SFML/Window/iOS/JoystickImpl.hpp
+++ b/src/SFML/Window/iOS/JoystickImpl.hpp
@@ -51,7 +51,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -61,7 +61,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);

--- a/src/SFML/Window/iOS/SFAppDelegate.hpp
+++ b/src/SFML/Window/iOS/SFAppDelegate.hpp
@@ -51,7 +51,7 @@
 ////////////////////////////////////////////////////////////
 /// \brief Show or hide the virtual keyboard
 ///
-/// \param visible True to show, false to hide
+/// \param visible `true` to show, `false` to hide
 ///
 ////////////////////////////////////////////////////////////
 - (void)setVirtualKeyboardVisible:(bool)visible;

--- a/src/SFML/Window/iOS/SFViewController.hpp
+++ b/src/SFML/Window/iOS/SFViewController.hpp
@@ -41,7 +41,7 @@
 ///
 /// \param interfaceOrientation Orientation to check
 ///
-/// \return True if auto-rotation is supported, false otherwise
+/// \return `true` if auto-rotation is supported, `false` otherwise
 ///
 ////////////////////////////////////////////////////////////
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
@@ -49,7 +49,7 @@
 ////////////////////////////////////////////////////////////
 /// \brief Tells if the controller supports auto-rotation (iOS >= 6)
 ///
-/// \return True if auto-rotation is supported, false otherwise
+/// \return `true` if auto-rotation is supported, `false` otherwise
 ///
 ////////////////////////////////////////////////////////////
 - (BOOL)shouldAutorotate;

--- a/src/SFML/Window/iOS/SensorImpl.hpp
+++ b/src/SFML/Window/iOS/SensorImpl.hpp
@@ -56,7 +56,7 @@ public:
     ///
     /// \param sensor Sensor to check
     ///
-    /// \return True if the sensor is available, false otherwise
+    /// \return `true` if the sensor is available, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isAvailable(Sensor::Type sensor);
@@ -66,7 +66,7 @@ public:
     ///
     /// \param sensor Type of the sensor
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(Sensor::Type sensor);
@@ -88,7 +88,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the sensor
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setEnabled(bool enabled);

--- a/src/SFML/Window/iOS/WindowImplUIKit.hpp
+++ b/src/SFML/Window/iOS/WindowImplUIKit.hpp
@@ -146,7 +146,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setVisible(bool visible) override;
@@ -154,7 +154,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the mouse cursor
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorVisible(bool visible) override;
@@ -162,7 +162,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Clips or releases the mouse cursor
     ///
-    /// \param grabbed True to enable, false to disable
+    /// \param grabbed `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorGrabbed(bool grabbed) override;
@@ -178,7 +178,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setKeyRepeatEnabled(bool enabled) override;
@@ -193,7 +193,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the window has the input focus
     ///
-    /// \return True if window has focus, false otherwise
+    /// \return `true` if window has focus, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool hasFocus() const override;
@@ -217,7 +217,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the virtual keyboard
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setVirtualKeyboardVisible(bool visible);

--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -253,7 +253,7 @@ private:
     ///
     /// \param elements HID elements mapping to this key
     ///
-    /// \return True if the key is pressed, false otherwise
+    /// \return `true` if the key is pressed, `false` otherwise
     ///
     /// \see isKeyPressed, isMouseButtonPressed
     ///

--- a/src/SFML/Window/macOS/JoystickImpl.hpp
+++ b/src/SFML/Window/macOS/JoystickImpl.hpp
@@ -61,7 +61,7 @@ public:
     ///
     /// \param index Index of the joystick to check
     ///
-    /// \return True if the joystick is connected, false otherwise
+    /// \return `true` if the joystick is connected, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isConnected(unsigned int index);
@@ -71,7 +71,7 @@ public:
     ///
     /// \param index Index assigned to the joystick
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(unsigned int index);

--- a/src/SFML/Window/macOS/SFContext.hpp
+++ b/src/SFML/Window/macOS/SFContext.hpp
@@ -121,7 +121,7 @@ public:
     /// This can avoid some visual artifacts, and limit the framerate
     /// to a good value (but not constant across different computers).
     ///
-    /// \param enabled True to enable v-sync, false to deactivate
+    /// \param enabled `true` to enable v-sync, `false` to deactivate
     ///
     ////////////////////////////////////////////////////////////
     void setVerticalSyncEnabled(bool enabled) override;
@@ -133,7 +133,7 @@ protected:
     ///
     /// \param current Whether to make the context current or no longer current
     ///
-    /// \return True on success, false if any error happened
+    /// \return `true` on success, `false` if any error happened
     ///
     ////////////////////////////////////////////////////////////
     bool makeCurrent(bool current) override;

--- a/src/SFML/Window/macOS/SensorImpl.hpp
+++ b/src/SFML/Window/macOS/SensorImpl.hpp
@@ -51,7 +51,7 @@ public:
     ///
     /// \param sensor Sensor to check
     ///
-    /// \return True if the sensor is available, false otherwise
+    /// \return `true` if the sensor is available, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static bool isAvailable(Sensor::Type sensor);
@@ -61,7 +61,7 @@ public:
     ///
     /// \param sensor Type of the sensor
     ///
-    /// \return True on success, false on failure
+    /// \return `true` on success, `false` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool open(Sensor::Type sensor);
@@ -83,7 +83,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable the sensor
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setEnabled(bool enabled);

--- a/src/SFML/Window/macOS/WindowImplCocoa.hpp
+++ b/src/SFML/Window/macOS/WindowImplCocoa.hpp
@@ -317,7 +317,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the window
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setVisible(bool visible) override;
@@ -325,7 +325,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Show or hide the mouse cursor
     ///
-    /// \param visible True to show, false to hide
+    /// \param visible `true` to show, `false` to hide
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorVisible(bool visible) override;
@@ -333,7 +333,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Grab or release the mouse cursor
     ///
-    /// \param grabbed True to grab, false to release
+    /// \param grabbed `true` to grab, `false` to release
     ///
     ////////////////////////////////////////////////////////////
     void setMouseCursorGrabbed(bool grabbed) override;
@@ -349,7 +349,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Enable or disable automatic key-repeat
     ///
-    /// \param enabled True to enable, false to disable
+    /// \param enabled `true` to enable, `false` to disable
     ///
     ////////////////////////////////////////////////////////////
     void setKeyRepeatEnabled(bool enabled) override;
@@ -364,7 +364,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Check whether the window has the input focus
     ///
-    /// \return True if window has focus, false otherwise
+    /// \return `true` if window has focus, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] bool hasFocus() const override;


### PR DESCRIPTION
Continues the work of pr #3213

I tried to find every instance of True or False being capitalized and them not being inclosed in `'`