### PR TITLE
Use correct type for accessing array

### DIFF
--- a/src/SFML/Window/FreeBSD/JoystickImpl.cpp
+++ b/src/SFML/Window/FreeBSD/JoystickImpl.cpp
@@ -304,8 +304,8 @@ JoystickState JoystickImpl::JoystickImpl::update()
         if (!data)
             continue;
 
-        int        buttonIndex = 0;
-        hid_item_t item;
+        std::size_t buttonIndex = 0;
+        hid_item_t  item;
 
         while (hid_get_item(data, &item))
         {


### PR DESCRIPTION
Error sporadically flagged by the buildbot freebsd checks:

> src/SFML/Window/FreeBSD/JoystickImpl.cpp:318:48: warning: implicit conversion changes signedness: 'int' to 'size_type' (aka 'unsigned long') [-Wsign-conversion]

Not immediately clear why sometimes it's not treated as an error but fix seems simple enough