### PR TITLE
Store IpAddress::m_address in host byte order

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -142,6 +142,7 @@ For a closer look at breaking changes and how to migrate from SFML 2, check out 
 
 -   Removed invalid internal state from `sf::IpAddress` (#2145)
 -   Fixed sockets not closing before being moved into (#2758)
+-   Fixed how `sf::IpAddress`'s internal representation is stored on big endian systems (#3339)
 
 ## SFML 2.6.2
 

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -93,13 +93,13 @@ std::optional<IpAddress> IpAddress::resolve(std::string_view address)
 
 ////////////////////////////////////////////////////////////
 IpAddress::IpAddress(std::uint8_t byte0, std::uint8_t byte1, std::uint8_t byte2, std::uint8_t byte3) :
-m_address(htonl(static_cast<std::uint32_t>((byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3)))
+m_address(static_cast<std::uint32_t>((byte0 << 24) | (byte1 << 16) | (byte2 << 8) | byte3))
 {
 }
 
 
 ////////////////////////////////////////////////////////////
-IpAddress::IpAddress(std::uint32_t address) : m_address(htonl(address))
+IpAddress::IpAddress(std::uint32_t address) : m_address(address)
 {
 }
 
@@ -108,7 +108,7 @@ IpAddress::IpAddress(std::uint32_t address) : m_address(htonl(address))
 std::string IpAddress::toString() const
 {
     in_addr address{};
-    address.s_addr = m_address;
+    address.s_addr = htonl(m_address);
 
     return inet_ntoa(address);
 }
@@ -117,7 +117,7 @@ std::string IpAddress::toString() const
 ////////////////////////////////////////////////////////////
 std::uint32_t IpAddress::toInteger() const
 {
-    return ntohl(m_address);
+    return m_address;
 }
 
 

--- a/test/Network/IpAddress.test.cpp
+++ b/test/Network/IpAddress.test.cpp
@@ -120,9 +120,9 @@ TEST_CASE("[Network] sf::IpAddress")
         {
             CHECK(sf::IpAddress(1) < sf::IpAddress(2));
             CHECK(sf::IpAddress(0, 0, 0, 0) < sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(1, 0, 0, 0) < sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) < sf::IpAddress(0, 0, 1, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) < sf::IpAddress(0, 0, 0, 1));
+            CHECK(sf::IpAddress(0, 1, 0, 0) < sf::IpAddress(1, 0, 0, 0));
+            CHECK(sf::IpAddress(0, 0, 1, 0) < sf::IpAddress(0, 1, 0, 0));
+            CHECK(sf::IpAddress(0, 0, 0, 1) < sf::IpAddress(0, 0, 1, 0));
             CHECK(sf::IpAddress(0, 0, 0, 1) < sf::IpAddress(1, 0, 0, 1));
         }
 
@@ -130,9 +130,9 @@ TEST_CASE("[Network] sf::IpAddress")
         {
             CHECK(sf::IpAddress(2) > sf::IpAddress(1));
             CHECK(sf::IpAddress(1, 0, 0, 0) > sf::IpAddress(0, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) > sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) > sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 0, 1) > sf::IpAddress(0, 0, 1, 0));
+            CHECK(sf::IpAddress(1, 0, 0, 0) > sf::IpAddress(0, 1, 0, 0));
+            CHECK(sf::IpAddress(0, 1, 0, 0) > sf::IpAddress(0, 0, 1, 0));
+            CHECK(sf::IpAddress(0, 0, 1, 0) > sf::IpAddress(0, 0, 0, 1));
             CHECK(sf::IpAddress(1, 0, 0, 1) > sf::IpAddress(0, 0, 0, 1));
         }
 
@@ -140,9 +140,9 @@ TEST_CASE("[Network] sf::IpAddress")
         {
             CHECK(sf::IpAddress(1) <= sf::IpAddress(2));
             CHECK(sf::IpAddress(0, 0, 0, 0) <= sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(1, 0, 0, 0) <= sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) <= sf::IpAddress(0, 0, 1, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) <= sf::IpAddress(0, 0, 0, 1));
+            CHECK(sf::IpAddress(0, 1, 0, 0) <= sf::IpAddress(1, 0, 0, 0));
+            CHECK(sf::IpAddress(0, 0, 1, 0) <= sf::IpAddress(0, 1, 0, 0));
+            CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(0, 0, 1, 0));
             CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(1, 0, 0, 1));
 
             CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) <= sf::IpAddress(0xC633647B));
@@ -153,9 +153,9 @@ TEST_CASE("[Network] sf::IpAddress")
         {
             CHECK(sf::IpAddress(2) >= sf::IpAddress(1));
             CHECK(sf::IpAddress(1, 0, 0, 0) >= sf::IpAddress(0, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) >= sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) >= sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 0, 1) >= sf::IpAddress(0, 0, 1, 0));
+            CHECK(sf::IpAddress(1, 0, 0, 0) >= sf::IpAddress(0, 1, 0, 0));
+            CHECK(sf::IpAddress(0, 1, 0, 0) >= sf::IpAddress(0, 0, 1, 0));
+            CHECK(sf::IpAddress(0, 0, 1, 0) >= sf::IpAddress(0, 0, 0, 1));
             CHECK(sf::IpAddress(1, 0, 0, 1) >= sf::IpAddress(0, 0, 0, 1));
 
             CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) >= sf::IpAddress(0xC633647B));


### PR DESCRIPTION
## Description

I'm looking at some big-endian failures in the Debian builds. One of them concerns the `sf::IpAddress` ordering being different in big-endian systems.

I found this issue where the ordering of `sf::IpAddress` was discussed and how it's a bit strange and maybe it should be fixed in SFML 3: https://github.com/SFML/SFML/pull/2134#discussion_r901088579

Switching to host ordering fixes the ordering and has the nice side effect of working on big-endian systems "for free", so that's what I've done in this PR. If the ordering is considered part of the API, then this is a breaking change.

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run this before and after to see the new ordering:

```cpp
#include <SFML/Network.hpp>
#include <algorithm>
#include <iostream>
#include <random>

int main()
{
    std::mt19937 gen;
    std::uniform_int_distribution<uint32_t> distrib;

    std::vector<sf::IpAddress> addresses;
    for (int i = 0; i < 50; i++)
        addresses.emplace_back(distrib(gen));

    std::sort(addresses.begin(), addresses.end());

    for (auto addr : addresses)
        std::cout << addr << std::endl;

    return 0;
}
```