### PR TITLE
Avoid string reallocations in glCheckError

### DIFF
--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -30,18 +30,17 @@
 
 #include <SFML/System/Err.hpp>
 
-#include <filesystem>
 #include <ostream>
-
 
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
 bool glCheckError(std::string_view file, unsigned int line, std::string_view expression)
 {
+    const std::string_view filename = file.substr(file.find_last_of("\\/") + 1);
     const auto logError = [&](const char* error, const char* description)
     {
-        err() << "An internal OpenGL call failed in " << std::filesystem::path(file).filename() << "(" << line << ")."
+        err() << "An internal OpenGL call failed in " << filename << "(" << line << ")."
               << "\nExpression:\n   " << expression << "\nError description:\n   " << error << "\n   " << description << '\n'
               << std::endl;
 


### PR DESCRIPTION
Didn't expect `std::filesystem::path` to have that much overhead behind the scenes (string conversion/reallocation). This replaces the `filename()` logic with a simplified approach that should be fully sufficient for any and all file paths within the SFML project following common naming conventions.