### PR TITLE
Use `std::queue` to model queues

### DIFF
--- a/examples/island/Island.cpp
+++ b/examples/island/Island.cpp
@@ -8,9 +8,9 @@
 
 #include <algorithm>
 #include <array>
-#include <deque>
 #include <iostream>
 #include <mutex>
+#include <queue>
 #include <sstream>
 #include <thread>
 #include <vector>
@@ -40,7 +40,7 @@ struct WorkItem
     unsigned int index{};
 };
 
-std::deque<WorkItem>     workQueue;
+std::queue<WorkItem>     workQueue;
 std::vector<std::thread> threads;
 int                      pendingWorkCount    = 0;
 bool                     workPending         = true;
@@ -356,7 +356,7 @@ void threadFunction()
             if (!workQueue.empty())
             {
                 workItem = workQueue.front();
-                workQueue.pop_front();
+                workQueue.pop();
             }
         }
 
@@ -409,7 +409,7 @@ void generateTerrain(sf::Vertex* buffer)
         for (unsigned int i = 0; i < blockCount; ++i)
         {
             const WorkItem workItem = {buffer, i};
-            workQueue.push_back(workItem);
+            workQueue.push(workItem);
         }
 
         pendingWorkCount = blockCount;

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -175,13 +175,13 @@ void ClipboardImpl::processEventsImpl()
 
     // Pick out the events that are interesting for this window
     while (XCheckIfEvent(m_display.get(), &event, &checkEvent, reinterpret_cast<XPointer>(m_window)))
-        m_events.push_back(event);
+        m_events.push(event);
 
     // Handle the events for this window that we just picked out
     while (!m_events.empty())
     {
         event = m_events.front();
-        m_events.pop_front();
+        m_events.pop();
         processEvent(event);
     }
 }

--- a/src/SFML/Window/Unix/ClipboardImpl.hpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.hpp
@@ -33,8 +33,8 @@
 
 #include <X11/Xlib.h>
 
-#include <deque>
 #include <memory>
+#include <queue>
 
 
 namespace sf::priv
@@ -143,7 +143,7 @@ private:
     Atom                       m_utf8String;        ///< X Atom identifying UTF8_STRING
     Atom                       m_targetProperty;    ///< X Atom identifying our destination window property
     String                     m_clipboardContents; ///< Our clipboard contents
-    std::deque<XEvent>         m_events;            ///< Queue we use to store pending events for this window
+    std::queue<XEvent>         m_events;            ///< Queue we use to store pending events for this window
     bool m_requestResponded{}; ///< Holds whether our selection request has been responded to or not
 };
 

--- a/src/SFML/Window/Unix/WindowImplX11.hpp
+++ b/src/SFML/Window/Unix/WindowImplX11.hpp
@@ -34,7 +34,6 @@
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 
-#include <deque>
 #include <memory>
 
 


### PR DESCRIPTION
## Description

If we're only pushing to the back and popping from the front of a deque, we can more simply use a queue. 