### PR TITLE
Ensure `sf::Image` remains unchanged after an unsuccessful load

### DIFF
--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -210,9 +210,6 @@ bool Image::loadFromFile(const std::filesystem::path& filename)
 
 #endif
 
-    // Clear the array (just in case)
-    m_pixels.clear();
-
     // Set up the stb_image callbacks for the std::ifstream
     const auto readStdIfStream = [](void* user, char* data, int size)
     {
@@ -267,9 +264,6 @@ bool Image::loadFromMemory(const void* data, std::size_t size)
     // Check input parameters
     if (data && size)
     {
-        // Clear the array (just in case)
-        m_pixels.clear();
-
         // Load the image and get a pointer to the pixels in memory
         Vector2i    imageSize;
         int         channels = 0;
@@ -295,9 +289,6 @@ bool Image::loadFromMemory(const void* data, std::size_t size)
 ////////////////////////////////////////////////////////////
 bool Image::loadFromStream(InputStream& stream)
 {
-    // Clear the array (just in case)
-    m_pixels.clear();
-
     // Make sure that the stream's reading position is at the beginning
     if (!stream.seek(0).has_value())
     {

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -321,6 +321,17 @@ TEST_CASE("[Graphics] sf::Image")
             CHECK(image.getSize() == sf::Vector2u(1001, 304));
             CHECK(image.getPixelsPtr() != nullptr);
         }
+
+        SECTION("Successful then unsuccessful load")
+        {
+            REQUIRE(image.loadFromFile("Graphics/sfml-logo-big.jpg"));
+            CHECK(image.getSize() == sf::Vector2u(1001, 304));
+            CHECK(image.getPixelsPtr() != nullptr);
+
+            REQUIRE(!image.loadFromFile("does-not-exist.jpg"));
+            CHECK(image.getSize() == sf::Vector2u(1001, 304));
+            CHECK(image.getPixelsPtr() != nullptr);
+        }
     }
 
     SECTION("loadFromMemory()")
@@ -355,20 +366,31 @@ TEST_CASE("[Graphics] sf::Image")
             CHECK(!image.loadFromMemory(memory.data(), memory.size()));
         }
 
+        const auto memory = []()
+        {
+            sf::Image savedImage;
+            savedImage.resize({24, 24}, sf::Color::Green);
+            return savedImage.saveToMemory("png").value();
+        }();
+
         SECTION("Successful load")
         {
-            const auto memory = []()
-            {
-                sf::Image savedImage;
-                savedImage.resize({24, 24}, sf::Color::Green);
-                return savedImage.saveToMemory("png").value();
-            }();
-
             CHECK(image.loadFromMemory(memory.data(), memory.size()));
             CHECK(image.getSize() == sf::Vector2u(24, 24));
             CHECK(image.getPixelsPtr() != nullptr);
             CHECK(image.getPixel({0, 0}) == sf::Color::Green);
             CHECK(image.getPixel({23, 23}) == sf::Color::Green);
+        }
+
+        SECTION("Successful then unsuccessful load")
+        {
+            REQUIRE(image.loadFromMemory(memory.data(), memory.size()));
+            CHECK(image.getSize() == sf::Vector2u(24, 24));
+            CHECK(image.getPixelsPtr() != nullptr);
+
+            REQUIRE(!image.loadFromMemory(memory.data(), 1));
+            CHECK(image.getSize() == sf::Vector2u(24, 24));
+            CHECK(image.getPixelsPtr() != nullptr);
         }
     }
 
@@ -382,14 +404,27 @@ TEST_CASE("[Graphics] sf::Image")
             CHECK(!image.loadFromStream(stream));
         }
 
+        REQUIRE(stream.open("Graphics/sfml-logo-big.png"));
+
         SECTION("Successful load")
         {
-            CHECK(stream.open("Graphics/sfml-logo-big.png"));
             REQUIRE(image.loadFromStream(stream));
             CHECK(image.getSize() == sf::Vector2u(1001, 304));
             CHECK(image.getPixelsPtr() != nullptr);
             CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
             CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+        }
+
+        SECTION("Successful then unsuccessful load")
+        {
+            REQUIRE(image.loadFromStream(stream));
+            CHECK(image.getSize() == sf::Vector2u(1001, 304));
+            CHECK(image.getPixelsPtr() != nullptr);
+
+            sf::FileInputStream emptyStream;
+            REQUIRE(!image.loadFromStream(emptyStream));
+            CHECK(image.getSize() == sf::Vector2u(1001, 304));
+            CHECK(image.getPixelsPtr() != nullptr);
         }
     }
 


### PR DESCRIPTION
## Description

If you successfully load an `sf::Image` then unsuccessfully local an image, the `Image` is left in a corrupted state where `m_pixels` is empty but `m_size` is still non-zero. This PR ensures that the image remains unchanged when loading fails. I added tests which enforce this behavior and prevent regressions.