### PR TITLE
Add GitHub Sponsors and OpenCollective buttons

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: SFML
+open_collective: sfml


### PR DESCRIPTION
Adding the necessary information for the Sponsoring/Funding buttons to be shown on the SFML repository.