### PR TITLE
Revamp `sf::String` tests

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -274,6 +274,10 @@ macro(sfml_add_library module)
         target_compile_definitions(${target} PUBLIC "SFML_STATIC")
     endif()
 
+    # Enable support for UTF-8 characters in source code
+    if(SFML_COMPILER_MSVC)
+        target_compile_options(${target} PRIVATE /utf-8)
+    endif()
 endmacro()
 
 # add a new target which is a SFML example
@@ -350,6 +354,11 @@ macro(sfml_add_example target)
     if(SFML_OS_WINDOWS AND SFML_USE_MESA3D)
         add_dependencies(${target} "install-mesa3d")
     endif()
+
+    # Enable support for UTF-8 characters in source code
+    if(SFML_COMPILER_MSVC)
+        target_compile_options(${target} PRIVATE /utf-8)
+    endif()
 endmacro()
 
 # add a new target which is a SFML test
@@ -405,6 +414,11 @@ function(sfml_add_test target SOURCES DEPENDS)
         if(SFML_OS_ANDROID)
             set_target_properties(${target} PROPERTIES CROSSCOMPILING_EMULATOR "${PROJECT_BINARY_DIR}/run-in-adb-shell.sh")
         endif()
+    endif()
+
+    # Enable support for UTF-8 characters in source code
+    if(SFML_COMPILER_MSVC)
+        target_compile_options(${target} PRIVATE /utf-8)
     endif()
 
     # Add the test

--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -171,12 +171,12 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
                 SECTION("Polish filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-\u0144.flac"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-ń.flac"));
                 }
 
                 SECTION("Emoji filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-\U0001F40C.flac"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-🐌.flac"));
                 }
 
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
@@ -196,12 +196,12 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
                 SECTION("Polish filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-\u0144.mp3"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-ń.mp3"));
                 }
 
                 SECTION("Emoji filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-\U0001F40C.mp3"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-🐌.mp3"));
                 }
 
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
@@ -221,12 +221,12 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
                 SECTION("Polish filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/doodle_pop-\u0144.ogg"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/doodle_pop-ń.ogg"));
                 }
 
                 SECTION("Emoji filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/doodle_pop-\U0001F40C.ogg"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/doodle_pop-🐌.ogg"));
                 }
 
                 CHECK(inputSoundFile.getSampleCount() == 2'116'992);
@@ -246,12 +246,12 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
                 SECTION("Polish filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/killdeer-\u0144.wav"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/killdeer-ń.wav"));
                 }
 
                 SECTION("Emoji filename")
                 {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/killdeer-\U0001F40C.wav"));
+                    REQUIRE(inputSoundFile.openFromFile(U"Audio/killdeer-🐌.wav"));
                 }
 
                 CHECK(inputSoundFile.getSampleCount() == 112'941);

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -140,12 +140,12 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
             SECTION("Polish filename")
             {
-                REQUIRE(music.openFromFile(U"Audio/ding-\u0144.mp3"));
+                REQUIRE(music.openFromFile(U"Audio/ding-ń.mp3"));
             }
 
             SECTION("Emoji filename")
             {
-                REQUIRE(music.openFromFile(U"Audio/ding-\U0001F40C.mp3"));
+                REQUIRE(music.openFromFile(U"Audio/ding-🐌.mp3"));
             }
 
             CHECK(music.getDuration() == sf::microseconds(1990884));

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -129,12 +129,12 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
 
             SECTION("Polish filename")
             {
-                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-\u0144.flac"));
+                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-ń.flac"));
             }
 
             SECTION("Emoji filename")
             {
-                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-\U0001F40C.flac"));
+                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-🐌.flac"));
             }
 
             CHECK(soundBuffer.getSamples() != nullptr);

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -266,16 +266,16 @@ TEST_CASE("[Graphics] sf::Image")
             CHECK(!image.loadFromFile("this/does/not/exist.jpg"));
 
             // small n with tilde, from Spanish, outside of ASCII, inside common Latin 1 codepage
-            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-\u00f1.png")));
+            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-ñ.png")));
 
             // small n with acute accent, from Polish, outside of Latin 1 codepage
-            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-\u0144.png")));
+            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-ń.png")));
 
             // CJK symbol for Sun, outside of any European language codepage
-            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-\u65E5.png")));
+            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-日.png")));
 
             // snail emoji, outside of Unicode Basic Multilingual Plane
-            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-\U0001F40C.png")));
+            CHECK(!image.loadFromFile(std::filesystem::path(U"missing-file-🐌.png")));
 
             CHECK(image.getSize() == sf::Vector2u(0, 0));
             CHECK(image.getPixelsPtr() == nullptr);
@@ -472,25 +472,25 @@ TEST_CASE("[Graphics] sf::Image")
             SECTION("To Spanish Latin1 filename .png")
             {
                 // small n with tilde, from Spanish, outside of ASCII, inside common Latin 1 codepage
-                filename /= U"test-\u00f1.png";
+                filename /= U"test-ñ.png";
             }
 
             SECTION("To Polish filename .png")
             {
                 // small n with acute accent, from Polish, outside of Latin 1 codepage
-                filename /= U"test-\u0144.png";
+                filename /= U"test-ń.png";
             }
 
             SECTION("To Japanese CJK filename .png")
             {
                 // CJK symbol for Sun, outside of any European language codepage
-                filename /= U"test-\u65E5.png";
+                filename /= U"test-日.png";
             }
 
             SECTION("To emoji non-BMP Unicode filename .png")
             {
                 // snail emoji, outside of Unicode Basic Multilingual Plane
-                filename /= U"test-\U0001F40C.png";
+                filename /= U"test-🐌.png";
             }
 
             // Cannot test JPEG encoding due to it triggering UB in stbiw__jpg_writeBits

--- a/test/Graphics/Shader.test.cpp
+++ b/test/Graphics/Shader.test.cpp
@@ -425,12 +425,10 @@ TEST_CASE("[Graphics] sf::Shader", skipShaderFullTests())
 
         SECTION("One shader with non-ASCII filename")
         {
-            CHECK(shader.loadFromFile(U"Graphics/shader-\u0144.vert", sf::Shader::Type::Vertex) ==
-                  sf::Shader::isAvailable());
+            CHECK(shader.loadFromFile(U"Graphics/shader-ń.vert", sf::Shader::Type::Vertex) == sf::Shader::isAvailable());
             CHECK(static_cast<bool>(shader.getNativeHandle()) == sf::Shader::isAvailable());
 
-            CHECK(shader.loadFromFile(U"Graphics/shader-\U0001F40C.vert", sf::Shader::Type::Vertex) ==
-                  sf::Shader::isAvailable());
+            CHECK(shader.loadFromFile(U"Graphics/shader-🐌.vert", sf::Shader::Type::Vertex) == sf::Shader::isAvailable());
             CHECK(static_cast<bool>(shader.getNativeHandle()) == sf::Shader::isAvailable());
         }
     }

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -102,12 +102,12 @@ TEST_CASE("[System] sf::FileInputStream")
 
         SECTION("From Polish filename")
         {
-            REQUIRE(fileInputStream.open(U"System/test-\u0144.txt"));
+            REQUIRE(fileInputStream.open(U"System/test-ń.txt"));
         }
 
         SECTION("From emoji filename")
         {
-            REQUIRE(fileInputStream.open(U"System/test-\U0001F40C.txt"));
+            REQUIRE(fileInputStream.open(U"System/test-🐌.txt"));
         }
 
         CHECK(fileInputStream.read(buffer.data(), 5) == 5);

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -353,14 +353,14 @@ TEST_CASE("[System] sf::String")
 
         SECTION("UTF-32 character constructor")
         {
-            const sf::String string = U'\U0010AFAF';
+            const sf::String string = U'🐌';
             CHECK(std::string(string) == "\0"s);
-            CHECK(std::wstring(string) == select(L""s, L"\U0010AFAF"s));
+            CHECK(std::wstring(string) == select(L""s, L"🐌"s));
             CHECK(string.toAnsiString() == "\0"s);
-            CHECK(string.toWideString() == select(L""s, L"\U0010AFAF"s));
-            CHECK(string.toUtf8() == sf::U8String{0xF4, 0x8A, 0xBE, 0xAF});
-            CHECK(string.toUtf16() == u"\U0010AFAF"s);
-            CHECK(string.toUtf32() == U"\U0010AFAF"s);
+            CHECK(string.toWideString() == select(L""s, L"🐌"s));
+            CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C});
+            CHECK(string.toUtf16() == u"🐌"s);
+            CHECK(string.toUtf32() == U"🐌"s);
             CHECK(string.getSize() == 1);
             CHECK(!string.isEmpty());
             CHECK(string.getData() != nullptr);
@@ -385,14 +385,14 @@ TEST_CASE("[System] sf::String")
 
             SECTION("Non-empty string")
             {
-                const sf::String string = U"\U0010ABCDrs";
+                const sf::String string = U"🐌rs";
                 CHECK(std::string(string) == "\0rs"s);
-                CHECK(std::wstring(string) == select(L"rs"s, L"\U0010ABCDrs"s));
+                CHECK(std::wstring(string) == select(L"rs"s, L"🐌rs"s));
                 CHECK(string.toAnsiString() == "\0rs"s);
-                CHECK(string.toWideString() == select(L"rs"s, L"\U0010ABCDrs"s));
-                CHECK(string.toUtf8() == sf::U8String{0xF4, 0x8A, 0xAF, 0x8D, 'r', 's'});
-                CHECK(string.toUtf16() == u"\U0010ABCDrs"s);
-                CHECK(string.toUtf32() == U"\U0010ABCDrs"s);
+                CHECK(string.toWideString() == select(L"rs"s, L"🐌rs"s));
+                CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C, 'r', 's'});
+                CHECK(string.toUtf16() == u"🐌rs"s);
+                CHECK(string.toUtf32() == U"🐌rs"s);
                 CHECK(string.getSize() == 3);
                 CHECK(!string.isEmpty());
                 CHECK(string.getData() != nullptr);
@@ -401,14 +401,14 @@ TEST_CASE("[System] sf::String")
 
         SECTION("UTF-32 string constructor")
         {
-            const sf::String string = U"tuv\U00104321"s;
+            const sf::String string = U"tuv🐌"s;
             CHECK(std::string(string) == "tuv\0"s);
-            CHECK(std::wstring(string) == select(L"tuv"s, L"tuv\U00104321"s));
+            CHECK(std::wstring(string) == select(L"tuv"s, L"tuv🐌"s));
             CHECK(string.toAnsiString() == "tuv\0"s);
-            CHECK(string.toWideString() == select(L"tuv"s, L"tuv\U00104321"s));
-            CHECK(string.toUtf8() == sf::U8String{'t', 'u', 'v', 0xF4, 0x84, 0x8C, 0xA1});
-            CHECK(string.toUtf16() == u"tuv\U00104321"s);
-            CHECK(string.toUtf32() == U"tuv\U00104321"s);
+            CHECK(string.toWideString() == select(L"tuv"s, L"tuv🐌"s));
+            CHECK(string.toUtf8() == sf::U8String{'t', 'u', 'v', 0xF0, 0x9F, 0x90, 0x8C});
+            CHECK(string.toUtf16() == u"tuv🐌"s);
+            CHECK(string.toUtf32() == U"tuv🐌"s);
             CHECK(string.getSize() == 4);
             CHECK(!string.isEmpty());
             CHECK(string.getData() != nullptr);
@@ -461,15 +461,15 @@ TEST_CASE("[System] sf::String")
 
     SECTION("fromUtf32()")
     {
-        constexpr std::array<char32_t, 4> characters{'w', 0x104321, 'y', 'z'};
+        constexpr std::array<char32_t, 4> characters{'w', U'🐌', 'y', 'z'};
         const sf::String                  string = sf::String::fromUtf32(characters.begin(), characters.end());
         CHECK(std::string(string) == "w\0yz"s);
-        CHECK(std::wstring(string) == select(L"wyz"s, L"w\U00104321yz"s));
+        CHECK(std::wstring(string) == select(L"wyz"s, L"w🐌yz"s));
         CHECK(string.toAnsiString() == "w\0yz"s);
-        CHECK(string.toWideString() == select(L"wyz"s, L"w\U00104321yz"s));
-        CHECK(string.toUtf8() == sf::U8String{'w', 0xF4, 0x84, 0x8C, 0xA1, 'y', 'z'});
-        CHECK(string.toUtf16() == u"w\U00104321yz"s);
-        CHECK(string.toUtf32() == U"w\U00104321yz"s);
+        CHECK(string.toWideString() == select(L"wyz"s, L"w🐌yz"s));
+        CHECK(string.toUtf8() == sf::U8String{'w', 0xF0, 0x9F, 0x90, 0x8C, 'y', 'z'});
+        CHECK(string.toUtf16() == u"w🐌yz"s);
+        CHECK(string.toUtf32() == U"w🐌yz"s);
         CHECK(string.getSize() == 4);
         CHECK(!string.isEmpty());
         CHECK(string.getData() != nullptr);

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -197,6 +197,7 @@ TEST_CASE("[System] sf::U8StringCharTraits")
 TEST_CASE("[System] sf::String")
 {
     using namespace std::string_literals;
+    using namespace std::string_view_literals;
 
     SECTION("Type traits")
     {
@@ -242,7 +243,6 @@ TEST_CASE("[System] sf::String")
 
         SECTION("ANSI C string constructor")
         {
-            SECTION("Nullptr")
             {
                 const sf::String string = static_cast<char*>(nullptr);
                 CHECK(std::string(string).empty());
@@ -256,18 +256,16 @@ TEST_CASE("[System] sf::String")
                 CHECK(string.isEmpty());
                 CHECK(string.getData() != nullptr);
             }
-
-            SECTION("Non-empty string")
             {
-                const sf::String string = "def";
-                CHECK(std::string(string) == "def"s);
-                CHECK(std::wstring(string) == L"def"s);
-                CHECK(string.toAnsiString() == "def"s);
-                CHECK(string.toWideString() == L"def"s);
-                CHECK(string.toUtf8() == sf::U8String{'d', 'e', 'f'});
-                CHECK(string.toUtf16() == u"def"s);
-                CHECK(string.toUtf32() == U"def"s);
-                CHECK(string.getSize() == 3);
+                const sf::String string = "Escargot";
+                CHECK(std::string(string) == "Escargot"s);
+                CHECK(std::wstring(string) == L"Escargot"s);
+                CHECK(string.toAnsiString() == "Escargot"s);
+                CHECK(string.toWideString() == L"Escargot"s);
+                CHECK(string.toUtf8() == sf::U8String{'E', 's', 'c', 'a', 'r', 'g', 'o', 't'});
+                CHECK(string.toUtf16() == u"Escargot"s);
+                CHECK(string.toUtf32() == U"Escargot"s);
+                CHECK(string.getSize() == 8);
                 CHECK(!string.isEmpty());
                 CHECK(string.getData() != nullptr);
             }
@@ -275,37 +273,51 @@ TEST_CASE("[System] sf::String")
 
         SECTION("ANSI string constructor")
         {
-            const sf::String string = "ghi"s;
-            CHECK(std::string(string) == "ghi"s);
-            CHECK(std::wstring(string) == L"ghi"s);
-            CHECK(string.toAnsiString() == "ghi"s);
-            CHECK(string.toWideString() == L"ghi"s);
-            CHECK(string.toUtf8() == sf::U8String{'g', 'h', 'i'});
-            CHECK(string.toUtf16() == u"ghi"s);
-            CHECK(string.toUtf32() == U"ghi"s);
-            CHECK(string.getSize() == 3);
+            const sf::String string = "Csiga"s;
+            CHECK(std::string(string) == "Csiga"s);
+            CHECK(std::wstring(string) == L"Csiga"s);
+            CHECK(string.toAnsiString() == "Csiga"s);
+            CHECK(string.toWideString() == L"Csiga"s);
+            CHECK(string.toUtf8() == sf::U8String{'C', 's', 'i', 'g', 'a'});
+            CHECK(string.toUtf16() == u"Csiga"s);
+            CHECK(string.toUtf32() == U"Csiga"s);
+            CHECK(string.getSize() == 5);
             CHECK(!string.isEmpty());
             CHECK(string.getData() != nullptr);
         }
 
         SECTION("Wide character constructor")
         {
-            const sf::String string = L'\xFA';
-            CHECK(std::string(string) == select("\xFA"s, "\0"s));
-            CHECK(std::wstring(string) == L"\xFA"s);
-            CHECK(string.toAnsiString() == select("\xFA"s, "\0"s));
-            CHECK(string.toWideString() == L"\xFA"s);
-            CHECK(string.toUtf8() == sf::U8String{0xC3, 0xBA});
-            CHECK(string.toUtf16() == u"\xFA"s);
-            CHECK(string.toUtf32() == U"\xFA"s);
-            CHECK(string.getSize() == 1);
-            CHECK(!string.isEmpty());
-            CHECK(string.getData() != nullptr);
+            {
+                const sf::String string = L'ú';
+                CHECK(std::string(string) == select("\xFA"s, "\0"s));
+                CHECK(std::wstring(string) == L"ú"s);
+                CHECK(string.toAnsiString() == select("\xFA"s, "\0"s));
+                CHECK(string.toWideString() == L"ú"s);
+                CHECK(string.toUtf8() == sf::U8String{0xC3, 0xBA});
+                CHECK(string.toUtf16() == u"ú"s);
+                CHECK(string.toUtf32() == U"ú"s);
+                CHECK(string.getSize() == 1);
+                CHECK(!string.isEmpty());
+                CHECK(string.getData() != nullptr);
+            }
+            {
+                const sf::String string = L'Ǻ';
+                CHECK(std::string(string) == "\0"s);
+                CHECK(std::wstring(string) == L"Ǻ"s);
+                CHECK(string.toAnsiString() == "\0"s);
+                CHECK(string.toWideString() == L"Ǻ"s);
+                CHECK(string.toUtf8() == sf::U8String{0xC7, 0xBA});
+                CHECK(string.toUtf16() == u"Ǻ"s);
+                CHECK(string.toUtf32() == U"Ǻ"s);
+                CHECK(string.getSize() == 1);
+                CHECK(!string.isEmpty());
+                CHECK(string.getData() != nullptr);
+            }
         }
 
         SECTION("Wide C string constructor")
         {
-            SECTION("Nullptr")
             {
                 const sf::String string = static_cast<wchar_t*>(nullptr);
                 CHECK(std::string(string).empty());
@@ -319,18 +331,17 @@ TEST_CASE("[System] sf::String")
                 CHECK(string.isEmpty());
                 CHECK(string.getData() != nullptr);
             }
-
-            SECTION("Non-empty string")
             {
-                const sf::String string = L"j\xFAl";
-                CHECK(std::string(string) == select("j\xFAl"s, "j\0l"s));
-                CHECK(std::wstring(string) == L"j\xFAl"s);
-                CHECK(string.toAnsiString() == select("j\xFAl"s, "j\0l"s));
-                CHECK(string.toWideString() == L"j\xFAl"s);
-                CHECK(string.toUtf8() == sf::U8String{'j', 0xC3, 0xBA, 'l'});
-                CHECK(string.toUtf16() == u"j\xFAl"s);
-                CHECK(string.toUtf32() == U"j\xFAl"s);
-                CHECK(string.getSize() == 3);
+                const sf::String string = L"Улитка";
+                CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+                CHECK(std::wstring(string) == L"Улитка"s);
+                CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+                CHECK(string.toWideString() == L"Улитка"s);
+                CHECK(string.toUtf8() ==
+                      sf::U8String{0xD0, 0xA3, 0xD0, 0xBB, 0xD0, 0xB8, 0xD1, 0x82, 0xD0, 0xBA, 0xD0, 0xB0});
+                CHECK(string.toUtf16() == u"Улитка"s);
+                CHECK(string.toUtf32() == U"Улитка"s);
+                CHECK(string.getSize() == 6);
                 CHECK(!string.isEmpty());
                 CHECK(string.getData() != nullptr);
             }
@@ -338,15 +349,15 @@ TEST_CASE("[System] sf::String")
 
         SECTION("Wide string constructor")
         {
-            const sf::String string = L"mno\xFA"s;
-            CHECK(std::string(string) == select("mno\xFA"s, "mno\0"s));
-            CHECK(std::wstring(string) == L"mno\xFA"s);
-            CHECK(string.toAnsiString() == select("mno\xFA"s, "mno\0"s));
-            CHECK(string.toWideString() == L"mno\xFA"s);
-            CHECK(string.toUtf8() == sf::U8String{'m', 'n', 'o', 0xC3, 0XBA});
-            CHECK(string.toUtf16() == u"mno\xFA"s);
-            CHECK(string.toUtf32() == U"mno\xFA"s);
-            CHECK(string.getSize() == 4);
+            const sf::String string = L"Полжав"s;
+            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::wstring(string) == L"Полжав"s);
+            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toWideString() == L"Полжав"s);
+            CHECK(string.toUtf8() == sf::U8String{0xD0, 0x9F, 0xD0, 0xBE, 0xD0, 0xBB, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB2});
+            CHECK(string.toUtf16() == u"Полжав"s);
+            CHECK(string.toUtf32() == U"Полжав"s);
+            CHECK(string.getSize() == 6);
             CHECK(!string.isEmpty());
             CHECK(string.getData() != nullptr);
         }
@@ -368,7 +379,6 @@ TEST_CASE("[System] sf::String")
 
         SECTION("UTF-32 C string constructor")
         {
-            SECTION("Nullptr")
             {
                 const sf::String string = static_cast<char32_t*>(nullptr);
                 CHECK(std::string(string).empty());
@@ -382,18 +392,30 @@ TEST_CASE("[System] sf::String")
                 CHECK(string.isEmpty());
                 CHECK(string.getData() != nullptr);
             }
-
-            SECTION("Non-empty string")
             {
-                const sf::String string = U"🐌rs";
-                CHECK(std::string(string) == "\0rs"s);
-                CHECK(std::wstring(string) == select(L"rs"s, L"🐌rs"s));
-                CHECK(string.toAnsiString() == "\0rs"s);
-                CHECK(string.toWideString() == select(L"rs"s, L"🐌rs"s));
-                CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C, 'r', 's'});
-                CHECK(string.toUtf16() == u"🐌rs"s);
-                CHECK(string.toUtf32() == U"🐌rs"s);
-                CHECK(string.getSize() == 3);
+                const sf::String string = U"カタツムリ";
+                CHECK(std::string(string) == "\0\0\0\0\0"s);
+                CHECK(std::wstring(string) == L"カタツムリ"s);
+                CHECK(string.toAnsiString() == "\0\0\0\0\0"s);
+                CHECK(string.toWideString() == L"カタツムリ"s);
+                CHECK(string.toUtf8() ==
+                      sf::U8String{0xE3, 0x82, 0xAB, 0xE3, 0x82, 0xBF, 0xE3, 0x83, 0x84, 0xE3, 0x83, 0xA0, 0xE3, 0x83, 0xAA});
+                CHECK(string.toUtf16() == u"カタツムリ"s);
+                CHECK(string.toUtf32() == U"カタツムリ"s);
+                CHECK(string.getSize() == 5);
+                CHECK(!string.isEmpty());
+                CHECK(string.getData() != nullptr);
+            }
+            {
+                const sf::String string = U"🐌🐚";
+                CHECK(std::string(string) == "\0\0"s);
+                CHECK(std::wstring(string) == select(L""s, L"🐌🐚"s));
+                CHECK(string.toAnsiString() == "\0\0"s);
+                CHECK(string.toWideString() == select(L""s, L"🐌🐚"s));
+                CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C, 0xF0, 0x9F, 0x90, 0x9A});
+                CHECK(string.toUtf16() == u"🐌🐚"s);
+                CHECK(string.toUtf32() == U"🐌🐚"s);
+                CHECK(string.getSize() == 2);
                 CHECK(!string.isEmpty());
                 CHECK(string.getData() != nullptr);
             }
@@ -401,15 +423,15 @@ TEST_CASE("[System] sf::String")
 
         SECTION("UTF-32 string constructor")
         {
-            const sf::String string = U"tuv🐌"s;
-            CHECK(std::string(string) == "tuv\0"s);
-            CHECK(std::wstring(string) == select(L"tuv"s, L"tuv🐌"s));
-            CHECK(string.toAnsiString() == "tuv\0"s);
-            CHECK(string.toWideString() == select(L"tuv"s, L"tuv🐌"s));
-            CHECK(string.toUtf8() == sf::U8String{'t', 'u', 'v', 0xF0, 0x9F, 0x90, 0x8C});
-            CHECK(string.toUtf16() == u"tuv🐌"s);
-            CHECK(string.toUtf32() == U"tuv🐌"s);
-            CHECK(string.getSize() == 4);
+            const sf::String string = U"گھونگا"s;
+            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::wstring(string) == L"گھونگا"s);
+            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toWideString() == L"گھونگا"s);
+            CHECK(string.toUtf8() == sf::U8String{0xDA, 0xAF, 0xDA, 0xBE, 0xD9, 0x88, 0xD9, 0x86, 0xDA, 0xAF, 0xD8, 0xA7});
+            CHECK(string.toUtf16() == u"گھونگا"s);
+            CHECK(string.toUtf32() == U"گھونگا"s);
+            CHECK(string.getSize() == 6);
             CHECK(!string.isEmpty());
             CHECK(string.getData() != nullptr);
         }
@@ -417,7 +439,12 @@ TEST_CASE("[System] sf::String")
 
     SECTION("fromUtf8()")
     {
-        SECTION("Nominal")
+        {
+            constexpr std::array<std::uint8_t, 1> characters{251};
+            const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
+            CHECK(string.getSize() == 1);
+            CHECK(string[0] == 0);
+        }
         {
             constexpr std::array<std::uint8_t, 4> characters{'w', 'x', 'y', 'z'};
             const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
@@ -432,45 +459,85 @@ TEST_CASE("[System] sf::String")
             CHECK(!string.isEmpty());
             CHECK(string.getData() != nullptr);
         }
-
-        SECTION("Insufficient input")
         {
-            constexpr std::array<std::uint8_t, 1> characters{251};
+            constexpr std::array<std::uint8_t, 4> characters{0xF0, 0x9F, 0x90, 0x8C};
             const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
-            constexpr char32_t                    defaultReplacementCharacter = 0;
+            CHECK(std::string(string) == "\0"s);
+            CHECK(std::wstring(string) == select(L""s, L"🐌"s));
+            CHECK(string.toAnsiString() == "\0"s);
+            CHECK(string.toWideString() == select(L""s, L"🐌"s));
+            CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C});
+            CHECK(string.toUtf16() == u"🐌"s);
+            CHECK(string.toUtf32() == U"🐌"s);
             CHECK(string.getSize() == 1);
-            CHECK(string[0] == defaultReplacementCharacter);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
         }
     }
 
     SECTION("fromUtf16()")
     {
-        constexpr std::array<char16_t, 4> characters{0xF1, 'x', 'y', 'z'};
-        const sf::String                  string = sf::String::fromUtf16(characters.begin(), characters.end());
-        CHECK(std::string(string) == select("\xF1xyz"s, "\0xyz"s));
-        CHECK(std::wstring(string) == L"\xF1xyz"s);
-        CHECK(string.toAnsiString() == select("\xF1xyz"s, "\0xyz"s));
-        CHECK(string.toWideString() == L"\xF1xyz"s);
-        CHECK(string.toUtf8() == sf::U8String{0xC3, 0xB1, 'x', 'y', 'z'});
-        CHECK(string.toUtf16() == u"\xF1xyz"s);
-        CHECK(string.toUtf32() == U"\xF1xyz"s);
-        CHECK(string.getSize() == 4);
-        CHECK(!string.isEmpty());
-        CHECK(string.getData() != nullptr);
+        {
+            constexpr std::u16string_view characters = u"SFML!"sv;
+            const sf::String              string     = sf::String::fromUtf16(characters.begin(), characters.end());
+            CHECK(std::string(string) == "SFML!"s);
+            CHECK(std::wstring(string) == L"SFML!"s);
+            CHECK(string.toAnsiString() == "SFML!"s);
+            CHECK(string.toWideString() == L"SFML!"s);
+            CHECK(string.toUtf8() == sf::U8String{'S', 'F', 'M', 'L', '!'});
+            CHECK(string.toUtf16() == u"SFML!"s);
+            CHECK(string.toUtf32() == U"SFML!"s);
+            CHECK(string.getSize() == 5);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
+        }
+        {
+            constexpr std::u16string_view characters = u"piñata"sv;
+            const sf::String              string     = sf::String::fromUtf16(characters.begin(), characters.end());
+            CHECK(std::string(string) == select("pi\xF1"
+                                                "ata"s,
+                                                "pi\0ata"s));
+            CHECK(std::wstring(string) == L"piñata"s);
+            CHECK(string.toAnsiString() == select("pi\xF1"
+                                                  "ata"s,
+                                                  "pi\0ata"s));
+            CHECK(string.toWideString() == L"piñata"s);
+            CHECK(string.toUtf8() == sf::U8String{'p', 'i', 0xC3, 0xB1, 'a', 't', 'a'});
+            CHECK(string.toUtf16() == u"piñata"s);
+            CHECK(string.toUtf32() == U"piñata"s);
+            CHECK(string.getSize() == 6);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
+        }
+        {
+            constexpr std::u16string_view characters = u"달팽이"sv;
+            const sf::String              string     = sf::String::fromUtf16(characters.begin(), characters.end());
+            CHECK(std::string(string) == "\0\0\0"s);
+            CHECK(std::wstring(string) == L"달팽이"s);
+            CHECK(string.toAnsiString() == "\0\0\0"s);
+            CHECK(string.toWideString() == L"달팽이"s);
+            CHECK(string.toUtf8() == sf::U8String{0xEB, 0x8B, 0xAC, 0xED, 0x8C, 0xBD, 0xEC, 0x9D, 0xB4});
+            CHECK(string.toUtf16() == u"달팽이"s);
+            CHECK(string.toUtf32() == U"달팽이"s);
+            CHECK(string.getSize() == 3);
+            CHECK(!string.isEmpty());
+            CHECK(string.getData() != nullptr);
+        }
     }
 
     SECTION("fromUtf32()")
     {
-        constexpr std::array<char32_t, 4> characters{'w', U'🐌', 'y', 'z'};
-        const sf::String                  string = sf::String::fromUtf32(characters.begin(), characters.end());
-        CHECK(std::string(string) == "w\0yz"s);
-        CHECK(std::wstring(string) == select(L"wyz"s, L"w🐌yz"s));
-        CHECK(string.toAnsiString() == "w\0yz"s);
-        CHECK(string.toWideString() == select(L"wyz"s, L"w🐌yz"s));
-        CHECK(string.toUtf8() == sf::U8String{'w', 0xF0, 0x9F, 0x90, 0x8C, 'y', 'z'});
-        CHECK(string.toUtf16() == u"w🐌yz"s);
-        CHECK(string.toUtf32() == U"w🐌yz"s);
-        CHECK(string.getSize() == 4);
+        constexpr std::u32string_view characters = U"👍+👎=🤷"sv;
+        const sf::String              string     = sf::String::fromUtf32(characters.begin(), characters.end());
+        CHECK(std::string(string) == "\0+\0=\0"s);
+        CHECK(std::wstring(string) == select(L"+="s, L"👍+👎=🤷"s));
+        CHECK(string.toAnsiString() == "\0+\0=\0"s);
+        CHECK(string.toWideString() == select(L"+="s, L"👍+👎=🤷"s));
+        CHECK(string.toUtf8() ==
+              sf::U8String{0xF0, 0x9F, 0x91, 0x8D, '+', 0xF0, 0x9F, 0x91, 0x8E, '=', 0xF0, 0x9F, 0xA4, 0xB7});
+        CHECK(string.toUtf16() == u"👍+👎=🤷"s);
+        CHECK(string.toUtf32() == U"👍+👎=🤷"s);
+        CHECK(string.getSize() == 5);
         CHECK(!string.isEmpty());
         CHECK(string.getData() != nullptr);
     }
@@ -479,7 +546,7 @@ TEST_CASE("[System] sf::String")
     {
         sf::String string("you'll never guess what happens when you call clear()");
         string.clear();
-        CHECK(string == sf::String());
+        CHECK(string.isEmpty());
         CHECK(string.getSize() == 0);
     }
 


### PR DESCRIPTION
## Description

Related to #3406 

I wrote the `sf::String` tests (see #2466) with no knowledge of how Unicode works, therefore the tests did a poor job actually testing all the Unicode-aware features of the class. I rewrote most of the tests to use Unicode codepoints more often. These new tests will do a much better job catching regressions.

In this same PR I also included a separate commit that removes hex code from strings in favor of the actual Unicode characters those hex values correspond to. Nobody would know that `\U0001F40D` means the 🐌 emoji. I know that because `\U0001F40D` is actually 🐍! The snail is `\U0001F40C`. Aren't you glad you can just see the character with your own eyes without having to check the web while reading the tests? Adding these characters required adding the `/utf-8` code to MSVC builds.

These tests mostly exercise happy path code. There are many more tests we could theoretically add with error cases and non-default `std::locale` values but I chose to hold off on those for now. 