### PR TITLE
Mention the removal of `sf::SoundStream::setProcessingInterval`

### DIFF
--- a/include/SFML/Audio/SoundRecorder.hpp
+++ b/include/SFML/Audio/SoundRecorder.hpp
@@ -278,12 +278,6 @@ private:
 /// \li `onStart` is called before the capture happens, to perform custom initializations
 /// \li `onStop` is called after the capture ends, to perform custom cleanup
 ///
-/// A derived class can also control the frequency of the onProcessSamples
-/// calls, with the `setProcessingInterval` protected function. The default
-/// interval is chosen so that recording thread doesn't consume too much
-/// CPU, but it can be changed to a smaller value if you need to process
-/// the recorded data in real time, for example.
-///
 /// The audio capture feature may not be supported or activated
 /// on every platform, thus it is recommended to check its
 /// availability with the isAvailable() function. If it returns

--- a/migration.md
+++ b/migration.md
@@ -448,3 +448,4 @@ SFML 3 includes various smaller changes that ought to be mentioned.
 * Renamed `sf::Mouse::Button::XButton1` and `sf::Mouse::Button::XButton2` enumerators to `sf::Mouse::Button::Extra1` and `sf::Mouse::Button::Extra2`
 * Removed NonCopyable.hpp header in favor of using built-in language features for disabling copy operators
 * Converted the following classes to namespaces: `sf::Clipboard`, `sf::Keyboard`, `sf::Joystick`, `sf::Listener`, `sf::Mouse`, `sf::Sensor`, `sf::Touch`, `sf::Vulkan`
+* Removed `sf::SoundStream::setProcessingInterval` as miniaudio matches the internal processing rate to the underlying backend


### PR DESCRIPTION
## Description

There is no replacement API for this. It's existence was rendered obsolete by the move to Miniaudio.