### PR TITLE
Add tests for `sf::Mouse`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ set(WINDOW_SRC
     Window/GlResource.test.cpp
     Window/Joystick.test.cpp
     Window/Keyboard.test.cpp
+    Window/Mouse.test.cpp
     Window/VideoMode.test.cpp
     Window/Vulkan.test.cpp
     Window/Window.test.cpp

--- a/test/Window/Mouse.test.cpp
+++ b/test/Window/Mouse.test.cpp
@@ -1,0 +1,17 @@
+#include <SFML/Window/Mouse.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <WindowUtil.hpp>
+
+TEST_CASE("[Window] sf::Mouse", runDisplayTests())
+{
+    SECTION("isButtonPressed()")
+    {
+        CHECK(!sf::Mouse::isButtonPressed(sf::Mouse::Button::Left));
+        CHECK(!sf::Mouse::isButtonPressed(sf::Mouse::Button::Right));
+        CHECK(!sf::Mouse::isButtonPressed(sf::Mouse::Button::Middle));
+        CHECK(!sf::Mouse::isButtonPressed(sf::Mouse::Button::Extra1));
+        CHECK(!sf::Mouse::isButtonPressed(sf::Mouse::Button::Extra2));
+    }
+}


### PR DESCRIPTION
## Description

APIs like this are hard to test but testing for mouse buttons being pressed is an easy place to start. Just like the `sf::Keyboard` tests, they will fail if you're holding down a mouse key while running the tests. A bit janky perhaps but we've been doing this with keyboard tests for a long time without issue so I think it's fine. 