### PR TITLE
Test loading sounds from non-ASCII filenames

### DIFF
--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -133,7 +133,21 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
         SECTION("Valid file")
         {
-            REQUIRE(music.openFromFile("Audio/ding.mp3"));
+            SECTION("ASCII filename")
+            {
+                REQUIRE(music.openFromFile("Audio/ding.mp3"));
+            }
+
+            SECTION("Polish filename")
+            {
+                REQUIRE(music.openFromFile(U"Audio/ding-\u0144.mp3"));
+            }
+
+            SECTION("Emoji filename")
+            {
+                REQUIRE(music.openFromFile(U"Audio/ding-\U0001F40C.mp3"));
+            }
+
             CHECK(music.getDuration() == sf::microseconds(1990884));
             const auto [offset, length] = music.getLoopPoints();
             CHECK(offset == sf::Time::Zero);

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -122,7 +122,21 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
 
         SECTION("Valid file")
         {
-            REQUIRE(soundBuffer.loadFromFile("Audio/ding.flac"));
+            SECTION("ASCII filename")
+            {
+                REQUIRE(soundBuffer.loadFromFile("Audio/ding.flac"));
+            }
+
+            SECTION("Polish filename")
+            {
+                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-\u0144.flac"));
+            }
+
+            SECTION("Emoji filename")
+            {
+                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-\U0001F40C.flac"));
+            }
+
             CHECK(soundBuffer.getSamples() != nullptr);
             CHECK(soundBuffer.getSampleCount() == 87798);
             CHECK(soundBuffer.getSampleRate() == 44100);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,6 @@ include(FetchContent)
 add_subdirectory(install)
 set_target_warnings(test-sfml-install)
 
-set(CATCH_CONFIG_FAST_COMPILE ON CACHE BOOL "")
 set(CATCH_CONFIG_NO_EXPERIMENTAL_STATIC_ANALYSIS_SUPPORT ON CACHE BOOL "")
 FetchContent_Declare(Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
## Description

The tests for `sf::Music` and `sf::SoundBuffer` are straightforward because they already support Unicode paths and #3415 already added the files we need to test them.

On top of that I removed a Catch2 option which was preventing exception information from being printed. Sometimes `std::filesystem::path::string` throws so we need to make sure we can see the error to track down the cause of the failure. This will come in handy with some future tests where we're trying to track down and remove uses of `std::filesystem::path::string`.