### PR TITLE
Remove FLAC microbench target from project

### DIFF
--- a/tools/flac/PatchFLAC.cmake
+++ b/tools/flac/PatchFLAC.cmake
@@ -7,4 +7,5 @@ string(REPLACE "set_target_properties(FLAC grabbag getopt replaygain_analysis re
 string(REPLACE "install(FILES \${FLAC_HEADERS} DESTINATION \"\${CMAKE_INSTALL_INCLUDEDIR}/FLAC\")" "" FLAC_CMAKELISTS_CONTENTS "${FLAC_CMAKELISTS_CONTENTS}")
 string(REPLACE "install(FILES \${FLAC++_HEADERS} DESTINATION \"\${CMAKE_INSTALL_INCLUDEDIR}/FLAC++\")" "" FLAC_CMAKELISTS_CONTENTS "${FLAC_CMAKELISTS_CONTENTS}")
 string(REPLACE "\n\nadd_subdirectory(\"src\")" "\nset(CMAKE_DEBUG_POSTFIX d)\nadd_subdirectory(\"src\")" FLAC_CMAKELISTS_CONTENTS "${FLAC_CMAKELISTS_CONTENTS}")
+string(REPLACE "add_subdirectory(\"microbench\")" "" FLAC_CMAKELISTS_CONTENTS "${FLAC_CMAKELISTS_CONTENTS}")
 file(WRITE "${FLAC_DIR}/CMakeLists.txt" "${FLAC_CMAKELISTS_CONTENTS}")


### PR DESCRIPTION
FLAC has a microbench target that is added to the project which we don't want