### PR TITLE
Use correct null state like `nullptr` instead of `0` for functions returning pointers in docs

### DIFF
--- a/include/SFML/Audio/PlaybackDevice.hpp
+++ b/include/SFML/Audio/PlaybackDevice.hpp
@@ -71,7 +71,7 @@ namespace sf::PlaybackDevice
 /// \brief Get the name of the default audio playback device
 ///
 /// This function returns the name of the default audio
-/// playback device. If none is available, an empty string
+/// playback device. If none is available, `std::nullopt`
 /// is returned.
 ///
 /// \return The name of the default audio playback device

--- a/include/SFML/Audio/SoundFileFactory.hpp
+++ b/include/SFML/Audio/SoundFileFactory.hpp
@@ -104,7 +104,7 @@ public:
     ///
     /// \param filename Path of the sound file
     ///
-    /// \return A new sound file reader that can read the given file, or null if no reader can handle it
+    /// \return A new sound file reader that can read the given file, or `nullptr` if no reader can handle it
     ///
     /// \see `createReaderFromMemory`, `createReaderFromStream`
     ///
@@ -117,7 +117,7 @@ public:
     /// \param data        Pointer to the file data in memory
     /// \param sizeInBytes Total size of the file data, in bytes
     ///
-    /// \return A new sound file codec that can read the given file, or null if no codec can handle it
+    /// \return A new sound file codec that can read the given file, or `nullptr` if no codec can handle it
     ///
     /// \see `createReaderFromFilename`, `createReaderFromStream`
     ///
@@ -129,7 +129,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return A new sound file codec that can read the given file, or null if no codec can handle it
+    /// \return A new sound file codec that can read the given file, or `nullptr` if no codec can handle it
     ///
     /// \see `createReaderFromFilename`, `createReaderFromMemory`
     ///
@@ -141,7 +141,7 @@ public:
     ///
     /// \param filename Path of the sound file
     ///
-    /// \return A new sound file writer that can write given file, or null if no writer can handle it
+    /// \return A new sound file writer that can write given file, or `nullptr` if no writer can handle it
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static std::unique_ptr<SoundFileWriter> createWriterFromFilename(const std::filesystem::path& filename);

--- a/include/SFML/Audio/SoundFileReader.hpp
+++ b/include/SFML/Audio/SoundFileReader.hpp
@@ -75,7 +75,7 @@ public:
     ///
     /// \param stream Source stream to read from
     ///
-    /// \return Properties of the loaded sound if the file was successfully opened
+    /// \return Properties of the loaded sound if the file was successfully opened, `std::nullopt` otherwise
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] virtual std::optional<Info> open(InputStream& stream) = 0;

--- a/include/SFML/Window/Context.hpp
+++ b/include/SFML/Window/Context.hpp
@@ -137,7 +137,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] static GlFunctionPointer getFunction(const char* name);

--- a/include/SFML/Window/Vulkan.hpp
+++ b/include/SFML/Window/Vulkan.hpp
@@ -85,7 +85,7 @@ namespace Vulkan
 ///
 /// \param name Name of the function to get the address of
 ///
-/// \return Address of the Vulkan function, 0 on failure
+/// \return Address of the Vulkan function, `nullptr` on failure
 ///
 ////////////////////////////////////////////////////////////
 [[nodiscard]] SFML_WINDOW_API VulkanFunctionPointer getFunction(const char* name);

--- a/src/SFML/Window/Android/SensorImpl.hpp
+++ b/src/SFML/Window/Android/SensorImpl.hpp
@@ -101,7 +101,7 @@ private:
     ///
     /// \param type Type of the sensor
     ///
-    /// \return The default Android sensor, a null pointer otherwise
+    /// \return The default Android sensor, `nullptr` otherwise
     ///
     ////////////////////////////////////////////////////////////
     static const ASensor* getDefaultSensor(Sensor::Type sensor);

--- a/src/SFML/Window/DRM/DRMContext.hpp
+++ b/src/SFML/Window/DRM/DRMContext.hpp
@@ -169,7 +169,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     static GlFunctionPointer getFunction(const char* name);

--- a/src/SFML/Window/EglContext.hpp
+++ b/src/SFML/Window/EglContext.hpp
@@ -85,7 +85,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     static GlFunctionPointer getFunction(const char* name);

--- a/src/SFML/Window/GlContext.hpp
+++ b/src/SFML/Window/GlContext.hpp
@@ -145,7 +145,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     static GlFunctionPointer getFunction(const char* name);
@@ -153,7 +153,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Get the currently active context
     ///
-    /// \return The currently active context or a null pointer if none is active
+    /// \return The currently active context or `nullptr` if none is active
     ///
     ////////////////////////////////////////////////////////////
     static const GlContext* getActiveContext();

--- a/src/SFML/Window/Unix/GlxContext.hpp
+++ b/src/SFML/Window/Unix/GlxContext.hpp
@@ -85,7 +85,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     static GlFunctionPointer getFunction(const char* name);

--- a/src/SFML/Window/Win32/WglContext.hpp
+++ b/src/SFML/Window/Win32/WglContext.hpp
@@ -90,7 +90,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     static GlFunctionPointer getFunction(const char* name);

--- a/src/SFML/Window/iOS/EaglContext.hpp
+++ b/src/SFML/Window/iOS/EaglContext.hpp
@@ -92,7 +92,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     static GlFunctionPointer getFunction(const char* name);

--- a/src/SFML/Window/macOS/HIDInputManager.hpp
+++ b/src/SFML/Window/macOS/HIDInputManager.hpp
@@ -243,7 +243,7 @@ private:
     ///
     /// \param page  HID page like kHIDPage_GenericDesktop
     /// \param usage HID usage page like kHIDUsage_GD_Keyboard or kHIDUsage_GD_Mouse
-    /// \return a retained, non-empty CFSetRef of IOHIDDeviceRef or a null pointer
+    /// \return a retained, non-empty CFSetRef of IOHIDDeviceRef or `nullptr`
     ///
     ////////////////////////////////////////////////////////////
     CFSetRef copyDevices(std::uint32_t page, std::uint32_t usage);

--- a/src/SFML/Window/macOS/HIDJoystickManager.hpp
+++ b/src/SFML/Window/macOS/HIDJoystickManager.hpp
@@ -75,7 +75,7 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Copy the devices associated with this HID manager
     ///
-    /// \return a retained CFSetRef of IOHIDDeviceRef or a null pointer
+    /// \return a retained CFSetRef of IOHIDDeviceRef or `nullptr`
     ///
     ////////////////////////////////////////////////////////////
     CFSetRef copyJoysticks();

--- a/src/SFML/Window/macOS/SFContext.hpp
+++ b/src/SFML/Window/macOS/SFContext.hpp
@@ -102,7 +102,7 @@ public:
     ///
     /// \param name Name of the function to get the address of
     ///
-    /// \return Address of the OpenGL function, 0 on failure
+    /// \return Address of the OpenGL function, `nullptr` on failure
     ///
     ////////////////////////////////////////////////////////////
     static GlFunctionPointer getFunction(const char* name);


### PR DESCRIPTION
Those functions returned pointers not numbers and `nullptr` just makes more sense.