### PR TITLE
Fix naming of PDB files for sfml-main

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -170,8 +170,12 @@ macro(sfml_add_library module)
                                   PDB_NAME "${target}${SFML_PDB_POSTFIX}"
                                   PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
         else()
+            if(NOT ${target} STREQUAL "sfml-main")
+                string(PREPEND SFML_PDB_POSTFIX "-s")
+            endif()
+
             if(SFML_ENABLE_PCH)
-                message(VERBOSE "overriding PDB name for '${target}' with \"sfml-s${SFML_PDB_POSTFIX}\" due to PCH being enabled")
+                message(VERBOSE "overriding PDB name for '${target}' with \"sfml-system\" due to PCH being enabled")
 
                 # For PCH builds with PCH reuse, the PDB name must be the same as the target that's being reused
                 set_target_properties(${target} PROPERTIES
@@ -180,7 +184,7 @@ macro(sfml_add_library module)
             else()
                 # Static libraries have no linker PDBs, thus the compiler PDBs are relevant
                 set_target_properties(${target} PROPERTIES
-                                      COMPILE_PDB_NAME "${target}-s${SFML_PDB_POSTFIX}"
+                                      COMPILE_PDB_NAME "${target}${SFML_PDB_POSTFIX}"
                                       COMPILE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
             endif()
         endif()


### PR DESCRIPTION
## Description

- sfml-main is always a static lib but shouldn't have `-s` postfix
- ~~The PCH target says in the comment that it uses `sfml-s`, but then used `sfml-system`~~

Someone asked for help with SFML [on the forum](https://en.sfml-dev.org/forums/index.php?topic=29740.0) and looking at the output, I realized that the naming of the PDB file(s) aren't correct.

What I don't know if `sfml-s` is useful in the PCH case, as it might not be automatically discovered.  
Edit: Looks like it should be name `sfml-system(-d)`, so I adjusted the message instead

## Tasks

-   [x] Tested on Windows

## How to test this PR?

The outputted PDB should have the correct naming