### PR TITLE
Revert `Event::visit` regression and add test

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -34,7 +34,6 @@
 
 #include <SFML/System/Vector2.hpp>
 
-#include <type_traits>
 #include <variant>
 
 
@@ -340,26 +339,26 @@ public:
     [[nodiscard]] const TEventSubtype* getIf() const;
 
     ////////////////////////////////////////////////////////////
-    /// \brief Apply handlers to the event
+    /// \brief Apply a visitor to the event
     ///
-    /// \param handlers Handlers to apply
+    /// \param visitor The visitor to apply
     ///
-    /// \return The result of applying the handlers to the event
+    /// \return The result of applying the visitor to the event
     ///
     ////////////////////////////////////////////////////////////
-    template <typename... Handlers>
-    decltype(auto) visit(Handlers&&... handlers);
+    template <typename T>
+    decltype(auto) visit(T&& visitor);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Apply handlers to the event
+    /// \brief Apply a visitor to the event
     ///
-    /// \param handlers Handlers to apply
+    /// \param visitor The visitor to apply
     ///
-    /// \return The result of applying the handlers to the event
+    /// \return The result of applying the visitor to the event
     ///
     ////////////////////////////////////////////////////////////
-    template <typename... Handlers>
-    decltype(auto) visit(Handlers&&... handlers) const;
+    template <typename T>
+    decltype(auto) visit(T&& visitor) const;
 
 private:
     ////////////////////////////////////////////////////////////
@@ -396,20 +395,11 @@ private:
     template <typename T, typename... Ts>
     [[nodiscard]] static constexpr bool isInParameterPack(const std::variant<Ts...>*)
     {
-        return std::disjunction_v<std::is_same<T, Ts>...>;
+        return (std::is_same_v<T, Ts> || ...);
     }
 
     template <typename T>
-    static constexpr bool isEventSubtype = isInParameterPack<T>(static_cast<decltype(&m_data)>(nullptr));
-
-    template <typename Handler, typename... Ts>
-    static constexpr bool isInvokableWithAnyOf(std::variant<Ts...>*)
-    {
-        return std::disjunction_v<std::is_invocable<Handler, Ts&>...>;
-    }
-
-    template <typename Handler>
-    static constexpr bool isValidHandler = isInvokableWithAnyOf<Handler>(static_cast<decltype(&m_data)>(nullptr));
+    static constexpr bool isEventSubtype = isInParameterPack<T>(decltype (&m_data)(nullptr));
 };
 
 } // namespace sf

--- a/include/SFML/Window/Event.inl
+++ b/include/SFML/Window/Event.inl
@@ -38,20 +38,6 @@
 
 namespace sf
 {
-namespace priv
-{
-template <typename... Ts>
-struct OverloadSet : Ts...
-{
-    using Ts::operator()...;
-#if defined(_MSC_VER) && !defined(__clang__)
-    unsigned char dummy; // Dummy variable to ensure that this struct is not empty thus avoiding a crash due to an MSVC bug
-#endif
-};
-template <typename... Ts>
-OverloadSet(Ts...) -> OverloadSet<Ts...>;
-} // namespace priv
-
 ////////////////////////////////////////////////////////////
 template <typename TEventSubtype>
 Event::Event(const TEventSubtype& eventSubtype)
@@ -93,20 +79,18 @@ const TEventSubtype* Event::getIf() const
 
 
 ////////////////////////////////////////////////////////////
-template <typename... Handlers>
-decltype(auto) Event::visit(Handlers&&... handlers)
+template <typename T>
+decltype(auto) Event::visit(T&& visitor)
 {
-    static_assert((isValidHandler<Handlers> && ...), "All handlers must accept a single event subtype parameter");
-    return std::visit(priv::OverloadSet{std::forward<Handlers>(handlers)...}, m_data);
+    return std::visit(std::forward<T>(visitor), m_data);
 }
 
 
 ////////////////////////////////////////////////////////////
-template <typename... Handlers>
-decltype(auto) Event::visit(Handlers&&... handlers) const
+template <typename T>
+decltype(auto) Event::visit(T&& visitor) const
 {
-    static_assert((isValidHandler<Handlers> && ...), "All handlers must accept a single event subtype parameter");
-    return std::visit(priv::OverloadSet{std::forward<Handlers>(handlers)...}, m_data);
+    return std::visit(std::forward<T>(visitor), m_data);
 }
 
 } // namespace sf

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <memory>
 #include <string_view>
 #include <type_traits>
 
@@ -339,6 +340,14 @@ TEST_CASE("[Window] sf::Event")
 
             const sf::Event focusLost = sf::Event::FocusLost{};
             CHECK(focusLost.visit(visitor) == "Other");
+        }
+
+        SECTION("Move-only visitor")
+        {
+            auto moveOnlyVisitor = [ptr = std::make_unique<std::string_view>("It works")](const auto&) { return *ptr; };
+
+            const sf::Event closed = sf::Event::Closed{};
+            CHECK(closed.visit(moveOnlyVisitor) == "It works");
         }
     }
 }


### PR DESCRIPTION
## Description

This is the first part of #3399 that reverts #3375 and adds a corresponding non-regression test.

@ChrisThrasher suggested to me I submit this part separately to merge it first.
Then the discussion can continue in #3399.

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

- [x] Unit test
