### PR TITLE
Enable range based looping of `sf::VertexArray`

### DIFF
--- a/include/SFML/Graphics/VertexArray.hpp
+++ b/include/SFML/Graphics/VertexArray.hpp
@@ -175,6 +175,54 @@ public:
     ////////////////////////////////////////////////////////////
     [[nodiscard]] FloatRect getBounds() const;
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the beginning of the array
+    ///
+    /// \return Read-write iterator to the beginning of the vertices
+    ///
+    /// \see `end`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] std::vector<Vertex>::iterator begin();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the beginning of the array
+    ///
+    /// \return Read-only iterator to the beginning of the vertices
+    ///
+    /// \see `end`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] std::vector<Vertex>::const_iterator begin() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the end of the array
+    ///
+    /// The end iterator refers to 1 position past the last vertex;
+    /// thus it represents an invalid vertex and should never be
+    /// accessed.
+    ///
+    /// \return Read-write iterator to the end of the vertices
+    ///
+    /// \see `begin`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] std::vector<Vertex>::iterator end();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the end of the array
+    ///
+    /// The end iterator refers to 1 position past the last vertex;
+    /// thus it represents an invalid vertex and should never be
+    /// accessed.
+    ///
+    /// \return Read-only iterator to the end of the vertices
+    ///
+    /// \see `begin`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] std::vector<Vertex>::const_iterator end() const;
+
 private:
     ////////////////////////////////////////////////////////////
     /// \brief Draw the vertex array to a render target

--- a/src/SFML/Graphics/Shape.cpp
+++ b/src/SFML/Graphics/Shape.cpp
@@ -255,8 +255,8 @@ void Shape::draw(RenderTarget& target, RenderStates states) const
 ////////////////////////////////////////////////////////////
 void Shape::updateFillColors()
 {
-    for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
-        m_vertices[i].color = m_fillColor;
+    for (auto& vertex : m_vertices)
+        vertex.color = m_fillColor;
 }
 
 
@@ -269,10 +269,10 @@ void Shape::updateTexCoords()
     const Vector2f safeInsideSize(m_insideBounds.size.x > 0 ? m_insideBounds.size.x : 1.f,
                                   m_insideBounds.size.y > 0 ? m_insideBounds.size.y : 1.f);
 
-    for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
+    for (auto& vertex : m_vertices)
     {
-        const Vector2f ratio    = (m_vertices[i].position - m_insideBounds.position).componentWiseDiv(safeInsideSize);
-        m_vertices[i].texCoords = convertedTextureRect.position + convertedTextureRect.size.componentWiseMul(ratio);
+        const Vector2f ratio = (vertex.position - m_insideBounds.position).componentWiseDiv(safeInsideSize);
+        vertex.texCoords     = convertedTextureRect.position + convertedTextureRect.size.componentWiseMul(ratio);
     }
 }
 
@@ -335,8 +335,8 @@ void Shape::updateOutline()
 ////////////////////////////////////////////////////////////
 void Shape::updateOutlineColors()
 {
-    for (std::size_t i = 0; i < m_outlineVertices.getVertexCount(); ++i)
-        m_outlineVertices[i].color = m_outlineColor;
+    for (auto& vertex : m_outlineVertices)
+        vertex.color = m_outlineColor;
 }
 
 } // namespace sf

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -169,8 +169,8 @@ void Text::setFillColor(Color color)
         // (if geometry is updated anyway, we can skip this step)
         if (!m_geometryNeedUpdate)
         {
-            for (std::size_t i = 0; i < m_vertices.getVertexCount(); ++i)
-                m_vertices[i].color = m_fillColor;
+            for (auto& vertex : m_vertices)
+                vertex.color = m_fillColor;
         }
     }
 }
@@ -187,8 +187,8 @@ void Text::setOutlineColor(Color color)
         // (if geometry is updated anyway, we can skip this step)
         if (!m_geometryNeedUpdate)
         {
-            for (std::size_t i = 0; i < m_outlineVertices.getVertexCount(); ++i)
-                m_outlineVertices[i].color = m_outlineColor;
+            for (auto& vertex : m_outlineVertices)
+                vertex.color = m_outlineColor;
         }
     }
 }

--- a/src/SFML/Graphics/VertexArray.cpp
+++ b/src/SFML/Graphics/VertexArray.cpp
@@ -133,6 +133,34 @@ FloatRect VertexArray::getBounds() const
 
 
 ////////////////////////////////////////////////////////////
+std::vector<Vertex>::iterator VertexArray::begin()
+{
+    return m_vertices.begin();
+}
+
+
+////////////////////////////////////////////////////////////
+std::vector<Vertex>::const_iterator VertexArray::begin() const
+{
+    return m_vertices.begin();
+}
+
+
+////////////////////////////////////////////////////////////
+std::vector<Vertex>::iterator VertexArray::end()
+{
+    return m_vertices.end();
+}
+
+
+////////////////////////////////////////////////////////////
+std::vector<Vertex>::const_iterator VertexArray::end() const
+{
+    return m_vertices.end();
+}
+
+
+////////////////////////////////////////////////////////////
 void VertexArray::draw(RenderTarget& target, RenderStates states) const
 {
     if (!m_vertices.empty())


### PR DESCRIPTION
## Description

`begin` and `end` iterators are all that is required of a container to supported C++11 ranged-for loops. This PR also uses this feature as much as possible internally. Let me know if I missed any more places we can be using this.