### PR TITLE
Allow event handlers to accept non-const references

### DIFF
--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -82,7 +82,8 @@ const TEventSubtype* Event::getIf() const
 template <typename T>
 decltype(auto) Event::visit(T&& visitor) const
 {
-    return std::visit(std::forward<T>(visitor), m_data);
+    auto data = m_data; // Copy event to allow visitors to take it by non-const reference
+    return std::visit(std::forward<T>(visitor), data);
 }
 
 } // namespace sf

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -213,6 +213,7 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
 
         // Should compile if user provides only a specific handler
         windowBase.handleEvents([](const sf::Event::Closed&) {});
+        windowBase.handleEvents([](sf::Event::Closed) {});
 
         // Should compile if user provides only a catch-all
         windowBase.handleEvents([](const auto&) {});


### PR DESCRIPTION
Alternative approach to #3375 that allows handlers to take non-const references. In other words

```cpp
while (window.isOpen())
{
    window.clear();
    window.handleEvents([&](sf::Event::Closed&) { window.close(); });
    window.display();
}
```

will compile and will work as expected (the window will be closed when `[X]` is pressed). 

Not claiming this approach is strictly better, but it seems simpler to me and it is a bit artificial to prevent specifically non-const-ref handlers to work via type-trait detection.