### PR TITLE
Fix saving FLAC files to non-ASCII paths

### DIFF
--- a/src/SFML/Audio/SoundFileWriterFlac.cpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.cpp
@@ -137,14 +137,16 @@ bool SoundFileWriterFlac::open(const std::filesystem::path&     filename,
         return false;
     }
 
+    // Open file
+    m_file = openFile(filename, "w+b");
+
     // Setup the encoder
     FLAC__stream_encoder_set_channels(m_encoder.get(), channelCount);
     FLAC__stream_encoder_set_bits_per_sample(m_encoder.get(), 16);
     FLAC__stream_encoder_set_sample_rate(m_encoder.get(), sampleRate);
 
     // Initialize the output stream
-    if (FLAC__stream_encoder_init_file(m_encoder.get(), filename.string().c_str(), nullptr, nullptr) !=
-        FLAC__STREAM_ENCODER_INIT_STATUS_OK)
+    if (FLAC__stream_encoder_init_FILE(m_encoder.get(), m_file, nullptr, nullptr) != FLAC__STREAM_ENCODER_INIT_STATUS_OK)
     {
         err() << "Failed to write flac file (failed to open the file)\n" << formatDebugPathInfo(filename) << std::endl;
         m_encoder.reset();

--- a/src/SFML/Audio/SoundFileWriterFlac.hpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.hpp
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include <cstdint>
+#include <cstdio>
 
 
 namespace sf::priv
@@ -90,6 +91,7 @@ private:
     {
         void operator()(FLAC__StreamEncoder* encoder) const;
     };
+    std::FILE*                                                     m_file{};
     std::unique_ptr<FLAC__StreamEncoder, FlacStreamEncoderDeleter> m_encoder;        //!< FLAC stream encoder
     unsigned int                                                   m_channelCount{}; //!< Number of channels
     std::array<std::size_t, 8> m_remapTable{}; //!< Table we use to remap source to target channel order

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Exception.hpp>
 #include <SFML/System/FileInputStream.hpp>
+#include <SFML/System/Utils.hpp>
 #ifdef SFML_SYSTEM_ANDROID
 #include <SFML/System/Android/Activity.hpp>
 #include <SFML/System/Android/ResourceStream.hpp>
@@ -78,11 +79,7 @@ bool FileInputStream::open(const std::filesystem::path& filename)
         return m_androidFile->tell().has_value();
     }
 #endif
-#ifdef SFML_SYSTEM_WINDOWS
-    m_file.reset(_wfopen(filename.c_str(), L"rb"));
-#else
-    m_file.reset(std::fopen(filename.c_str(), "rb"));
-#endif
+    m_file.reset(openFile(filename, "rb"));
     return m_file != nullptr;
 }
 

--- a/src/SFML/System/Utils.cpp
+++ b/src/SFML/System/Utils.cpp
@@ -51,4 +51,14 @@ std::string formatDebugPathInfo(const std::filesystem::path& path)
     return oss.str();
 }
 
+std::FILE* openFile(const std::filesystem::path& filename, std::string_view mode)
+{
+#ifdef SFML_SYSTEM_WINDOWS
+    const std::wstring wmode(mode.begin(), mode.end());
+    return _wfopen(filename.c_str(), wmode.data());
+#else
+    return std::fopen(filename.c_str(), mode.data());
+#endif
+}
+
 } // namespace sf

--- a/src/SFML/System/Utils.hpp
+++ b/src/SFML/System/Utils.hpp
@@ -31,8 +31,10 @@
 
 #include <filesystem>
 #include <string>
+#include <string_view>
 
 #include <cstddef>
+#include <cstdio>
 
 
 namespace sf
@@ -51,4 +53,6 @@ template <typename IntegerType, typename... Bytes>
     std::size_t index   = 0;
     return ((integer |= static_cast<IntegerType>(static_cast<IntegerType>(byte) << 8 * index++)), ...);
 }
+
+[[nodiscard]] SFML_SYSTEM_API std::FILE* openFile(const std::filesystem::path& filename, std::string_view mode);
 } // namespace sf

--- a/test/Audio/OutputSoundFile.test.cpp
+++ b/test/Audio/OutputSoundFile.test.cpp
@@ -17,7 +17,7 @@ TEST_CASE("[Audio] sf::OutputSoundFile")
     }
 
     const std::u32string stem      = GENERATE(U"tmp", U"tmp-ń", U"tmp-🐌");
-    const std::u32string extension = GENERATE(U".wav", U".ogg"); // , U".flac"); FLAC fails to handle Unicode strings
+    const std::u32string extension = GENERATE(U".wav", U".ogg", U".flac");
     const auto           filename  = std::filesystem::temp_directory_path() / std::filesystem::path(stem + extension);
     const std::vector<sf::SoundChannel> channelMap{sf::SoundChannel::FrontLeft, sf::SoundChannel::FrontRight};
 

--- a/test/Audio/SoundBuffer.test.cpp
+++ b/test/Audio/SoundBuffer.test.cpp
@@ -183,12 +183,13 @@ TEST_CASE("[Audio] sf::SoundBuffer", runAudioDeviceTests())
 
     SECTION("saveToFile()")
     {
-        const auto filename = std::filesystem::temp_directory_path() / "ding.flac";
+        const std::u32string stem      = GENERATE(U"tmp", U"tmp-ń", U"tmp-🐌");
+        const std::u32string extension = GENERATE(U".wav", U".ogg", U".flac");
+        const auto filename = std::filesystem::temp_directory_path() / std::filesystem::path(stem + extension);
 
-        {
-            const sf::SoundBuffer soundBuffer("Audio/ding.flac");
-            REQUIRE(soundBuffer.saveToFile(filename));
-        }
+        INFO("Filename: " << reinterpret_cast<const char*>(filename.u8string().c_str()));
+
+        REQUIRE(sf::SoundBuffer("Audio/ding.flac").saveToFile(filename));
 
         const sf::SoundBuffer soundBuffer(filename);
         CHECK(soundBuffer.getSamples() != nullptr);


### PR DESCRIPTION
## Description

Related to #3406

To make this work I added a new `openFile` function that abstracts over platform differences in opening files from non-ASCII paths.