### PR TITLE
Install pkgconfig only if module is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,14 +227,14 @@ if(SFML_INSTALL_PKGCONFIG_FILES)
 
     sfml_set_option(SFML_PKGCONFIG_INSTALL_DIR "${SFML_PKGCONFIG_DIR}" PATH "Install directory for SFML's pkg-config .pc files")
 
-    foreach(sfml_module IN ITEMS all system window graphics audio network)
+    if(SFML_BUILD_AUDIO AND SFML_BUILD_NETWORK AND SFML_BUILD_GRAPHICS AND SFML_BUILD_WINDOW)
         configure_file(
-            "tools/pkg-config/sfml-${sfml_module}.pc.in"
-            "tools/pkg-config/sfml-${sfml_module}.pc"
+            "tools/pkg-config/sfml-all.pc.in"
+            "tools/pkg-config/sfml-all.pc"
             @ONLY)
-        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tools/pkg-config/sfml-${sfml_module}.pc"
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tools/pkg-config/sfml-all.pc"
             DESTINATION "${SFML_PKGCONFIG_INSTALL_DIR}")
-    endforeach()
+    endif()
 endif()
 
 # option to enable precompiled headers

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -237,6 +237,16 @@ macro(sfml_add_library module)
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel
             FRAMEWORK DESTINATION "." COMPONENT bin)
 
+    # install pkgconfig
+    if(SFML_INSTALL_PKGCONFIG_FILES)
+        configure_file(
+            "${PROJECT_SOURCE_DIR}/tools/pkg-config/${target}.pc.in"
+            "${CMAKE_CURRENT_BINARY_DIR}/tools/pkg-config/${target}.pc"
+            @ONLY)
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tools/pkg-config/${target}.pc"
+            DESTINATION "${SFML_PKGCONFIG_INSTALL_DIR}")
+    endif()
+
     # because the frameworks directory hierarchy has to be set up before any target files
     # are installed we can't call install(EXPORT ...Targets) here
     # this is because frameworks are only set up after all modules directories have already been added
@@ -387,7 +397,7 @@ function(sfml_add_test target SOURCES DEPENDS)
     # set the target flags to use the appropriate C++ standard library
     sfml_set_stdlib(${target})
 
-    set_target_properties(${target} PROPERTIES 
+    set_target_properties(${target} PROPERTIES
         VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} # set the Visual Studio startup path for debugging
         VS_DEBUGGER_COMMAND_ARGUMENTS "-b" # Break into debugger
 


### PR DESCRIPTION
## Description

Another upstream fix that was patched in vcpkg. Currently SFML always installs all pkgconfig files, even if you don't build for example sfml-audio. Moving the install command into the `Macros.cmake` should make sure that they're only installed if the module is also built.

This PR is related to the issue https://github.com/microsoft/vcpkg/pull/42913

## Tasks

-   [ ] Tested on Linux

## How to test this PR?

Install SFML on a platform supporting pkgconfig and don't build one module. the sfml-all.pc and the specifically deselected sfml-module.pc should not be installed.