### PR TITLE
Remove backticks which are not correctly formatted

### DIFF
--- a/include/SFML/Audio/InputSoundFile.hpp
+++ b/include/SFML/Audio/InputSoundFile.hpp
@@ -73,7 +73,7 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \throws `sf::Exception` if opening the file was unsuccessful
+    /// \throws sf::Exception if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     explicit InputSoundFile(const std::filesystem::path& filename);
@@ -87,7 +87,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `sf::Exception` if opening the file was unsuccessful
+    /// \throws sf::Exception if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     InputSoundFile(const void* data, std::size_t sizeInBytes);
@@ -100,7 +100,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `sf::Exception` if opening the file was unsuccessful
+    /// \throws sf::Exception if opening the file was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     explicit InputSoundFile(InputStream& stream);

--- a/include/SFML/Audio/Music.hpp
+++ b/include/SFML/Audio/Music.hpp
@@ -88,7 +88,7 @@ public:
     ///
     /// \param filename Path of the music file to open
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `openFromMemory`, `openFromStream`
     ///
@@ -111,7 +111,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `openFromFile`, `openFromStream`
     ///
@@ -132,7 +132,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `openFromFile`, `openFromMemory`
     ///

--- a/include/SFML/Audio/OutputSoundFile.hpp
+++ b/include/SFML/Audio/OutputSoundFile.hpp
@@ -67,7 +67,7 @@ public:
     /// \param channelCount Number of channels in the sound
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \throws `sf::Exception` if the file could not be opened successfully
+    /// \throws sf::Exception if the file could not be opened successfully
     ///
     ////////////////////////////////////////////////////////////
     OutputSoundFile(const std::filesystem::path&     filename,

--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -79,7 +79,7 @@ public:
     ///
     /// \param filename Path of the sound file to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromMemory`, `loadFromStream`, `loadFromSamples`, `saveToFile`
     ///
@@ -95,7 +95,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromStream`, `loadFromSamples`
     ///
@@ -110,7 +110,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromSamples`
     ///
@@ -128,7 +128,7 @@ public:
     /// \param sampleRate   Sample rate (number of samples to play per second)
     /// \param channelMap   Map of position in sample frame to sound channel
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `saveToFile`
     ///

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -95,7 +95,7 @@ public:
     ///
     /// \param filename Path of the font file to open
     ///
-    /// \throws `sf::Exception` if opening was unsuccessful
+    /// \throws sf::Exception if opening was unsuccessful
     ///
     /// \see `openFromFile`, `openFromMemory`, `openFromStream`
     ///
@@ -116,7 +116,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Size of the data to load, in bytes
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `openFromFile`, `openFromMemory`, `openFromStream`
     ///
@@ -138,7 +138,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `openFromFile`, `openFromMemory`, `openFromStream`
     ///

--- a/include/SFML/Graphics/Image.hpp
+++ b/include/SFML/Graphics/Image.hpp
@@ -95,7 +95,7 @@ public:
     ///
     /// \param filename Path of the image file to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -112,7 +112,7 @@ public:
     /// \param data Pointer to the file data in memory
     /// \param size Size of the data to load, in bytes
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -128,7 +128,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///

--- a/include/SFML/Graphics/RenderTexture.hpp
+++ b/include/SFML/Graphics/RenderTexture.hpp
@@ -77,7 +77,7 @@ public:
     /// \param size     Width and height of the render-texture
     /// \param settings Additional settings for the underlying OpenGL texture and context
     ///
-    /// \throws `sf::Exception` if creation was unsuccessful
+    /// \throws sf::Exception if creation was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     RenderTexture(Vector2u size, const ContextSettings& settings = {});

--- a/include/SFML/Graphics/Shader.hpp
+++ b/include/SFML/Graphics/Shader.hpp
@@ -139,7 +139,7 @@ public:
     /// \param filename Path of the vertex, geometry or fragment shader file to load
     /// \param type     Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -160,7 +160,7 @@ public:
     /// \param vertexShaderFilename   Path of the vertex shader file to load
     /// \param fragmentShaderFilename Path of the fragment shader file to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -182,7 +182,7 @@ public:
     /// \param geometryShaderFilename Path of the geometry shader file to load
     /// \param fragmentShaderFilename Path of the fragment shader file to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -204,7 +204,7 @@ public:
     /// \param shader String containing the source code of the shader
     /// \param type   Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -225,7 +225,7 @@ public:
     /// \param vertexShader   String containing the source code of the vertex shader
     /// \param fragmentShader String containing the source code of the fragment shader
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -247,7 +247,7 @@ public:
     /// \param geometryShader String containing the source code of the geometry shader
     /// \param fragmentShader String containing the source code of the fragment shader
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -267,7 +267,7 @@ public:
     /// \param stream Source stream to read from
     /// \param type   Type of shader (vertex, geometry or fragment)
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -288,7 +288,7 @@ public:
     /// \param vertexShaderStream   Source stream to read the vertex shader from
     /// \param fragmentShaderStream Source stream to read the fragment shader from
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///
@@ -310,7 +310,7 @@ public:
     /// \param geometryShaderStream Source stream to read the geometry shader from
     /// \param fragmentShaderStream Source stream to read the fragment shader from
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`
     ///

--- a/include/SFML/Graphics/Texture.hpp
+++ b/include/SFML/Graphics/Texture.hpp
@@ -106,7 +106,7 @@ public:
     /// \param filename Path of the image file to load
     /// \param sRgb     `true` to enable sRGB conversion, `false` to disable it
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -129,7 +129,7 @@ public:
     /// \param sRgb     `true` to enable sRGB conversion, `false` to disable it
     /// \param area     Area of the image to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -146,7 +146,7 @@ public:
     /// \param size Size of the data to load, in bytes
     /// \param sRgb `true` to enable sRGB conversion, `false` to disable it
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -170,7 +170,7 @@ public:
     /// \param sRgb `true` to enable sRGB conversion, `false` to disable it
     /// \param area Area of the image to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -186,7 +186,7 @@ public:
     /// \param stream Source stream to read from
     /// \param sRgb   `true` to enable sRGB conversion, `false` to disable it
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -209,7 +209,7 @@ public:
     /// \param sRgb   `true` to enable sRGB conversion, `false` to disable it
     /// \param area   Area of the image to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -225,7 +225,7 @@ public:
     /// \param image Image to load into the texture
     /// \param sRgb  `true` to enable sRGB conversion, `false` to disable it
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -247,7 +247,7 @@ public:
     /// \param sRgb  `true` to enable sRGB conversion, `false` to disable it
     /// \param area  Area of the image to load
     ///
-    /// \throws `sf::Exception` if loading was unsuccessful
+    /// \throws sf::Exception if loading was unsuccessful
     ///
     /// \see `loadFromFile`, `loadFromMemory`, `loadFromStream`, `loadFromImage`
     ///
@@ -260,7 +260,7 @@ public:
     /// \param size Width and height of the texture
     /// \param sRgb `true` to enable sRGB conversion, `false` to disable it
     ///
-    /// \throws `sf::Exception` if construction was unsuccessful
+    /// \throws sf::Exception if construction was unsuccessful
     ///
     ////////////////////////////////////////////////////////////
     explicit Texture(Vector2u size, bool sRgb = false);

--- a/include/SFML/System/FileInputStream.hpp
+++ b/include/SFML/System/FileInputStream.hpp
@@ -100,7 +100,7 @@ public:
     ///
     /// \param filename Name of the file to open
     ///
-    /// \throws `sf::Exception` on error
+    /// \throws sf::Exception on error
     ///
     ////////////////////////////////////////////////////////////
     explicit FileInputStream(const std::filesystem::path& filename);

--- a/include/SFML/Window/Cursor.hpp
+++ b/include/SFML/Window/Cursor.hpp
@@ -171,7 +171,7 @@ public:
     /// \param size    Width and height of the image
     /// \param hotspot (x,y) location of the hotspot
     ///
-    /// \throws `sf::Exception` if the cursor could not be constructed
+    /// \throws sf::Exception if the cursor could not be constructed
     ///
     ////////////////////////////////////////////////////////////
     Cursor(const std::uint8_t* pixels, Vector2u size, Vector2u hotspot);
@@ -186,7 +186,7 @@ public:
     ///
     /// \param type Native system cursor type
     ///
-    /// \throws `sf::Exception` if the corresponding cursor
+    /// \throws sf::Exception if the corresponding cursor
     ///         is not natively supported by the operating
     ///         system
     ///


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/fc414ded-c488-4222-85e3-06c4f508339c)

For whatever reason these backticks are not correctly formatted so I removed them.