### PR TITLE
Hide `<filesystem>` dependency in [E]GLCheck `.cpp`

### DIFF
--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -30,6 +30,7 @@
 
 #include <SFML/System/Err.hpp>
 
+#include <filesystem>
 #include <ostream>
 
 

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -33,7 +33,6 @@
 
 #include <SFML/System/Err.hpp>
 
-#include <filesystem>
 #include <string_view>
 #include <type_traits>
 

--- a/src/SFML/Graphics/GLCheck.hpp
+++ b/src/SFML/Graphics/GLCheck.hpp
@@ -33,6 +33,7 @@
 
 #include <SFML/System/Err.hpp>
 
+#include <ostream>
 #include <string_view>
 #include <type_traits>
 

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -32,6 +32,7 @@
 
 #include <glad/egl.h>
 
+#include <filesystem>
 #include <ostream>
 
 

--- a/src/SFML/Window/EGLCheck.hpp
+++ b/src/SFML/Window/EGLCheck.hpp
@@ -33,6 +33,7 @@
 
 #include <glad/egl.h>
 
+#include <ostream>
 #include <string_view>
 #include <type_traits>
 

--- a/src/SFML/Window/EGLCheck.hpp
+++ b/src/SFML/Window/EGLCheck.hpp
@@ -33,7 +33,6 @@
 
 #include <glad/egl.h>
 
-#include <filesystem>
 #include <string_view>
 #include <type_traits>
 


### PR DESCRIPTION
Small compilation time improvement over #3359.