### PR TITLE
Fix using Emoji in Windows window titles

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -213,7 +213,7 @@ m_cursorGrabbed(m_fullscreen)
 
     // Create the window
     m_handle = CreateWindowW(className,
-                             title.toWideString().c_str(),
+                             reinterpret_cast<const wchar_t*>(title.toUtf16().c_str()),
                              win32Style,
                              left,
                              top,
@@ -358,7 +358,7 @@ void WindowImplWin32::setSize(Vector2u size)
 ////////////////////////////////////////////////////////////
 void WindowImplWin32::setTitle(const String& title)
 {
-    SetWindowTextW(m_handle, title.toWideString().c_str());
+    SetWindowTextW(m_handle, reinterpret_cast<const wchar_t*>(title.toUtf16().c_str()));
 }
 
 


### PR DESCRIPTION
## Description

Related to #3406 

Just like #3435, the fix is to use UTF-16 instead of UCS-2 which is what wide strings current encode. Perhaps we should change `sf::String::toWideString` to return a Unicode string instead. Windows is already treating a `wchar_t[]` as being UTF-16 so I think it would be worth doing.

I have manually tested that Emoji titles work on macOS and Linux. I do need someone to help me test on Windows though.

EDIT: FRex has confirmed this PR fixes the bug on Windows 👍🏻