### PR TITLE
Add extra testcases showing that some Win32-window styles are not taken into account

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -579,9 +579,13 @@ void WindowImplWin32::grabCursor(bool grabbed)
 ////////////////////////////////////////////////////////////
 Vector2i WindowImplWin32::contentSizeToWindowSize(Vector2u size)
 {
-    // SetWindowPos wants the total size of the window (including title bar and borders) so we have to compute it
+    // SetWindowPos wants the total size of the window (including title bar, borders, and menu) so we have to compute it
+    const auto style   = static_cast<DWORD>(GetWindowLongPtr(m_handle, GWL_STYLE));
+    const BOOL hasMenu = ((style & WS_CHILD) == 0) && GetMenu(m_handle) != nullptr;
+    const auto exStyle = static_cast<DWORD>(GetWindowLongPtr(m_handle, GWL_EXSTYLE));
+
     RECT rectangle = {0, 0, static_cast<long>(size.x), static_cast<long>(size.y)};
-    AdjustWindowRect(&rectangle, static_cast<DWORD>(GetWindowLongPtr(m_handle, GWL_STYLE)), false);
+    AdjustWindowRectEx(&rectangle, style, hasMenu, exStyle);
     const auto width  = rectangle.right - rectangle.left;
     const auto height = rectangle.bottom - rectangle.top;
 


### PR DESCRIPTION
This builds upon the tests from #3444 .

Currently there are a few failures, because both a Windows' 'ex-' style is not taken into account,
and the possibility that the Window can have a menu bar is not taken into account.

Current test output:
```
Randomness seeded to: 4046885590
Failed to open the Win32 clipboard: Access is denied.
Failed to create cursor from pixels (invalid arguments)
Failed to create cursor from pixels (invalid arguments)
Failed to create cursor from pixels (invalid arguments)

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test-sfml-window.exe is a Catch2 v3.8.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - NormalMenuWindow
  sf::WindowBase
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(131)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(156): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(157): FAILED:
  CHECK( windowBase->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - NormalMenuWindow
  sf::WindowBase
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(131)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(156): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(157): FAILED:
  CHECK( windowBase->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - NormalMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - NormalMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - NormalMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - NormalMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleWindow
  sf::WindowBase
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(131)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(156): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(157): FAILED:
  CHECK( windowBase->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleWindow
  sf::WindowBase
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(131)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(156): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(157): FAILED:
  CHECK( windowBase->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleMenuWindow
  sf::WindowBase
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(131)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(156): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(157): FAILED:
  CHECK( windowBase->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleMenuWindow
  sf::WindowBase
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(131)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(156): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(157): FAILED:
  CHECK( windowBase->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

-------------------------------------------------------------------------------
[Window] sf::WindowHandle (Win32) - ExStyleMenuWindow
  sf::Window
-------------------------------------------------------------------------------
D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(160)
...............................................................................

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(209): FAILED:
  CHECK( size == newSize )
with expansion:
  {?} == {?}

D:\src\sfml\SFML\test\Window\WindowHandleWin32.test.cpp(210): FAILED:
  CHECK( window->getSize() == size )
with expansion:
  {?} == {?}

===============================================================================
test cases:   16 |   13 passed |  3 failed as expected
assertions: 1338 | 1302 passed | 36 failed as expected

```


