### PR TITLE
Use `char32_t` for UTF-32 characters

### DIFF
--- a/examples/keyboard/Keyboard.cpp
+++ b/examples/keyboard/Keyboard.cpp
@@ -730,7 +730,7 @@ sf::String keyEventDescription(sf::String text, const KeyEventType& keyEvent)
 sf::String textEventDescription(const sf::Event::TextEntered& textEntered)
 {
     sf::String text = "Text Entered\n\n";
-    text += static_cast<char32_t>(textEntered.unicode);
+    text += textEntered.unicode;
     text += "\nU+";
 
     std::ostringstream oss;

--- a/include/SFML/Graphics/Font.hpp
+++ b/include/SFML/Graphics/Font.hpp
@@ -237,10 +237,7 @@ public:
     /// \return The glyph corresponding to `codePoint` and `characterSize`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] const Glyph& getGlyph(std::uint32_t codePoint,
-                                        unsigned int  characterSize,
-                                        bool          bold,
-                                        float         outlineThickness = 0) const;
+    [[nodiscard]] const Glyph& getGlyph(char32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness = 0) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Determine if this font has a glyph representing the requested code point
@@ -258,7 +255,7 @@ public:
     /// \return `true` if the codepoint has a glyph representation, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool hasGlyph(std::uint32_t codePoint) const;
+    [[nodiscard]] bool hasGlyph(char32_t codePoint) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the kerning offset of two glyphs
@@ -423,7 +420,7 @@ private:
     /// \return The glyph corresponding to `codePoint` and `characterSize`
     ///
     ////////////////////////////////////////////////////////////
-    Glyph loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness) const;
+    Glyph loadGlyph(char32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Find a suitable rectangle within the texture for a glyph

--- a/include/SFML/System/Utf.hpp
+++ b/include/SFML/System/Utf.hpp
@@ -70,7 +70,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static In decode(In begin, In end, std::uint32_t& output, std::uint32_t replacement = 0);
+    static In decode(In begin, In end, char32_t& output, char32_t replacement = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-8 character
@@ -86,7 +86,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encode(std::uint32_t input, Out output, std::uint8_t replacement = 0);
+    static Out encode(char32_t input, Out output, std::uint8_t replacement = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Advance to the next UTF-8 character
@@ -276,7 +276,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static In decode(In begin, In end, std::uint32_t& output, std::uint32_t replacement = 0);
+    static In decode(In begin, In end, char32_t& output, char32_t replacement = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-16 character
@@ -292,7 +292,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encode(std::uint32_t input, Out output, std::uint16_t replacement = 0);
+    static Out encode(char32_t input, Out output, char16_t replacement = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Advance to the next UTF-16 character
@@ -483,7 +483,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static In decode(In begin, In end, std::uint32_t& output, std::uint32_t replacement = 0);
+    static In decode(In begin, In end, char32_t& output, char32_t replacement = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-32 character
@@ -500,7 +500,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encode(std::uint32_t input, Out output, std::uint32_t replacement = 0);
+    static Out encode(char32_t input, Out output, char32_t replacement = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Advance to the next UTF-32 character
@@ -679,7 +679,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static std::uint32_t decodeAnsi(In input, const std::locale& locale = {});
+    static char32_t decodeAnsi(In input, const std::locale& locale = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Decode a single wide character to UTF-32
@@ -694,7 +694,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static std::uint32_t decodeWide(In input);
+    static char32_t decodeWide(In input);
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-32 character to ANSI
@@ -712,7 +712,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encodeAnsi(std::uint32_t codepoint, Out output, char replacement = 0, const std::locale& locale = {});
+    static Out encodeAnsi(char32_t codepoint, Out output, char replacement = 0, const std::locale& locale = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-32 character to wide
@@ -729,7 +729,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encodeWide(std::uint32_t codepoint, Out output, wchar_t replacement = 0);
+    static Out encodeWide(char32_t codepoint, Out output, wchar_t replacement = 0);
 };
 
 // Make type aliases to get rid of the template syntax

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -52,7 +52,7 @@ OutputIt priv::copy(InputIt first, InputIt last, OutputIt dFirst)
 }
 
 template <typename In>
-In Utf<8>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replacement)
+In Utf<8>::decode(In begin, In end, char32_t& output, char32_t replacement)
 {
     // clang-format off
     // Some useful precomputed data
@@ -107,7 +107,7 @@ In Utf<8>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replace
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<8>::encode(std::uint32_t input, Out output, std::uint8_t replacement)
+Out Utf<8>::encode(char32_t input, Out output, std::uint8_t replacement)
 {
     // Some useful precomputed data
     static constexpr std::array<std::uint8_t, 7> firstBytes = {0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC};
@@ -158,7 +158,7 @@ Out Utf<8>::encode(std::uint32_t input, Out output, std::uint8_t replacement)
 template <typename In>
 In Utf<8>::next(In begin, In end)
 {
-    std::uint32_t codepoint = 0;
+    char32_t codepoint = 0;
     return decode(begin, end, codepoint);
 }
 
@@ -184,8 +184,8 @@ Out Utf<8>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
     while (begin != end)
     {
-        const std::uint32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
-        output                        = encode(codepoint, output);
+        const char32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
+        output                   = encode(codepoint, output);
     }
 
     return output;
@@ -198,8 +198,8 @@ Out Utf<8>::fromWide(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = Utf<32>::decodeWide(*begin++);
-        output                  = encode(codepoint, output);
+        char32_t codepoint = Utf<32>::decodeWide(*begin++);
+        output             = encode(codepoint, output);
     }
 
     return output;
@@ -225,9 +225,9 @@ Out Utf<8>::toAnsi(In begin, In end, Out output, char replacement, const std::lo
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        output                  = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        output             = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
     }
 
     return output;
@@ -240,9 +240,9 @@ Out Utf<8>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        output                  = Utf<32>::encodeWide(codepoint, output, replacement);
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        output             = Utf<32>::encodeWide(codepoint, output, replacement);
     }
 
     return output;
@@ -257,9 +257,9 @@ Out Utf<8>::toLatin1(In begin, In end, Out output, char replacement)
     // and can thus be treated as (a sub-range of) UTF-32
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        *output++               = codepoint < 256 ? static_cast<char>(codepoint) : replacement;
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        *output++          = codepoint < 256 ? static_cast<char>(codepoint) : replacement;
     }
 
     return output;
@@ -280,9 +280,9 @@ Out Utf<8>::toUtf16(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        output                  = Utf<16>::encode(codepoint, output);
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        output             = Utf<16>::encode(codepoint, output);
     }
 
     return output;
@@ -295,9 +295,9 @@ Out Utf<8>::toUtf32(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        *output++               = codepoint;
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        *output++          = codepoint;
     }
 
     return output;
@@ -306,9 +306,9 @@ Out Utf<8>::toUtf32(In begin, In end, Out output)
 
 ////////////////////////////////////////////////////////////
 template <typename In>
-In Utf<16>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replacement)
+In Utf<16>::decode(In begin, In end, char32_t& output, char32_t replacement)
 {
-    const std::uint16_t first = *begin++;
+    const char16_t first = *begin++;
 
     // If it's a surrogate pair, first convert to a single UTF-32 character
     if ((first >= 0xD800) && (first <= 0xDBFF))
@@ -346,7 +346,7 @@ In Utf<16>::decode(In begin, In end, std::uint32_t& output, std::uint32_t replac
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<16>::encode(std::uint32_t input, Out output, std::uint16_t replacement)
+Out Utf<16>::encode(char32_t input, Out output, char16_t replacement)
 {
     if (input <= 0xFFFF)
     {
@@ -360,7 +360,7 @@ Out Utf<16>::encode(std::uint32_t input, Out output, std::uint16_t replacement)
         else
         {
             // Valid character directly convertible to a single UTF-16 character
-            *output++ = static_cast<std::uint16_t>(input);
+            *output++ = static_cast<char16_t>(input);
         }
     }
     else if (input > 0x0010FFFF)
@@ -373,8 +373,8 @@ Out Utf<16>::encode(std::uint32_t input, Out output, std::uint16_t replacement)
     {
         // The input character will be converted to two UTF-16 elements
         input -= 0x0010000;
-        *output++ = static_cast<std::uint16_t>((input >> 10) + 0xD800);
-        *output++ = static_cast<std::uint16_t>((input & 0x3FFUL) + 0xDC00);
+        *output++ = static_cast<char16_t>((input >> 10) + 0xD800);
+        *output++ = static_cast<char16_t>((input & 0x3FFUL) + 0xDC00);
     }
 
     return output;
@@ -385,7 +385,7 @@ Out Utf<16>::encode(std::uint32_t input, Out output, std::uint16_t replacement)
 template <typename In>
 In Utf<16>::next(In begin, In end)
 {
-    std::uint32_t codepoint = 0;
+    char32_t codepoint = 0;
     return decode(begin, end, codepoint);
 }
 
@@ -411,8 +411,8 @@ Out Utf<16>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
-        output                  = encode(codepoint, output);
+        char32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
+        output             = encode(codepoint, output);
     }
 
     return output;
@@ -425,8 +425,8 @@ Out Utf<16>::fromWide(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = Utf<32>::decodeWide(*begin++);
-        output                  = encode(codepoint, output);
+        char32_t codepoint = Utf<32>::decodeWide(*begin++);
+        output             = encode(codepoint, output);
     }
 
     return output;
@@ -449,9 +449,9 @@ Out Utf<16>::toAnsi(In begin, In end, Out output, char replacement, const std::l
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        output                  = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        output             = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
     }
 
     return output;
@@ -464,9 +464,9 @@ Out Utf<16>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        output                  = Utf<32>::encodeWide(codepoint, output, replacement);
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        output             = Utf<32>::encodeWide(codepoint, output, replacement);
     }
 
     return output;
@@ -495,9 +495,9 @@ Out Utf<16>::toUtf8(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        output                  = Utf<8>::encode(codepoint, output);
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        output             = Utf<8>::encode(codepoint, output);
     }
 
     return output;
@@ -518,9 +518,9 @@ Out Utf<16>::toUtf32(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        std::uint32_t codepoint = 0;
-        begin                   = decode(begin, end, codepoint);
-        *output++               = codepoint;
+        char32_t codepoint = 0;
+        begin              = decode(begin, end, codepoint);
+        *output++          = codepoint;
     }
 
     return output;
@@ -529,7 +529,7 @@ Out Utf<16>::toUtf32(In begin, In end, Out output)
 
 ////////////////////////////////////////////////////////////
 template <typename In>
-In Utf<32>::decode(In begin, In /*end*/, std::uint32_t& output, std::uint32_t /*replacement*/)
+In Utf<32>::decode(In begin, In /*end*/, char32_t& output, char32_t /*replacement*/)
 {
     output = *begin++;
     return begin;
@@ -538,7 +538,7 @@ In Utf<32>::decode(In begin, In /*end*/, std::uint32_t& output, std::uint32_t /*
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<32>::encode(std::uint32_t input, Out output, std::uint32_t /*replacement*/)
+Out Utf<32>::encode(char32_t input, Out output, char32_t /*replacement*/)
 {
     *output++ = input;
     return output;
@@ -662,19 +662,19 @@ Out Utf<32>::toUtf32(In begin, In end, Out output)
 
 ////////////////////////////////////////////////////////////
 template <typename In>
-std::uint32_t Utf<32>::decodeAnsi(In input, const std::locale& locale)
+char32_t Utf<32>::decodeAnsi(In input, const std::locale& locale)
 {
     // Get the facet of the locale which deals with character conversion
     const auto& facet = std::use_facet<std::ctype<wchar_t>>(locale);
 
     // Use the facet to convert each character of the input string
-    return static_cast<std::uint32_t>(facet.widen(input));
+    return static_cast<char32_t>(facet.widen(input));
 }
 
 
 ////////////////////////////////////////////////////////////
 template <typename In>
-std::uint32_t Utf<32>::decodeWide(In input)
+char32_t Utf<32>::decodeWide(In input)
 {
     // The encoding of wide characters is not well defined and is left to the system;
     // however we can safely assume that it is UCS-2 on Windows and
@@ -682,13 +682,13 @@ std::uint32_t Utf<32>::decodeWide(In input)
     // In both cases, a simple copy is enough (UCS-2 is a subset of UCS-4,
     // and UCS-4 *is* UTF-32).
 
-    return static_cast<std::uint32_t>(input);
+    return static_cast<char32_t>(input);
 }
 
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<32>::encodeAnsi(std::uint32_t codepoint, Out output, char replacement, const std::locale& locale)
+Out Utf<32>::encodeAnsi(char32_t codepoint, Out output, char replacement, const std::locale& locale)
 {
     // Get the facet of the locale which deals with character conversion
     const auto& facet = std::use_facet<std::ctype<wchar_t>>(locale);
@@ -702,7 +702,7 @@ Out Utf<32>::encodeAnsi(std::uint32_t codepoint, Out output, char replacement, c
 
 ////////////////////////////////////////////////////////////
 template <typename Out>
-Out Utf<32>::encodeWide(std::uint32_t codepoint, Out output, wchar_t replacement)
+Out Utf<32>::encodeWide(char32_t codepoint, Out output, wchar_t replacement)
 {
     // The encoding of wide characters is not well defined and is left to the system;
     // however we can safely assume that it is UCS-2 on Windows and

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -85,7 +85,7 @@ public:
     ////////////////////////////////////////////////////////////
     struct TextEntered
     {
-        std::uint32_t unicode{}; //!< UTF-32 Unicode value of the character
+        char32_t unicode{}; //!< UTF-32 Unicode value of the character
     };
 
     ////////////////////////////////////////////////////////////

--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -338,7 +338,7 @@ const Font::Info& Font::getInfo() const
 
 
 ////////////////////////////////////////////////////////////
-const Glyph& Font::getGlyph(std::uint32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness) const
+const Glyph& Font::getGlyph(char32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness) const
 {
     // Get the page corresponding to the character size
     GlyphTable& glyphs = loadPage(characterSize).glyphs;
@@ -362,7 +362,7 @@ const Glyph& Font::getGlyph(std::uint32_t codePoint, unsigned int characterSize,
 
 
 ////////////////////////////////////////////////////////////
-bool Font::hasGlyph(std::uint32_t codePoint) const
+bool Font::hasGlyph(char32_t codePoint) const
 {
     return FT_Get_Char_Index(m_fontHandles ? m_fontHandles->face : nullptr, codePoint) != 0;
 }
@@ -503,7 +503,7 @@ Font::Page& Font::loadPage(unsigned int characterSize) const
 
 
 ////////////////////////////////////////////////////////////
-Glyph Font::loadGlyph(std::uint32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness) const
+Glyph Font::loadGlyph(char32_t codePoint, unsigned int characterSize, bool bold, float outlineThickness) const
 {
     // The glyph to return
     Glyph glyph;

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -430,8 +430,8 @@ int WindowImplAndroid::processKeyEvent(AInputEvent* inputEvent, ActivityStates& 
         case AKEY_EVENT_ACTION_UP:
             forwardKeyEvent(Event::KeyReleased{});
 
-            if (auto unicode = static_cast<std::uint32_t>(getUnicode(inputEvent)))
-                forwardEvent(Event::TextEntered{static_cast<std::uint32_t>(unicode)});
+            if (const auto unicode = getUnicode(inputEvent))
+                forwardEvent(Event::TextEntered{unicode});
             return 1;
         case AKEY_EVENT_ACTION_MULTIPLE:
             // Since complex inputs don't get separate key down/up events
@@ -447,9 +447,9 @@ int WindowImplAndroid::processKeyEvent(AInputEvent* inputEvent, ActivityStates& 
                 // https://code.google.com/p/android/issues/detail?id=33998
                 return 0;
             }
-            if (auto unicode = static_cast<std::uint32_t>(getUnicode(inputEvent))) // This is a repeated sequence
+            if (const auto unicode = getUnicode(inputEvent)) // This is a repeated sequence
             {
-                const Event event(Event::TextEntered{static_cast<std::uint32_t>(unicode)});
+                const Event event(Event::TextEntered{unicode});
 
                 const std::int32_t repeats = AKeyEvent_getRepeatCount(inputEvent);
                 for (std::int32_t i = 0; i < repeats; ++i)
@@ -676,7 +676,7 @@ Keyboard::Key WindowImplAndroid::androidKeyToSF(std::int32_t key)
 
 
 ////////////////////////////////////////////////////////////
-int WindowImplAndroid::getUnicode(AInputEvent* event)
+char32_t WindowImplAndroid::getUnicode(AInputEvent* event)
 {
     // Retrieve activity states
     ActivityStates&       states = getActivity();
@@ -736,7 +736,7 @@ int WindowImplAndroid::getUnicode(AInputEvent* event)
     // Detach this thread from the JVM
     lJavaVM->DetachCurrentThread();
 
-    return unicode;
+    return static_cast<char32_t>(unicode);
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -249,7 +249,7 @@ private:
     /// \return The Unicode value
     ///
     ////////////////////////////////////////////////////////////
-    static int getUnicode(AInputEvent* event);
+    static char32_t getUnicode(AInputEvent* event);
 
     Vector2u m_size;
     bool     m_windowBeingCreated{};

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -1855,7 +1855,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                     {
                         // There might be more than 1 characters in this event,
                         // so we must iterate it
-                        std::uint32_t unicode = 0;
+                        char32_t      unicode = 0;
                         std::uint8_t* iter    = keyBuffer.data();
                         while (iter < keyBuffer.data() + length)
                         {
@@ -1870,7 +1870,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                     static XComposeStatus status;
                     std::array<char, 16>  keyBuffer{};
                     if (XLookupString(&windowEvent.xkey, keyBuffer.data(), keyBuffer.size(), nullptr, &status))
-                        pushEvent(Event::TextEntered{static_cast<std::uint32_t>(keyBuffer[0])});
+                        pushEvent(Event::TextEntered{static_cast<char32_t>(keyBuffer[0])});
                 }
             }
 

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -850,13 +850,13 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
             if (m_keyRepeatEnabled || ((lParam & (1 << 30)) == 0))
             {
                 // Get the code of the typed character
-                auto character = static_cast<std::uint32_t>(wParam);
+                auto character = static_cast<char32_t>(wParam);
 
                 // Check if it is the first part of a surrogate pair, or a regular character
                 if ((character >= 0xD800) && (character <= 0xDBFF))
                 {
                     // First part of a surrogate pair: store it and wait for the second one
-                    m_surrogate = static_cast<std::uint16_t>(character);
+                    m_surrogate = static_cast<char16_t>(character);
                 }
                 else
                 {
@@ -864,7 +864,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
                     if ((character >= 0xDC00) && (character <= 0xDFFF))
                     {
                         // Convert the UTF-16 surrogate pair to a single UTF-32 value
-                        const std::array utf16 = {m_surrogate, static_cast<std::uint16_t>(character)};
+                        const std::array utf16 = {m_surrogate, static_cast<char16_t>(character)};
                         sf::Utf16::toUtf32(utf16.begin(), utf16.end(), &character);
                         m_surrogate = 0;
                     }

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -304,7 +304,7 @@ private:
     bool     m_keyRepeatEnabled{true}; //!< Automatic key-repeat state for keydown events
     Vector2u m_lastSize;               //!< The last handled size of the window
     bool     m_resizing{};             //!< Is the window being resized?
-    std::uint16_t m_surrogate{}; //!< First half of the surrogate pair, in case we're receiving a Unicode character in two events
+    char16_t m_surrogate{}; //!< First half of the surrogate pair, in case we're receiving a Unicode character in two events
     bool m_mouseInside{};   //!< Mouse is inside the window?
     bool m_fullscreen{};    //!< Is the window fullscreen?
     bool m_cursorGrabbed{}; //!< Is the mouse cursor trapped?

--- a/src/SFML/Window/iOS/SFAppDelegate.hpp
+++ b/src/SFML/Window/iOS/SFAppDelegate.hpp
@@ -99,7 +99,7 @@
 /// \param character The typed character
 ///
 ////////////////////////////////////////////////////////////
-- (void)notifyCharacter:(std::uint32_t)character;
+- (void)notifyCharacter:(char32_t)character;
 
 ////////////////////////////////////////////////////////////
 /// \brief Tells if the dimensions of the current window must be flipped when switching to a given orientation

--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -288,7 +288,7 @@ std::vector<sf::Vector2i> touchPositions;
 
 
 ////////////////////////////////////////////////////////////
-- (void)notifyCharacter:(std::uint32_t)character
+- (void)notifyCharacter:(char32_t)character
 {
     if (self.sfWindow)
         sfWindow->forwardEvent(sf::Event::TextEntered{character});

--- a/src/SFML/Window/iOS/SFView.mm
+++ b/src/SFML/Window/iOS/SFView.mm
@@ -80,8 +80,8 @@
     const char* end = utf8 + std::strlen(utf8);
     while (utf8 < end)
     {
-        std::uint32_t character = 0;
-        utf8                    = sf::Utf8::decode(utf8, end, character);
+        char32_t character = 0;
+        utf8               = sf::Utf8::decode(utf8, end, character);
         [[SFAppDelegate getInstance] notifyCharacter:character];
     }
 }

--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -106,7 +106,7 @@ public:
     /// US keyboard layouts.)
     ///
     ////////////////////////////////////////////////////////////
-    static Keyboard::Key localizedKey(UniChar ch);
+    static Keyboard::Key localizedKey(char16_t ch);
 
     ////////////////////////////////////////////////////////////
     /// \brief Opposite transformation as localizedKeys
@@ -116,7 +116,7 @@ public:
     /// Some returned value are specific to macOS.
     ///
     ////////////////////////////////////////////////////////////
-    static UniChar toUnicode(Keyboard::Key key);
+    static char16_t toUnicode(Keyboard::Key key);
 
     ////////////////////////////////////////////////////////////
     /// \brief Try to convert a virtual keycode (HID level) into a
@@ -125,7 +125,7 @@ public:
     /// Return `sf::Keyboard::Scan::Unknown` if the keycode is unknown.
     ///
     ////////////////////////////////////////////////////////////
-    static Keyboard::Scancode nonLocalizedKey(UniChar virtualKeycode);
+    static Keyboard::Scancode nonLocalizedKey(char16_t virtualKeycode);
 
     ////////////////////////////////////////////////////////////
     /// \copydoc sf::Keyboard::isKeyPressed(Key)

--- a/src/SFML/Window/macOS/HIDInputManager.mm
+++ b/src/SFML/Window/macOS/HIDInputManager.mm
@@ -93,7 +93,7 @@ CFDictionaryRef HIDInputManager::copyDevicesMask(std::uint32_t page, std::uint32
 
 
 ////////////////////////////////////////////////////////
-Keyboard::Key HIDInputManager::localizedKey(UniChar ch)
+Keyboard::Key HIDInputManager::localizedKey(char16_t ch)
 {
     // Apple is using the private range 0xE000 - 0xF8FF for special keys.
     // Otherwise one can refer to the usual Unicode table.
@@ -252,7 +252,7 @@ Keyboard::Key HIDInputManager::localizedKey(UniChar ch)
 
 
 ////////////////////////////////////////////////////////
-UniChar HIDInputManager::toUnicode(Keyboard::Key key)
+char16_t HIDInputManager::toUnicode(Keyboard::Key key)
 {
     // clang-format off
     switch (key)
@@ -381,7 +381,7 @@ UniChar HIDInputManager::toUnicode(Keyboard::Key key)
 
 
 ////////////////////////////////////////////////////////
-Keyboard::Scancode HIDInputManager::nonLocalizedKey(UniChar virtualKeycode)
+Keyboard::Scancode HIDInputManager::nonLocalizedKey(char16_t virtualKeycode)
 {
     // See Chapter 2, esp. Figure 2-10 of
     // https://developer.apple.com/legacy/library/documentation/mac/pdf/MacintoshToolboxEssentials.pdf
@@ -697,9 +697,9 @@ String HIDInputManager::getDescription(Keyboard::Scancode code)
         default:
         {
             // Phase 2: Try to convert the key to unicode
-            const UniChar unicode = toUnicode(localize(code));
+            const char16_t unicode = toUnicode(localize(code));
             if (unicode != 0x00)
-                return {static_cast<char32_t>(unicode)};
+                return {char32_t{unicode}};
         }
 
         // Phase 3: Return final fallback

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -26,7 +26,7 @@ auto select(const std::basic_string<T>& string16, const std::basic_string<T>& st
         return string32;
 }
 
-auto toHex(const std::uint32_t character)
+auto toHex(const char32_t character)
 {
     std::ostringstream stream;
     stream << "[\\x" << std::uppercase << std::hex << character << ']';
@@ -445,8 +445,8 @@ TEST_CASE("[System] sf::String")
 
     SECTION("fromUtf16()")
     {
-        constexpr std::array<std::uint16_t, 4> characters{0xF1, 'x', 'y', 'z'};
-        const sf::String                       string = sf::String::fromUtf16(characters.begin(), characters.end());
+        constexpr std::array<char16_t, 4> characters{0xF1, 'x', 'y', 'z'};
+        const sf::String                  string = sf::String::fromUtf16(characters.begin(), characters.end());
         CHECK(std::string(string) == select("\xF1xyz"s, "\0xyz"s));
         CHECK(std::wstring(string) == L"\xF1xyz"s);
         CHECK(string.toAnsiString() == select("\xF1xyz"s, "\0xyz"s));
@@ -461,8 +461,8 @@ TEST_CASE("[System] sf::String")
 
     SECTION("fromUtf32()")
     {
-        constexpr std::array<std::uint32_t, 4> characters{'w', 0x104321, 'y', 'z'};
-        const sf::String                       string = sf::String::fromUtf32(characters.begin(), characters.end());
+        constexpr std::array<char32_t, 4> characters{'w', 0x104321, 'y', 'z'};
+        const sf::String                  string = sf::String::fromUtf32(characters.begin(), characters.end());
         CHECK(std::string(string) == "w\0yz"s);
         CHECK(std::wstring(string) == select(L"wyz"s, L"w\U00104321yz"s));
         CHECK(string.toAnsiString() == "w\0yz"s);

--- a/test/System/Utf.test.cpp
+++ b/test/System/Utf.test.cpp
@@ -13,7 +13,7 @@ TEST_CASE("[System] sf::Utf8")
     SECTION("decode")
     {
         std::u32string output;
-        std::uint32_t  character = 0;
+        char32_t       character = 0;
         for (std::string_view::const_iterator begin = input.begin(); begin < input.end();)
         {
             begin = sf::Utf8::decode(begin, input.end(), character);
@@ -147,7 +147,7 @@ TEST_CASE("[System] sf::Utf32")
     SECTION("decode")
     {
         std::u32string output;
-        std::uint32_t  character = 0;
+        char32_t       character = 0;
         for (std::u32string_view::const_iterator begin = input.begin(); begin < input.end();)
         {
             begin = sf::Utf32::decode(begin, {}, character);


### PR DESCRIPTION
## Description

Closes #3324

This is probably an oversight from https://github.com/SFML/SFML/pull/2480
