### PR TITLE
Update Catch2 to v3.8.0

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
 set(CATCH_CONFIG_NO_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT ON CACHE BOOL "")
 FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.7.0
+    GIT_TAG v3.8.0
     GIT_SHALLOW ON)
 FetchContent_MakeAvailable(Catch2)
 include(Catch)


### PR DESCRIPTION
## Description

Updating Catch2 to [v3.8.0](https://github.com/catchorg/Catch2/releases/tag/v3.8.0)

## How to test this PR?

CI passes