### PR TITLE
Make pi/tau variables inline

### DIFF
--- a/include/SFML/System/Angle.inl
+++ b/include/SFML/System/Angle.inl
@@ -34,8 +34,8 @@ namespace sf
 {
 namespace priv
 {
-constexpr float pi  = 3.141592654f;
-constexpr float tau = pi * 2.f;
+inline constexpr float pi  = 3.141592654f;
+inline constexpr float tau = pi * 2.f;
 
 constexpr float positiveRemainder(float a, float b)
 {


### PR DESCRIPTION
Fixes build errors when using SFML with modules which would cause conflicting linkage for these variables.

Generally best practice for constexpr variables in headers to be declared inline anyway so all uses share the same address