### PR TITLE
iOS fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,11 @@ jobs:
             arch: arm64-v8a
             api: 33
           type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_FATAL_OPENGL_ERRORS=ON }
+        exclude: # Shared libraries are not supported on iOS
+        - platform: { name: iOS }
+          config: { name: Shared }
+        - platform: { name: iOS Xcode }
+          config: { name: Shared }
 
 
     steps:

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -383,7 +383,7 @@ function(sfml_add_test target SOURCES DEPENDS)
     source_group("" FILES ${SOURCES})
 
     # create the target
-    add_executable(${target} ${SOURCES})
+    add_executable(${target} ${SOURCES} ${PROJECT_SOURCE_DIR}/test/main.cpp)
 
     # enable precompiled headers
     if (SFML_ENABLE_PCH)

--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -28,4 +28,6 @@ if(SFML_OS_ANDROID)
 
     # glad sources
     target_include_directories(sfml-main SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/glad/include")
+elseif(SFML_OS_IOS)
+    target_link_libraries(sfml-main PUBLIC SFML::Window)
 endif()

--- a/src/SFML/Main/MainiOS.mm
+++ b/src/SFML/Main/MainiOS.mm
@@ -43,17 +43,19 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Config.hpp>
 
+#include <SFML/Window/iOS/SFAppDelegate.hpp>
+
 #include <UIKit/UIKit.h>
 
 
 ////////////////////////////////////////////////////////////
 int main(int argc, char** argv)
 {
-    // Note: we intentionally drop command line arguments,
-    // there's no such thing as a command line on an iOS device :)
-
-    // Important: "SFAppDelegate" must always match the name of the
-    // application delegate class defined in sfml-window
-
-    return UIApplicationMain(argc, argv, nil, @"SFAppDelegate");
+    NSString* appDelegateClassName = {};
+    @autoreleasepool
+    {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([SFAppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
 }

--- a/src/SFML/Window/iOS/SFAppDelegate.mm
+++ b/src/SFML/Window/iOS/SFAppDelegate.mm
@@ -28,7 +28,12 @@
 #include <SFML/Window/iOS/SFAppDelegate.hpp>
 #include <SFML/Window/iOS/SFMain.hpp>
 
+#import <TargetConditionals.h>
 #include <vector>
+
+#if TARGET_IPHONE_SIMULATOR
+#include <crt_externs.h>
+#endif
 
 
 namespace
@@ -69,8 +74,11 @@ std::vector<sf::Vector2i> touchPositions;
 ////////////////////////////////////////////////////////////
 - (void)runUserMain
 {
-    // Arguments intentionally dropped, see comments in main in sfml-main
+#if TARGET_IPHONE_SIMULATOR
+    sfmlMain(*_NSGetArgc(), *_NSGetArgv());
+#else
     sfmlMain(0, nullptr);
+#endif
 }
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,15 @@ add_library(sfml-test-main STATIC
     TestUtilities/AudioUtil.cpp
 )
 target_include_directories(sfml-test-main PUBLIC TestUtilities)
-target_link_libraries(sfml-test-main PUBLIC SFML::System Catch2::Catch2WithMain)
+target_link_libraries(sfml-test-main PUBLIC SFML::System)
+
+# Main is required on some platforms and is completely removed on others, so we can only depend on it when it exists
+if(TARGET SFML::Main)
+    target_link_libraries(sfml-test-main PUBLIC SFML::Main Catch2::Catch2)
+else()
+    target_link_libraries(sfml-test-main PUBLIC Catch2::Catch2WithMain)
+endif()
+
 set_target_warnings(sfml-test-main)
 
 # set the target flags to use the appropriate C++ standard library
@@ -73,21 +81,40 @@ target_compile_definitions(test-sfml-system PRIVATE
     EXPECTED_SFML_VERSION_IS_RELEASE=$<IF:$<BOOL:${VERSION_IS_RELEASE}>,true,false>
 )
 
+if(XCODE AND SFML_OS_IOS)
+    set(SYSTEM_RESOURCE 
+        System/test.txt
+        System/test2.txt
+        System/test-ń.txt
+        System/test-🐌.txt
+    )
+    target_sources(test-sfml-system PRIVATE ${SYSTEM_RESOURCE})
+    set_source_files_properties(${SYSTEM_RESOURCE} PROPERTIES MACOSX_PACKAGE_LOCATION "System")
+endif()
+
 set(WINDOW_SRC
     Window/Clipboard.test.cpp
     Window/Context.test.cpp
     Window/ContextSettings.test.cpp
-    Window/Cursor.test.cpp
     Window/Event.test.cpp
     Window/GlResource.test.cpp
     Window/Joystick.test.cpp
-    Window/Keyboard.test.cpp
     Window/Mouse.test.cpp
     Window/VideoMode.test.cpp
-    Window/Vulkan.test.cpp
-    Window/Window.test.cpp
-    Window/WindowBase.test.cpp
 )
+
+if(NOT SFML_OS_IOS)
+    list(APPEND WINDOW_SRC
+        # These modules aren't supported/relevant for iOS
+        Window/Cursor.test.cpp
+        Window/Keyboard.test.cpp
+        Window/Vulkan.test.cpp
+
+        # At the time of writing these tests all pass except the window size ones
+        Window/Window.test.cpp
+        Window/WindowBase.test.cpp
+    )
+endif()
 sfml_add_test(test-sfml-window "${WINDOW_SRC}" SFML::Window)
 
 set(GRAPHICS_SRC
@@ -131,6 +158,27 @@ if(SFML_RUN_DISPLAY_TESTS)
     target_compile_definitions(test-sfml-graphics PRIVATE SFML_RUN_DISPLAY_TESTS)
 endif()
 
+if (XCODE AND SFML_OS_IOS)
+    set(GRAPHICS_RESOURCES
+        Graphics/invalid_shader.vert
+        Graphics/sfml-logo-big.bmp
+        Graphics/sfml-logo-big.gif
+        Graphics/sfml-logo-big.jpg
+        Graphics/sfml-logo-big.png
+        Graphics/sfml-logo-big.psd
+        Graphics/shader-🐌.vert
+        Graphics/shader-ń.vert
+        Graphics/shader.frag
+        Graphics/shader.geom
+        Graphics/shader.vert
+        Graphics/tuffy-🐌.ttf
+        Graphics/tuffy-ń.ttf
+        Graphics/tuffy.ttf
+    )
+    target_sources(test-sfml-graphics PRIVATE ${GRAPHICS_RESOURCES})
+    set_source_files_properties(${GRAPHICS_RESOURCES} MACOSX_PACKAGE_LOCATION "Graphics")
+endif()
+
 set(NETWORK_SRC
     Network/Ftp.test.cpp
     Network/Http.test.cpp
@@ -161,6 +209,25 @@ set(AUDIO_SRC
     Audio/SoundStream.test.cpp
 )
 sfml_add_test(test-sfml-audio "${AUDIO_SRC}" SFML::Audio)
+
+if(SFML_OS_IOS)
+    set(AUDIO_RESOURCE
+        Audio/ding-🐌.flac
+        Audio/ding-🐌.mp3
+        Audio/ding-ń.flac
+        Audio/ding-ń.mp3
+        Audio/ding.flac
+        Audio/ding.mp3
+        Audio/doodle_pop-🐌.ogg
+        Audio/doodle_pop-ń.ogg
+        Audio/doodle_pop.ogg
+        Audio/killdeer-🐌.wav
+        Audio/killdeer-ń.wav
+        Audio/killdeer.wav
+    )
+    target_sources(test-sfml-audio PRIVATE ${AUDIO_RESOURCE})
+    set_source_files_properties(${AUDIO_RESOURCE} PROPERTIES MACOSX_PACKAGE_LOCATION "Audio")
+endif()
 
 if(SFML_OS_ANDROID AND DEFINED ENV{LIBCXX_SHARED_SO})
     # Because we can only write to the tmp directory on the Android virtual device we will need to build our directory tree under it

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,9 @@
+#include <catch2/catch_session.hpp>
+
+#include <SFML/Main.hpp>
+
+////////////////////////////////////////////////////////////
+int main(int argc, char** argv)
+{
+    return Catch::Session().run(argc, argv);
+}


### PR DESCRIPTION
Been a while since I've properly looked at iOS bits so there's a few things accumulated:
- Removed the CI tests for shared libraries on iOS as they [aren't supported by apple](https://developer.apple.com/library/archive/technotes/tn2435/_index.html#//apple_ref/doc/uid/DTS40017543-CH1-TROUBLESHOOTING-BUNDLE_ERRORS)
- SFML main module depends on SFML window and requires a fix to make sure the delegate is loaded correctly
- We need to use the main module to run the tests
- We *can* use command line arguments for iOS builds under some circumstances (debugging mostly)
- We need to add the test resources to the bundle
- Cursor, Keyboard and Vulkan test source files are excluded as not supported on iOS
- ~~Test validating the window size is set correctly excluded by preprocessor as on iOS it always returns display size~~ Now just excluded all windows tests as requested