### PR TITLE
Harden copyability tests to test for triviality

### DIFF
--- a/test/Audio/SoundFileFactory.test.cpp
+++ b/test/Audio/SoundFileFactory.test.cpp
@@ -63,8 +63,8 @@ TEST_CASE("[Audio] sf::SoundFileFactory")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::SoundFileFactory>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::SoundFileFactory>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::SoundFileFactory>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::SoundFileFactory>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::SoundFileFactory>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::SoundFileFactory>);
     }

--- a/test/Graphics/BlendMode.test.cpp
+++ b/test/Graphics/BlendMode.test.cpp
@@ -9,8 +9,8 @@ TEST_CASE("[Graphics] sf::BlendMode")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::BlendMode>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::BlendMode>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::BlendMode>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::BlendMode>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::BlendMode>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::BlendMode>);
     }

--- a/test/Graphics/Color.test.cpp
+++ b/test/Graphics/Color.test.cpp
@@ -10,8 +10,8 @@ TEST_CASE("[Graphics] sf::Color")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Color>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Color>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Color>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Color>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Color>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Color>);
         STATIC_CHECK(std::is_trivially_copyable_v<sf::Color>);

--- a/test/Graphics/CoordinateType.test.cpp
+++ b/test/Graphics/CoordinateType.test.cpp
@@ -8,8 +8,8 @@ TEST_CASE("[Graphics] sf::CoordinateType")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::CoordinateType>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::CoordinateType>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::CoordinateType>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::CoordinateType>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::CoordinateType>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::CoordinateType>);
     }

--- a/test/Graphics/Glsl.test.cpp
+++ b/test/Graphics/Glsl.test.cpp
@@ -16,8 +16,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Vec2>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Vec2>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Vec2>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Vec2>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Vec2>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Vec2>);
         }
@@ -31,8 +31,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Ivec2>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Ivec2>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Ivec2>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Ivec2>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Ivec2>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Ivec2>);
         }
@@ -46,8 +46,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Bvec2>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Bvec2>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Bvec2>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Bvec2>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Bvec2>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Bvec2>);
         }
@@ -61,8 +61,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Vec3>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Vec3>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Vec3>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Vec3>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Vec3>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Vec3>);
         }
@@ -77,8 +77,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Ivec3>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Ivec3>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Ivec3>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Ivec3>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Ivec3>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Ivec3>);
         }
@@ -93,8 +93,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Bvec3>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Bvec3>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Bvec3>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Bvec3>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Bvec3>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Bvec3>);
         }
@@ -109,8 +109,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Vec4>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Vec4>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Vec4>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Vec4>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Vec4>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Vec4>);
         }
@@ -159,8 +159,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Ivec4>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Ivec4>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Ivec4>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Ivec4>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Ivec4>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Ivec4>);
         }
@@ -209,8 +209,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Bvec4>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Bvec4>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Bvec4>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Bvec4>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Bvec4>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Bvec4>);
         }
@@ -250,8 +250,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Mat3>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Mat3>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Mat3>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Mat3>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Mat3>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Mat3>);
         }
@@ -291,8 +291,8 @@ TEST_CASE("[Graphics] sf::Glsl")
     {
         SECTION("Type traits")
         {
-            STATIC_CHECK(std::is_copy_constructible_v<sf::Glsl::Mat4>);
-            STATIC_CHECK(std::is_copy_assignable_v<sf::Glsl::Mat4>);
+            STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glsl::Mat4>);
+            STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glsl::Mat4>);
             STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glsl::Mat4>);
             STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glsl::Mat4>);
         }

--- a/test/Graphics/Glyph.test.cpp
+++ b/test/Graphics/Glyph.test.cpp
@@ -9,8 +9,8 @@ TEST_CASE("[Graphics] sf::Glyph")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Glyph>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Glyph>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Glyph>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Glyph>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Glyph>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Glyph>);
     }

--- a/test/Graphics/Rect.test.cpp
+++ b/test/Graphics/Rect.test.cpp
@@ -11,8 +11,8 @@ TEMPLATE_TEST_CASE("[Graphics] sf::Rect", "", int, float)
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Rect<TestType>>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Rect<TestType>>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Rect<TestType>>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Rect<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Rect<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Rect<TestType>>);
     }

--- a/test/Graphics/RenderStates.test.cpp
+++ b/test/Graphics/RenderStates.test.cpp
@@ -9,8 +9,8 @@ TEST_CASE("[Graphics] sf::RenderStates")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::RenderStates>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::RenderStates>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::RenderStates>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::RenderStates>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::RenderStates>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::RenderStates>);
     }

--- a/test/Graphics/StencilMode.test.cpp
+++ b/test/Graphics/StencilMode.test.cpp
@@ -8,8 +8,8 @@ TEST_CASE("[Graphics] sf::StencilMode")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::StencilMode>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::StencilMode>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::StencilMode>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::StencilMode>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::StencilMode>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::StencilMode>);
     }

--- a/test/Graphics/Transform.test.cpp
+++ b/test/Graphics/Transform.test.cpp
@@ -15,8 +15,8 @@ TEST_CASE("[Graphics] sf::Transform")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Transform>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Transform>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Transform>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Transform>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Transform>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Transform>);
     }

--- a/test/Graphics/Vertex.test.cpp
+++ b/test/Graphics/Vertex.test.cpp
@@ -9,8 +9,8 @@ TEST_CASE("[Graphics] sf::Vertex")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Vertex>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Vertex>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Vertex>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Vertex>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vertex>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vertex>);
         STATIC_CHECK(std::is_aggregate_v<sf::Vertex>);

--- a/test/Graphics/View.test.cpp
+++ b/test/Graphics/View.test.cpp
@@ -9,8 +9,8 @@ TEST_CASE("[Graphics] sf::View")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::View>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::View>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::View>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::View>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::View>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::View>);
     }

--- a/test/Network/IpAddress.test.cpp
+++ b/test/Network/IpAddress.test.cpp
@@ -13,8 +13,8 @@ TEST_CASE("[Network] sf::IpAddress")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::IpAddress>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::IpAddress>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::IpAddress>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::IpAddress>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::IpAddress>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::IpAddress>);
         STATIC_CHECK(std::is_trivially_copyable_v<sf::IpAddress>);

--- a/test/System/Angle.test.cpp
+++ b/test/System/Angle.test.cpp
@@ -9,8 +9,8 @@ TEST_CASE("[System] sf::Angle")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Angle>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Angle>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Angle>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Angle>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Angle>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Angle>);
         STATIC_CHECK(std::is_trivially_copyable_v<sf::Angle>);

--- a/test/System/Clock.test.cpp
+++ b/test/System/Clock.test.cpp
@@ -13,8 +13,8 @@ TEST_CASE("[System] sf::Clock")
 
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Clock>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Clock>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Clock>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Clock>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Clock>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Clock>);
     }

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -61,8 +61,8 @@ TEST_CASE("[System] sf::U8StringCharTraits")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::U8StringCharTraits>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::U8StringCharTraits>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::U8StringCharTraits>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::U8StringCharTraits>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::U8StringCharTraits>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::U8StringCharTraits>);
     }

--- a/test/System/Time.test.cpp
+++ b/test/System/Time.test.cpp
@@ -11,8 +11,8 @@ TEST_CASE("[System] sf::Time")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Time>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Time>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Time>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Time>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Time>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Time>);
         STATIC_CHECK(std::is_trivially_copyable_v<sf::Time>);

--- a/test/System/Vector2.test.cpp
+++ b/test/System/Vector2.test.cpp
@@ -13,8 +13,8 @@ TEMPLATE_TEST_CASE("[System] sf::Vector2", "", int, float)
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Vector2<TestType>>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Vector2<TestType>>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Vector2<TestType>>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Vector2<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector2<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector2<TestType>>);
         STATIC_CHECK(std::is_trivially_copyable_v<sf::Vector2<TestType>>);

--- a/test/System/Vector3.test.cpp
+++ b/test/System/Vector3.test.cpp
@@ -9,8 +9,8 @@ TEMPLATE_TEST_CASE("[System] sf::Vector3", "", int, float)
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Vector3<TestType>>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Vector3<TestType>>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Vector3<TestType>>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Vector3<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Vector3<TestType>>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Vector3<TestType>>);
     }

--- a/test/Window/ContextSettings.test.cpp
+++ b/test/Window/ContextSettings.test.cpp
@@ -8,8 +8,8 @@ TEST_CASE("[Window] sf::ContextSettings")
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::ContextSettings>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::ContextSettings>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::ContextSettings>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::ContextSettings>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::ContextSettings>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::ContextSettings>);
     }

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -43,8 +43,8 @@ TEST_CASE("[Window] sf::Event")
     SECTION("Type traits")
     {
         STATIC_CHECK(!std::is_default_constructible_v<sf::Event>);
-        STATIC_CHECK(std::is_copy_constructible_v<sf::Event>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::Event>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::Event>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::Event>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::Event>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::Event>);
     }

--- a/test/Window/VideoMode.test.cpp
+++ b/test/Window/VideoMode.test.cpp
@@ -10,8 +10,8 @@ TEST_CASE("[Window] sf::VideoMode", runDisplayTests())
 {
     SECTION("Type traits")
     {
-        STATIC_CHECK(std::is_copy_constructible_v<sf::VideoMode>);
-        STATIC_CHECK(std::is_copy_assignable_v<sf::VideoMode>);
+        STATIC_CHECK(std::is_trivially_copy_constructible_v<sf::VideoMode>);
+        STATIC_CHECK(std::is_trivially_copy_assignable_v<sf::VideoMode>);
         STATIC_CHECK(std::is_nothrow_move_constructible_v<sf::VideoMode>);
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::VideoMode>);
     }


### PR DESCRIPTION
## Description

Trivial copyability is good to test for because such types are the most efficient for the compiler to work with. They can be `memcpy`'d by the compiler which allows for optimizations. If trivial copyability is broken, we ought to know that, which is what these tests will do.