### PR TITLE
Remove unused RESOURCES_DIR cmake option

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -280,12 +280,11 @@ endmacro()
 # example: sfml_add_example(ftp
 #                           SOURCES ftp.cpp ...
 #                           BUNDLE_RESOURCES MainMenu.nib ...    # Files to be added in target but not installed next to the executable
-#                           DEPENDS SFML::Network
-#                           RESOURCES_DIR resources)             # A directory to install next to the executable and sources
+#                           DEPENDS SFML::Network)
 macro(sfml_add_example target)
 
     # parse the arguments
-    cmake_parse_arguments(THIS "GUI_APP" "RESOURCES_DIR" "SOURCES;BUNDLE_RESOURCES;DEPENDS" ${ARGN})
+    cmake_parse_arguments(THIS "GUI_APP" "" "SOURCES;BUNDLE_RESOURCES;DEPENDS" ${ARGN})
 
     # set a source group for the source files
     source_group("" FILES ${THIS_SOURCES})

--- a/examples/island/CMakeLists.txt
+++ b/examples/island/CMakeLists.txt
@@ -6,8 +6,7 @@ set(SRC Island.cpp)
 # define the island target
 sfml_add_example(island GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Graphics)
 
 # external dependency headers
 target_include_directories(island SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/island)

--- a/examples/joystick/CMakeLists.txt
+++ b/examples/joystick/CMakeLists.txt
@@ -4,5 +4,4 @@ set(SRC Joystick.cpp)
 # define the joystick target
 sfml_add_example(joystick GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Graphics)

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -12,8 +12,7 @@ endif()
 sfml_add_example(opengl GUI_APP
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
-                 DEPENDS SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Graphics)
 
 # external dependency headers
 target_include_directories(opengl SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/include)

--- a/examples/shader/CMakeLists.txt
+++ b/examples/shader/CMakeLists.txt
@@ -4,5 +4,4 @@ set(SRC Shader.cpp)
 # define the shader target
 sfml_add_example(shader GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Graphics)

--- a/examples/sound/CMakeLists.txt
+++ b/examples/sound/CMakeLists.txt
@@ -4,5 +4,4 @@ set(SRC Sound.cpp)
 # define the sound target
 sfml_add_example(sound
                  SOURCES ${SRC}
-                 DEPENDS SFML::Audio
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Audio)

--- a/examples/sound_effects/CMakeLists.txt
+++ b/examples/sound_effects/CMakeLists.txt
@@ -12,5 +12,4 @@ endif()
 sfml_add_example(sound-effects GUI_APP
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
-                 DEPENDS SFML::Audio SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Audio SFML::Graphics)

--- a/examples/tennis/CMakeLists.txt
+++ b/examples/tennis/CMakeLists.txt
@@ -11,5 +11,4 @@ endif()
 sfml_add_example(tennis GUI_APP
                  SOURCES ${SRC}
                  BUNDLE_RESOURCES ${RESOURCES}
-                 DEPENDS SFML::Audio SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Audio SFML::Graphics)

--- a/examples/vulkan/CMakeLists.txt
+++ b/examples/vulkan/CMakeLists.txt
@@ -4,8 +4,7 @@ set(SRC Vulkan.cpp)
 # define the window target
 sfml_add_example(vulkan GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Graphics)
 
 # external dependency headers
 target_include_directories(vulkan SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/examples/vulkan)

--- a/examples/win32/CMakeLists.txt
+++ b/examples/win32/CMakeLists.txt
@@ -4,5 +4,4 @@ set(SRC Win32.cpp)
 # define the win32 target
 sfml_add_example(win32 GUI_APP
                  SOURCES ${SRC}
-                 DEPENDS SFML::Graphics
-                 RESOURCES_DIR resources)
+                 DEPENDS SFML::Graphics)


### PR DESCRIPTION
-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!


## Description

Since 27a4c83ebc724a978e554e77f5f231b887e0bdd9 the examples are no longer installed.
Now the `RESOURCES_DIR` option is still parsed but is fully ignored, so remove it.

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android


