### PR TITLE
Fix using Emoji with `sf::Clipboard`

### DIFF
--- a/test/Window/Clipboard.test.cpp
+++ b/test/Window/Clipboard.test.cpp
@@ -12,11 +12,31 @@ TEST_CASE("[Window] sf::Clipboard", runDisplayTests())
     // Capture current clipboard state
     const auto currentClipboard = sf::Clipboard::getString();
 
-    SECTION("Set/get string")
+    sf::String string;
+
+    SECTION("ASCII")
     {
-        sf::Clipboard::setString("Welcome to SFML!");
-        CHECK(sf::Clipboard::getString() == "Welcome to SFML!");
+        string = "Snail";
     }
+
+    SECTION("Latin1")
+    {
+        string = U"Limacé";
+    }
+
+    SECTION("Basic Multilingual Plane")
+    {
+        string = U"カタツムリ";
+    }
+
+    SECTION("Emoji")
+    {
+        string = U"🐌";
+    }
+
+    INFO("String: " << reinterpret_cast<const char*>(string.toUtf8().c_str()));
+    sf::Clipboard::setString(string);
+    CHECK(sf::Clipboard::getString() == string);
 
     // Restore clipboard
     sf::Clipboard::setString(currentClipboard);


### PR DESCRIPTION
## Description

Related to https://github.com/SFML/SFML/issues/3406

I was able to fix using Emoji with the Windows clipboard by switching from a wide string to a UTF-16 string. This makes sense because wide strings are UCS-2 on Windows which is a fixed-width encoding, not able to encode Emoji.