### PR TITLE
Silence C4275 warning for `sf::Exception`

### DIFF
--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -140,10 +140,11 @@
 #define SFML_API_EXPORT __declspec(dllexport)
 #define SFML_API_IMPORT __declspec(dllimport)
 
-// For Visual C++ compilers, we also need to turn off this annoying C4251 warning
+// For Visual C++ compilers, we also need to turn off this annoying C4251 & C4275 warning
 #ifdef _MSC_VER
 
-#pragma warning(disable : 4251)
+#pragma warning(disable : 4251) // Using standard library types in our own exported types is okay
+#pragma warning(disable : 4275) // Exporting types derived from the standard library is okay
 
 #endif
 


### PR DESCRIPTION
## Description

Warning is not relevant when deriving from standard library types as the documentation states:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275

This PR is related to the issue #3404 

## Tasks

-   [x] Tested on Windows

## How to test this PR?

- Build SFML as DLL on Windows
- Build & link SFML using the MSVC toolchain

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        window.clear();
        window.display();
    }
}
```