### PR TITLE
Use Catch2 generators to simplify tests

### DIFF
--- a/test/Audio/InputSoundFile.test.cpp
+++ b/test/Audio/InputSoundFile.test.cpp
@@ -6,10 +6,10 @@
 #include <SFML/System/Time.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <SystemUtil.hpp>
 #include <array>
-#include <fstream>
 #include <type_traits>
 
 TEST_CASE("[Audio] sf::InputSoundFile")
@@ -162,23 +162,14 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
         SECTION("Valid file")
         {
+            const std::u32string filenameSuffix = GENERATE(U"", U"-ń", U"-🐌");
+
             SECTION("flac")
             {
-                SECTION("ASCII filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile("Audio/ding.flac"));
-                }
+                const std::filesystem::path filename = U"Audio/ding" + filenameSuffix + U".flac";
+                INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
 
-                SECTION("Polish filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-ń.flac"));
-                }
-
-                SECTION("Emoji filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-🐌.flac"));
-                }
-
+                REQUIRE(inputSoundFile.openFromFile(filename));
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -189,21 +180,10 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("mp3")
             {
-                SECTION("ASCII filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile("Audio/ding.mp3"));
-                }
+                const std::filesystem::path filename = U"Audio/ding" + filenameSuffix + U".mp3";
+                INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
 
-                SECTION("Polish filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-ń.mp3"));
-                }
-
-                SECTION("Emoji filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/ding-🐌.mp3"));
-                }
-
+                REQUIRE(inputSoundFile.openFromFile(filename));
                 CHECK(inputSoundFile.getSampleCount() == 87'798);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -214,21 +194,10 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("ogg")
             {
-                SECTION("ASCII filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile("Audio/doodle_pop.ogg"));
-                }
+                const std::filesystem::path filename = U"Audio/doodle_pop" + filenameSuffix + U".ogg";
+                INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
 
-                SECTION("Polish filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/doodle_pop-ń.ogg"));
-                }
-
-                SECTION("Emoji filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/doodle_pop-🐌.ogg"));
-                }
-
+                REQUIRE(inputSoundFile.openFromFile(filename));
                 CHECK(inputSoundFile.getSampleCount() == 2'116'992);
                 CHECK(inputSoundFile.getChannelCount() == 2);
                 CHECK(inputSoundFile.getSampleRate() == 44'100);
@@ -239,21 +208,10 @@ TEST_CASE("[Audio] sf::InputSoundFile")
 
             SECTION("wav")
             {
-                SECTION("ASCII filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile("Audio/killdeer.wav"));
-                }
+                const std::filesystem::path filename = U"Audio/killdeer" + filenameSuffix + U".wav";
+                INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
 
-                SECTION("Polish filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/killdeer-ń.wav"));
-                }
-
-                SECTION("Emoji filename")
-                {
-                    REQUIRE(inputSoundFile.openFromFile(U"Audio/killdeer-🐌.wav"));
-                }
-
+                REQUIRE(inputSoundFile.openFromFile(filename));
                 CHECK(inputSoundFile.getSampleCount() == 112'941);
                 CHECK(inputSoundFile.getChannelCount() == 1);
                 CHECK(inputSoundFile.getSampleRate() == 22'050);

--- a/test/Audio/Music.test.cpp
+++ b/test/Audio/Music.test.cpp
@@ -5,6 +5,7 @@
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <AudioUtil.hpp>
 #include <SystemUtil.hpp>
@@ -133,21 +134,11 @@ TEST_CASE("[Audio] sf::Music", runAudioDeviceTests())
 
         SECTION("Valid file")
         {
-            SECTION("ASCII filename")
-            {
-                REQUIRE(music.openFromFile("Audio/ding.mp3"));
-            }
+            const std::u32string        filenameSuffix = GENERATE(U"", U"-ń", U"-🐌");
+            const std::filesystem::path filename       = U"Audio/ding" + filenameSuffix + U".mp3";
+            INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
 
-            SECTION("Polish filename")
-            {
-                REQUIRE(music.openFromFile(U"Audio/ding-ń.mp3"));
-            }
-
-            SECTION("Emoji filename")
-            {
-                REQUIRE(music.openFromFile(U"Audio/ding-🐌.mp3"));
-            }
-
+            REQUIRE(music.openFromFile(filename));
             CHECK(music.getDuration() == sf::microseconds(1990884));
             const auto [offset, length] = music.getLoopPoints();
             CHECK(offset == sf::Time::Zero);

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -5,6 +5,7 @@
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <AudioUtil.hpp>
 #include <SystemUtil.hpp>
@@ -122,21 +123,11 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
 
         SECTION("Valid file")
         {
-            SECTION("ASCII filename")
-            {
-                REQUIRE(soundBuffer.loadFromFile("Audio/ding.flac"));
-            }
+            const std::u32string        filenameSuffix = GENERATE(U"", U"-ń", U"-🐌");
+            const std::filesystem::path filename       = U"Audio/ding" + filenameSuffix + U".flac";
+            INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
 
-            SECTION("Polish filename")
-            {
-                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-ń.flac"));
-            }
-
-            SECTION("Emoji filename")
-            {
-                REQUIRE(soundBuffer.loadFromFile(U"Audio/ding-🐌.flac"));
-            }
-
+            REQUIRE(soundBuffer.loadFromFile(filename));
             CHECK(soundBuffer.getSamples() != nullptr);
             CHECK(soundBuffer.getSampleCount() == 87798);
             CHECK(soundBuffer.getSampleRate() == 44100);

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -1,6 +1,7 @@
 #include <SFML/System/FileInputStream.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include <array>
 #include <string_view>
@@ -93,22 +94,12 @@ TEST_CASE("[System] sf::FileInputStream")
 
     SECTION("open()")
     {
+        const std::u32string        filenameSuffix = GENERATE(U"", U"-ń", U"-🐌");
+        const std::filesystem::path filename       = U"System/test" + filenameSuffix + U".txt";
+        INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
+
         sf::FileInputStream fileInputStream;
-
-        SECTION("From ASCII filename")
-        {
-            REQUIRE(fileInputStream.open("System/test.txt"));
-        }
-
-        SECTION("From Polish filename")
-        {
-            REQUIRE(fileInputStream.open(U"System/test-ń.txt"));
-        }
-
-        SECTION("From emoji filename")
-        {
-            REQUIRE(fileInputStream.open(U"System/test-🐌.txt"));
-        }
+        CHECK(fileInputStream.open(filename));
 
         CHECK(fileInputStream.read(buffer.data(), 5) == 5);
         CHECK(fileInputStream.tell() == 5);


### PR DESCRIPTION
## Description

These Unicode tests are a great candidate for [Catch2 generators](https://github.com/catchorg/Catch2/blob/devel/docs/generators.md) which let us more succinctly express the idea of testing the same code with a variety of inputs.

I added some `INFO` statements so that when a test fails you a see the filename that was used in the failing test. Otherwise it would be pretty hard to know exactly what failed. Note that `INFO` logging macros only print out upon failure so they add no extra console noise to successful runs.