### PR TITLE
Fix iOS debug build and update xcode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
         - { name: Linux Clang,                    os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: Linux GCC DRM,                  os: ubuntu-22.04, flags: -DSFML_USE_DRM=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
         - { name: Linux GCC OpenGL ES,            os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
-        - { name: macOS x64,                      os: macos-13, flags: -GNinja }
-        - { name: macOS x64 Xcode,                os: macos-13, flags: -GXcode }
-        - { name: macOS arm64,                    os: macos-14, flags: -GNinja -DSFML_RUN_AUDIO_DEVICE_TESTS=OFF }
-        - { name: iOS,                            os: macos-14, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
-        - { name: iOS Xcode,                      os: macos-14, flags: -DCMAKE_SYSTEM_NAME=iOS -GXcode -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO }
+        - { name: macOS x64,                      os: macos-15, flags: -GNinja }
+        - { name: macOS x64 Xcode,                os: macos-15, flags: -GXcode }
+        - { name: macOS arm64,                    os: macos-15, flags: -GNinja -DSFML_RUN_AUDIO_DEVICE_TESTS=OFF }
+        - { name: iOS,                            os: macos-15, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
+        - { name: iOS Xcode,                      os: macos-15, flags: -DCMAKE_SYSTEM_NAME=iOS -GXcode -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO }
         config:
         - { name: Shared, flags: -DBUILD_SHARED_LIBS=ON }
         - { name: Static, flags: -DBUILD_SHARED_LIBS=OFF }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         - { name: Linux Clang,                    os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: Linux GCC DRM,                  os: ubuntu-22.04, flags: -DSFML_USE_DRM=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
         - { name: Linux GCC OpenGL ES,            os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
-        - { name: macOS x64,                      os: macos-15, flags: -GNinja }
-        - { name: macOS x64 Xcode,                os: macos-15, flags: -GXcode }
+        - { name: macOS x64,                      os: macos-13, flags: -GNinja }
+        - { name: macOS x64 Xcode,                os: macos-13, flags: -GXcode }
         - { name: macOS arm64,                    os: macos-15, flags: -GNinja -DSFML_RUN_AUDIO_DEVICE_TESTS=OFF }
         - { name: iOS,                            os: macos-15, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
         - { name: iOS Xcode,                      os: macos-15, flags: -DCMAKE_SYSTEM_NAME=iOS -GXcode -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,8 +184,14 @@ endif()
 option(SFML_ENABLE_STDLIB_ASSERTIONS "Enable standard library assertions" OFF)
 if(SFML_ENABLE_STDLIB_ASSERTIONS)
     # intentionally using `add_definitions` here to propagate defines to subdirectories
-    add_definitions(-D_GLIBCXX_ASSERTIONS=1)                                   # see https://gcc.gnu.org/wiki/LibstdcxxDebugMode
-    add_definitions(-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE) # see https://libcxx.llvm.org/Hardening.html
+    add_compile_definitions(_GLIBCXX_ASSERTIONS=1)                                   # see https://gcc.gnu.org/wiki/LibstdcxxDebugMode
+
+    # Xcode has a property to control this - adding the define ourselves causes multiple definitions
+    if (XCODE)
+        set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_STANDARD_LIBRARY_HARDENING "Yes (extensive)")
+    else()
+        add_compile_definitions(_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE) # see https://libcxx.llvm.org/Hardening.html
+    endif()
 endif()
 
 # set the output directory for SFML DLLs and executables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,11 +183,11 @@ endif()
 
 option(SFML_ENABLE_STDLIB_ASSERTIONS "Enable standard library assertions" OFF)
 if(SFML_ENABLE_STDLIB_ASSERTIONS)
-    # intentionally using `add_definitions` here to propagate defines to subdirectories
+    # intentionally using `add_compile_definitions` here to propagate defines to subdirectories
     add_compile_definitions(_GLIBCXX_ASSERTIONS=1)                                   # see https://gcc.gnu.org/wiki/LibstdcxxDebugMode
 
     # Xcode has a property to control this - adding the define ourselves causes multiple definitions
-    if (XCODE)
+    if(XCODE)
         set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_STANDARD_LIBRARY_HARDENING "Yes (extensive)")
     else()
         add_compile_definitions(_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE) # see https://libcxx.llvm.org/Hardening.html


### PR DESCRIPTION
iOS currently doesn't build with xcode >= 16 (latest) due to `_LIBCPP_HARDENING_MODE ` being redefined.

This is mentioned in the release notes [here](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#C++-Standard-Library). Simplest solution is to use the xcode attribute when using the xcode generator so have done that.

This also updates the CI to use the latest github mac images for xcode 15. While it's technically possible to maintain tests/support for older versions I don't believe it's worth the cost, and apple more so than other platforms it's most common (and often required) to use the latest versions anyway