### PR TITLE
Fix unsigned overflow in sf::Packet size check

### DIFF
--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -571,6 +571,8 @@ Packet& Packet::operator<<(const String& data)
 ////////////////////////////////////////////////////////////
 bool Packet::checkSize(std::size_t size)
 {
+    // Unsigned overflow is defined behavior
+    m_isValid = m_isValid && !(m_readPos + size < m_readPos);
     m_isValid = m_isValid && (m_readPos + size <= m_data.size());
 
     return m_isValid;

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -571,9 +571,9 @@ Packet& Packet::operator<<(const String& data)
 ////////////////////////////////////////////////////////////
 bool Packet::checkSize(std::size_t size)
 {
-    // Unsigned overflow is defined behavior
-    m_isValid = m_isValid && !(m_readPos + size < m_readPos);
-    m_isValid = m_isValid && (m_readPos + size <= m_data.size());
+    // Determine if size is big enough to trigger an overflow
+    const bool overflowDetected = m_readPos + size < m_readPos;
+    m_isValid = m_isValid && (m_readPos + size <= m_data.size()) && ! overflowDetected
 
     return m_isValid;
 }

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -573,7 +573,7 @@ bool Packet::checkSize(std::size_t size)
 {
     // Determine if size is big enough to trigger an overflow
     const bool overflowDetected = m_readPos + size < m_readPos;
-    m_isValid = m_isValid && (m_readPos + size <= m_data.size()) && ! overflowDetected
+    m_isValid = m_isValid && (m_readPos + size <= m_data.size()) && ! overflowDetected;
 
     return m_isValid;
 }

--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -573,7 +573,7 @@ bool Packet::checkSize(std::size_t size)
 {
     // Determine if size is big enough to trigger an overflow
     const bool overflowDetected = m_readPos + size < m_readPos;
-    m_isValid = m_isValid && (m_readPos + size <= m_data.size()) && ! overflowDetected;
+    m_isValid                   = m_isValid && (m_readPos + size <= m_data.size()) && !overflowDetected;
 
     return m_isValid;
 }

--- a/test/Network/Packet.test.cpp
+++ b/test/Network/Packet.test.cpp
@@ -288,4 +288,20 @@ TEST_CASE("[Network] sf::Packet")
         CHECK(packet.getData() != nullptr);
         CHECK(packet.getDataSize() == data.size());
     }
+
+    SECTION("Attempt overflow")
+    {
+        static constexpr struct
+        {
+            std::uint32_t       length{std::numeric_limits<decltype(length)>::max()};
+            std::array<char, 4> data{{'S', 'F', 'M', 'L'}};
+        } string;
+
+        sf::Packet packet;
+        packet.append(&string, sizeof(string));
+
+        std::string out;
+        packet >> out; // Ensure this does not trigger a crash
+        CHECK(out.empty());
+    }
 }


### PR DESCRIPTION
## Description

This PR fixes the issue described in #3433.

## Tasks

-   [X] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

```cpp
#include <iostream>
#include <cstdlib>
#include <cstdint>

#include <SFML/Network/Packet.hpp>

struct serial_str {
	uint32_t length;
	char data[2];
};

int main(void)
{
	serial_str str;
	str.length = 0xffffffff;
	str.data[0] = 'h';
	str.data[1] = 'i';

	sf::Packet packet;
	packet.append(&str, sizeof(str));

	std::string out;
	packet >> out;

	std::cout << out << std::endl;

	return EXIT_SUCCESS;
}
```
This code, which emulates a received crafted packet from the network, would previously crash when compiled in 32-bit mode. This is now fixed, the library no longer crashes and the packet is marked as invalid.