### PR TITLE
Upgrade to clang-format-17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,17 +269,17 @@ jobs:
 
   format:
     name: Formatting
-    runs-on: ubuntu-22.04
-
-    strategy:
-      fail-fast: false
+    runs-on: ubuntu-24.04
 
     steps:
+    - name: Install Clang Format
+      run: sudo apt-get install clang-format-17
+
     - name: Checkout Code
       uses: actions/checkout@v4
 
     - name: Format Code
-      run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-14 -P cmake/Format.cmake
+      run: cmake -DCLANG_FORMAT_EXECUTABLE=clang-format-17 -P cmake/Format.cmake
 
     - name: Check Formatting
       run: git diff --exit-code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,7 +529,7 @@ if(SFML_BUILD_TEST_SUITE)
     endif()
 endif()
 
-sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires version 14")
+sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires version 17")
 add_custom_target(format
     COMMAND ${CMAKE_COMMAND} -DCLANG_FORMAT_EXECUTABLE=${CLANG_FORMAT_EXECUTABLE} -P ./cmake/Format.cmake
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} VERBATIM)

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -13,8 +13,8 @@ endif()
 execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} --version OUTPUT_VARIABLE CLANG_FORMAT_VERSION)
 string(REGEX MATCH "clang-format version ([0-9]+)" CLANG_FORMAT_VERSION ${CLANG_FORMAT_VERSION})
 unset(CLANG_FORMAT_VERSION)
-if(NOT CMAKE_MATCH_1 EQUAL 14)
-    message(FATAL_ERROR "clang-format version ${CMAKE_MATCH_1} not supported. Must use version 14")
+if(NOT CMAKE_MATCH_1 EQUAL 17)
+    message(FATAL_ERROR "clang-format version ${CMAKE_MATCH_1} not supported. Must use version 17")
 endif()
 
 # Run

--- a/examples/event_handling/EventHandling.cpp
+++ b/examples/event_handling/EventHandling.cpp
@@ -316,10 +316,10 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     sf::RenderWindow m_window{sf::VideoMode({800u, 600u}), "SFML Event Handling", sf::Style::Titlebar | sf::Style::Close};
-    const sf::Font   m_font{"resources/tuffy.ttf"};
-    sf::Text         m_logText{m_font, "", 20};
-    sf::Text         m_handlerText{m_font, "Current Handler: Classic", 24};
-    sf::Text         m_instructions{m_font, "Press Enter to change handler type", 24};
+    const sf::Font           m_font{"resources/tuffy.ttf"};
+    sf::Text                 m_logText{m_font, "", 20};
+    sf::Text                 m_handlerText{m_font, "Current Handler: Classic", 24};
+    sf::Text                 m_instructions{m_font, "Press Enter to change handler type", 24};
     std::vector<std::string> m_log;
     HandlerType              m_handlerType{HandlerType::Classic};
 };

--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -285,12 +285,12 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::unique_ptr<SoundFileReader>            m_reader; //!< Reader that handles I/O on the file's format
+    std::unique_ptr<SoundFileReader> m_reader; //!< Reader that handles I/O on the file's format
     std::unique_ptr<InputStream, StreamDeleter> m_stream{nullptr, false}; //!< Input stream used to access the file's data
-    std::uint64_t                               m_sampleOffset{};         //!< Sample Read Position
-    std::uint64_t                               m_sampleCount{};          //!< Total number of samples in the file
-    unsigned int                                m_sampleRate{};           //!< Number of samples per second
-    std::vector<SoundChannel>                   m_channelMap; //!< The map of position in sample frame to sound channel
+    std::uint64_t             m_sampleOffset{};                           //!< Sample Read Position
+    std::uint64_t             m_sampleCount{};                            //!< Total number of samples in the file
+    unsigned int              m_sampleRate{};                             //!< Number of samples per second
+    std::vector<SoundChannel> m_channelMap; //!< The map of position in sample frame to sound channel
 };
 
 } // namespace sf

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -365,8 +365,8 @@ private:
     std::vector<std::int16_t> m_samples;                        //!< Samples buffer
     unsigned int              m_sampleRate{44100};              //!< Number of samples per second
     std::vector<SoundChannel> m_channelMap{SoundChannel::Mono}; //!< The map of position in sample frame to sound channel
-    Time                      m_duration;                       //!< Sound duration
-    mutable SoundList         m_sounds;                         //!< List of sounds that are using this buffer
+    Time              m_duration;                               //!< Sound duration
+    mutable SoundList m_sounds;                                 //!< List of sounds that are using this buffer
 };
 
 } // namespace sf

--- a/include/SFML/Graphics/StencilMode.hpp
+++ b/include/SFML/Graphics/StencilMode.hpp
@@ -110,7 +110,7 @@ struct SFML_GRAPHICS_API StencilMode
         StencilUpdateOperation::Keep}; //!< The update operation to perform if the stencil test passes
     StencilValue stencilReference{0};  //!< The reference value we're performing the stencil test with
     StencilValue stencilMask{~0u}; //!< The mask to apply to both the reference value and the value in the stencil buffer
-    bool         stencilOnly{};    //!< Whether we should update the color buffer in addition to the stencil buffer
+    bool stencilOnly{};            //!< Whether we should update the color buffer in addition to the stencil buffer
 };
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -214,10 +214,10 @@ public:
             NotModified = 304, //!< For conditional requests, means the requested page hasn't changed and doesn't need to be refreshed
 
             // 4xx: client error
-            BadRequest          = 400, //!< The server couldn't understand the request (syntax error)
-            Unauthorized        = 401, //!< The requested page needs an authentication to be accessed
-            Forbidden           = 403, //!< The requested page cannot be accessed at all, even with authentication
-            NotFound            = 404, //!< The requested page doesn't exist
+            BadRequest   = 400,        //!< The server couldn't understand the request (syntax error)
+            Unauthorized = 401,        //!< The requested page needs an authentication to be accessed
+            Forbidden    = 403,        //!< The requested page cannot be accessed at all, even with authentication
+            NotFound     = 404,        //!< The requested page doesn't exist
             RangeNotSatisfiable = 407, //!< The server can't satisfy the partial GET request (with a "Range" header field)
 
             // 5xx: server error

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -123,8 +123,8 @@ public:
     struct MouseWheelScrolled
     {
         Mouse::Wheel wheel{}; //!< Which wheel (for mice with multiple ones)
-        float        delta{}; //!< Wheel offset (positive is up/left, negative is down/right). High-precision mice may use non-integral offsets.
-        Vector2i     position; //!< Position of the mouse pointer, relative to the top left of the owner window
+        float delta{}; //!< Wheel offset (positive is up/left, negative is down/right). High-precision mice may use non-integral offsets.
+        Vector2i position; //!< Position of the mouse pointer, relative to the top left of the owner window
     };
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Audio/MiniaudioUtils.hpp
+++ b/src/SFML/Audio/MiniaudioUtils.hpp
@@ -92,12 +92,12 @@ struct SoundBase
     };
 
     ma_data_source_base dataSourceBase{}; //!< The struct that makes this object a miniaudio data source (must be first member)
-    ma_node_vtable          effectNodeVTable{}; //!< Vtable of the effect node
-    EffectNode              effectNode;         //!< The engine node that performs effect processing
+    ma_node_vtable effectNodeVTable{};       //!< Vtable of the effect node
+    EffectNode     effectNode;               //!< The engine node that performs effect processing
     std::vector<ma_channel> soundChannelMap; //!< The map of position in sample frame to sound channel (miniaudio channels)
-    ma_sound                sound{};         //!< The sound
-    SoundSource::Status     status{SoundSource::Status::Stopped}; //!< The status
-    SoundSource::EffectProcessor   effectProcessor;               //!< The effect processor
+    ma_sound                     sound{};    //!< The sound
+    SoundSource::Status          status{SoundSource::Status::Stopped}; //!< The status
+    SoundSource::EffectProcessor effectProcessor;                      //!< The effect processor
     AudioDevice::ResourceEntryIter resourceEntryIter; //!< Iterator to the resource entry registered with the AudioDevice
     MiniaudioUtils::SavedSettings savedSettings; //!< Saved settings used to restore ma_sound state in case we need to recreate it
 };

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -211,15 +211,15 @@ struct SoundStream::Impl : priv::MiniaudioUtils::SoundBase
     // Member data
     ////////////////////////////////////////////////////////////
     static constexpr ma_data_source_vtable vtable{read, seek, getFormat, getCursor, getLength, setLooping, /* flags */ 0};
-    SoundStream*                           owner;        //!< Owning SoundStream object
-    std::vector<std::int16_t>              sampleBuffer; //!< Our temporary sample buffer
-    std::size_t               sampleBufferCursor{};      //!< The current read position in the temporary sample buffer
-    std::uint64_t             samplesProcessed{};        //!< Number of samples processed since beginning of the stream
-    unsigned int              channelCount{};            //!< Number of channels (1 = mono, 2 = stereo, ...)
-    unsigned int              sampleRate{};              //!< Frequency (samples / second)
-    std::vector<SoundChannel> channelMap;                //!< The map of position in sample frame to sound channel
-    bool                      loop{};                    //!< Loop flag (`true` to loop, `false` to play once)
-    bool                      streaming{true};           //!< `true` if we are still streaming samples from the source
+    SoundStream*              owner;                //!< Owning SoundStream object
+    std::vector<std::int16_t> sampleBuffer;         //!< Our temporary sample buffer
+    std::size_t               sampleBufferCursor{}; //!< The current read position in the temporary sample buffer
+    std::uint64_t             samplesProcessed{};   //!< Number of samples processed since beginning of the stream
+    unsigned int              channelCount{};       //!< Number of channels (1 = mono, 2 = stereo, ...)
+    unsigned int              sampleRate{};         //!< Frequency (samples / second)
+    std::vector<SoundChannel> channelMap;           //!< The map of position in sample frame to sound channel
+    bool                      loop{};               //!< Loop flag (`true` to loop, `false` to play once)
+    bool                      streaming{true};      //!< `true` if we are still streaming samples from the source
 };
 
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -474,7 +474,7 @@ bool Image::copy(const Image& source, Vector2u dest, const IntRect& sourceRect, 
     const unsigned int dstStride = m_size.x * 4;
 
     const std::uint8_t* srcPixels = source.m_pixels.data() + (srcRect.position.x + srcRect.position.y * source.m_size.x) * 4;
-    std::uint8_t*       dstPixels = m_pixels.data() + (dest.x + dest.y * m_size.x) * 4;
+    std::uint8_t* dstPixels = m_pixels.data() + (dest.x + dest.y * m_size.x) * 4;
 
     // Copy the pixels
     if (applyAlpha)

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -890,7 +890,7 @@ void RenderTarget::drawPrimitives(PrimitiveType type, std::size_t firstVertex, s
 {
     // Find the OpenGL primitive type
     static constexpr GLenum modes[] = {GL_POINTS, GL_LINES, GL_LINE_STRIP, GL_TRIANGLES, GL_TRIANGLE_STRIP, GL_TRIANGLE_FAN};
-    const GLenum            mode = modes[static_cast<std::size_t>(type)];
+    const GLenum mode = modes[static_cast<std::size_t>(type)];
 
     // Draw the primitives
     glCheck(glDrawArrays(mode, static_cast<GLint>(firstVertex), static_cast<GLsizei>(vertexCount)));

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -515,10 +515,10 @@ Image Texture::copyToImage() const
         glCheck(glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, allPixels.data()));
 
         // Then we copy the useful pixels from the temporary array to the final one
-        const std::uint8_t* src = allPixels.data();
-        std::uint8_t* dst = pixels.data();
-        int srcPitch = static_cast<int>(m_actualSize.x * 4);
-        const unsigned int dstPitch = m_size.x * 4;
+        const std::uint8_t* src      = allPixels.data();
+        std::uint8_t*       dst      = pixels.data();
+        int                 srcPitch = static_cast<int>(m_actualSize.x * 4);
+        const unsigned int  dstPitch = m_size.x * 4;
 
         // Handle the case where source pixels are flipped vertically
         if (m_pixelsFlipped)

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -171,7 +171,7 @@ void goToFullscreenMode(ANativeActivity& activity)
     // API Level 19
     if (apiLevel >= 19)
     {
-        jfieldID   fieldSystemUiFlagImmersiveSticky = lJNIEnv->GetStaticFieldID(classView,
+        jfieldID fieldSystemUiFlagImmersiveSticky = lJNIEnv->GetStaticFieldID(classView,
                                                                               "SYSTEM_UI_FLAG_IMMERSIVE_STICKY",
                                                                               "I");
         const jint systemUiFlagImmersiveSticky = lJNIEnv->GetStaticIntField(classView, fieldSystemUiFlagImmersiveSticky);

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -441,7 +441,7 @@ Packet& Packet::operator<<(std::int64_t data)
                           static_cast<std::uint8_t>((data >> 24) & 0xFF),
                           static_cast<std::uint8_t>((data >> 16) & 0xFF),
                           static_cast<std::uint8_t>((data >> 8) & 0xFF),
-                          static_cast<std::uint8_t>((data)&0xFF)};
+                          static_cast<std::uint8_t>((data) & 0xFF)};
 
     append(&toWrite, sizeof(toWrite));
     return *this;
@@ -461,7 +461,7 @@ Packet& Packet::operator<<(std::uint64_t data)
                           static_cast<std::uint8_t>((data >> 24) & 0xFF),
                           static_cast<std::uint8_t>((data >> 16) & 0xFF),
                           static_cast<std::uint8_t>((data >> 8) & 0xFF),
-                          static_cast<std::uint8_t>((data)&0xFF)};
+                          static_cast<std::uint8_t>((data) & 0xFF)};
 
     append(&toWrite, sizeof(toWrite));
     return *this;

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -413,7 +413,7 @@ XVisualInfo EglContext::selectBestVisual(::Display* xDisplay, unsigned int bitsP
     vTemplate.visualid = static_cast<VisualID>(nativeVisualId);
 
     // Get X11 visuals compatible with this EGL config
-    int        visualCount      = 0;
+    int visualCount = 0;
     const auto availableVisuals = X11Ptr<XVisualInfo[]>(XGetVisualInfo(xDisplay, VisualIDMask, &vTemplate, &visualCount));
 
     if (visualCount == 0)

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -1053,7 +1053,7 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
 void GlContext::checkSettings(const ContextSettings& requestedSettings) const
 {
     // Perform checks to inform the user if they are getting a context they might not have expected
-    const int version          = static_cast<int>(m_settings.majorVersion * 10u + m_settings.minorVersion);
+    const int version = static_cast<int>(m_settings.majorVersion * 10u + m_settings.minorVersion);
     const int requestedVersion = static_cast<int>(requestedSettings.majorVersion * 10u + requestedSettings.minorVersion);
 
     if ((m_settings.attributeFlags != requestedSettings.attributeFlags) || (version < requestedVersion) ||

--- a/src/SFML/Window/Unix/CursorImpl.cpp
+++ b/src/SFML/Window/Unix/CursorImpl.cpp
@@ -80,8 +80,8 @@ bool CursorImpl::loadFromPixelsARGB(const std::uint8_t* pixels, Vector2u size, V
 {
     // Create cursor image, convert from RGBA to ARGB.
     const auto cursorImage = X11Ptr<XcursorImage>(XcursorImageCreate(static_cast<int>(size.x), static_cast<int>(size.y)));
-    cursorImage->xhot      = hotspot.x;
-    cursorImage->yhot      = hotspot.y;
+    cursorImage->xhot = hotspot.x;
+    cursorImage->yhot = hotspot.y;
 
     const std::size_t numPixels = static_cast<std::size_t>(size.x) * static_cast<std::size_t>(size.y);
     for (std::size_t pixelIndex = 0; pixelIndex < numPixels; ++pixelIndex)

--- a/src/SFML/Window/Unix/JoystickImpl.cpp
+++ b/src/SFML/Window/Unix/JoystickImpl.cpp
@@ -579,7 +579,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
     {
         switch (m_mapping[static_cast<std::size_t>(i)])
         {
-            // clang-format off
+                // clang-format off
             case ABS_X:        caps.axes[Joystick::Axis::X]    = true; break;
             case ABS_Y:        caps.axes[Joystick::Axis::Y]    = true; break;
             case ABS_Z:

--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -48,8 +48,8 @@
 namespace
 {
 
-const KeyCode                                                                     nullKeyCode = 0;
-const int                                                                         maxKeyCode  = 256;
+const KeyCode nullKeyCode = 0;
+const int     maxKeyCode  = 256;
 sf::priv::EnumArray<sf::Keyboard::Scancode, KeyCode, sf::Keyboard::ScancodeCount> scancodeToKeycode; ///< Mapping of SFML scancode to X11 KeyCode
 std::array<sf::Keyboard::Scancode, maxKeyCode> keycodeToScancode; ///< Mapping of X11 KeyCode to SFML scancode
 

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -327,15 +327,15 @@ private:
     RRCrtc                   m_oldRRCrtc{};    ///< RRCrtc in use before we switch to fullscreen
     ::Cursor m_hiddenCursor{}; ///< As X11 doesn't provide cursor hiding, we must create a transparent one
     ::Cursor m_lastCursor{None}; ///< Last cursor used -- this data is not owned by the window and is required to be always valid
-    bool     m_keyRepeat{true}; ///< Is the KeyRepeat feature enabled?
+    bool m_keyRepeat{true}; ///< Is the KeyRepeat feature enabled?
     Vector2i m_previousSize{-1, -1}; ///< Previous size of the window, to find if a ConfigureNotify event is a resize event (could be a move event only)
-    bool     m_useSizeHints{};   ///< Is the size of the window fixed with size hints?
-    bool     m_fullscreen{};     ///< Is the window in fullscreen?
-    bool     m_cursorGrabbed{};  ///< Is the mouse cursor trapped?
-    bool     m_windowMapped{};   ///< Has the window been mapped by the window manager?
-    Pixmap   m_iconPixmap{};     ///< The current icon pixmap if in use
-    Pixmap   m_iconMaskPixmap{}; ///< The current icon mask pixmap if in use
-    ::Time   m_lastInputTime{};  ///< Last time we received user input
+    bool   m_useSizeHints{};   ///< Is the size of the window fixed with size hints?
+    bool   m_fullscreen{};     ///< Is the window in fullscreen?
+    bool   m_cursorGrabbed{};  ///< Is the mouse cursor trapped?
+    bool   m_windowMapped{};   ///< Has the window been mapped by the window manager?
+    Pixmap m_iconPixmap{};     ///< The current icon pixmap if in use
+    Pixmap m_iconMaskPixmap{}; ///< The current icon mask pixmap if in use
+    ::Time m_lastInputTime{};  ///< Last time we received user input
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -213,10 +213,10 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int                                        m_index{};      //!< Index of the joystick
-    JOYCAPS                                             m_caps{};       //!< Joystick capabilities
-    IDirectInputDevice8W*                               m_device{};     //!< DirectInput 8.x device
-    DIDEVCAPS                                           m_deviceCaps{}; //!< DirectInput device capabilities
+    unsigned int          m_index{};                              //!< Index of the joystick
+    JOYCAPS               m_caps{};                               //!< Joystick capabilities
+    IDirectInputDevice8W* m_device{};                             //!< DirectInput 8.x device
+    DIDEVCAPS             m_deviceCaps{};                         //!< DirectInput device capabilities
     EnumArray<Joystick::Axis, int, Joystick::AxisCount> m_axes{}; //!< Offsets to the bytes containing the axes states, -1 if not available
     int m_buttons[Joystick::ButtonCount]{}; //!< Offsets to the bytes containing the button states, -1 if not available
     Joystick::Identification m_identification; //!< Joystick identification

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -305,9 +305,9 @@ private:
     Vector2u m_lastSize;               //!< The last handled size of the window
     bool     m_resizing{};             //!< Is the window being resized?
     std::uint16_t m_surrogate{}; //!< First half of the surrogate pair, in case we're receiving a Unicode character in two events
-    bool          m_mouseInside{};   //!< Mouse is inside the window?
-    bool          m_fullscreen{};    //!< Is the window fullscreen?
-    bool          m_cursorGrabbed{}; //!< Is the mouse cursor trapped?
+    bool m_mouseInside{};   //!< Mouse is inside the window?
+    bool m_fullscreen{};    //!< Is the window fullscreen?
+    bool m_cursorGrabbed{}; //!< Is the mouse cursor trapped?
 };
 
 } // namespace priv

--- a/src/SFML/Window/iOS/EaglContext.mm
+++ b/src/SFML/Window/iOS/EaglContext.mm
@@ -86,7 +86,7 @@ void ensureInit()
             sf::priv::EaglContext::getFunction("glRenderbufferStorageOES"));
     }
 }
-}
+} // namespace
 
 
 namespace sf::priv

--- a/src/SFML/Window/iOS/InputImpl.mm
+++ b/src/SFML/Window/iOS/InputImpl.mm
@@ -138,4 +138,4 @@ Vector2i getTouchPosition(unsigned int finger, const WindowBase& /* relativeTo *
     return getTouchPosition(finger);
 }
 
-} // namespace sf::priv
+} // namespace sf::priv::InputImpl

--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -38,7 +38,7 @@ SFAppDelegate* delegateInstance = nullptr;
 
 // Current touches positions
 std::vector<sf::Vector2i> touchPositions;
-}
+} // namespace
 
 
 @interface SFAppDelegate ()

--- a/src/SFML/Window/macOS/CursorImpl.mm
+++ b/src/SFML/Window/macOS/CursorImpl.mm
@@ -45,7 +45,7 @@ NSCursor* loadFromSelector(SEL selector)
     return nil;
 }
 
-}
+} // namespace
 
 namespace sf::priv
 {

--- a/src/SFML/Window/macOS/HIDInputManager.mm
+++ b/src/SFML/Window/macOS/HIDInputManager.mm
@@ -37,7 +37,7 @@ namespace
 {
 const std::uint8_t unknownVirtualCode = 0xff;
 const bool         isIsoKeyboard      = (KBGetLayoutType(LMGetKbdType()) == kKeyboardISO);
-}
+} // namespace
 
 namespace sf::priv
 {

--- a/src/SFML/Window/macOS/InputImpl.mm
+++ b/src/SFML/Window/macOS/InputImpl.mm
@@ -115,7 +115,7 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const sf::WindowBase& window)
 
     return view;
 }
-}
+} // namespace
 
 namespace sf::priv::InputImpl
 {
@@ -263,4 +263,4 @@ Vector2i getTouchPosition(unsigned int /*finger*/, const WindowBase& /*relativeT
     return {};
 }
 
-} // namespace sf::priv
+} // namespace sf::priv::InputImpl

--- a/src/SFML/Window/macOS/SFKeyboardModifiersHelper.mm
+++ b/src/SFML/Window/macOS/SFKeyboardModifiersHelper.mm
@@ -131,7 +131,7 @@ void processLeftRightModifiers(
     processOneModifier(modifiers, leftMask, leftWasDown, leftKey, leftCode, requester);
     processOneModifier(modifiers, rightMask, rightWasDown, rightKey, rightCode, requester);
 }
-}
+} // namespace
 
 
 ////////////////////////////////////////////////////////

--- a/src/SFML/Window/macOS/WindowImplCocoa.mm
+++ b/src/SFML/Window/macOS/WindowImplCocoa.mm
@@ -93,7 +93,7 @@ void showMouseCursor()
         isCursorHidden = false;
     }
 }
-}
+} // namespace
 
 #pragma mark
 #pragma mark WindowImplCocoa's ctor/dtor


### PR DESCRIPTION
## Description

We've been using clang-format-14 as our sole formatting program for a while but it's starting to get old. LLVM 19 is now out which macOS Homebrew ships. For years Homebrew has not shipped version 14 so I had to get a standalone clang-format-14 executable to keep formatting SFML. The latest stable Ubuntu release ships with versions 14 through 18 so Ubuntu hasn't quite yet abandoned version 14 but it's on the cusp. We periodically need to upgrade the version of clang-format we use to make sure developers have a somewhat easy time acquiring the right version of clang-format. I'm unsure what the situation is for shipping and packaging clang-format on Windows but surely this version is easier to get than 14.

Along with this upgrade we have access to 3 more major versions worth of new features. I chose to not touch the .clang-format file but it's worth looking at what features were added in case we'd like to take advantage of any of them. For future reference, here are the release notes for clang-format versions 15, 16, and 17.

- https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#clang-format
- https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#clang-format
- https://releases.llvm.org/17.0.1/tools/clang/docs/ReleaseNotes.html#clang-format

_Why not clang-format-18 if Homebrew and Ubuntu ship it?_

Weirdly enough, the two versions shipped on each OS have a different patch version which surprisingly results in differing formatting between the two. It would be pretty annoying if two devs, one on Debian and one on macOS, both used the "same version" of clang-format just to get different results. Version 17 does not have this problem. Homebrew and Debian ship the same version down to the patch number so that won't be a problem.

_Why does the formatting keep changing as we upgrade?_

clang-format does not try to produce identical results between releases. There are certainly unit tests which catch regressions to some extent but for some combinations of rules, there are not tests to prevent changes or perhaps the changes are intentional. My hope is that over time these "random" or perhaps unplanned changes between releases slow down but I don't have firm evidence to prove that's the case. The vertical alignment rules seem to be a hot spot for these differences. In codebases of mine that don't use vertical alignment rules I've noticed many fewer changes in clang-format results between versions.