### PR TITLE
Make `glCheckError` use `std::string_view` instead for file path argument

### DIFF
--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -36,11 +36,11 @@
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-bool glCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression)
+bool glCheckError(std::string_view file, unsigned int line, std::string_view expression)
 {
     const auto logError = [&](const char* error, const char* description)
     {
-        err() << "An internal OpenGL call failed in " << file.filename() << "(" << line << ")."
+        err() << "An internal OpenGL call failed in " << std::filesystem::path(file).filename() << "(" << line << ")."
               << "\nExpression:\n   " << expression << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
 

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -50,7 +50,7 @@ namespace sf::priv
 /// \return `false` if an error occurred, `true` otherwise
 ///
 ////////////////////////////////////////////////////////////
-bool glCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression);
+bool glCheckError(std::string_view file, unsigned int line, std::string_view expression);
 
 ////////////////////////////////////////////////////////////
 /// Macro to quickly check every OpenGL API call

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -38,11 +38,11 @@
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-bool eglCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression)
+bool eglCheckError(std::string_view file, unsigned int line, std::string_view expression)
 {
     const auto logError = [&](const char* error, const char* description)
     {
-        err() << "An internal EGL call failed in " << file.filename() << "(" << line << ")."
+        err() << "An internal EGL call failed in " << std::filesystem::path(file).filename() << "(" << line << ")."
               << "\nExpression:\n   " << expression << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
 

--- a/src/SFML/Window/EGLCheck.hpp
+++ b/src/SFML/Window/EGLCheck.hpp
@@ -50,7 +50,7 @@ namespace sf::priv
 /// \return `false` if an error occurred, `true` otherwise
 ///
 ////////////////////////////////////////////////////////////
-bool eglCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression);
+bool eglCheckError(std::string_view file, unsigned int line, std::string_view expression);
 
 ////////////////////////////////////////////////////////////
 /// Macro to quickly check every EGL API call


### PR DESCRIPTION
(Note: Discussions on this topic were done on the SFML Discord [here](https://discord.com/channels/175298431294636032/477173543281491968/1321093199640658021))

To reduce the overhead for v3 debug builds this PR alters the arguments for `glCheckError` function to take the file path as a `std::string_view` instead of a `std::filesystem::path`. The path construction in debug builds was causing noticeable performance impact for users. By swapping to `std::string_view` we can remove this overhead for the happy path and only construct the path when a gl error is actually encountered.