### PR TITLE
Fix Ogg ov_read call on big-endian systems

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -135,6 +135,7 @@ For a closer look at breaking changes and how to migrate from SFML 2, check out 
 
 -   Fixed `sf::SoundStream::play` bug (#2037)
 -   Fixed poor `sf::SoundStream::setPlayingOffset` precision (#3101)
+-   Fixed a bug when reading Ogg files on big endian systems (#3340)
 
 ### Network
 

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -169,6 +169,9 @@ target_compile_definitions(sfml-audio PRIVATE MA_NO_MP3 MA_NO_FLAC MA_NO_ENCODIN
 # use standard fixed-width integer types
 target_compile_definitions(sfml-audio PRIVATE MA_USE_STDINT)
 
+# detect the endianness as required by Ogg
+target_compile_definitions(sfml-audio PRIVATE SFML_IS_BIG_ENDIAN=$<STREQUAL:${CMAKE_CXX_BYTE_ORDER},BIG_ENDIAN>)
+
 # setup dependencies
 target_link_libraries(sfml-audio
                       PUBLIC SFML::System

--- a/src/SFML/Audio/SoundFileReaderOgg.cpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.cpp
@@ -196,8 +196,8 @@ std::uint64_t SoundFileReaderOgg::read(std::int16_t* samples, std::uint64_t maxC
     std::uint64_t count = 0;
     while (count < maxCount)
     {
-        const int  bytesToRead = static_cast<int>(maxCount - count) * static_cast<int>(sizeof(std::int16_t));
-        const long bytesRead   = ov_read(&m_vorbis, reinterpret_cast<char*>(samples), bytesToRead, 0, 2, 1, nullptr);
+        const int bytesToRead = static_cast<int>(maxCount - count) * static_cast<int>(sizeof(std::int16_t));
+        const long bytesRead = ov_read(&m_vorbis, reinterpret_cast<char*>(samples), bytesToRead, SFML_IS_BIG_ENDIAN, 2, 1, nullptr);
         if (bytesRead > 0)
         {
             const long samplesRead = bytesRead / static_cast<long>(sizeof(std::int16_t));


### PR DESCRIPTION
## Description

In the `ov_read` API, the fouth parameter says what endianness the samples should be returned in - `0` for little-endian, and `1` for big-endian. SFML wants samples in the host endian, so we need to set this parameter to 1 on big-endian systems.

Fixes a unit test failure on big-endian systems.

There's a very old forum thread mentioning this: https://en.sfml-dev.org/forums/index.php?topic=22653

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

I have run the testsuite on a big-endian system and it passes with this change (it was previously failing). 