### PR TITLE
Include SystemUtil.hpp in Event.test.cpp to fix printing sf::Vector2 in test-sfml-window

### DIFF
--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <SystemUtil.hpp>
 #include <memory>
 #include <string_view>
 #include <type_traits>


### PR DESCRIPTION

Thanks to ZXshady for identifying the issue
