### PR TITLE
Use digit separators for large constants or hexadecimal doublets

### DIFF
--- a/examples/ftp/Ftp.cpp
+++ b/examples/ftp/Ftp.cpp
@@ -87,7 +87,7 @@ int main()
                 // Wrong choice
                 std::cout << "Invalid choice!" << std::endl;
                 std::cin.clear();
-                std::cin.ignore(10000, '\n');
+                std::cin.ignore(10'000, '\n');
                 break;
             }
 
@@ -203,6 +203,6 @@ int main()
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;
-    std::cin.ignore(10000, '\n');
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
+    std::cin.ignore(10'000, '\n');
 }

--- a/examples/shader/Shader.cpp
+++ b/examples/shader/Shader.cpp
@@ -141,7 +141,7 @@ public:
         // Create the points
         m_points.setPrimitiveType(sf::PrimitiveType::Points);
 
-        for (int i = 0; i < 40000; ++i)
+        for (int i = 0; i < 40'000; ++i)
         {
             const auto x = xDistribution(rng);
             const auto y = yDistribution(rng);
@@ -254,10 +254,10 @@ public:
     explicit Geometry(sf::Texture&& logoTexture, sf::Shader&& shader) :
     m_logoTexture(std::move(logoTexture)),
     m_shader(std::move(shader)),
-    m_pointCloud(sf::PrimitiveType::Points, 10000)
+    m_pointCloud(sf::PrimitiveType::Points, 10'000)
     {
         // Move the points in the point cloud to random positions
-        for (std::size_t i = 0; i < 10000; ++i)
+        for (std::size_t i = 0; i < 10'000; ++i)
         {
             // Spread the coordinates from -480 to +480 so they'll always fill the viewport at 800x600
             std::uniform_real_distribution<float> positionDistribution(-480, 480);

--- a/examples/sockets/Sockets.cpp
+++ b/examples/sockets/Sockets.cpp
@@ -47,6 +47,6 @@ int main()
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;
-    std::cin.ignore(10000, '\n');
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
+    std::cin.ignore(10'000, '\n');
 }

--- a/examples/sound/Sound.cpp
+++ b/examples/sound/Sound.cpp
@@ -96,5 +96,5 @@ int main()
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 }

--- a/examples/sound_capture/SoundCapture.cpp
+++ b/examples/sound_capture/SoundCapture.cpp
@@ -43,7 +43,7 @@ int main()
         do
         {
             std::cin >> deviceIndex;
-            std::cin.ignore(10000, '\n');
+            std::cin.ignore(10'000, '\n');
         } while (deviceIndex >= devices.size());
     }
 
@@ -51,11 +51,11 @@ int main()
     unsigned int sampleRate = 0;
     std::cout << "Please choose the sample rate for sound capture (44100 is CD quality): ";
     std::cin >> sampleRate;
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 
     // Wait for user input...
     std::cout << "Press enter to start recording audio";
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 
     // Here we'll use an integrated custom recorder, which saves the captured data into a SoundBuffer
     sf::SoundBufferRecorder recorder;
@@ -74,7 +74,7 @@ int main()
     }
 
     std::cout << "Recording... press enter to stop";
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
     recorder.stop();
 
     // Get the buffer containing the captured data
@@ -90,7 +90,7 @@ int main()
     char choice = 0;
     std::cout << "What do you want to do with captured sound (p = play, s = save) ? ";
     std::cin >> choice;
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 
     if (choice == 's')
     {
@@ -126,5 +126,5 @@ int main()
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 }

--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -133,9 +133,9 @@ void doClient(unsigned short port)
     NetworkRecorder recorder(server.value(), port);
 
     // Wait for user input...
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
     std::cout << "Press enter to start recording audio";
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 
     // Start capturing audio data
     if (!recorder.start(44100))
@@ -145,6 +145,6 @@ void doClient(unsigned short port)
     }
 
     std::cout << "Recording... press enter to stop";
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
     recorder.stop();
 }

--- a/examples/voip/Server.cpp
+++ b/examples/voip/Server.cpp
@@ -187,11 +187,11 @@ void doServer(unsigned short port)
         sf::sleep(sf::milliseconds(100));
     }
 
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to replay the sound..." << std::endl;
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 
     // Replay the sound (just to make sure replaying the received data is OK)
     audioStream.play();

--- a/examples/voip/VoIP.cpp
+++ b/examples/voip/VoIP.cpp
@@ -36,5 +36,5 @@ int main()
 
     // Wait until the user presses 'enter' key
     std::cout << "Press enter to exit..." << std::endl;
-    std::cin.ignore(10000, '\n');
+    std::cin.ignore(10'000, '\n');
 }

--- a/include/SFML/Graphics/Color.inl
+++ b/include/SFML/Graphics/Color.inl
@@ -42,10 +42,10 @@ a(alpha)
 
 ////////////////////////////////////////////////////////////
 constexpr Color::Color(std::uint32_t color) :
-r(static_cast<std::uint8_t>((color & 0xff000000) >> 24)),
-g(static_cast<std::uint8_t>((color & 0x00ff0000) >> 16)),
-b(static_cast<std::uint8_t>((color & 0x0000ff00) >> 8)),
-a(static_cast<std::uint8_t>(color & 0x000000ff))
+r(static_cast<std::uint8_t>((color & 0xff'00'00'00) >> 24)),
+g(static_cast<std::uint8_t>((color & 0x00'ff'00'00) >> 16)),
+b(static_cast<std::uint8_t>((color & 0x00'00'ff'00) >> 8)),
+a(static_cast<std::uint8_t>((color & 0x00'00'00'ff) >> 0))
 {
 }
 

--- a/include/SFML/System/Time.hpp
+++ b/include/SFML/System/Time.hpp
@@ -477,13 +477,13 @@ constexpr Time& operator%=(Time& left, Time right);
 /// std::int32_t milli = t1.asMilliseconds(); // 100
 ///
 /// sf::Time t2 = sf::milliseconds(30);
-/// std::int64_t micro = t2.asMicroseconds(); // 30000
+/// std::int64_t micro = t2.asMicroseconds(); // 30'000
 ///
-/// sf::Time t3 = sf::microseconds(-800000);
+/// sf::Time t3 = sf::microseconds(-800'000);
 /// float sec = t3.asSeconds(); // -0.8
 ///
 /// sf::Time t4 = std::chrono::milliseconds(250);
-/// std::chrono::microseconds micro2 = t4.toDuration(); // 250000us
+/// std::chrono::microseconds micro2 = t4.toDuration(); // 250'000us
 /// \endcode
 ///
 /// \code

--- a/src/SFML/Audio/Music.cpp
+++ b/src/SFML/Audio/Music.cpp
@@ -317,9 +317,10 @@ std::uint64_t Music::timeToSamples(Time position) const
 {
     // Always ROUND, no unchecked truncation, hence the addition in the numerator.
     // This avoids most precision errors arising from "samples => Time => samples" conversions
-    // Original rounding calculation is ((Micros * Freq * Channels) / 1000000) + 0.5
+    // Original rounding calculation is ((Micros * Freq * Channels) / 1'000'000) + 0.5
     // We refactor it to keep std::int64_t as the data type throughout the whole operation.
-    return ((static_cast<std::uint64_t>(position.asMicroseconds()) * getSampleRate() * getChannelCount()) + 500000) / 1000000;
+    return ((static_cast<std::uint64_t>(position.asMicroseconds()) * getSampleRate() * getChannelCount()) + 500'000) /
+           1'000'000;
 }
 
 
@@ -330,7 +331,7 @@ Time Music::samplesToTime(std::uint64_t samples) const
 
     // Make sure we don't divide by 0
     if (getSampleRate() != 0 && getChannelCount() != 0)
-        position = microseconds(static_cast<std::int64_t>((samples * 1000000) / (getChannelCount() * getSampleRate())));
+        position = microseconds(static_cast<std::int64_t>((samples * 1'000'000) / (getChannelCount() * getSampleRate())));
 
     return position;
 }

--- a/src/SFML/Audio/SoundFileWriterFlac.cpp
+++ b/src/SFML/Audio/SoundFileWriterFlac.cpp
@@ -166,7 +166,7 @@ void SoundFileWriterFlac::write(const std::int16_t* samples, std::uint64_t count
     while (count > 0)
     {
         // Make sure that we don't process too many samples at once
-        const unsigned int frames = std::min(static_cast<unsigned int>(count / m_channelCount), 10000u);
+        const unsigned int frames = std::min(static_cast<unsigned int>(count / m_channelCount), 10'000u);
 
         // Convert the samples to 32-bits and remap the channels
         m_samples32.clear();

--- a/src/SFML/Audio/SoundFileWriterWav.cpp
+++ b/src/SFML/Audio/SoundFileWriterWav.cpp
@@ -59,10 +59,10 @@ void encode(std::ostream& stream, std::uint16_t value)
 void encode(std::ostream& stream, std::uint32_t value)
 {
     const std::array bytes = {
-        static_cast<char>(value & 0x000000FF),
-        static_cast<char>((value & 0x0000FF00) >> 8),
-        static_cast<char>((value & 0x00FF0000) >> 16),
-        static_cast<char>((value & 0xFF000000) >> 24),
+        static_cast<char>((value & 0x00'00'00'FF) >> 0),
+        static_cast<char>((value & 0x00'00'FF'00) >> 8),
+        static_cast<char>((value & 0x00'FF'00'00) >> 16),
+        static_cast<char>((value & 0xFF'00'00'00) >> 24),
     };
     stream.write(bytes.data(), bytes.size());
 }

--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -172,8 +172,8 @@ bool SocketSelector::wait(Time timeout)
 {
     // Setup the timeout
     timeval time{};
-    time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1000000);
-    time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1000000);
+    time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1'000'000);
+    time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1'000'000);
 
     // Initialize the set that will contain the sockets that are ready
     m_impl->socketsReady = m_impl->allSockets;

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -176,8 +176,8 @@ Socket::Status TcpSocket::connect(IpAddress remoteAddress, unsigned short remote
 
         // Setup the timeout
         timeval time{};
-        time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1000000);
-        time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1000000);
+        time.tv_sec  = static_cast<long>(timeout.asMicroseconds() / 1'000'000);
+        time.tv_usec = static_cast<int>(timeout.asMicroseconds() % 1'000'000);
 
         // Wait for something to write on our socket (which means that the connection request has returned)
         if (select(static_cast<int>(getNativeHandle() + 1), nullptr, &selector, nullptr, &time) > 0)

--- a/src/SFML/System/Unix/SleepImpl.cpp
+++ b/src/SFML/System/Unix/SleepImpl.cpp
@@ -41,8 +41,8 @@ void sleepImpl(Time time)
 
     // Construct the time to wait
     timespec ti{};
-    ti.tv_sec  = static_cast<time_t>(usecs / 1000000);
-    ti.tv_nsec = static_cast<long>((usecs % 1000000) * 1000);
+    ti.tv_sec  = static_cast<time_t>(usecs / 1'000'000);
+    ti.tv_nsec = static_cast<long>((usecs % 1'000'000) * 1'000);
 
     // Wait...
     // If nanosleep returns -1, we check errno. If it is EINTR

--- a/src/SFML/Window/GlContext.cpp
+++ b/src/SFML/Window/GlContext.cpp
@@ -814,21 +814,21 @@ int GlContext::evaluateFormat(
     int antiAliasingDiff = static_cast<int>(settings.antiAliasingLevel) - antiAliasing;
 
     // Weight sub-scores so that better settings don't score equally as bad as worse settings
-    colorDiff *= ((colorDiff > 0) ? 100000 : 1);
-    depthDiff *= ((depthDiff > 0) ? 100000 : 1);
-    stencilDiff *= ((stencilDiff > 0) ? 100000 : 1);
-    antiAliasingDiff *= ((antiAliasingDiff > 0) ? 100000 : 1);
+    colorDiff *= ((colorDiff > 0) ? 100'000 : 1);
+    depthDiff *= ((depthDiff > 0) ? 100'000 : 1);
+    stencilDiff *= ((stencilDiff > 0) ? 100'000 : 1);
+    antiAliasingDiff *= ((antiAliasingDiff > 0) ? 100'000 : 1);
 
     // Aggregate the scores
     int score = std::abs(colorDiff) + std::abs(depthDiff) + std::abs(stencilDiff) + std::abs(antiAliasingDiff);
 
     // If the user wants an sRGB capable format, try really hard to get one
     if (settings.sRgbCapable && !sRgb)
-        score += 10000000;
+        score += 10'000'000;
 
     // Make sure we prefer hardware acceleration over features
     if (!accelerated)
-        score += 100000000;
+        score += 100'000'000;
 
     return score;
 }

--- a/src/SFML/Window/Win32/CursorImpl.cpp
+++ b/src/SFML/Window/Win32/CursorImpl.cpp
@@ -57,10 +57,10 @@ bool CursorImpl::loadFromPixels(const std::uint8_t* pixels, Vector2u size, Vecto
     bitmapHeader.bV5Planes      = 1;
     bitmapHeader.bV5BitCount    = 32;
     bitmapHeader.bV5Compression = BI_BITFIELDS;
-    bitmapHeader.bV5RedMask     = 0x00ff0000;
-    bitmapHeader.bV5GreenMask   = 0x0000ff00;
-    bitmapHeader.bV5BlueMask    = 0x000000ff;
-    bitmapHeader.bV5AlphaMask   = 0xff000000;
+    bitmapHeader.bV5RedMask     = 0x00'ff'00'00;
+    bitmapHeader.bV5GreenMask   = 0x00'00'ff'00;
+    bitmapHeader.bV5BlueMask    = 0x00'00'00'ff;
+    bitmapHeader.bV5AlphaMask   = 0xff'00'00'00;
 
     std::uint32_t* bitmapData = nullptr;
 

--- a/test/Graphics/Color.test.cpp
+++ b/test/Graphics/Color.test.cpp
@@ -48,17 +48,17 @@ TEST_CASE("[Graphics] sf::Color")
 
         SECTION("std::int32_t constructor")
         {
-            STATIC_CHECK(sf::Color(0x00000000) == sf::Color(0, 0, 0, 0));
-            STATIC_CHECK(sf::Color(0x01020304) == sf::Color(1, 2, 3, 4));
-            STATIC_CHECK(sf::Color(0xFFFFFFFF) == sf::Color(255, 255, 255, 255));
+            STATIC_CHECK(sf::Color(0x00'00'00'00) == sf::Color(0, 0, 0, 0));
+            STATIC_CHECK(sf::Color(0x01'02'03'04) == sf::Color(1, 2, 3, 4));
+            STATIC_CHECK(sf::Color(0xFF'FF'FF'FF) == sf::Color(255, 255, 255, 255));
         }
     }
 
     SECTION("toInteger()")
     {
-        STATIC_CHECK(sf::Color(0, 0, 0, 0).toInteger() == 0x00000000);
-        STATIC_CHECK(sf::Color(1, 2, 3, 4).toInteger() == 0x01020304);
-        STATIC_CHECK(sf::Color(255, 255, 255, 255).toInteger() == 0xFFFFFFFF);
+        STATIC_CHECK(sf::Color(0, 0, 0, 0).toInteger() == 0x00'00'00'00);
+        STATIC_CHECK(sf::Color(1, 2, 3, 4).toInteger() == 0x01'02'03'04);
+        STATIC_CHECK(sf::Color(255, 255, 255, 255).toInteger() == 0xFF'FF'FF'FF);
     }
 
     SECTION("Operations")

--- a/test/Graphics/ConvexShape.test.cpp
+++ b/test/Graphics/ConvexShape.test.cpp
@@ -101,10 +101,10 @@ TEST_CASE("[Graphics] sf::ConvexShape")
     SECTION("Geometric center for three points with a small area")
     {
         sf::ConvexShape convex(3);
-        convex.setPoint(0, {-100000.f, 0.f});
-        convex.setPoint(1, {100000.f, 0.f});
-        convex.setPoint(2, {100000.f, 0.000001f});
-        CHECK(convex.getGeometricCenter().x == Catch::Approx(100000. / 3.).margin(1e-2));
+        convex.setPoint(0, {-100'000.f, 0.f});
+        convex.setPoint(1, {100'000.f, 0.f});
+        convex.setPoint(2, {100'000.f, 0.000001f});
+        CHECK(convex.getGeometricCenter().x == Catch::Approx(100'000. / 3.).margin(1e-2));
         CHECK(convex.getGeometricCenter().y == Catch::Approx(0).margin(1e-5));
     }
 

--- a/test/Network/IpAddress.test.cpp
+++ b/test/Network/IpAddress.test.cpp
@@ -27,7 +27,7 @@ TEST_CASE("[Network] sf::IpAddress")
             const auto ipAddress = sf::IpAddress::resolve("203.0.113.2"sv);
             REQUIRE(ipAddress.has_value());
             CHECK(ipAddress->toString() == "203.0.113.2"s);
-            CHECK(ipAddress->toInteger() == 0xCB007102);
+            CHECK(ipAddress->toInteger() == 0xCB'00'71'02);
             CHECK(*ipAddress != sf::IpAddress::Any);
             CHECK(*ipAddress != sf::IpAddress::Broadcast);
             CHECK(*ipAddress != sf::IpAddress::LocalHost);
@@ -35,19 +35,19 @@ TEST_CASE("[Network] sf::IpAddress")
             const auto broadcast = sf::IpAddress::resolve("255.255.255.255"sv);
             REQUIRE(broadcast.has_value());
             CHECK(broadcast->toString() == "255.255.255.255"s);
-            CHECK(broadcast->toInteger() == 0xFFFFFFFF);
+            CHECK(broadcast->toInteger() == 0xFF'FF'FF'FF);
             CHECK(*broadcast == sf::IpAddress::Broadcast);
 
             const auto any = sf::IpAddress::resolve("0.0.0.0"sv);
             REQUIRE(any.has_value());
             CHECK(any->toString() == "0.0.0.0"s);
-            CHECK(any->toInteger() == 0x00000000);
+            CHECK(any->toInteger() == 0x00'00'00'00);
             CHECK(*any == sf::IpAddress::Any);
 
             const auto localHost = sf::IpAddress::resolve("localhost"s);
             REQUIRE(localHost.has_value());
             CHECK(localHost->toString() == "127.0.0.1"s);
-            CHECK(localHost->toInteger() == 0x7F000001);
+            CHECK(localHost->toInteger() == 0x7F'00'00'01);
             CHECK(*localHost == sf::IpAddress::LocalHost);
 
             CHECK(!sf::IpAddress::resolve("255.255.255.256"s).has_value());
@@ -58,14 +58,14 @@ TEST_CASE("[Network] sf::IpAddress")
         {
             const sf::IpAddress ipAddress(198, 51, 100, 234);
             CHECK(ipAddress.toString() == "198.51.100.234"s);
-            CHECK(ipAddress.toInteger() == 0xC63364EA);
+            CHECK(ipAddress.toInteger() == 0xC6'33'64'EA);
         }
 
         SECTION("std::uint32_t constructor")
         {
-            const sf::IpAddress ipAddress(0xCB00719A);
+            const sf::IpAddress ipAddress(0xCB'00'71'9A);
             CHECK(ipAddress.toString() == "203.0.113.154"s);
-            CHECK(ipAddress.toInteger() == 0xCB00719A);
+            CHECK(ipAddress.toInteger() == 0xCB'00'71'9A);
         }
     }
 
@@ -100,23 +100,23 @@ TEST_CASE("[Network] sf::IpAddress")
         CHECK(sf::IpAddress::Any.toInteger() == 0);
 
         CHECK(sf::IpAddress::LocalHost.toString() == "127.0.0.1"s);
-        CHECK(sf::IpAddress::LocalHost.toInteger() == 0x7F000001);
+        CHECK(sf::IpAddress::LocalHost.toInteger() == 0x7F'00'00'01);
 
         CHECK(sf::IpAddress::Broadcast.toString() == "255.255.255.255"s);
-        CHECK(sf::IpAddress::Broadcast.toInteger() == 0xFFFFFFFF);
+        CHECK(sf::IpAddress::Broadcast.toInteger() == 0xFF'FF'FF'FF);
     }
 
     SECTION("Operators")
     {
         SECTION("operator==")
         {
-            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) == sf::IpAddress(0xC633647B));
-            CHECK(sf::IpAddress(0xCB0071D2) == sf::IpAddress(203, 0, 113, 210));
+            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) == sf::IpAddress(0xC6'33'64'7B));
+            CHECK(sf::IpAddress(0xCB'00'71'D2) == sf::IpAddress(203, 0, 113, 210));
         }
 
         SECTION("operator!=")
         {
-            CHECK(sf::IpAddress(0x12344321) != sf::IpAddress(1234));
+            CHECK(sf::IpAddress(0x12'34'43'21) != sf::IpAddress(1234));
             CHECK(sf::IpAddress(198, 51, 100, 1) != sf::IpAddress(198, 51, 100, 11));
         }
 
@@ -149,8 +149,8 @@ TEST_CASE("[Network] sf::IpAddress")
             CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(0, 0, 1, 0));
             CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(1, 0, 0, 1));
 
-            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) <= sf::IpAddress(0xC633647B));
-            CHECK(sf::IpAddress(0xCB0071D2) <= sf::IpAddress(203, 0, 113, 210));
+            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) <= sf::IpAddress(0xC6'33'64'7B));
+            CHECK(sf::IpAddress(0xCB'00'71'D2) <= sf::IpAddress(203, 0, 113, 210));
         }
 
         SECTION("operator>=")
@@ -162,8 +162,8 @@ TEST_CASE("[Network] sf::IpAddress")
             CHECK(sf::IpAddress(0, 0, 1, 0) >= sf::IpAddress(0, 0, 0, 1));
             CHECK(sf::IpAddress(1, 0, 0, 1) >= sf::IpAddress(0, 0, 0, 1));
 
-            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) >= sf::IpAddress(0xC633647B));
-            CHECK(sf::IpAddress(0xCB0071D2) >= sf::IpAddress(203, 0, 113, 210));
+            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) >= sf::IpAddress(0xC6'33'64'7B));
+            CHECK(sf::IpAddress(0xCB'00'71'D2) >= sf::IpAddress(203, 0, 113, 210));
         }
 
         SECTION("operator>>")
@@ -172,12 +172,12 @@ TEST_CASE("[Network] sf::IpAddress")
             std::istringstream("198.51.100.4") >> ipAddress;
             REQUIRE(ipAddress.has_value());
             CHECK(ipAddress->toString() == "198.51.100.4"s);
-            CHECK(ipAddress->toInteger() == 0xC6336404);
+            CHECK(ipAddress->toInteger() == 0xC6'33'64'04);
 
             std::istringstream("203.0.113.72") >> ipAddress;
             REQUIRE(ipAddress.has_value());
             CHECK(ipAddress->toString() == "203.0.113.72"s);
-            CHECK(ipAddress->toInteger() == 0xCB007148);
+            CHECK(ipAddress->toInteger() == 0xCB'00'71'48);
 
             std::istringstream("") >> ipAddress;
             CHECK(!ipAddress.has_value());


### PR DESCRIPTION
I have applied C++14 digit separators to large integral constants (over 10000) and to hexadecimal constants where the doublets are significant (e.g. colors or IPv4 addresses).

I think this improves readability quite a bit, especially in places where large microsecond constants are used (it's quite easy to accidentally read one million as 100'000).