### PR TITLE
Test `sf::FileInputStream::open` with non-ASCII filepaths

### DIFF
--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -3,63 +3,9 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
-#include <filesystem>
-#include <fstream>
-#include <sstream>
-#include <string>
 #include <string_view>
 #include <type_traits>
-#include <utility>
 
-#include <cassert>
-
-namespace
-{
-std::filesystem::path getTemporaryFilePath()
-{
-    static int counter = 0;
-
-    std::ostringstream oss;
-    oss << "sfmltemp" << counter++ << ".tmp";
-
-    return std::filesystem::temp_directory_path() / oss.str();
-}
-
-class TemporaryFile
-{
-public:
-    // Create a temporary file with a randomly generated path, containing 'contents'.
-    explicit TemporaryFile(const std::string& contents) : m_path(getTemporaryFilePath())
-    {
-        std::ofstream ofs(m_path);
-        assert(ofs && "Stream encountered an error");
-
-        ofs << contents;
-        assert(ofs && "Stream encountered an error");
-    }
-
-    // Close and delete the generated file.
-    ~TemporaryFile()
-    {
-        [[maybe_unused]] const bool removed = std::filesystem::remove(m_path);
-        assert(removed && "m_path failed to be removed from filesystem");
-    }
-
-    // Prevent copies.
-    TemporaryFile(const TemporaryFile&) = delete;
-
-    TemporaryFile& operator=(const TemporaryFile&) = delete;
-
-    // Return the randomly generated path.
-    [[nodiscard]] const std::filesystem::path& getPath() const
-    {
-        return m_path;
-    }
-
-private:
-    std::filesystem::path m_path;
-};
-} // namespace
 
 TEST_CASE("[System] sf::FileInputStream")
 {
@@ -73,7 +19,6 @@ TEST_CASE("[System] sf::FileInputStream")
         STATIC_CHECK(std::is_nothrow_move_assignable_v<sf::FileInputStream>);
     }
 
-    const TemporaryFile  temporaryFile("Hello world");
     std::array<char, 32> buffer{};
 
     SECTION("Construction")
@@ -89,10 +34,10 @@ TEST_CASE("[System] sf::FileInputStream")
 
         SECTION("File path constructor")
         {
-            sf::FileInputStream fileInputStream(temporaryFile.getPath());
+            sf::FileInputStream fileInputStream("System/test.txt");
             CHECK(fileInputStream.read(buffer.data(), 5) == 5);
             CHECK(fileInputStream.tell() == 5);
-            CHECK(fileInputStream.getSize() == 11);
+            CHECK(fileInputStream.getSize() == 12);
             CHECK(std::string_view(buffer.data(), 5) == "Hello"sv);
             CHECK(fileInputStream.seek(6) == 6);
             CHECK(fileInputStream.tell() == 6);
@@ -103,23 +48,22 @@ TEST_CASE("[System] sf::FileInputStream")
     {
         SECTION("Move constructor")
         {
-            sf::FileInputStream movedFileInputStream(temporaryFile.getPath());
+            sf::FileInputStream movedFileInputStream("System/test.txt");
             sf::FileInputStream fileInputStream = std::move(movedFileInputStream);
             CHECK(fileInputStream.read(buffer.data(), 6) == 6);
             CHECK(fileInputStream.tell() == 6);
-            CHECK(fileInputStream.getSize() == 11);
+            CHECK(fileInputStream.getSize() == 12);
             CHECK(std::string_view(buffer.data(), 6) == "Hello "sv);
         }
 
         SECTION("Move assignment")
         {
-            sf::FileInputStream movedFileInputStream(temporaryFile.getPath());
-            const TemporaryFile temporaryFile2("Hello world the sequel");
-            sf::FileInputStream fileInputStream(temporaryFile2.getPath());
+            sf::FileInputStream movedFileInputStream("System/test.txt");
+            sf::FileInputStream fileInputStream("System/test2.txt");
             fileInputStream = std::move(movedFileInputStream);
             CHECK(fileInputStream.read(buffer.data(), 6) == 6);
             CHECK(fileInputStream.tell() == 6);
-            CHECK(fileInputStream.getSize() == 11);
+            CHECK(fileInputStream.getSize() == 12);
             CHECK(std::string_view(buffer.data(), 6) == "Hello "sv);
         }
     }
@@ -127,10 +71,10 @@ TEST_CASE("[System] sf::FileInputStream")
     SECTION("Temporary file stream open")
     {
         sf::FileInputStream fileInputStream;
-        REQUIRE(fileInputStream.open(temporaryFile.getPath()));
+        REQUIRE(fileInputStream.open("System/test.txt"));
         CHECK(fileInputStream.read(buffer.data(), 5) == 5);
         CHECK(fileInputStream.tell() == 5);
-        CHECK(fileInputStream.getSize() == 11);
+        CHECK(fileInputStream.getSize() == 12);
         CHECK(std::string_view(buffer.data(), 5) == "Hello"sv);
         CHECK(fileInputStream.seek(6) == 6);
         CHECK(fileInputStream.tell() == 6);
@@ -138,10 +82,37 @@ TEST_CASE("[System] sf::FileInputStream")
 
     SECTION("Temporary file stream create")
     {
-        sf::FileInputStream fileInputStream(temporaryFile.getPath());
+        sf::FileInputStream fileInputStream("System/test.txt");
         CHECK(fileInputStream.read(buffer.data(), 5) == 5);
         CHECK(fileInputStream.tell() == 5);
-        CHECK(fileInputStream.getSize() == 11);
+        CHECK(fileInputStream.getSize() == 12);
+        CHECK(std::string_view(buffer.data(), 5) == "Hello"sv);
+        CHECK(fileInputStream.seek(6) == 6);
+        CHECK(fileInputStream.tell() == 6);
+    }
+
+    SECTION("open()")
+    {
+        sf::FileInputStream fileInputStream;
+
+        SECTION("From ASCII filename")
+        {
+            REQUIRE(fileInputStream.open("System/test.txt"));
+        }
+
+        SECTION("From Polish filename")
+        {
+            REQUIRE(fileInputStream.open(U"System/test-\u0144.txt"));
+        }
+
+        SECTION("From emoji filename")
+        {
+            REQUIRE(fileInputStream.open(U"System/test-\U0001F40C.txt"));
+        }
+
+        CHECK(fileInputStream.read(buffer.data(), 5) == 5);
+        CHECK(fileInputStream.tell() == 5);
+        CHECK(fileInputStream.getSize() == 12);
         CHECK(std::string_view(buffer.data(), 5) == "Hello"sv);
         CHECK(fileInputStream.seek(6) == 6);
         CHECK(fileInputStream.tell() == 6);

--- a/test/System/test-ń.txt
+++ b/test/System/test-ń.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/test/System/test-🐌.txt
+++ b/test/System/test-🐌.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/test/System/test.txt
+++ b/test/System/test.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/test/System/test2.txt
+++ b/test/System/test2.txt
@@ -1,0 +1,1 @@
+Hello world the sequel


### PR DESCRIPTION
## Description

Related to #3406. Now that we have files on disk we no longer need `TemporaryFile` to create and destroy files on the fly. Besides, we need precise control over the names of the files which is something `TemporaryFile` does not expose in its interface. 