### PR TITLE
Stop uploading code coverage from non-pull request CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
     name: Finalize Coverage Upload
     needs: build
     runs-on: ubuntu-22.04
-    if: github.repository == 'SFML/SFML' # Disable upload in forks
+    if: github.repository == 'SFML/SFML' && github.event_name == 'pull_request' # Only run for PRs to main repository
 
     steps:
     - name: Coveralls Finished


### PR DESCRIPTION
We only care about code coverage in PRs so let's save some CI time and stop doing this for non-pull request CI pipelines. It's just another job that is prone to run for a long just to fail for some silly reason.