### PR TITLE
Revamp `sf::Utf<N>` tests

### DIFF
--- a/include/SFML/System/Utf.hpp
+++ b/include/SFML/System/Utf.hpp
@@ -38,12 +38,6 @@
 
 namespace sf
 {
-namespace priv
-{
-template <class InputIt, class OutputIt>
-OutputIt copy(InputIt first, InputIt last, OutputIt dFirst);
-}
-
 template <unsigned int N>
 class Utf;
 

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -41,15 +41,18 @@
 
 namespace sf
 {
+namespace priv
+{
 ////////////////////////////////////////////////////////////
 template <typename InputIt, typename OutputIt>
-OutputIt priv::copy(InputIt first, InputIt last, OutputIt dFirst)
+OutputIt copy(InputIt first, InputIt last, OutputIt dFirst)
 {
     while (first != last)
         *dFirst++ = static_cast<typename OutputIt::container_type::value_type>(*first++);
 
     return dFirst;
 }
+} // namespace priv
 
 template <typename In>
 In Utf<8>::decode(In begin, In end, char32_t& output, char32_t replacement)

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -79,6 +79,8 @@ Out copyBits(In begin, In end, Out output)
 template <typename In>
 In Utf<8>::decode(In begin, In end, char32_t& output, char32_t replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     // clang-format off
     // Some useful precomputed data
     static constexpr std::array<std::uint8_t, 256> trailing =
@@ -183,6 +185,8 @@ Out Utf<8>::encode(char32_t input, Out output, std::uint8_t replacement)
 template <typename In>
 In Utf<8>::next(In begin, In end)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     char32_t codepoint = 0;
     return decode(begin, end, codepoint);
 }
@@ -192,6 +196,8 @@ In Utf<8>::next(In begin, In end)
 template <typename In>
 std::size_t Utf<8>::count(In begin, In end)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     std::size_t length = 0;
     while (begin != end)
     {
@@ -207,6 +213,8 @@ std::size_t Utf<8>::count(In begin, In end)
 template <typename In, typename Out>
 Out Utf<8>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     while (begin != end)
     {
         const char32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
@@ -221,6 +229,8 @@ Out Utf<8>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 template <typename In, typename Out>
 Out Utf<8>::fromWide(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(wchar_t));
+
     while (begin != end)
     {
         const char32_t codepoint = Utf<32>::decodeWide(*begin++);
@@ -235,6 +245,8 @@ Out Utf<8>::fromWide(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<8>::fromLatin1(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
     while (begin != end)
@@ -248,6 +260,8 @@ Out Utf<8>::fromLatin1(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<8>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -263,6 +277,8 @@ Out Utf<8>::toAnsi(In begin, In end, Out output, char replacement, const std::lo
 template <typename In, typename Out>
 Out Utf<8>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -278,6 +294,8 @@ Out Utf<8>::toWide(In begin, In end, Out output, wchar_t replacement)
 template <typename In, typename Out>
 Out Utf<8>::toLatin1(In begin, In end, Out output, char replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
     while (begin != end)
@@ -295,6 +313,8 @@ Out Utf<8>::toLatin1(In begin, In end, Out output, char replacement)
 template <typename In, typename Out>
 Out Utf<8>::toUtf8(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     return priv::copyBits(begin, end, output);
 }
 
@@ -303,6 +323,8 @@ Out Utf<8>::toUtf8(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<8>::toUtf16(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -318,6 +340,8 @@ Out Utf<8>::toUtf16(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<8>::toUtf32(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -333,6 +357,8 @@ Out Utf<8>::toUtf32(In begin, In end, Out output)
 template <typename In>
 In Utf<16>::decode(In begin, In end, char32_t& output, char32_t replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     const char16_t first = *begin++;
 
     // If it's a surrogate pair, first convert to a single UTF-32 character
@@ -410,6 +436,8 @@ Out Utf<16>::encode(char32_t input, Out output, char16_t replacement)
 template <typename In>
 In Utf<16>::next(In begin, In end)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     char32_t codepoint = 0;
     return decode(begin, end, codepoint);
 }
@@ -419,6 +447,8 @@ In Utf<16>::next(In begin, In end)
 template <typename In>
 std::size_t Utf<16>::count(In begin, In end)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     std::size_t length = 0;
     while (begin != end)
     {
@@ -434,6 +464,8 @@ std::size_t Utf<16>::count(In begin, In end)
 template <typename In, typename Out>
 Out Utf<16>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     while (begin != end)
     {
         const char32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
@@ -448,6 +480,8 @@ Out Utf<16>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 template <typename In, typename Out>
 Out Utf<16>::fromWide(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(wchar_t));
+
     while (begin != end)
     {
         const char32_t codepoint = Utf<32>::decodeWide(*begin++);
@@ -462,6 +496,8 @@ Out Utf<16>::fromWide(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<16>::fromLatin1(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
     return priv::copyBits(begin, end, output);
@@ -472,6 +508,8 @@ Out Utf<16>::fromLatin1(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<16>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -487,6 +525,8 @@ Out Utf<16>::toAnsi(In begin, In end, Out output, char replacement, const std::l
 template <typename In, typename Out>
 Out Utf<16>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -502,6 +542,8 @@ Out Utf<16>::toWide(In begin, In end, Out output, wchar_t replacement)
 template <typename In, typename Out>
 Out Utf<16>::toLatin1(In begin, In end, Out output, char replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
     while (begin != end)
@@ -518,6 +560,8 @@ Out Utf<16>::toLatin1(In begin, In end, Out output, char replacement)
 template <typename In, typename Out>
 Out Utf<16>::toUtf8(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -533,6 +577,8 @@ Out Utf<16>::toUtf8(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<16>::toUtf16(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     return priv::copyBits(begin, end, output);
 }
 
@@ -541,6 +587,8 @@ Out Utf<16>::toUtf16(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<16>::toUtf32(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char16_t));
+
     while (begin != end)
     {
         char32_t codepoint = 0;
@@ -556,6 +604,8 @@ Out Utf<16>::toUtf32(In begin, In end, Out output)
 template <typename In>
 In Utf<32>::decode(In begin, In /*end*/, char32_t& output, char32_t /*replacement*/)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     output = *begin++;
     return begin;
 }
@@ -574,6 +624,8 @@ Out Utf<32>::encode(char32_t input, Out output, char32_t /*replacement*/)
 template <typename In>
 In Utf<32>::next(In begin, In /*end*/)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     return ++begin;
 }
 
@@ -582,6 +634,8 @@ In Utf<32>::next(In begin, In /*end*/)
 template <typename In>
 std::size_t Utf<32>::count(In begin, In end)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     return static_cast<std::size_t>(end - begin);
 }
 
@@ -590,6 +644,8 @@ std::size_t Utf<32>::count(In begin, In end)
 template <typename In, typename Out>
 Out Utf<32>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     while (begin != end)
         *output++ = decodeAnsi(*begin++, locale);
 
@@ -601,6 +657,8 @@ Out Utf<32>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 template <typename In, typename Out>
 Out Utf<32>::fromWide(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(wchar_t));
+
     while (begin != end)
         *output++ = decodeWide(*begin++);
 
@@ -612,6 +670,8 @@ Out Utf<32>::fromWide(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<32>::fromLatin1(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char));
+
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
     return priv::copyBits(begin, end, output);
@@ -622,6 +682,8 @@ Out Utf<32>::fromLatin1(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<32>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     while (begin != end)
         output = encodeAnsi(*begin++, output, replacement, locale);
 
@@ -633,6 +695,8 @@ Out Utf<32>::toAnsi(In begin, In end, Out output, char replacement, const std::l
 template <typename In, typename Out>
 Out Utf<32>::toWide(In begin, In end, Out output, wchar_t replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     while (begin != end)
         output = encodeWide(*begin++, output, replacement);
 
@@ -644,6 +708,8 @@ Out Utf<32>::toWide(In begin, In end, Out output, wchar_t replacement)
 template <typename In, typename Out>
 Out Utf<32>::toLatin1(In begin, In end, Out output, char replacement)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     // Latin-1 is directly compatible with Unicode encodings,
     // and can thus be treated as (a sub-range of) UTF-32
     while (begin != end)
@@ -660,6 +726,8 @@ Out Utf<32>::toLatin1(In begin, In end, Out output, char replacement)
 template <typename In, typename Out>
 Out Utf<32>::toUtf8(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     while (begin != end)
         output = Utf<8>::encode(*begin++, output);
 
@@ -670,6 +738,8 @@ Out Utf<32>::toUtf8(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<32>::toUtf16(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     while (begin != end)
         output = Utf<16>::encode(*begin++, output);
 
@@ -681,6 +751,8 @@ Out Utf<32>::toUtf16(In begin, In end, Out output)
 template <typename In, typename Out>
 Out Utf<32>::toUtf32(In begin, In end, Out output)
 {
+    static_assert(sizeof(decltype(*begin)) == sizeof(char32_t));
+
     return priv::copyBits(begin, end, output);
 }
 

--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -198,8 +198,8 @@ Out Utf<8>::fromWide(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        char32_t codepoint = Utf<32>::decodeWide(*begin++);
-        output             = encode(codepoint, output);
+        const char32_t codepoint = Utf<32>::decodeWide(*begin++);
+        output                   = encode(codepoint, output);
     }
 
     return output;
@@ -411,8 +411,8 @@ Out Utf<16>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
 {
     while (begin != end)
     {
-        char32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
-        output             = encode(codepoint, output);
+        const char32_t codepoint = Utf<32>::decodeAnsi(*begin++, locale);
+        output                   = encode(codepoint, output);
     }
 
     return output;
@@ -425,8 +425,8 @@ Out Utf<16>::fromWide(In begin, In end, Out output)
 {
     while (begin != end)
     {
-        char32_t codepoint = Utf<32>::decodeWide(*begin++);
-        output             = encode(codepoint, output);
+        const char32_t codepoint = Utf<32>::decodeWide(*begin++);
+        output                   = encode(codepoint, output);
     }
 
     return output;

--- a/test/System/Utf.test.cpp
+++ b/test/System/Utf.test.cpp
@@ -4,237 +4,608 @@
 
 #include <string_view>
 
+namespace
+{
+// Return either argument depending on whether wchar_t is 16 or 32 bits
+// Lets us write tests that work on both Windows where wchar_t is 16 bits
+// and elsewhere where it is 32. Otherwise the tests would only work on
+// one OS or the other.
+template <typename T>
+auto select(const std::basic_string_view<T>& string16, const std::basic_string_view<T>& string32)
+{
+    assert(string16 != string32 && "Invalid to select between identical inputs");
+    if constexpr (sizeof(wchar_t) == 2)
+        return string16;
+    else
+        return string32;
+}
+} // namespace
+
 using namespace std::string_view_literals;
+
+// Create C++17-compatible aliases for std::u8string{_view}
+using u8string      = std::basic_string<decltype(u8' ')>;
+using u8string_view = std::basic_string_view<decltype(u8' ')>;
+
+// NOLINTBEGIN(readability-qualified-auto)
 
 TEST_CASE("[System] sf::Utf8")
 {
-    static constexpr std::string_view input = "Hello, World!"sv;
+    static constexpr auto utf8 = u8"SFML 🐌"sv;
 
     SECTION("decode")
     {
         std::u32string output;
-        char32_t       character = 0;
-        for (std::string_view::const_iterator begin = input.begin(); begin < input.end();)
+        for (auto begin = utf8.cbegin(); begin < utf8.cend();)
         {
-            begin = sf::Utf8::decode(begin, input.end(), character);
+            char32_t character = 0;
+            begin              = sf::Utf8::decode(begin, utf8.cend(), character);
             output.push_back(character);
         }
-        CHECK(output == U"Hello, World!"sv);
+        CHECK(output == U"SFML 🐌"sv);
     }
 
     SECTION("encode")
     {
+        u8string output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf8::encode(U' ', std::back_inserter(output));
+            CHECK(output == u8" "sv);
+            sf::Utf8::encode(U'🐌', std::back_inserter(output));
+            CHECK(output == u8" 🐌"sv);
+            sf::Utf8::encode(0xFFFFFFFF, std::back_inserter(output));
+            CHECK(output == u8" 🐌"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf8::encode(U' ', std::back_inserter(output), '?');
+            CHECK(output == u8" "sv);
+            sf::Utf8::encode(U'🐌', std::back_inserter(output), '?');
+            CHECK(output == u8" 🐌"sv);
+            sf::Utf8::encode(0xFFFFFFFF, std::back_inserter(output), '?');
+            CHECK(output == u8" 🐌?"sv);
+        }
     }
 
     SECTION("next")
     {
+        auto next = utf8.cbegin();
+        CHECK(*next == u8'S');
+        next = sf::Utf8::next(next, utf8.cend());
+        CHECK(*next == u8'F');
+        next = sf::Utf8::next(next, utf8.cend());
+        CHECK(*next == u8'M');
+        next = sf::Utf8::next(next, utf8.cend());
+        CHECK(*next == u8'L');
+        next = sf::Utf8::next(next, utf8.cend());
+        CHECK(*next == u8' ');
+        next = sf::Utf8::next(next, utf8.cend());
+        CHECK(u8string_view(&*next, 4) == u8"🐌"sv);
+        next = sf::Utf8::next(next, utf8.cend());
+        CHECK(next == utf8.cend());
     }
 
     SECTION("count")
     {
+        REQUIRE(utf8.size() == 9);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cend()) == 6);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 9) == 6);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 8) == 6);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 7) == 6);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 6) == 6);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 5) == 5);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 4) == 4);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 3) == 3);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 2) == 2);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 1) == 1);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin()) == 0);
     }
 
     SECTION("fromAnsi")
     {
+        static constexpr auto ansi = "abcdefg"sv;
+        u8string              output;
+        sf::Utf8::fromAnsi(ansi.cbegin(), ansi.cend(), std::back_inserter(output));
+        CHECK(output == u8"abcdefg"sv);
     }
 
     SECTION("fromWide")
     {
+        static constexpr auto wide = L"abçdéfgń"sv;
+        u8string              output;
+        sf::Utf8::fromWide(wide.cbegin(), wide.cend(), std::back_inserter(output));
+        CHECK(output == u8"abçdéfgń"sv);
     }
 
     SECTION("fromLatin1")
     {
+        static constexpr auto latin1 =
+            "\xA1"
+            "ab\xE7"
+            "d\xE9!"sv;
+        u8string output;
+        sf::Utf8::fromLatin1(latin1.cbegin(), latin1.cend(), std::back_inserter(output));
+        CHECK(output == u8"¡abçdé!"sv);
     }
 
     SECTION("toAnsi")
     {
+        std::string output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf8::toAnsi(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+            CHECK(output == "SFML \0"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf8::toAnsi(utf8.cbegin(), utf8.cend(), std::back_inserter(output), '_');
+            CHECK(output == "SFML _"sv);
+        }
     }
 
     SECTION("toWide")
     {
+        std::wstring output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf8::toWide(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+            CHECK(output == select(L"SFML "sv, L"SFML 🐌"sv));
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf8::toWide(utf8.cbegin(), utf8.cend(), std::back_inserter(output), L'_');
+            CHECK(output == select(L"SFML _"sv, L"SFML 🐌"sv));
+        }
     }
 
     SECTION("toLatin1")
     {
+        std::string output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf8::toLatin1(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+            CHECK(output == "SFML \0"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf8::toLatin1(utf8.cbegin(), utf8.cend(), std::back_inserter(output), '_');
+            CHECK(output == "SFML _"sv);
+        }
     }
 
     SECTION("toUtf8")
     {
-        std::string output;
-        sf::Utf8::toUtf8(input.begin(), input.end(), std::back_inserter(output));
-        CHECK(output == input);
+        u8string output;
+        sf::Utf8::toUtf8(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+        CHECK(output == utf8);
     }
 
     SECTION("toUtf16")
     {
+        std::u16string output;
+        sf::Utf8::toUtf16(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+        CHECK(output == u"SFML 🐌"sv);
     }
 
     SECTION("toUtf32")
     {
+        std::u32string output;
+        sf::Utf8::toUtf32(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+        CHECK(output == U"SFML 🐌"sv);
     }
 }
 
 TEST_CASE("[System] sf::Utf16")
 {
-    static constexpr std::u16string_view input = u"Hello, World!"sv;
+    static constexpr auto utf16 = u"SFML 🐌"sv;
 
     SECTION("decode")
     {
+        std::u32string output;
+        for (auto begin = utf16.cbegin(); begin < utf16.cend();)
+        {
+            char32_t character = 0;
+            begin              = sf::Utf16::decode(begin, utf16.cend(), character);
+            output.push_back(character);
+        }
+        CHECK(output == U"SFML 🐌"sv);
     }
 
     SECTION("encode")
     {
+        std::u16string output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf16::encode(U' ', std::back_inserter(output));
+            CHECK(output == u" "sv);
+            sf::Utf16::encode(U'🐌', std::back_inserter(output));
+            CHECK(output == u" 🐌"sv);
+            sf::Utf16::encode(0xFFFFFFFF, std::back_inserter(output));
+            CHECK(output == u" 🐌"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf16::encode(U' ', std::back_inserter(output), '?');
+            CHECK(output == u" "sv);
+            sf::Utf16::encode(U'🐌', std::back_inserter(output), '?');
+            CHECK(output == u" 🐌"sv);
+            sf::Utf16::encode(0xFFFFFFFF, std::back_inserter(output), '?');
+            CHECK(output == u" 🐌?"sv);
+        }
     }
 
     SECTION("next")
     {
+        auto next = utf16.cbegin();
+        CHECK(*next == u'S');
+        next = sf::Utf16::next(next, utf16.cend());
+        CHECK(*next == u'F');
+        next = sf::Utf16::next(next, utf16.cend());
+        CHECK(*next == u'M');
+        next = sf::Utf16::next(next, utf16.cend());
+        CHECK(*next == u'L');
+        next = sf::Utf16::next(next, utf16.cend());
+        CHECK(*next == u' ');
+        next = sf::Utf16::next(next, utf16.cend());
+        CHECK(std::u16string_view(&*next, 2) == u"🐌"sv);
+        next = sf::Utf16::next(next, utf16.cend());
+        CHECK(next == utf16.cend());
     }
 
     SECTION("count")
     {
+        REQUIRE(utf16.size() == 7);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cend()) == 6);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin() + 7) == 6);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin() + 6) == 6);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin() + 5) == 5);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin() + 4) == 4);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin() + 3) == 3);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin() + 2) == 2);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin() + 1) == 1);
+        CHECK(sf::Utf16::count(utf16.cbegin(), utf16.cbegin()) == 0);
     }
 
     SECTION("fromAnsi")
     {
+        static constexpr auto ansi = "abcdefg"sv;
+        std::u16string        output;
+        sf::Utf16::fromAnsi(ansi.cbegin(), ansi.cend(), std::back_inserter(output));
+        CHECK(output == u"abcdefg"sv);
     }
 
     SECTION("fromWide")
     {
+        static constexpr auto wide = L"abçdéfgń"sv;
+        std::u16string        output;
+        sf::Utf16::fromWide(wide.cbegin(), wide.cend(), std::back_inserter(output));
+        CHECK(output == u"abçdéfgń"sv);
     }
 
     SECTION("fromLatin1")
     {
+        static constexpr auto latin1 =
+            "\xA1"
+            "ab\xE7"
+            "d\xE9!"sv;
         std::u16string output;
-        sf::Utf16::fromLatin1(input.begin(), input.end(), std::back_inserter(output));
-        CHECK(output == input);
+        sf::Utf16::fromLatin1(latin1.cbegin(), latin1.cend(), std::back_inserter(output));
+        CHECK(output == u"¡abçdé!"sv);
     }
 
     SECTION("toAnsi")
     {
+        std::string output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf16::toAnsi(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+            CHECK(output == "SFML \0"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf16::toAnsi(utf16.cbegin(), utf16.cend(), std::back_inserter(output), '_');
+            CHECK(output == "SFML _"sv);
+        }
     }
 
     SECTION("toWide")
     {
+        std::wstring output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf16::toWide(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+            CHECK(output == select(L"SFML "sv, L"SFML 🐌"sv));
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf16::toWide(utf16.cbegin(), utf16.cend(), std::back_inserter(output), '_');
+            CHECK(output == select(L"SFML _"sv, L"SFML 🐌"sv));
+        }
     }
 
     SECTION("toLatin1")
     {
         std::string output;
-        sf::Utf16::toLatin1(input.begin(), input.end(), std::back_inserter(output));
-        CHECK(output == "Hello, World!"sv);
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf16::toLatin1(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+            CHECK(output == "SFML \0\0"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf16::toLatin1(utf16.cbegin(), utf16.cend(), std::back_inserter(output), '_');
+            CHECK(output == "SFML __"sv);
+        }
     }
 
     SECTION("toUtf8")
     {
+        u8string output;
+        sf::Utf16::toUtf8(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+        CHECK(output == u8"SFML 🐌"sv);
     }
 
     SECTION("toUtf16")
     {
         std::u16string output;
-        sf::Utf16::toUtf16(input.begin(), input.end(), std::back_inserter(output));
-        CHECK(output == input);
+        sf::Utf16::toUtf16(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+        CHECK(output == utf16);
     }
 
     SECTION("toUtf32")
     {
+        std::u32string output;
+        sf::Utf16::toUtf32(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+        CHECK(output == U"SFML 🐌"sv);
     }
 }
 
 TEST_CASE("[System] sf::Utf32")
 {
-    static constexpr std::u32string_view input = U"Hello, World!"sv;
+    static constexpr auto utf32 = U"SFML 🐌"sv;
 
     SECTION("decode")
     {
         std::u32string output;
-        char32_t       character = 0;
-        for (std::u32string_view::const_iterator begin = input.begin(); begin < input.end();)
+        for (auto begin = utf32.cbegin(); begin < utf32.cend();)
         {
-            begin = sf::Utf32::decode(begin, {}, character);
+            char32_t character = 0;
+            begin              = sf::Utf32::decode(begin, {}, character);
             output.push_back(character);
         }
-        CHECK(output == input);
+        CHECK(output == utf32);
     }
 
     SECTION("encode")
     {
         std::u32string output;
-        for (const auto character : input)
+        for (const auto character : utf32)
             sf::Utf32::encode(character, std::back_inserter(output));
-        CHECK(output == input);
+        CHECK(output == utf32);
     }
 
     SECTION("next")
     {
-        CHECK(sf::Utf32::next(input.begin(), {}) == std::next(input.begin()));
+        auto next = utf32.cbegin();
+        CHECK(*next == U'S');
+        next = sf::Utf32::next(next, utf32.cend());
+        CHECK(*next == U'F');
+        next = sf::Utf32::next(next, utf32.cend());
+        CHECK(*next == U'M');
+        next = sf::Utf32::next(next, utf32.cend());
+        CHECK(*next == U'L');
+        next = sf::Utf32::next(next, utf32.cend());
+        CHECK(*next == U' ');
+        next = sf::Utf32::next(next, utf32.cend());
+        CHECK(*next == U'🐌');
+        next = sf::Utf32::next(next, utf32.cend());
+        CHECK(next == utf32.cend());
     }
 
     SECTION("count")
     {
-        CHECK(sf::Utf32::count(input.begin(), input.end()) == input.size());
+        REQUIRE(utf32.size() == 6);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cend()) == 6);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cbegin() + 6) == 6);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cbegin() + 5) == 5);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cbegin() + 4) == 4);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cbegin() + 3) == 3);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cbegin() + 2) == 2);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cbegin() + 1) == 1);
+        CHECK(sf::Utf32::count(utf32.cbegin(), utf32.cbegin()) == 0);
     }
 
     SECTION("fromAnsi")
     {
+        static constexpr auto ansi = "abcdefg"sv;
+        std::u32string        output;
+        sf::Utf32::fromAnsi(ansi.cbegin(), ansi.cend(), std::back_inserter(output));
+        CHECK(output == U"abcdefg"sv);
     }
 
     SECTION("fromWide")
     {
+        static constexpr auto wide = L"abçdéfgń"sv;
+        std::u32string        output;
+        sf::Utf32::fromWide(wide.cbegin(), wide.cend(), std::back_inserter(output));
+        CHECK(output == U"abçdéfgń"sv);
     }
 
     SECTION("fromLatin1")
     {
+        static constexpr auto latin1 =
+            "\xA1"
+            "ab\xE7"
+            "d\xE9!"sv;
         std::u32string output;
-        sf::Utf32::fromLatin1(input.begin(), input.end(), std::back_inserter(output));
-        CHECK(output == input);
+        sf::Utf32::fromLatin1(latin1.cbegin(), latin1.cend(), std::back_inserter(output));
+        CHECK(output == U"¡abçdé!"sv);
     }
 
     SECTION("toAnsi")
     {
+        std::string output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf32::toAnsi(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+            CHECK(output == "SFML \0"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf32::toAnsi(utf32.cbegin(), utf32.cend(), std::back_inserter(output), '_');
+            CHECK(output == "SFML _"sv);
+        }
     }
 
     SECTION("toWide")
     {
+        std::wstring output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf32::toWide(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+            CHECK(output == select(L"SFML "sv, L"SFML 🐌"sv));
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf32::toWide(utf32.cbegin(), utf32.cend(), std::back_inserter(output), L'_');
+            CHECK(output == select(L"SFML _"sv, L"SFML 🐌"sv));
+        }
     }
 
     SECTION("toLatin1")
     {
         std::string output;
-        sf::Utf32::toLatin1(input.begin(), input.end(), std::back_inserter(output));
-        CHECK(output == "Hello, World!");
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf32::toLatin1(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+            CHECK(output == "SFML \0"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf32::toLatin1(utf32.cbegin(), utf32.cend(), std::back_inserter(output), '_');
+            CHECK(output == "SFML _"sv);
+        }
     }
 
     SECTION("toUtf8")
     {
+        u8string output;
+        sf::Utf32::toUtf8(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+        CHECK(output == u8"SFML 🐌"sv);
     }
 
     SECTION("toUtf16")
     {
+        std::u16string output;
+        sf::Utf32::toUtf16(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+        CHECK(output == u"SFML 🐌"sv);
     }
 
     SECTION("toUtf32")
     {
         std::u32string output;
-        sf::Utf32::toUtf32(input.begin(), input.end(), std::back_inserter(output));
-        CHECK(output == input);
+        sf::Utf32::toUtf32(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+        CHECK(output == utf32);
     }
 
     SECTION("decodeAnsi")
     {
+        CHECK(sf::Utf32::decodeAnsi('\0') == U'\0');
+        CHECK(sf::Utf32::decodeAnsi(' ') == U' ');
+        CHECK(sf::Utf32::decodeAnsi('a') == U'a');
+        CHECK(sf::Utf32::decodeAnsi('A') == U'A');
     }
 
     SECTION("decodeWide")
     {
-        CHECK(sf::Utf32::decodeWide(0) == 0);
-        CHECK(sf::Utf32::decodeWide(1) == 1);
-        CHECK(sf::Utf32::decodeWide(-1) == std::numeric_limits<std::uint32_t>::max());
+        CHECK(sf::Utf32::decodeWide(L'\0') == U'\0');
+        CHECK(sf::Utf32::decodeWide(L' ') == U' ');
+        CHECK(sf::Utf32::decodeWide(L'a') == U'a');
+        CHECK(sf::Utf32::decodeWide(L'A') == U'A');
+        CHECK(sf::Utf32::decodeWide(L'é') == U'é');
+        CHECK(sf::Utf32::decodeWide(L'ń') == U'ń');
     }
 
     SECTION("encodeAnsi")
     {
+        std::string output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf32::encodeAnsi(U' ', std::back_inserter(output));
+            CHECK(output == " "sv);
+            sf::Utf32::encodeAnsi(U'_', std::back_inserter(output));
+            CHECK(output == " _"sv);
+            sf::Utf32::encodeAnsi(U'a', std::back_inserter(output));
+            CHECK(output == " _a"sv);
+            sf::Utf32::encodeAnsi(U'🐌', std::back_inserter(output));
+            CHECK(output == " _a\0"sv);
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf32::encodeAnsi(U' ', std::back_inserter(output), '?');
+            CHECK(output == " "sv);
+            sf::Utf32::encodeAnsi(U'_', std::back_inserter(output), '?');
+            CHECK(output == " _"sv);
+            sf::Utf32::encodeAnsi(U'a', std::back_inserter(output), '?');
+            CHECK(output == " _a"sv);
+            sf::Utf32::encodeAnsi(U'🐌', std::back_inserter(output), '?');
+            CHECK(output == " _a?"sv);
+        }
     }
 
     SECTION("encodeWide")
     {
+        std::wstring output;
+
+        SECTION("Default replacement character")
+        {
+            sf::Utf32::encodeWide(U' ', std::back_inserter(output));
+            CHECK(output == L" "sv);
+            sf::Utf32::encodeWide(U'_', std::back_inserter(output));
+            CHECK(output == L" _"sv);
+            sf::Utf32::encodeWide(U'a', std::back_inserter(output));
+            CHECK(output == L" _a"sv);
+            sf::Utf32::encodeWide(U'🐌', std::back_inserter(output));
+            CHECK(output == select(L" _a"sv, L" _a🐌"sv));
+        }
+
+        SECTION("Custom replacement character")
+        {
+            sf::Utf32::encodeWide(U' ', std::back_inserter(output), L'?');
+            CHECK(output == L" "sv);
+            sf::Utf32::encodeWide(U'_', std::back_inserter(output), L'?');
+            CHECK(output == L" _"sv);
+            sf::Utf32::encodeWide(U'a', std::back_inserter(output), L'?');
+            CHECK(output == L" _a"sv);
+            sf::Utf32::encodeWide(U'🐌', std::back_inserter(output), L'?');
+            CHECK(output == select(L" _a?"sv, L" _a🐌"sv));
+        }
     }
 }
+
+// NOLINTEND(readability-qualified-auto)


### PR DESCRIPTION
## Description

Related to https://github.com/SFML/SFML/issues/3406

In the same spirit as #3418 I basically rewrote all the `sf::Utf` unit tests originally added in #3328. When I first wrote these tests I did not understand Unicode in general or our specific implementation of `sf::Utf`. I now have much better understanding of what all these functions do and feel confident these tests do a great job capturing the current functionality. 

Along the way I discovered a few things that needed to change. clang-tidy flagged some missing `const`s so I had to add those and I also removed an unnecessary function declaration from Utf.hpp. These two changes are in their own atomic commits so you can clearly see those changes separate from the new tests.

On top of that I elected to add `static_assert`s which check that we're using these functions correctly. For example `sf::Utf8::fromWide` needs to be called with a wide string so I assert that the provided iterators point to somethign the same size as a `wchar_t`. In the future I may make the asserts more strict and assert for specifically `wchar_t` but this is a decent starting point that checks for the most egregious misuses. Turns out the original tests I wrote used the wrong input data and these asserts caught that :) Eventually I would like to add similar `static_assert`s for output iterators types but that's a bit more complicated and will have to wait.

In writing these tests I discovered a bug in `sf::priv::copy` (renamed to `sf::priv::copyBits` to better reflect its new functionality) and wrote a huge comment block explaining why I had to make some unintuitive changes to fix that so I hope that's clear. This bug went unnoticed because until now we were not testing anything with Latin1 strings.

As for shortcomings, I these tests don't really cover error case behavior. Those tests probably ought to be added but I thought it was out of scope for this PR. I also skipped doing anything with locales. Certain functions have default `std::locale` parameters. I never provided non-default values so that's something to potentially do in the future. The last major shortcoming is due to MinGW. It produces different result when converting characters than all other compilers which limits what strings we can test. This is why there are no Latin1 characters in our tests for example. ASCII and Emoji work fine but things like `é` or Polish `ń` (outside of Latin1) don't get converted the same way as other compilers. I don't know why this is the case. Perhaps we can fix this with careful locale manipulation but I'm really not sure. MinGW just continues to be a thorn in my side.

---

These tests provide more great groundwork for future Unicode work. These tests don't go too far towards testing error cases but I wager there are some edge case bugs to be found as we dig deeper. I also suspect now that we have these tests I may want to clean up the implementation of `sf::Utf` a bit. 