### PR TITLE
Use `true` and `false` literals instead of API specific macros

### DIFF
--- a/src/SFML/Graphics/GLCheck.cpp
+++ b/src/SFML/Graphics/GLCheck.cpp
@@ -33,6 +33,10 @@
 #include <filesystem>
 #include <ostream>
 
+// NOLINTBEGIN(readability-simplify-boolean-expr)
+static_assert(GL_TRUE == true);
+static_assert(GL_FALSE == false);
+// NOLINTEND(readability-simplify-boolean-expr)
 
 namespace sf::priv
 {

--- a/src/SFML/Graphics/RenderTarget.cpp
+++ b/src/SFML/Graphics/RenderTarget.cpp
@@ -611,7 +611,7 @@ void RenderTarget::resetGLStates()
         glCheck(glEnableClientState(GL_VERTEX_ARRAY));
         glCheck(glEnableClientState(GL_COLOR_ARRAY));
         glCheck(glEnableClientState(GL_TEXTURE_COORD_ARRAY));
-        glCheck(glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE));
+        glCheck(glColorMask(true, true, true, true));
         m_cache.scissorEnabled = false;
         m_cache.stencilEnabled = false;
         m_cache.glStatesSet    = true;
@@ -760,7 +760,7 @@ void RenderTarget::applyStencilMode(const StencilMode& mode)
         if (!m_cache.enable || m_cache.stencilEnabled)
         {
             glCheck(glDisable(GL_STENCIL_TEST));
-            glCheck(glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE));
+            glCheck(glColorMask(true, true, true, true));
 
             m_cache.stencilEnabled = false;
         }
@@ -860,7 +860,7 @@ void RenderTarget::setupDraw(bool useVertexCache, const RenderStates& states)
 
     // Mask the color buffer off if necessary
     if (states.stencilMode.stencilOnly)
-        glCheck(glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE));
+        glCheck(glColorMask(false, false, false, false));
 
     // Apply the texture
     if (!m_cache.enable || (states.texture && states.texture->m_fboAttachment))
@@ -913,7 +913,7 @@ void RenderTarget::cleanupDraw(const RenderStates& states)
 
     // Mask the color buffer back on if necessary
     if (states.stencilMode.stencilOnly)
-        glCheck(glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE));
+        glCheck(glColorMask(true, true, true, true));
 
     // Re-enable the cache at the end of the draw if it was disabled
     m_cache.enable = true;

--- a/src/SFML/Graphics/RenderTextureImplFBO.cpp
+++ b/src/SFML/Graphics/RenderTextureImplFBO.cpp
@@ -614,10 +614,10 @@ void RenderTextureImplFBO::updateTexture(unsigned int)
             {
                 // Scissor testing affects framebuffer blits as well
                 // Since we don't want scissor testing to interfere with our copying, we temporarily disable it for the blit if it is enabled
-                GLboolean scissorEnabled = GL_FALSE;
+                GLboolean scissorEnabled = false;
                 glCheck(glGetBooleanv(GL_SCISSOR_TEST, &scissorEnabled));
 
-                if (scissorEnabled == GL_TRUE)
+                if (scissorEnabled)
                     glCheck(glDisable(GL_SCISSOR_TEST));
 
                 // Set up the blit target (draw framebuffer) and blit (from the read framebuffer, our multisample FBO)
@@ -635,7 +635,7 @@ void RenderTextureImplFBO::updateTexture(unsigned int)
                 glCheck(GLEXT_glBindFramebuffer(GLEXT_GL_DRAW_FRAMEBUFFER, multiSampleFrameBuffer->object));
 
                 // Re-enable scissor testing if it was previously enabled
-                if (scissorEnabled == GL_TRUE)
+                if (scissorEnabled)
                     glCheck(glEnable(GL_SCISSOR_TEST));
             }
         }

--- a/src/SFML/Graphics/Shader.cpp
+++ b/src/SFML/Graphics/Shader.cpp
@@ -635,7 +635,7 @@ void Shader::setUniform(const std::string& name, const Glsl::Mat3& matrix)
 {
     const UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniformMatrix3fv(binder.location, 1, GL_FALSE, matrix.array.data()));
+        glCheck(GLEXT_glUniformMatrix3fv(binder.location, 1, false, matrix.array.data()));
 }
 
 
@@ -644,7 +644,7 @@ void Shader::setUniform(const std::string& name, const Glsl::Mat4& matrix)
 {
     const UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniformMatrix4fv(binder.location, 1, GL_FALSE, matrix.array.data()));
+        glCheck(GLEXT_glUniformMatrix4fv(binder.location, 1, false, matrix.array.data()));
 }
 
 
@@ -749,7 +749,7 @@ void Shader::setUniformArray(const std::string& name, const Glsl::Mat3* matrixAr
 
     const UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniformMatrix3fv(binder.location, static_cast<GLsizei>(length), GL_FALSE, contiguous.data()));
+        glCheck(GLEXT_glUniformMatrix3fv(binder.location, static_cast<GLsizei>(length), false, contiguous.data()));
 }
 
 
@@ -764,7 +764,7 @@ void Shader::setUniformArray(const std::string& name, const Glsl::Mat4* matrixAr
 
     const UniformBinder binder(*this, name);
     if (binder.location != -1)
-        glCheck(GLEXT_glUniformMatrix4fv(binder.location, static_cast<GLsizei>(length), GL_FALSE, contiguous.data()));
+        glCheck(GLEXT_glUniformMatrix4fv(binder.location, static_cast<GLsizei>(length), false, contiguous.data()));
 }
 
 
@@ -881,7 +881,7 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
         // Check the compile log
         GLint success = 0;
         glCheck(GLEXT_glGetObjectParameteriv(shader, GLEXT_GL_OBJECT_COMPILE_STATUS, &success));
-        if (success == GL_FALSE)
+        if (!success)
         {
             std::array<char, 1024> log{};
             glCheck(GLEXT_glGetInfoLog(shader, static_cast<GLsizei>(log.size()), nullptr, log.data()));
@@ -918,7 +918,7 @@ bool Shader::compile(std::string_view vertexShaderCode, std::string_view geometr
     // Check the link log
     GLint success = 0;
     glCheck(GLEXT_glGetObjectParameteriv(shaderProgram, GLEXT_GL_OBJECT_LINK_STATUS, &success));
-    if (success == GL_FALSE)
+    if (!success)
     {
         std::array<char, 1024> log{};
         glCheck(GLEXT_glGetInfoLog(shaderProgram, static_cast<GLsizei>(log.size()), nullptr, log.data()));

--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -656,10 +656,10 @@ void Texture::update(const Texture& texture, Vector2u dest)
         {
             // Scissor testing affects framebuffer blits as well
             // Since we don't want scissor testing to interfere with our copying, we temporarily disable it for the blit if it is enabled
-            GLboolean scissorEnabled = GL_FALSE;
+            GLboolean scissorEnabled = false;
             glCheck(glGetBooleanv(GL_SCISSOR_TEST, &scissorEnabled));
 
-            if (scissorEnabled == GL_TRUE)
+            if (scissorEnabled)
                 glCheck(glDisable(GL_SCISSOR_TEST));
 
             // Blit the texture contents from the source to the destination texture
@@ -675,7 +675,7 @@ void Texture::update(const Texture& texture, Vector2u dest)
                                             GL_NEAREST));
 
             // Re-enable scissor testing if it was previously enabled
-            if (scissorEnabled == GL_TRUE)
+            if (scissorEnabled)
                 glCheck(glEnable(GL_SCISSOR_TEST));
         }
         else
@@ -924,7 +924,7 @@ void Texture::bind(const Texture* texture, CoordinateType coordinateType)
     if (texture && texture->m_texture)
     {
         // When debugging, ensure that the texture name is valid
-        assert((glIsTexture(texture->m_texture) == GL_TRUE) &&
+        assert(glIsTexture(texture->m_texture) &&
                "Texture to be bound is invalid, check if the texture is still being used after it has been destroyed");
 
         // Bind the texture

--- a/src/SFML/Graphics/VertexBuffer.cpp
+++ b/src/SFML/Graphics/VertexBuffer.cpp
@@ -252,7 +252,7 @@ bool VertexBuffer::update([[maybe_unused]] const VertexBuffer& vertexBuffer)
 
     glCheck(GLEXT_glBindBuffer(GLEXT_GL_ARRAY_BUFFER, 0));
 
-    return (sourceResult == GL_TRUE) && (destinationResult == GL_TRUE);
+    return sourceResult && destinationResult;
 
 #endif // SFML_OPENGL_ES
 }

--- a/src/SFML/Window/EGLCheck.cpp
+++ b/src/SFML/Window/EGLCheck.cpp
@@ -35,6 +35,10 @@
 #include <filesystem>
 #include <ostream>
 
+// NOLINTBEGIN(readability-simplify-boolean-expr)
+static_assert(EGL_TRUE == true);
+static_assert(EGL_FALSE == false);
+// NOLINTEND(readability-simplify-boolean-expr)
 
 namespace sf::priv
 {

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -228,9 +228,9 @@ bool EglContext::makeCurrent(bool current)
         return false;
 
     if (current)
-        return EGL_FALSE != eglCheck(eglMakeCurrent(m_display, m_surface, m_surface, m_context));
+        return eglCheck(eglMakeCurrent(m_display, m_surface, m_surface, m_context));
 
-    return EGL_FALSE != eglCheck(eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT));
+    return eglCheck(eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT));
 }
 
 
@@ -368,14 +368,14 @@ void EglContext::updateSettings()
     EGLint tmp = 0;
 
     // Update the internal context settings with the current config
-    if (eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_DEPTH_SIZE, &tmp)) != EGL_FALSE)
+    if (eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_DEPTH_SIZE, &tmp)))
         m_settings.depthBits = static_cast<unsigned int>(tmp);
 
-    if (eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_STENCIL_SIZE, &tmp)) != EGL_FALSE)
+    if (eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_STENCIL_SIZE, &tmp)))
         m_settings.stencilBits = static_cast<unsigned int>(tmp);
 
-    if (eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_SAMPLE_BUFFERS, &tmp)) != EGL_FALSE && tmp &&
-        eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_SAMPLES, &tmp)) != EGL_FALSE)
+    if (eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_SAMPLE_BUFFERS, &tmp)) && tmp &&
+        eglCheck(eglGetConfigAttrib(m_display, m_config, EGL_SAMPLES, &tmp)))
         m_settings.antiAliasingLevel = static_cast<unsigned int>(tmp);
 }
 

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -1029,7 +1029,7 @@ void GlContext::initialize(const ContextSettings& requestedSettings)
         glEnableFunc(GL_FRAMEBUFFER_SRGB);
 
         // Check to see if the enable was successful
-        if (glIsEnabledFunc(GL_FRAMEBUFFER_SRGB) == GL_FALSE)
+        if (!glIsEnabledFunc(GL_FRAMEBUFFER_SRGB))
         {
             err() << "Warning: Failed to enable GL_FRAMEBUFFER_SRGB" << std::endl;
             m_settings.sRgbCapable = false;

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -37,6 +37,10 @@
 #include <ostream>
 #include <vector>
 
+// NOLINTBEGIN(readability-simplify-boolean-expr)
+static_assert(True == true);
+static_assert(False == false);
+// NOLINTEND(readability-simplify-boolean-expr)
 
 namespace
 {
@@ -229,7 +233,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
                                                   m_targetProperty,
                                                   0,
                                                   0x7fffffff,
-                                                  False,
+                                                  false,
                                                   AnyPropertyType,
                                                   &type,
                                                   &format,
@@ -308,7 +312,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
 
                     XSendEvent(m_display.get(),
                                selectionRequestEvent.requestor,
-                               True,
+                               true,
                                NoEventMask,
                                reinterpret_cast<XEvent*>(&selectionEvent));
 
@@ -334,7 +338,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
 
                     XSendEvent(m_display.get(),
                                selectionRequestEvent.requestor,
-                               True,
+                               true,
                                NoEventMask,
                                reinterpret_cast<XEvent*>(&selectionEvent));
 
@@ -361,7 +365,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
 
                     XSendEvent(m_display.get(),
                                selectionRequestEvent.requestor,
-                               True,
+                               true,
                                NoEventMask,
                                reinterpret_cast<XEvent*>(&selectionEvent));
 
@@ -375,7 +379,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
 
             XSendEvent(m_display.get(),
                        selectionRequestEvent.requestor,
-                       True,
+                       true,
                        NoEventMask,
                        reinterpret_cast<XEvent*>(&selectionEvent));
 

--- a/src/SFML/Window/Unix/Display.cpp
+++ b/src/SFML/Window/Unix/Display.cpp
@@ -133,7 +133,7 @@ Atom getAtom(const std::string& name, bool onlyIfExists)
         return it->second;
 
     const auto display = openDisplay();
-    const Atom atom    = XInternAtom(display.get(), name.c_str(), onlyIfExists ? True : False);
+    const Atom atom    = XInternAtom(display.get(), name.c_str(), onlyIfExists);
     if (atom)
         atoms[name] = atom;
 

--- a/src/SFML/Window/Unix/GlxContext.cpp
+++ b/src/SFML/Window/Unix/GlxContext.cpp
@@ -92,7 +92,7 @@ public:
 
     ~GlxErrorHandler()
     {
-        XSync(m_display, False);
+        XSync(m_display, false);
         XSetErrorHandler(m_previousHandler);
     }
 
@@ -360,14 +360,7 @@ XVisualInfo GlxContext::selectBestVisual(::Display* display, unsigned int bitsPe
 
             // Evaluate the visual
             const int color = red + green + blue + alpha;
-            const int score = evaluateFormat(bitsPerPixel,
-                                             settings,
-                                             color,
-                                             depth,
-                                             stencil,
-                                             multiSampling ? samples : 0,
-                                             accelerated,
-                                             sRgb == True);
+            const int score = evaluateFormat(bitsPerPixel, settings, color, depth, stencil, multiSampling ? samples : 0, accelerated, sRgb);
 
             // If it's better than the current best, make it the new best
             if (score < bestScore)
@@ -422,7 +415,7 @@ void GlxContext::updateSettingsFromVisualInfo(XVisualInfo* visualInfo)
     m_settings.depthBits         = static_cast<unsigned int>(depth);
     m_settings.stencilBits       = static_cast<unsigned int>(stencil);
     m_settings.antiAliasingLevel = multiSampling ? static_cast<unsigned int>(samples) : 0;
-    m_settings.sRgbCapable       = (sRgb == True);
+    m_settings.sRgbCapable       = sRgb;
 }
 
 

--- a/src/SFML/Window/Unix/KeyboardImpl.cpp
+++ b/src/SFML/Window/Unix/KeyboardImpl.cpp
@@ -496,8 +496,8 @@ void ensureMapping()
         keycodeToScancode[static_cast<KeyCode>(keycode)] = scancode;
     }
 
-    XkbFreeNames(descriptor, XkbKeyNamesMask, True);
-    XkbFreeKeyboard(descriptor, 0, True);
+    XkbFreeNames(descriptor, XkbKeyNamesMask, true);
+    XkbFreeKeyboard(descriptor, 0, true);
 
     // Phase 3: Translate un-translated keycodes using traditional X11 KeySym lookups
     for (int keycode = 8; keycode < maxKeyCode; ++keycode)

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -534,7 +534,7 @@ m_cursorGrabbed(m_fullscreen)
     XSetWindowAttributes attributes;
     attributes.colormap   = XCreateColormap(m_display.get(), DefaultRootWindow(m_display.get()), visual, AllocNone);
     attributes.event_mask = eventMask;
-    attributes.override_redirect = (m_fullscreen && !ewmhSupported()) ? True : False;
+    attributes.override_redirect = m_fullscreen && !ewmhSupported();
 
     m_window = XCreateWindow(m_display.get(),
                              DefaultRootWindow(m_display.get()),
@@ -1132,7 +1132,7 @@ void WindowImplX11::setMouseCursorGrabbed(bool grabbed)
         // Try multiple times to grab the cursor
         for (unsigned int trial = 0; trial < maxTrialsCount; ++trial)
         {
-            const int result = XGrabPointer(m_display.get(), m_window, True, None, GrabModeAsync, GrabModeAsync, m_window, None, CurrentTime);
+            const int result = XGrabPointer(m_display.get(), m_window, true, None, GrabModeAsync, GrabModeAsync, m_window, None, CurrentTime);
 
             if (result == GrabSuccess)
             {
@@ -1695,7 +1695,7 @@ bool WindowImplX11::processEvent(XEvent& windowEvent)
                 {
                     const int result = XGrabPointer(m_display.get(),
                                                     m_window,
-                                                    True,
+                                                    true,
                                                     None,
                                                     GrabModeAsync,
                                                     GrabModeAsync,

--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -99,7 +99,7 @@ bool CursorImpl::loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vecto
 
     // Create the structure that describes our cursor
     auto cursorInfo     = ICONINFO();
-    cursorInfo.fIcon    = FALSE; // This is a cursor and not an icon
+    cursorInfo.fIcon    = false; // This is a cursor and not an icon
     cursorInfo.xHotspot = hotspot.x;
     cursorInfo.yHotspot = hotspot.y;
     cursorInfo.hbmColor = color;

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -130,7 +130,7 @@ void initRawMouse()
 {
     const RAWINPUTDEVICE rawMouse{0x01, 0x02, 0, nullptr}; // HID usage: mouse device class, no flags, follow keyboard focus
 
-    if (RegisterRawInputDevices(&rawMouse, 1, sizeof(rawMouse)) != TRUE)
+    if (!RegisterRawInputDevices(&rawMouse, 1, sizeof(rawMouse)))
         sf::err() << "Failed to initialize raw mouse input" << std::endl;
 }
 } // namespace


### PR DESCRIPTION
Replace api specific macros with C++ literals.

Previously, we used API specific macros and way too many different ways to compare with API booleans we used 
```cpp
Var != API_TRUE
Var != API_FALSE
Var == API_FALSE
Var == API_TRUE
```

now it is uniform with the rest of our modern C++ codebase and I added `static_assert`s just incase `API_TRUE` gets defined into `42` at some point.