### PR TITLE
Add comment regarding input monitoring access on macOS

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -338,6 +338,9 @@ static constexpr unsigned int ScancodeCount{static_cast<unsigned int>(Scan::Laun
 ////////////////////////////////////////////////////////////
 /// \brief Check if a key is pressed
 ///
+/// \warning On macOS you're required to grant input monitoring access for
+///          your application in order for `isKeyPressed` to work.
+///
 /// \param key Key to check
 ///
 /// \return `true` if the key is pressed, `false` otherwise
@@ -347,6 +350,9 @@ static constexpr unsigned int ScancodeCount{static_cast<unsigned int>(Scan::Laun
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a key is pressed
+///
+/// \warning On macOS you're required to grant input monitoring access for
+///          your application in order for `isKeyPressed` to work.
 ///
 /// \param code Scancode to check
 ///


### PR DESCRIPTION
## Description

For a few macOS versions now, if you want to use `sf::Keyboard::isKeyPressed()` you have to grant input monitoring access to the application. Adding this information to the doc.

Wonder if we should:
- Mention this link: https://support.apple.com/guide/mac-help/control-access-to-input-monitoring-on-mac-mchl4cedafb6/mac
- Mention events as alternative