### PR TITLE
Added support for making OpenGL errors fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         - { name: Static, flags: -DBUILD_SHARED_LIBS=OFF }
         type:
         - { name: Release }
-        - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=ON }
+        - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=ON -DSFML_FATAL_OPENGL_ERRORS=ON }
 
         include:
         - platform: { name: Windows VS2022 x64, os: windows-2022 }
@@ -93,14 +93,14 @@ jobs:
             flags: -GNinja -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=29 -DCMAKE_ANDROID_NDK=$ANDROID_NDK_ROOT -DBUILD_SHARED_LIBS=ON -DCMAKE_ANDROID_STL_TYPE=c++_shared
             arch: armeabi-v7a
             api: 29
-          type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
+          type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_FATAL_OPENGL_ERRORS=ON }
         - platform: { name: Android, os: ubuntu-22.04 }
           config:
             name: arm64-v8a (API 33)
             flags: -GNinja -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=33 -DCMAKE_ANDROID_NDK=$ANDROID_NDK_ROOT -DBUILD_SHARED_LIBS=ON -DCMAKE_ANDROID_STL_TYPE=c++_shared -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_RUN_AUDIO_DEVICE_TESTS=OFF
             arch: arm64-v8a
             api: 33
-          type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
+          type: { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_FATAL_OPENGL_ERRORS=ON }
 
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,9 @@ if(SFML_BUILD_TEST_SUITE)
     endif()
 endif()
 
+# add an option for making OpenGL errors fatal
+sfml_set_option(SFML_FATAL_OPENGL_ERRORS OFF BOOL "ON to make SFML OpenGL errors fatal, OFF to simply warn about them")
+
 sfml_set_option(CLANG_FORMAT_EXECUTABLE clang-format STRING "Override clang-format executable, requires version 17")
 add_custom_target(format
     COMMAND ${CMAKE_COMMAND} -DCLANG_FORMAT_EXECUTABLE=${CLANG_FORMAT_EXECUTABLE} -P ./cmake/Format.cmake

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -158,6 +158,10 @@ target_link_libraries(sfml-graphics PRIVATE Freetype::Freetype)
 # add preprocessor symbols
 target_compile_definitions(sfml-graphics PRIVATE "STBI_FAILURE_USERMSG")
 
+if(SFML_FATAL_OPENGL_ERRORS)
+    target_compile_definitions(sfml-graphics PRIVATE "SFML_FATAL_OPENGL_ERRORS")
+endif()
+
 # Image.cpp must be compiled with the -fno-strict-aliasing
 # when gcc is used; otherwise saving PNGs may crash in stb_image_write
 if(SFML_COMPILER_GCC)


### PR DESCRIPTION
Since any detected OpenGL error is an indication that something went wrong somewhere, we should have support for strict error checking that `assert(false)`s when running a debug build. Since not everybody will be able to make sense of these errors, this strict mode is only enabled when explicitly requested via CMake option.

Since we have seen in #3369 that different driver implementations will have different interpretations of what to do when making OpenGL calls without an active context, this change also additionally checks if an OpenGL context was active on the current thread at the time of the function call. While the implementations that silently ignore this scenario are technically still within specification, I think we can all agree that making an OpenGL call without an active context is never done intentionally and thus constitutes programmer error.

The new CMake option `SFML_FATAL_OPENGL_ERRORS` will enable making OpenGL errors fatal. This includes our newly detected no-active-context errors. Until #3369 is resolved `SFML_FATAL_OPENGL_ERRORS` should not be enabled in CI since that might lead to CI never completing successfully. After #3369 is resolved we can add `SFML_FATAL_OPENGL_ERRORS` to the debug build options in CI as well to have the additional checks enabled.

Whoever wants to tackle #3369 can enable `SFML_FATAL_OPENGL_ERRORS` to make the error visible even when testing on implementations that silently ignore the error (AMD, Mesa3D, etc.).