### PR TITLE
Revert "Stop uploading code coverage from non-pull request CI runs"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
     name: Finalize Coverage Upload
     needs: build
     runs-on: ubuntu-22.04
-    if: github.repository == 'SFML/SFML' && github.event_name == 'pull_request' # Only run for PRs to main repository
+    if: github.repository == 'SFML/SFML' # Disable upload in forks
 
     steps:
     - name: Coveralls Finished


### PR DESCRIPTION
## Description

This reverts commit 46a1b568a981d7854f498b417a2ab6a0e3f1ae3e as it seems to cause wrong reporting on pull request coverage info, likely due to missing baselines from the master branch "push".

This PR is related to the issue #3281

I've heard @kimci86 has some additional ideas, but maybe it's worth to revert first.

## How to test this PR?

Have CI pass and coverage report uploaded for both push and pull request.