### PR TITLE
Introducing SFML Guru on Gurubase.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![SFML logo](https://www.sfml-dev.org/images/logo.png)](https://www.sfml-dev.org)
+[![SFML logo](https://www.sfml-dev.org/images/logo.png)](https://www.sfml-dev.org) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20SFML%20Guru-006BFF)](https://gurubase.io/g/sfml)
 
 # SFML — Simple and Fast Multimedia Library
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![SFML logo](https://www.sfml-dev.org/images/logo.png)](https://www.sfml-dev.org) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20SFML%20Guru-006BFF)](https://gurubase.io/g/sfml)
+[![SFML logo](https://www.sfml-dev.org/images/logo.png)](https://www.sfml-dev.org)
 
 # SFML — Simple and Fast Multimedia Library
 
@@ -34,6 +34,7 @@ There are several places to learn SFML:
 -   The [official tutorials](https://www.sfml-dev.org/tutorials/)
 -   The [online API documentation](https://www.sfml-dev.org/documentation/)
 -   The [community wiki](https://github.com/SFML/SFML/wiki/)
+-   The [SFML Guru](https://gurubase.io/g/sfml), it is a third-party AI agent designed to answer your questions about SFML.
 
 ## Community
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [SFML Guru](https://gurubase.io/g/sfml) to Gurubase. SFML Guru uses the data from this repo and data from the [docs](https://www.sfml-dev.org/tutorials/) to answer questions by leveraging the LLM.

In this PR, I showcased the "SFML Guru", which highlights that SFML now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable SFML Guru in Gurubase, just let me know that's totally fine.
