### PR TITLE
Prefer standard fixed width integers to Miniaudio's integer aliases

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -76,7 +76,7 @@ AudioDevice::AudioDevice()
     // Register our logging callback to output any warning/error messages
     if (const auto result = ma_log_register_callback(&*m_log,
                                                      ma_log_callback_init(
-                                                         [](void*, ma_uint32 level, const char* message)
+                                                         [](void*, std::uint32_t level, const char* message)
                                                          {
                                                              if (level <= MA_LOG_LEVEL_WARNING)
                                                                  err() << "miniaudio " << ma_log_level_to_string(level)
@@ -91,7 +91,7 @@ AudioDevice::AudioDevice()
 
     auto contextConfig                                 = ma_context_config_init();
     contextConfig.pLog                                 = &*m_log;
-    ma_uint32                              deviceCount = 0;
+    std::uint32_t                          deviceCount = 0;
     const auto                             nullBackend = ma_backend_null;
     const std::array<const ma_backend*, 2> backendLists{nullptr, &nullBackend};
 
@@ -217,7 +217,7 @@ std::vector<AudioDevice::DeviceEntry> AudioDevice::getAvailableDevices()
     const auto getDevices = [](auto& context)
     {
         ma_device_info* deviceInfos{};
-        ma_uint32       deviceCount{};
+        std::uint32_t   deviceCount{};
 
         // Get the playback devices
         if (const auto result = ma_context_get_devices(&context, &deviceInfos, &deviceCount, nullptr, nullptr);
@@ -482,7 +482,7 @@ bool AudioDevice::initialize()
     m_playbackDevice.emplace();
 
     auto playbackDeviceConfig         = ma_device_config_init(ma_device_type_playback);
-    playbackDeviceConfig.dataCallback = [](ma_device* device, void* output, const void*, ma_uint32 frameCount)
+    playbackDeviceConfig.dataCallback = [](ma_device* device, void* output, const void*, std::uint32_t frameCount)
     {
         auto& audioDevice = *static_cast<AudioDevice*>(device->pUserData);
 

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -88,6 +88,9 @@ target_compile_definitions(sfml-audio PRIVATE OV_EXCLUDE_STATIC_CALLBACKS FLAC__
 # disable miniaudio features we do not use
 target_compile_definitions(sfml-audio PRIVATE MA_NO_MP3 MA_NO_FLAC MA_NO_ENCODING MA_NO_RESOURCE_MANAGER MA_NO_GENERATION)
 
+# use standard fixed-width integer types
+target_compile_definitions(sfml-audio PRIVATE MA_USE_STDINT)
+
 # setup dependencies
 target_link_libraries(sfml-audio
                       PUBLIC SFML::System

--- a/src/SFML/Audio/MiniaudioUtils.cpp
+++ b/src/SFML/Audio/MiniaudioUtils.cpp
@@ -165,7 +165,7 @@ void MiniaudioUtils::SoundBase::initialize(ma_sound_end_proc endCallback)
 
     // Initialize the custom effect node
     effectNodeVTable.onProcess =
-        [](ma_node* node, const float** framesIn, ma_uint32* frameCountIn, float** framesOut, ma_uint32* frameCountOut)
+        [](ma_node* node, const float** framesIn, std::uint32_t* frameCountIn, float** framesOut, std::uint32_t* frameCountOut)
     { static_cast<EffectNode*>(node)->impl->processEffect(framesIn, *frameCountIn, framesOut, *frameCountOut); };
     effectNodeVTable.onGetRequiredInputFrameCount = nullptr;
     effectNodeVTable.inputBusCount                = 1;
@@ -205,10 +205,10 @@ void MiniaudioUtils::SoundBase::deinitialize()
 
 
 ////////////////////////////////////////////////////////////
-void MiniaudioUtils::SoundBase::processEffect(const float** framesIn,
-                                              ma_uint32&    frameCountIn,
-                                              float**       framesOut,
-                                              ma_uint32&    frameCountOut) const
+void MiniaudioUtils::SoundBase::processEffect(const float**  framesIn,
+                                              std::uint32_t& frameCountIn,
+                                              float**        framesOut,
+                                              std::uint32_t& frameCountOut) const
 {
     // If a processor is set, call it
     if (effectProcessor)
@@ -392,15 +392,15 @@ Time MiniaudioUtils::getPlayingOffset(ma_sound& sound)
 
 
 ////////////////////////////////////////////////////////////
-ma_uint64 MiniaudioUtils::getFrameIndex(ma_sound& sound, Time timeOffset)
+std::uint64_t MiniaudioUtils::getFrameIndex(ma_sound& sound, Time timeOffset)
 {
-    ma_uint32 sampleRate{};
+    std::uint32_t sampleRate{};
 
     if (const ma_result result = ma_sound_get_data_format(&sound, nullptr, nullptr, &sampleRate, nullptr, 0);
         result != MA_SUCCESS)
         err() << "Failed to get sound data format: " << ma_result_description(result) << std::endl;
 
-    const auto frameIndex = static_cast<ma_uint64>(timeOffset.asSeconds() * static_cast<float>(sampleRate));
+    const auto frameIndex = static_cast<std::uint64_t>(timeOffset.asSeconds() * static_cast<float>(sampleRate));
 
     if (const ma_result result = ma_sound_seek_to_pcm_frame(&sound, frameIndex); result != MA_SUCCESS)
         err() << "Failed to seek sound to pcm frame: " << ma_result_description(result) << std::endl;

--- a/src/SFML/Audio/MiniaudioUtils.hpp
+++ b/src/SFML/Audio/MiniaudioUtils.hpp
@@ -78,7 +78,7 @@ struct SoundBase
     ~SoundBase();
     void initialize(ma_sound_end_proc endCallback);
     void deinitialize();
-    void processEffect(const float** framesIn, ma_uint32& frameCountIn, float** framesOut, ma_uint32& frameCountOut) const;
+    void processEffect(const float** framesIn, std::uint32_t& frameCountIn, float** framesOut, std::uint32_t& frameCountOut) const;
     void connectEffect(bool connect);
 
     ////////////////////////////////////////////////////////////
@@ -86,9 +86,9 @@ struct SoundBase
     ////////////////////////////////////////////////////////////
     struct EffectNode
     {
-        ma_node_base base{};
-        SoundBase*   impl{};
-        ma_uint32    channelCount{};
+        ma_node_base  base{};
+        SoundBase*    impl{};
+        std::uint32_t channelCount{};
     };
 
     ma_data_source_base dataSourceBase{}; //!< The struct that makes this object a miniaudio data source (must be first member)
@@ -102,10 +102,10 @@ struct SoundBase
     MiniaudioUtils::SavedSettings savedSettings; //!< Saved settings used to restore ma_sound state in case we need to recreate it
 };
 
-[[nodiscard]] ma_channel   soundChannelToMiniaudioChannel(SoundChannel soundChannel);
-[[nodiscard]] SoundChannel miniaudioChannelToSoundChannel(ma_channel soundChannel);
-[[nodiscard]] Time         getPlayingOffset(ma_sound& sound);
-[[nodiscard]] ma_uint64    getFrameIndex(ma_sound& sound, Time timeOffset);
+[[nodiscard]] ma_channel    soundChannelToMiniaudioChannel(SoundChannel soundChannel);
+[[nodiscard]] SoundChannel  miniaudioChannelToSoundChannel(ma_channel soundChannel);
+[[nodiscard]] Time          getPlayingOffset(ma_sound& sound);
+[[nodiscard]] std::uint64_t getFrameIndex(ma_sound& sound, Time timeOffset);
 
 } // namespace priv::MiniaudioUtils
 } // namespace sf

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -83,7 +83,7 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
             err() << "Failed to seek sound to frame 0: " << ma_result_description(result) << std::endl;
     }
 
-    static ma_result read(ma_data_source* dataSource, void* framesOut, ma_uint64 frameCount, ma_uint64* framesRead)
+    static ma_result read(ma_data_source* dataSource, void* framesOut, std::uint64_t frameCount, std::uint64_t* framesRead)
     {
         auto&       impl   = *static_cast<Impl*>(dataSource);
         const auto* buffer = impl.buffer;
@@ -92,7 +92,7 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
             return MA_NO_DATA_AVAILABLE;
 
         // Determine how many frames we can read
-        *framesRead = std::min<ma_uint64>(frameCount, (buffer->getSampleCount() - impl.cursor) / buffer->getChannelCount());
+        *framesRead = std::min(frameCount, (buffer->getSampleCount() - impl.cursor) / buffer->getChannelCount());
 
         // Copy the samples to the output
         const auto sampleCount = *framesRead * buffer->getChannelCount();
@@ -110,7 +110,7 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
         return MA_SUCCESS;
     }
 
-    static ma_result seek(ma_data_source* dataSource, ma_uint64 frameIndex)
+    static ma_result seek(ma_data_source* dataSource, std::uint64_t frameIndex)
     {
         auto&       impl   = *static_cast<Impl*>(dataSource);
         const auto* buffer = impl.buffer;
@@ -125,8 +125,8 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
 
     static ma_result getFormat(ma_data_source* dataSource,
                                ma_format*      format,
-                               ma_uint32*      channels,
-                               ma_uint32*      sampleRate,
+                               std::uint32_t*  channels,
+                               std::uint32_t*  sampleRate,
                                ma_channel*,
                                size_t)
     {
@@ -141,7 +141,7 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
         return MA_SUCCESS;
     }
 
-    static ma_result getCursor(ma_data_source* dataSource, ma_uint64* cursor)
+    static ma_result getCursor(ma_data_source* dataSource, std::uint64_t* cursor)
     {
         const auto& impl   = *static_cast<const Impl*>(dataSource);
         const auto* buffer = impl.buffer;
@@ -154,7 +154,7 @@ struct Sound::Impl : priv::MiniaudioUtils::SoundBase
         return MA_SUCCESS;
     }
 
-    static ma_result getLength(ma_data_source* dataSource, ma_uint64* length)
+    static ma_result getLength(ma_data_source* dataSource, std::uint64_t* length)
     {
         const auto& impl   = *static_cast<const Impl*>(dataSource);
         const auto* buffer = impl.buffer;

--- a/src/SFML/Audio/SoundFileReaderWav.cpp
+++ b/src/SFML/Audio/SoundFileReaderWav.cpp
@@ -53,7 +53,7 @@ ma_result onRead(ma_decoder* decoder, void* buffer, size_t bytesToRead, size_t* 
     return MA_SUCCESS;
 }
 
-ma_result onSeek(ma_decoder* decoder, ma_int64 byteOffset, ma_seek_origin origin)
+ma_result onSeek(ma_decoder* decoder, std::int64_t byteOffset, ma_seek_origin origin)
 {
     auto* stream = static_cast<sf::InputStream*>(decoder->pUserData);
 
@@ -141,7 +141,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderWav::open(InputStream& strea
         return std::nullopt;
     }
 
-    ma_uint64 frameCount{};
+    std::uint64_t frameCount{};
     if (const ma_result result = ma_decoder_get_available_frames(&*m_decoder, &frameCount); result != MA_SUCCESS)
     {
         err() << "Failed to get available frames from wav decoder: " << ma_result_description(result) << std::endl;
@@ -149,7 +149,7 @@ std::optional<SoundFileReader::Info> SoundFileReaderWav::open(InputStream& strea
     }
 
     auto                       format = ma_format_unknown;
-    ma_uint32                  sampleRate{};
+    std::uint32_t              sampleRate{};
     std::array<ma_channel, 20> channelMap{};
     if (const ma_result result = ma_decoder_get_data_format(&*m_decoder,
                                                             &format,
@@ -189,7 +189,7 @@ std::uint64_t SoundFileReaderWav::read(std::int16_t* samples, std::uint64_t maxC
 {
     assert(m_decoder && "wav decoder not initialized. Call SoundFileReaderWav::open() to initialize it.");
 
-    ma_uint64 framesRead{};
+    std::uint64_t framesRead{};
 
     if (const ma_result result = ma_decoder_read_pcm_frames(&*m_decoder, samples, maxCount / m_channelCount, &framesRead);
         result != MA_SUCCESS)

--- a/src/SFML/Audio/SoundFileReaderWav.hpp
+++ b/src/SFML/Audio/SoundFileReaderWav.hpp
@@ -107,7 +107,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     std::optional<ma_decoder> m_decoder;        //!< wav decoder
-    ma_uint32                 m_channelCount{}; //!< Number of channels
+    std::uint32_t             m_channelCount{}; //!< Number of channels
 };
 
 } // namespace sf::priv

--- a/src/SFML/Audio/SoundRecorder.cpp
+++ b/src/SFML/Audio/SoundRecorder.cpp
@@ -80,7 +80,7 @@ struct SoundRecorder::Impl
         captureDeviceConfig.capture.format    = ma_format_s16;
         captureDeviceConfig.sampleRate        = sampleRate;
         captureDeviceConfig.pUserData         = this;
-        captureDeviceConfig.dataCallback      = [](ma_device* device, void*, const void* input, ma_uint32 frameCount)
+        captureDeviceConfig.dataCallback = [](ma_device* device, void*, const void* input, std::uint32_t frameCount)
         {
             auto& impl = *static_cast<Impl*>(device->pUserData);
 
@@ -127,7 +127,7 @@ struct SoundRecorder::Impl
 
         // Enumerate the capture devices
         ma_device_info* deviceInfos = nullptr;
-        ma_uint32       deviceCount = 0;
+        std::uint32_t   deviceCount = 0;
 
         if (const auto result = ma_context_get_devices(&context, nullptr, nullptr, &deviceInfos, &deviceCount);
             result != MA_SUCCESS)
@@ -175,7 +175,7 @@ SoundRecorder::SoundRecorder() : m_impl(std::make_unique<Impl>(this))
     // Register our logging callback to output any warning/error messages
     if (const auto result = ma_log_register_callback(&*m_impl->log,
                                                      ma_log_callback_init(
-                                                         [](void*, ma_uint32 level, const char* message)
+                                                         [](void*, std::uint32_t level, const char* message)
                                                          {
                                                              if (level <= MA_LOG_LEVEL_WARNING)
                                                                  err() << "miniaudio " << ma_log_level_to_string(level)
@@ -190,7 +190,7 @@ SoundRecorder::SoundRecorder() : m_impl(std::make_unique<Impl>(this))
 
     auto contextConfig                                 = ma_context_config_init();
     contextConfig.pLog                                 = &*m_impl->log;
-    ma_uint32                              deviceCount = 0;
+    std::uint32_t                          deviceCount = 0;
     const auto                             nullBackend = ma_backend_null;
     const std::array<const ma_backend*, 2> backendLists{nullptr, &nullBackend};
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -86,7 +86,7 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
             err() << "Failed to seek sound to frame 0: " << ma_result_description(result) << std::endl;
     }
 
-    static ma_result read(ma_data_source* dataSource, void* framesOut, ma_uint64 frameCount, ma_uint64* framesRead)
+    static ma_result read(ma_data_source* dataSource, void* framesOut, std::uint64_t frameCount, std::uint64_t* framesRead)
     {
         auto& impl  = *static_cast<Impl*>(dataSource);
         auto* owner = impl.owner;
@@ -109,8 +109,8 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
         if (!impl.sampleBuffer.empty())
         {
             // Determine how many frames we can read
-            *framesRead = std::min<ma_uint64>(frameCount,
-                                              (impl.sampleBuffer.size() - impl.sampleBufferCursor) / impl.channelCount);
+            *framesRead = std::min<std::uint64_t>(frameCount,
+                                                  (impl.sampleBuffer.size() - impl.sampleBufferCursor) / impl.channelCount);
 
             const auto sampleCount = *framesRead * impl.channelCount;
 
@@ -146,7 +146,7 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
         return MA_SUCCESS;
     }
 
-    static ma_result seek(ma_data_source* dataSource, ma_uint64 frameIndex)
+    static ma_result seek(ma_data_source* dataSource, std::uint64_t frameIndex)
     {
         auto& impl  = *static_cast<Impl*>(dataSource);
         auto* owner = impl.owner;
@@ -170,8 +170,8 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
 
     static ma_result getFormat(ma_data_source* dataSource,
                                ma_format*      format,
-                               ma_uint32*      channels,
-                               ma_uint32*      sampleRate,
+                               std::uint32_t*  channels,
+                               std::uint32_t*  sampleRate,
                                ma_channel*,
                                size_t)
     {
@@ -185,7 +185,7 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
         return MA_SUCCESS;
     }
 
-    static ma_result getCursor(ma_data_source* dataSource, ma_uint64* cursor)
+    static ma_result getCursor(ma_data_source* dataSource, std::uint64_t* cursor)
     {
         auto& impl = *static_cast<Impl*>(dataSource);
         *cursor    = impl.channelCount ? impl.samplesProcessed / impl.channelCount : 0;
@@ -193,7 +193,7 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
         return MA_SUCCESS;
     }
 
-    static ma_result getLength(ma_data_source*, ma_uint64* length)
+    static ma_result getLength(ma_data_source*, std::uint64_t* length)
     {
         *length = 0;
 


### PR DESCRIPTION
See miniaudio.h:3752-3787

```cpp
/* Sized types. */
#if defined(MA_USE_STDINT)
    #include <stdint.h>
    typedef int8_t   ma_int8;
    typedef uint8_t  ma_uint8;
    typedef int16_t  ma_int16;
    typedef uint16_t ma_uint16;
    typedef int32_t  ma_int32;
    typedef uint32_t ma_uint32;
    typedef int64_t  ma_int64;
    typedef uint64_t ma_uint64;
#else
    typedef   signed char           ma_int8;
    typedef unsigned char           ma_uint8;
    typedef   signed short          ma_int16;
    typedef unsigned short          ma_uint16;
    typedef   signed int            ma_int32;
    typedef unsigned int            ma_uint32;
    #if defined(_MSC_VER) && !defined(__clang__)
        typedef   signed __int64    ma_int64;
        typedef unsigned __int64    ma_uint64;
    #else
        #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)))
            #pragma GCC diagnostic push
            #pragma GCC diagnostic ignored "-Wlong-long"
            #if defined(__clang__)
                #pragma GCC diagnostic ignored "-Wc++11-long-long"
            #endif
        #endif
        typedef   signed long long  ma_int64;
        typedef unsigned long long  ma_uint64;
        #if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)))
            #pragma GCC diagnostic pop
        #endif
    #endif
#endif  /* MA_USE_STDINT */
```

We're better off enabling C99's `<stdint.h>` because we're not stuck with a pre-C99 compiler. This lets us stop using Miniaudio's aliases for integers and use the corresponding C++ types in more places. This makes the codebase more uniform.

Credit @ZXShady for the idea.