### PR TITLE
Fixes for the Xorg dummy driver

### DIFF
--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -104,7 +104,12 @@ std::shared_ptr<_XIM> openXim()
         XSetLocaleModifiers("");
 
         // Create the input context
-        sharedXIM.reset(XOpenIM(UnixDisplayImpl::weakSharedDisplay.lock().get(), nullptr, nullptr, nullptr), XCloseIM);
+        const auto closeIM = [](XIM im)
+        {
+            if (im)
+                XCloseIM(im);
+        };
+        sharedXIM.reset(XOpenIM(UnixDisplayImpl::weakSharedDisplay.lock().get(), nullptr, nullptr, nullptr), closeIM);
         xim = sharedXIM;
 
         // Restore the previous locale

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -129,7 +129,8 @@ Atom getAtom(const std::string& name, bool onlyIfExists)
 
     const auto display = openDisplay();
     const Atom atom    = XInternAtom(display.get(), name.c_str(), onlyIfExists ? True : False);
-    atoms[name]        = atom;
+    if (atom)
+        atoms[name] = atom;
 
     return atom;
 }


### PR DESCRIPTION
## Description

Some fixes for some small bugs I found while playing around running the SFML tests with the Xorg dummy video driver.

* The first commit fixes a `BadAtom` error if we cache a `None` atom. This could happen if `onlyIfExists == true` and if we're the very first client to connect to the sever so some atoms don't exist yet.
* The second commit fixes a segfault which happens if `XOpenIM` fails.

## Tasks

-   [x] Tested on Linux (note: I have only been testing this on bleeding edge Debian sid)

N/A to other OSes