### PR TITLE
Make keyboard key/scancode count variables inline

### DIFF
--- a/include/SFML/Window/Keyboard.hpp
+++ b/include/SFML/Window/Keyboard.hpp
@@ -159,7 +159,7 @@ enum class Key
 ///
 ////////////////////////////////////////////////////////////
 // NOLINTNEXTLINE(readability-identifier-naming)
-static constexpr unsigned int KeyCount{static_cast<unsigned int>(Key::Pause) + 1};
+inline constexpr unsigned int KeyCount{static_cast<unsigned int>(Key::Pause) + 1};
 
 ////////////////////////////////////////////////////////////
 /// \brief Scancodes
@@ -333,7 +333,7 @@ using Scancode = Scan;
 ///
 ////////////////////////////////////////////////////////////
 // NOLINTNEXTLINE(readability-identifier-naming)
-static constexpr unsigned int ScancodeCount{static_cast<unsigned int>(Scan::LaunchMediaSelect) + 1};
+inline constexpr unsigned int ScancodeCount{static_cast<unsigned int>(Scan::LaunchMediaSelect) + 1};
 
 ////////////////////////////////////////////////////////////
 /// \brief Check if a key is pressed


### PR DESCRIPTION
Similar to #3373 , We want these constants to be shared between all translation units

While this doesn't cause compiler errors immediately when using SFML header modules, it does when you try to use these variables as they have internal linkage, so you get an error like `'ScancodeCount': is not a member of 'sf::Keyboard'`