### PR TITLE
Close the open window first

### DIFF
--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -84,6 +84,9 @@ void Window::create(VideoMode mode, const String& title, std::uint32_t style, St
 ////////////////////////////////////////////////////////////
 void Window::create(VideoMode mode, const String& title, std::uint32_t style, State state, const ContextSettings& settings)
 {
+    // Ensure the open window is closed first
+    close();
+
     // Recreate the window implementation
     m_impl = priv::WindowImpl::create(mode, title, style, state, settings);
 

--- a/src/SFML/Window/WindowBase.cpp
+++ b/src/SFML/Window/WindowBase.cpp
@@ -112,6 +112,9 @@ void WindowBase::create(VideoMode mode, const String& title, State state)
 ////////////////////////////////////////////////////////////
 void WindowBase::create(WindowHandle handle)
 {
+    // Ensure the open window is closed first
+    close();
+
     // Recreate the window implementation
     m_impl = priv::WindowImpl::create(handle);
 


### PR DESCRIPTION
## Description

This prevents race conditions where for a brief moment two different window implementations can exist and cause uniqueness issues. Or likely rather related to having two contexts "active" at the same time.

@Lorenzooone reported on Discord that they sometimes get some OpenGL errors when recreating a window with SFML 3

Windows
![image](https://github.com/user-attachments/assets/1a6c2270-87d5-4d48-a6c1-fdeb39c4c508)

Linux
![image](https://github.com/user-attachments/assets/fef29eb4-9474-4949-9c74-899edd8a6018)

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
            if (event->is<sf::Event::KeyPressed>())
                window.create(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
        }

        window.clear();
        window.display();
    }
}
```
