### PR TITLE
Always print filepaths as UTF-8 to a char stream #3406

### DIFF
--- a/src/SFML/System/Utils.cpp
+++ b/src/SFML/System/Utils.cpp
@@ -44,8 +44,10 @@ std::string toLower(std::string str)
 std::string formatDebugPathInfo(const std::filesystem::path& path)
 {
     std::ostringstream oss;
-    oss << "    Provided path: " << path << '\n' //
-        << "    Absolute path: " << std::filesystem::absolute(path);
+    // convert to UTF-8 to handle non-ascii/non-latin1 filenames on windows
+    // cast is required to work in C++20 where u8string is char8_t which can't be printed to char stream
+    oss << "    Provided path: " << reinterpret_cast<const char*>(path.u8string().c_str()) << '\n' //
+        << "    Absolute path: " << reinterpret_cast<const char*>(std::filesystem::absolute(path).u8string().c_str());
     return oss.str();
 }
 


### PR DESCRIPTION
[x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
[x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
[x] Have you provided some example/test code for your changes?
[ ] If you have additional steps which need to be performed, please list them as tasks!

## Description

This PR is related to the issue https://github.com/SFML/SFML/issues/3406 and https://github.com/SFML/SFML/issues/647

This PR is one of the commits from the PR https://github.com/SFML/SFML/pull/3403

The only commit in this PR is the one that uses UTF-8 to print filepath to `sf::err()`.

I was asked to make it its own PR on Discord by @ChrisThrasher 

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run this program. `sf::Shader` is used since it already uses `std::ifstream` and supports Unicode
filenames, so there is no exception due to using `.string()` on Windows there.

```cpp
#include <SFML/Graphics.hpp>
#include <iostream>

int main(void)
{
    const char32_t totry[] = {
        0xF1, // spanish n tilde
        0x144, // polish n accent
        0x65E5, // sun cjk char
        0x1F40C, // snail emoji
    };

    sf::Shader shader;
    for(const auto c : totry)
    {
        char32_t fname[] = U"missing-file-X.txt";
        fname[13] = c;
        shader.loadFromFile(fname, sf::Shader::Type::Vertex);
    }
}
```

Without this PR the result will be abort (due to uncaught exception) on the first Unicode path that is printed that isn't possible to represent in current codepage (I have Western Europe codepage set so ñ passes but ń doesn't):

![image](https://github.com/user-attachments/assets/afb9a41a-7c0a-4dea-8703-0383f935a771)

![image](https://github.com/user-attachments/assets/c04f5466-8a89-4671-b215-521c8994fbce)

---

With this PR change applied the output in cmd will be (by default for me since I have Western Europe codepage set):

![image](https://github.com/user-attachments/assets/4502a88f-7a41-4421-8d87-5c6450245ed3)

With `chcp.com 65001` ran before the program, the console is set to "codepage" for UTF-8, which results in:
![image](https://github.com/user-attachments/assets/39c30b4a-148a-42c7-84bc-bb209e3300c5)

The boxes are due to missing fonts for CJK and emojis in cmd terminal, but if the text is redirected to file or copy pasted from the terminal, it's fully correct:

```
Failed to open shader file
    Provided path: missing-file-ñ.txt
    Absolute path: D:\vs\SFML-3-testing\missing-file-ñ.txt
Failed to open shader file
    Provided path: missing-file-ń.txt
    Absolute path: D:\vs\SFML-3-testing\missing-file-ń.txt
Failed to open shader file
    Provided path: missing-file-日.txt
    Absolute path: D:\vs\SFML-3-testing\missing-file-日.txt
Failed to open shader file
    Provided path: missing-file-🐌.txt
    Absolute path: D:\vs\SFML-3-testing\missing-file-🐌.txt
```
