### PR TITLE
Add non-const overload of `sf::Event::getIf`

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -325,6 +325,17 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename TEventSubtype>
+    [[nodiscard]] TEventSubtype* getIf();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Attempt to get specified event subtype
+    ///
+    /// \tparam `TEventSubtype` Type of the desired event subtype
+    ///
+    /// \return Address of current event subtype, otherwise `nullptr`
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename TEventSubtype>
     [[nodiscard]] const TEventSubtype* getIf() const;
 
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -60,6 +60,16 @@ bool Event::is() const
 
 ////////////////////////////////////////////////////////////
 template <typename TEventSubtype>
+TEventSubtype* Event::getIf()
+{
+    static_assert(isEventSubtype<TEventSubtype>, "TEventSubtype must be a subtype of sf::Event");
+    if constexpr (isEventSubtype<TEventSubtype>)
+        return std::get_if<TEventSubtype>(&m_data);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename TEventSubtype>
 const TEventSubtype* Event::getIf() const
 {
     static_assert(isEventSubtype<TEventSubtype>, "TEventSubtype must be a subtype of sf::Event");

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -295,6 +295,15 @@ TEST_CASE("[Window] sf::Event")
         CHECK(sensorChanged.value == sf::Vector3f());
     }
 
+    SECTION("getIf()")
+    {
+        sf::Event event      = sf::Event::MouseMoved{{4, 2}};
+        auto*     mouseMoved = event.getIf<sf::Event::MouseMoved>();
+        REQUIRE(mouseMoved);
+        mouseMoved->position = sf::Vector2i(6, 9);
+        CHECK(mouseMoved->position == sf::Vector2i(6, 9));
+    }
+
     SECTION("visit()")
     {
         CHECK(sf::Event(sf::Event::Closed{}).visit(visitor) == "Closed");


### PR DESCRIPTION
## Description

While [upgrading SFGUI to SFML 3](https://github.com/TankOs/SFGUI/compare/master...ChrisThrasher:SFGUI:feature/sfml-three) I found a number of places where event data is being modified. This caused some problems because `sf::Event` currently provides on easy way to modify the event short of creating a brand new `Event` object then using `operator=` to assign it to the initial event. The `sf::Event` class is just some data with a type-safe interface. I see no reason to prevent easy modification of the underlying data. Most users will never need this, but for some more advanced use cases it will come in handy.