### PR TITLE
Fixed sf::Window::create(WindowHandle) calling WindowBase::initialize() twice

### DIFF
--- a/src/SFML/Window/Window.cpp
+++ b/src/SFML/Window/Window.cpp
@@ -122,8 +122,11 @@ void Window::create(WindowHandle handle)
 ////////////////////////////////////////////////////////////
 void Window::create(WindowHandle handle, const ContextSettings& settings)
 {
+    // Ensure the open window is closed first
+    close();
+
     // Recreate the window implementation
-    WindowBase::create(handle);
+    m_impl = priv::WindowImpl::create(handle);
 
     // Recreate the context
     m_context = priv::GlContext::create(settings, *m_impl, VideoMode::getDesktopMode().bitsPerPixel);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,11 +88,6 @@ set(WINDOW_SRC
     Window/Window.test.cpp
     Window/WindowBase.test.cpp
 )
-if(SFML_OS_WINDOWS)
-    list(APPEND WINDOW_SRC
-        Window/WindowHandleWin32.test.cpp
-    )
-endif()
 sfml_add_test(test-sfml-window "${WINDOW_SRC}" SFML::Window)
 
 set(GRAPHICS_SRC
@@ -126,6 +121,11 @@ set(GRAPHICS_SRC
     Graphics/VertexBuffer.test.cpp
     Graphics/View.test.cpp
 )
+if(SFML_OS_WINDOWS)
+    list(APPEND GRAPHICS_SRC
+        Graphics/WindowHandleWin32.test.cpp
+    )
+endif()
 sfml_add_test(test-sfml-graphics "${GRAPHICS_SRC}" SFML::Graphics)
 if(SFML_RUN_DISPLAY_TESTS)
     target_compile_definitions(test-sfml-graphics PRIVATE SFML_RUN_DISPLAY_TESTS)

--- a/test/Graphics/WindowHandleWin32.test.cpp
+++ b/test/Graphics/WindowHandleWin32.test.cpp
@@ -1,6 +1,8 @@
 #include <SFML/Window/WindowHandle.hpp>
 
 // Other 1st party headers
+#include <SFML/Graphics/RenderWindow.hpp>
+
 #include <SFML/Window/Window.hpp>
 #include <SFML/Window/WindowBase.hpp>
 
@@ -173,6 +175,61 @@ TEST_CASE("[Window] sf::WindowHandle (Win32)")
         const auto size = sf::Vector2u(sf::Vector2(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top));
         CHECK(size == newSize);           // Validate that the actual client rect is indeed what we asked for
         CHECK(window->getSize() == size); // Validate that the `getSize` also returns the _actual_ client size
+    }
+
+    SECTION("sf::RenderWindow")
+    {
+        std::optional<sf::RenderWindow> renderWindow;
+
+        SECTION("Default context settings")
+        {
+            SECTION("WindowHandle constructor")
+            {
+                renderWindow.emplace(handle);
+            }
+
+            SECTION("create(WindowHandle)")
+            {
+                renderWindow.emplace().create(handle);
+            }
+
+            INFO("ExStyle: " << std::hex << exStyle << ", withMenu: " << withMenu);
+            CHECK(renderWindow->getSettings().attributeFlags == sf::ContextSettings::Default);
+        }
+
+        SECTION("Custom context settings")
+        {
+            static constexpr sf::ContextSettings contextSettings{/* depthBits*/ 1, /* stencilBits */ 1, /* antiAliasingLevel */ 1};
+
+            SECTION("WindowHandle constructor")
+            {
+                renderWindow.emplace(handle, contextSettings);
+            }
+
+            SECTION("create(WindowHandle)")
+            {
+                renderWindow.emplace().create(handle, contextSettings);
+            }
+
+            INFO("ExStyle: " << std::hex << exStyle << ", withMenu: " << withMenu);
+            CHECK(renderWindow->getSettings().depthBits >= 1);
+            CHECK(renderWindow->getSettings().stencilBits >= 1);
+            CHECK(renderWindow->getSettings().antiAliasingLevel >= 1);
+        }
+
+        INFO("ExStyle: " << std::hex << exStyle << ", withMenu: " << withMenu);
+        CHECK(renderWindow->isOpen());
+        CHECK(renderWindow->getPosition() == position);
+        CHECK(renderWindow->getSize() == initialSize);
+        CHECK(renderWindow->getNativeHandle() == handle);
+
+        CHECK(renderWindow->getSize() != newSize);
+        renderWindow->setSize(newSize);
+
+        REQUIRE(GetClientRect(handle, &clientRect));
+        const auto size = sf::Vector2u(sf::Vector2(clientRect.right - clientRect.left, clientRect.bottom - clientRect.top));
+        CHECK(size == newSize);                 // Validate that the actual client rect is indeed what we asked for
+        CHECK(renderWindow->getSize() == size); // Validate that the `getSize` also returns the _actual_ client size
     }
 
     INFO("ExStyle: " << std::hex << exStyle << ", withMenu: " << withMenu);


### PR DESCRIPTION
Fixed `sf::Window::create(WindowHandle)` incorrectly causing `WindowBase::initialize()` to be called before its OpenGL context is created.

Delegating window creation in `sf::Window::create(WindowHandle)` up to `sf::WindowBase::create(WindowHandle)` would cause `WindowBase::initialize()` to be called twice.
1. Called by `sf::WindowBase::create(WindowHandle)`
2. Called by `sf::Window::initialize()`

Both calls to `WindowBase::initialize()` would end up calling `onCreate()`.

The problem with delegating creation this way is that the first time `WindowBase::initialize()` is called, it will already make a call to `onCreate()`. Because `sf::Window::create(WindowHandle)` is only able to create the OpenGL context after the call to `sf::WindowBase::create(WindowHandle)` it meant that the first call to `onCreate()` would always happen without an OpenGL context, thus leading to #3369. This only happens when creating a `RenderWindow` using a window handle because only its `onCreate()` expects an OpenGL context to already be available and active when it is called.

This change replaces the call to `sf::WindowBase::create(WindowHandle)` with equivalent code excluding the call to `initialize()` since we already intend to call it after the OpenGL context has been created.

Corresponding tests were added for `RenderWindow` creation using a Win32 handle analog to the tests for `Window` and `WindowBase`.

Test with the code provided in #3369.

Closes #3369.