### PR TITLE
Fix build errors when compiling in C++20 mode

### DIFF
--- a/examples/keyboard/Keyboard.cpp
+++ b/examples/keyboard/Keyboard.cpp
@@ -734,7 +734,7 @@ sf::String textEventDescription(const sf::Event::TextEntered& textEntered)
     text += "\nU+";
 
     std::ostringstream oss;
-    oss << std::hex << std::setw(4) << std::setfill('0') << textEntered.unicode;
+    oss << std::hex << std::setw(4) << std::setfill('0') << std::uint32_t{textEntered.unicode};
     text += oss.str();
 
     return text;

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -29,7 +29,7 @@ auto select(const std::basic_string<T>& string16, const std::basic_string<T>& st
 auto toHex(const char32_t character)
 {
     std::ostringstream stream;
-    stream << "[\\x" << std::uppercase << std::hex << character << ']';
+    stream << "[\\x" << std::uppercase << std::hex << std::uint32_t{character} << ']';
     return stream.str();
 }
 } // namespace


### PR DESCRIPTION
## Description

C++20 removes the ability to stream `char32_t` characters. This is the error I get when setting `CMAKE_CXX_STANDARD` to 20.

```
    /Users/thrasher/Projects/sfml/test/System/String.test.cpp:32:52: error: overload resolution selected deleted operator '<<'
       32 |     stream << "[\\x" << std::uppercase << std::hex << character << ']';
          |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/include/c++/v1/ostream:1009:31: note: candidate function [with _Traits = std::char_traits<char>] has been explicitly deleted
     1009 | basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, char32_t) = delete;
          |                               ^
```