### PR TITLE
Make `glCheckError` take a `std::string_view` rather than constructing a `std::filesystem::path` on error checks

### DIFF
--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -36,11 +36,11 @@
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-bool glCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression)
+bool glCheckError(std::string_view file, unsigned int line, std::string_view expression)
 {
     const auto logError = [&](const char* error, const char* description)
     {
-        err() << "An internal OpenGL call failed in " << file.filename() << "(" << line << ")."
+        err() << "An internal OpenGL call failed in " << std::filesystem::path(file).filename() << "(" << line << ")."
               << "\nExpression:\n   " << expression << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
 

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -50,7 +50,7 @@ namespace sf::priv
 /// \return `false` if an error occurred, `true` otherwise
 ///
 ////////////////////////////////////////////////////////////
-bool glCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression);
+bool glCheckError(std::string_view file, unsigned int line, std::string_view expression);
 
 ////////////////////////////////////////////////////////////
 /// Macro to quickly check every OpenGL API call

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -38,11 +38,11 @@
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
-bool eglCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression)
+bool eglCheckError(std::string_view file, unsigned int line, std::string_view expression)
 {
     const auto logError = [&](const char* error, const char* description)
     {
-        err() << "An internal EGL call failed in " << file.filename() << "(" << line << ")."
+        err() << "An internal EGL call failed in " << std::filesystem::path(file).filename() << "(" << line << ")."
               << "\nExpression:\n   " << expression << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
 

--- a/src/SFML/Window/EGLCheck.hpp
+++ b/src/SFML/Window/EGLCheck.hpp
@@ -50,7 +50,7 @@ namespace sf::priv
 /// \return `false` if an error occurred, `true` otherwise
 ///
 ////////////////////////////////////////////////////////////
-bool eglCheckError(const std::filesystem::path& file, unsigned int line, std::string_view expression);
+bool eglCheckError(std::string_view file, unsigned int line, std::string_view expression);
 
 ////////////////////////////////////////////////////////////
 /// Macro to quickly check every EGL API call


### PR DESCRIPTION
## Description

Port of #3358 for `master` branch.