### PR TITLE
Add catch2 argument to break into debugger when tests fail

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -385,8 +385,14 @@ function(sfml_add_test target SOURCES DEPENDS)
     # set the target flags to use the appropriate C++ standard library
     sfml_set_stdlib(${target})
 
-    # set the Visual Studio startup path for debugging
-    set_target_properties(${target} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    set_target_properties(${target} PROPERTIES 
+    
+        VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} # set the Visual Studio startup path for debugging
+        VS_DEBUGGER_COMMAND_ARGUMENTS "-b" # Break into debugger
+
+        XCODE_GENERATE_SCHEME ON # Required to set arguments
+        XCODE_SCHEME_ARGUMENTS "-b" # Break into debugger
+    )
 
     # link the target to its SFML dependencies
     target_link_libraries(${target} PRIVATE ${DEPENDS} sfml-test-main)

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -386,7 +386,6 @@ function(sfml_add_test target SOURCES DEPENDS)
     sfml_set_stdlib(${target})
 
     set_target_properties(${target} PROPERTIES 
-    
         VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} # set the Visual Studio startup path for debugging
         VS_DEBUGGER_COMMAND_ARGUMENTS "-b" # Break into debugger
 


### PR DESCRIPTION
Makes debugging test failures a lot easier using Xcode or Visual studio