### PR TITLE
Revert to no -s suffix for sfml-main

### DIFF
--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -15,6 +15,13 @@ endif()
 # define the sfml-main target
 sfml_add_library(Main STATIC SOURCES ${SRC})
 
+# don't use -s suffix for sfml-main
+set_target_properties(sfml-main PROPERTIES
+                      DEBUG_POSTFIX -d
+                      RELEASE_POSTFIX ""
+                      MINSIZEREL_POSTFIX ""
+                      RELWITHDEBINFO_POSTFIX "")
+
 if(SFML_OS_ANDROID)
     # ensure that linking into shared libraries doesn't fail
     set_target_properties(sfml-main PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
## Description

In #2787 we removed this override as it mentioned compatibility with FindSFML.cmake this however now also changed in the way that `sfml-main` will generate a `sfml-main-s` and `sfml-main-s-d` variant, instead of the previous `sfml-main` and `sfml-main-d`. As `sfml-main` is always a static library, I'm not sure if it makes sense to mark it with the `-s` suffix.

Note, that if want to keep this behavior, we'd have to revert #3346, as I assumed we didn't use the `-s` suffix for `sfml-main`.

## How to test this PR?

Build SFML on Windows and check the create library names.