### PR TITLE
Add non-`const` overload of `Event::visit`

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -347,6 +347,17 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
+    decltype(auto) visit(T&& visitor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Apply a visitor to the event
+    ///
+    /// \param visitor The visitor to apply
+    ///
+    /// \return The result of applying the visitor to the event
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
     decltype(auto) visit(T&& visitor) const;
 
 private:

--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -80,6 +80,14 @@ const TEventSubtype* Event::getIf() const
 
 ////////////////////////////////////////////////////////////
 template <typename T>
+decltype(auto) Event::visit(T&& visitor)
+{
+    return std::visit(std::forward<T>(visitor), m_data);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
 decltype(auto) Event::visit(T&& visitor) const
 {
     return std::visit(std::forward<T>(visitor), m_data);

--- a/include/SFML/Window/WindowBase.inl
+++ b/include/SFML/Window/WindowBase.inl
@@ -68,7 +68,7 @@ void WindowBase::handleEvents(Ts&&... handlers) // NOLINT(cppcoreguidelines-miss
     // NOLINTNEXTLINE(misc-const-correctness)
     priv::OverloadSet overloadSet{std::forward<Ts>(handlers)..., [](const priv::DelayOverloadResolution&) { /* ignore */ }};
 
-    while (const std::optional event = pollEvent())
+    while (std::optional event = pollEvent())
         event->visit(overloadSet);
 }
 

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -9,17 +9,22 @@ namespace
 {
 struct
 {
-    std::string_view operator()(const sf::Event::Closed&) const
+    std::string_view operator()(sf::Event::Closed&) const
     {
-        return "Closed";
+        return "Closed (non-const)";
     }
 
-    std::string_view operator()(const sf::Event::Resized&) const
+    std::string_view operator()(const sf::Event::Closed&) const
+    {
+        return "Closed (const)";
+    }
+
+    std::string_view operator()(sf::Event::Resized&) const
     {
         return "Resized";
     }
 
-    std::string_view operator()(const sf::Event::KeyPressed&) const
+    std::string_view operator()(sf::Event::KeyPressed) const
     {
         return "KeyPressed";
     }
@@ -306,10 +311,34 @@ TEST_CASE("[Window] sf::Event")
 
     SECTION("visit()")
     {
-        CHECK(sf::Event(sf::Event::Closed{}).visit(visitor) == "Closed");
-        CHECK(sf::Event(sf::Event::Resized{}).visit(visitor) == "Resized");
-        CHECK(sf::Event(sf::Event::FocusLost{}).visit(visitor) == "Other");
-        CHECK(sf::Event(sf::Event::FocusGained{}).visit(visitor) == "Other");
-        CHECK(sf::Event(sf::Event::KeyPressed{}).visit(visitor) == "KeyPressed");
+        SECTION("Non-const")
+        {
+            sf::Event closed = sf::Event::Closed{};
+            CHECK(closed.visit(visitor) == "Closed (non-const)");
+
+            sf::Event resized = sf::Event::Resized{};
+            CHECK(resized.visit(visitor) == "Resized");
+
+            sf::Event keyPressed = sf::Event::KeyPressed{};
+            CHECK(keyPressed.visit(visitor) == "KeyPressed");
+
+            sf::Event focusLost = sf::Event::FocusLost{};
+            CHECK(focusLost.visit(visitor) == "Other");
+        }
+
+        SECTION("Const")
+        {
+            const sf::Event closed = sf::Event::Closed{};
+            CHECK(closed.visit(visitor) == "Closed (const)");
+
+            const sf::Event resized = sf::Event::Resized{};
+            CHECK(resized.visit(visitor) == "Other"); // Cannot use non-const reference callback
+
+            const sf::Event keyPressed = sf::Event::KeyPressed{};
+            CHECK(keyPressed.visit(visitor) == "KeyPressed");
+
+            const sf::Event focusLost = sf::Event::FocusLost{};
+            CHECK(focusLost.visit(visitor) == "Other");
+        }
     }
 }


### PR DESCRIPTION
Alternative approach to #3375 and #3395 that allows handlers to take non-const references. In other words

```cpp
while (window.isOpen())
{
    window.clear();
    window.handleEvents([&](sf::Event::Closed&) { window.close(); });
    window.display();
}
```

will compile and will work as expected (the window will be closed when `[X]` is pressed). 

This approach gives `Event` a more sensible and homogeneous API. It was already possible to get a mutable reference to the event by using `getIf`, now you can also do the same with `visit`. Thanks to @ZXShady for the suggestion.