### PR TITLE
Add Desktop mode to valid MacOS Fullscreen modes

### DIFF
--- a/src/SFML/Window/OSX/VideoModeImpl.cpp
+++ b/src/SFML/Window/OSX/VideoModeImpl.cpp
@@ -51,6 +51,7 @@ std::vector<VideoMode> VideoModeImpl::getFullscreenModes()
     }
 
     VideoMode desktop = getDesktopMode();
+    modes.push_back(desktop);
 
     // Loop on each mode and convert it into a sf::VideoMode object.
     const CFIndex modesCount = CFArrayGetCount(cgmodes);


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [X] Have you provided some example/test code for your changes?
-->

## Description

<!-- Please describe your pull request. -->

Adds the current Desktop mode to the valid Fullscreen Modes (which makes sense, as being <= of the Desktop mode is the parameter for being a valid Fullscreen Mode).

MacOS fullscreen mode just takes the desktop mode and creates black borders around it to match the wanted resolution, in its current implementation. So this change is fully compatible.

The change also has the benefit of making it so there is always going to be a valid Fullscreen mode, unless a catastrofic error occurred.
I didn't add this line of code in the previous PR because I thought for sure the current Desktop mode would also be a Fullscreen mode. However, that doesn't seem to be guaranteed.

This PR is related to the issue #3330 .

Should be ported to master as well.

## Tasks

-   [X] Tested on macOS

## How to test this PR?

You probably need to set some intermediate HiDPI mode, like the user who reported the issue and tested the fix.
As for the code, look at issue #3330 .
I say probably because I couldn't experience this...