### PR TITLE
Add getter for `sf::Texture::m_pixelsFlipped`

### DIFF
--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -711,6 +711,14 @@ public:
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static unsigned int getMaximumSize();
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the state of whether the Y orientatino of pixels are flipped
+    ///
+    /// \return `true` if pixels are flipped, otherwise `false`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool getPixelsFlipped() const;
+
 private:
     friend class Text;
     friend class RenderTexture;

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -1032,6 +1032,13 @@ unsigned int Texture::getMaximumSize()
 
 
 ////////////////////////////////////////////////////////////
+bool Texture::getPixelsFlipped() const
+{
+    return m_pixelsFlipped;
+}
+
+
+////////////////////////////////////////////////////////////
 Texture& Texture::operator=(const Texture& right)
 {
     Texture temp(right);

--- a/test/Graphics/Texture.test.cpp
+++ b/test/Graphics/Texture.test.cpp
@@ -132,6 +132,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
             CHECK(!texture.isSrgb());
             CHECK(!texture.isRepeated());
             CHECK(texture.getNativeHandle() == 0);
+            CHECK(!texture.getPixelsFlipped());
         }
 
         SECTION("Assignment")
@@ -144,6 +145,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
             CHECK(!texture.isSrgb());
             CHECK(!texture.isRepeated());
             CHECK(texture.getNativeHandle() == 0);
+            CHECK(!texture.getPixelsFlipped());
         }
     }
 
@@ -158,6 +160,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
             CHECK(!texture.isSrgb());
             CHECK(!texture.isRepeated());
             CHECK(texture.getNativeHandle() != 0);
+            CHECK(!texture.getPixelsFlipped());
         }
 
         SECTION("Assignment")
@@ -170,6 +173,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
             CHECK(!texture.isSrgb());
             CHECK(!texture.isRepeated());
             CHECK(texture.getNativeHandle() != 0);
+            CHECK(!texture.getPixelsFlipped());
         }
     }
 
@@ -207,6 +211,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         CHECK(!texture.isSrgb());
         CHECK(!texture.isRepeated());
         CHECK(texture.getNativeHandle() != 0);
+        CHECK(!texture.getPixelsFlipped());
     }
 
     SECTION("loadFromMemory()")
@@ -219,6 +224,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         CHECK(!texture.isSrgb());
         CHECK(!texture.isRepeated());
         CHECK(texture.getNativeHandle() != 0);
+        CHECK(!texture.getPixelsFlipped());
     }
 
     SECTION("loadFromStream()")
@@ -232,6 +238,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
         CHECK(!texture.isSrgb());
         CHECK(!texture.isRepeated());
         CHECK(texture.getNativeHandle() != 0);
+        CHECK(!texture.getPixelsFlipped());
     }
 
     SECTION("loadFromImage()")
@@ -269,6 +276,7 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
             }
 
             CHECK(texture.getNativeHandle() != 0);
+            CHECK(!texture.getPixelsFlipped());
         }
     }
 
@@ -293,6 +301,8 @@ TEST_CASE("[Graphics] sf::Texture", runDisplayTests())
             REQUIRE(textureCopy.getSize() == sf::Vector2u(1, 2));
             CHECK(textureCopy.copyToImage().getPixel(sf::Vector2u(0, 1)) == sf::Color::Red);
         }
+
+        CHECK(!texture.getPixelsFlipped());
     }
 
     SECTION("update()")


### PR DESCRIPTION
Closes #1770 

There is reason to believe that larger rendering changes in SFML 4 will render (pun intended) this API moot and thus it will get removed. Nevertheless I think there is value in providing this feature even if this feature only lives for as long as SFML 3. It's trivial to write, test, and maintain and I see no reason why this would limit any implementation changes we wish to make in the v3 release cycle.