### PR TITLE
Add the clang-tidy folder as hint for finding run-clang-tidy

### DIFF
--- a/cmake/Tidy.cmake
+++ b/cmake/Tidy.cmake
@@ -22,7 +22,8 @@ endif()
 # Find Python and run-clang-tidy script
 find_package(Python 3 REQUIRED)
 
-find_program(RUN_CLANG_TIDY run-clang-tidy)
+get_filename_component(CLANG_TIDY_DIR ${CLANG_TIDY_EXECUTABLE} DIRECTORY)
+find_program(RUN_CLANG_TIDY run-clang-tidy HINTS ${CLANG_TIDY_DIR})
 if(NOT RUN_CLANG_TIDY)
     message(FATAL_ERROR "Failed to find run-clang-tidy script")
 endif()


### PR DESCRIPTION
I did not have clang-tidy in my path, but passed it manually.
This helps find the `run-clang-tidy` script in those cases.