### PR TITLE
Use approximation when comparing floats in tests

### DIFF
--- a/test/Graphics/Glsl.test.cpp
+++ b/test/Graphics/Glsl.test.cpp
@@ -149,9 +149,9 @@ TEST_CASE("[Graphics] sf::Glsl")
         {
             constexpr sf::Glsl::Vec4 vec = sf::Color(0, 128, 192, 255);
             STATIC_CHECK(vec.x == 0.f);
-            STATIC_CHECK(vec.y == 128 / 255.f);
-            STATIC_CHECK(vec.z == 192 / 255.f);
             STATIC_CHECK(vec.w == 1.f);
+            CHECK(vec.y == Approx(128 / 255.f));
+            CHECK(vec.z == Approx(192 / 255.f));
         }
     }
 

--- a/test/System/Angle.test.cpp
+++ b/test/System/Angle.test.cpp
@@ -229,8 +229,8 @@ TEST_CASE("[System] sf::Angle")
         SECTION("operator/")
         {
             STATIC_CHECK(sf::Angle::Zero / 10 == sf::Angle::Zero);
-            STATIC_CHECK(sf::degrees(10) / 2.5f == sf::degrees(4));
             STATIC_CHECK(sf::radians(12) / 3 == sf::radians(4));
+            CHECK(sf::degrees(10) / 2.5f == Approx(sf::degrees(4)));
 
             STATIC_CHECK(sf::Angle::Zero / sf::degrees(1) == 0.f);
             STATIC_CHECK(sf::degrees(10) / sf::degrees(10) == 1.f);

--- a/test/System/Time.test.cpp
+++ b/test/System/Time.test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("[System] sf::Time")
         SECTION("Construct from milliseconds")
         {
             constexpr sf::Time time = sf::milliseconds(42);
-            STATIC_CHECK(time.asSeconds() == 0.042f);
+            CHECK(time.asSeconds() == Approx(0.042f));
             STATIC_CHECK(time.asMilliseconds() == 42);
             STATIC_CHECK(time.asMicroseconds() == 42'000);
         }
@@ -58,7 +58,7 @@ TEST_CASE("[System] sf::Time")
         SECTION("Construct from microseconds")
         {
             constexpr sf::Time time = sf::microseconds(987654);
-            STATIC_CHECK(time.asSeconds() == 0.987654f);
+            CHECK(time.asSeconds() == Approx(0.987654f));
             STATIC_CHECK(time.asMilliseconds() == 987);
             STATIC_CHECK(time.asMicroseconds() == 987'654);
         }
@@ -79,13 +79,13 @@ TEST_CASE("[System] sf::Time")
             }
             {
                 constexpr sf::Time time = 10ms;
-                STATIC_CHECK(time.asSeconds() == 0.01f);
+                CHECK(time.asSeconds() == Approx(0.01f));
                 STATIC_CHECK(time.asMilliseconds() == 10);
                 STATIC_CHECK(time.asMicroseconds() == 10'000);
             }
             {
                 constexpr sf::Time time = 2048us;
-                STATIC_CHECK(time.asSeconds() == 0.002048f);
+                CHECK(time.asSeconds() == Approx(0.002048f));
                 STATIC_CHECK(time.asMilliseconds() == 2);
                 STATIC_CHECK(time.asMicroseconds() == 2048);
             }


### PR DESCRIPTION
## Description

This should fix the MinGW 32-bits test failures, see: https://ci.sfml-dev.org/#/builders/18/builds/64/steps/5/logs/stdio

Question is, whether we shouldn't be doing this for *all* float tests.

## How to test this PR?

Buildbot CI succeeds