### PR TITLE
Win32: Recover from invalid device context (DC)

### DIFF
--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -224,8 +224,17 @@ bool WglContext::makeCurrent(bool current)
 ////////////////////////////////////////////////////////////
 void WglContext::display()
 {
-    if (m_deviceContext && m_context)
-        SwapBuffers(m_deviceContext);
+    if (m_deviceContext && m_context) 
+    {
+        bool success = SwapBuffers(m_deviceContext);
+        if (!success) 
+        {
+            err() << "SwapBuffers error: " << GetLastError() << std::endl;
+            ReleaseDC(m_window, m_deviceContext);
+            m_deviceContext = GetDC(m_window);
+            success = SwapBuffers(m_deviceContext);
+        }
+    }
 }
 
 

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -226,8 +226,7 @@ void WglContext::display()
 {
     if (m_deviceContext && m_context)
     {
-        bool success = SwapBuffers(m_deviceContext);
-        if (!success)
+        if (!SwapBuffers(m_deviceContext))
         {
             err() << "SwapBuffers error: " << GetLastError() << std::endl;
             ReleaseDC(m_window, m_deviceContext);

--- a/src/SFML/Window/Win32/WglContext.cpp
+++ b/src/SFML/Window/Win32/WglContext.cpp
@@ -224,15 +224,15 @@ bool WglContext::makeCurrent(bool current)
 ////////////////////////////////////////////////////////////
 void WglContext::display()
 {
-    if (m_deviceContext && m_context) 
+    if (m_deviceContext && m_context)
     {
         bool success = SwapBuffers(m_deviceContext);
-        if (!success) 
+        if (!success)
         {
             err() << "SwapBuffers error: " << GetLastError() << std::endl;
             ReleaseDC(m_window, m_deviceContext);
             m_deviceContext = GetDC(m_window);
-            success = SwapBuffers(m_deviceContext);
+            SwapBuffers(m_deviceContext);
         }
     }
 }


### PR DESCRIPTION
## Description

This code change will check the result of `SwapBuffers()`. If `SwapBuffers()` fails, it will retrieve a new device context from Windows and proceed with the new context.

I made this change on my fork in 2021, evidently facing an issue where the window wasn't redrawing in some scenario because the device context needed to be updated. I no longer recall the exact scenario so I can't currently reproduce, but I thought it might be useful anyway.

In short, in case Windows decides to give the window a new DC, this change allows SFML to recover from that without freezing up.