### PR TITLE
Improved `Event::visit` and `WindowBase::handleEvents`

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -346,8 +346,8 @@ public:
     /// \return The result of applying the visitor to the event
     ///
     ////////////////////////////////////////////////////////////
-    template <typename T>
-    decltype(auto) visit(T&& visitor);
+    template <typename Visitor>
+    decltype(auto) visit(Visitor&& visitor);
 
     ////////////////////////////////////////////////////////////
     /// \brief Apply a visitor to the event
@@ -357,8 +357,8 @@ public:
     /// \return The result of applying the visitor to the event
     ///
     ////////////////////////////////////////////////////////////
-    template <typename T>
-    decltype(auto) visit(T&& visitor) const;
+    template <typename Visitor>
+    decltype(auto) visit(Visitor&& visitor) const;
 
 private:
     ////////////////////////////////////////////////////////////

--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -34,6 +34,7 @@
 
 #include <SFML/System/Vector2.hpp>
 
+#include <type_traits>
 #include <variant>
 
 
@@ -395,11 +396,22 @@ private:
     template <typename T, typename... Ts>
     [[nodiscard]] static constexpr bool isInParameterPack(const std::variant<Ts...>*)
     {
-        return (std::is_same_v<T, Ts> || ...);
+        return std::disjunction_v<std::is_same<T, Ts>...>;
     }
 
     template <typename T>
     static constexpr bool isEventSubtype = isInParameterPack<T>(decltype (&m_data)(nullptr));
+
+    friend class WindowBase;
+
+    template <typename Handler, typename... Ts>
+    [[nodiscard]] static constexpr bool isInvocableWithEventSubtype(const std::variant<Ts...>*)
+    {
+        return std::disjunction_v<std::is_invocable<Handler&, Ts&>...>;
+    }
+
+    template <typename Handler>
+    static constexpr bool isEventHandler = isInvocableWithEventSubtype<Handler>(decltype (&m_data)(nullptr));
 };
 
 } // namespace sf

--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -79,18 +79,18 @@ const TEventSubtype* Event::getIf() const
 
 
 ////////////////////////////////////////////////////////////
-template <typename T>
-decltype(auto) Event::visit(T&& visitor)
+template <typename Visitor>
+decltype(auto) Event::visit(Visitor&& visitor)
 {
-    return std::visit(std::forward<T>(visitor), m_data);
+    return std::visit(std::forward<Visitor>(visitor), m_data);
 }
 
 
 ////////////////////////////////////////////////////////////
-template <typename T>
-decltype(auto) Event::visit(T&& visitor) const
+template <typename Visitor>
+decltype(auto) Event::visit(Visitor&& visitor) const
 {
-    return std::visit(std::forward<T>(visitor), m_data);
+    return std::visit(std::forward<Visitor>(visitor), m_data);
 }
 
 } // namespace sf

--- a/include/SFML/Window/WindowBase.hpp
+++ b/include/SFML/Window/WindowBase.hpp
@@ -326,8 +326,8 @@ public:
     /// \see `waitEvent`, `pollEvent`
     ///
     ////////////////////////////////////////////////////////////
-    template <typename... Ts>
-    void handleEvents(Ts&&... handlers);
+    template <typename... Handlers>
+    void handleEvents(Handlers&&... handlers);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the position of the window

--- a/include/SFML/Window/WindowBase.inl
+++ b/include/SFML/Window/WindowBase.inl
@@ -61,6 +61,7 @@ template <typename... Handlers>
 void WindowBase::handleEvents(Handlers&&... handlers)
 {
     static_assert(sizeof...(Handlers) > 0, "Must provide at least one handler");
+    static_assert((Event::isEventHandler<Handlers> && ...), "Handlers must accept at least one subtype of sf::Event");
 
     // Disable misc-const-correctness for this line since clang-tidy
     // complains about it even though the code would become incorrect

--- a/include/SFML/Window/WindowBase.inl
+++ b/include/SFML/Window/WindowBase.inl
@@ -57,16 +57,17 @@ struct DelayOverloadResolution
 
 
 ////////////////////////////////////////////////////////////
-template <typename... Ts>
-void WindowBase::handleEvents(Ts&&... handlers) // NOLINT(cppcoreguidelines-missing-std-forward)
+template <typename... Handlers>
+void WindowBase::handleEvents(Handlers&&... handlers)
 {
-    static_assert(sizeof...(Ts) > 0, "Must provide at least one handler");
+    static_assert(sizeof...(Handlers) > 0, "Must provide at least one handler");
 
     // Disable misc-const-correctness for this line since clang-tidy
-    // complains about it even though the code would become uncompilable
+    // complains about it even though the code would become incorrect
 
     // NOLINTNEXTLINE(misc-const-correctness)
-    priv::OverloadSet overloadSet{std::forward<Ts>(handlers)..., [](const priv::DelayOverloadResolution&) { /* ignore */ }};
+    priv::OverloadSet overloadSet{std::forward<Handlers>(handlers)...,
+                                  [](const priv::DelayOverloadResolution&) { /* ignore */ }};
 
     while (std::optional event = pollEvent())
         event->visit(overloadSet);

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
 {
@@ -240,5 +241,13 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
             void operator()(const sf::Event::Closed&) && = delete;
         };
         windowBase.handleEvents(LvalueOnlyHandler{});
+
+        // Should compile if user provides a reference to a handler
+        auto handler = [](const sf::Event::Closed&) {};
+        windowBase.handleEvents(handler);
+        windowBase.handleEvents(std::as_const(handler));
+
+        // Should compile if user provides a function pointer
+        windowBase.handleEvents(+[](const sf::Event::Closed&) {});
     };
 }


### PR DESCRIPTION
## Description

PR #3375 made valid code not compilable.

For example, the following code failed to compile because the implementation needed to make a copy of the visitor to initialize the `sf::priv::OverloadSet` instance.

```c++
const auto visitor = [ptr = std::make_unique<int>()](const auto&) {};
sf::Event event;
event.visit(visitor);
```

So I suggested to revert it -> This has been merged already in #3400.

What remains in this PR is about:
- Implementing sanity checks on handlers #3375 was about, but in a different way: `isEventHandler` in `Event` accessible in `WindowBase::handleEvents` via `friend`.
- Adding support for move-only event handlers in `WindowBase::handleEvents`. Thinking about the regression with `Event::visit` made me realize we can also support move-only handlers in `WindowBase::handleEvents`.
- Adding support for free functions in `WindowBase::handleEvents`. This was documented but never worked as far as I understand.
- Some renaming for clarity.

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

See unit tests
