### PR TITLE
Work around issue with Catch2

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -77,6 +77,7 @@ function(set_target_warnings target)
     if(SFML_COMPILER_CLANG OR SFML_COMPILER_CLANG_CL)
         target_compile_options(${target} PRIVATE
             -Wno-unknown-warning-option # do not warn on GCC-specific warning diagnostic pragmas
+            -Wno-c++20-extensions # work around https://github.com/catchorg/Catch2/issues/2910
         )
     endif()
 


### PR DESCRIPTION
## Description

https://github.com/catchorg/Catch2/issues/2910

This Catch2 issue is preventing us from using Clang 19. Some GitHub jobs have started using Clang 19 already so we need to merge this to prevent CI issues cropping up soon.