### PR TITLE
Fix clang-tidy-19 errors on Windows

### DIFF
--- a/examples/win32/Win32.cpp
+++ b/examples/win32/Win32.cpp
@@ -9,8 +9,9 @@
 
 #include <cmath>
 
+namespace
+{
 HWND button;
-
 
 ////////////////////////////////////////////////////////////
 /// Function called whenever one of our windows receives a message
@@ -40,6 +41,7 @@ LRESULT CALLBACK onEvent(HWND handle, UINT message, WPARAM wParam, LPARAM lParam
 
     return DefWindowProc(handle, message, wParam, lParam);
 }
+} // namespace
 
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -310,7 +310,7 @@ void AudioDevice::unregisterResource(AudioDevice::ResourceEntryIter resourceEntr
     auto* instance = getInstance();
     assert(instance && "AudioDevice instance should exist when calling AudioDevice::unregisterResource");
     const std::lock_guard lock(instance->m_resourcesMutex);
-    instance->m_resources.erase(resourceEntry);
+    instance->m_resources.erase(resourceEntry); // NOLINT(performance-unnecessary-value-param)
 }
 
 

--- a/src/SFML/Network/Win32/SocketImpl.cpp
+++ b/src/SFML/Network/Win32/SocketImpl.cpp
@@ -30,6 +30,29 @@
 #include <cstdint>
 
 
+namespace
+{
+////////////////////////////////////////////////////////////
+// Windows needs some initialization and cleanup to get
+// sockets working properly... so let's create a class that will
+// do it automatically
+////////////////////////////////////////////////////////////
+struct SocketInitializer
+{
+    SocketInitializer()
+    {
+        WSADATA init;
+        WSAStartup(MAKEWORD(2, 2), &init);
+    }
+
+    ~SocketInitializer()
+    {
+        WSACleanup();
+    }
+} globalInitializer;
+} // namespace
+
+
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
@@ -84,27 +107,4 @@ Socket::Status SocketImpl::getErrorStatus()
     }
     // clang-format on
 }
-
-
-////////////////////////////////////////////////////////////
-// Windows needs some initialization and cleanup to get
-// sockets working properly... so let's create a class that will
-// do it automatically
-////////////////////////////////////////////////////////////
-struct SocketInitializer
-{
-    SocketInitializer()
-    {
-        WSADATA init;
-        WSAStartup(MAKEWORD(2, 2), &init);
-    }
-
-    ~SocketInitializer()
-    {
-        WSACleanup();
-    }
-};
-
-SocketInitializer globalInitializer;
-
 } // namespace sf::priv

--- a/src/SFML/Window/Win32/JoystickImpl.cpp
+++ b/src/SFML/Window/Win32/JoystickImpl.cpp
@@ -310,9 +310,7 @@ JoystickCaps JoystickImpl::getCapabilities() const
 
     JoystickCaps caps;
 
-    caps.buttonCount = m_caps.wNumButtons;
-    if (caps.buttonCount > Joystick::ButtonCount)
-        caps.buttonCount = Joystick::ButtonCount;
+    caps.buttonCount = std::min(m_caps.wNumButtons, Joystick::ButtonCount);
 
     caps.axes[Joystick::Axis::X]    = true;
     caps.axes[Joystick::Axis::Y]    = true;

--- a/test/Window/Event.test.cpp
+++ b/test/Window/Event.test.cpp
@@ -345,6 +345,7 @@ TEST_CASE("[Window] sf::Event")
 
         SECTION("Move-only visitor")
         {
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
             auto moveOnlyVisitor = [ptr = std::make_unique<std::string_view>("It works")](const auto&) { return *ptr; };
 
             const sf::Event closed = sf::Event::Closed{};


### PR DESCRIPTION
## Description

I ran clang-tidy on Windows and it caught some stuff the CI pipeline doesn't yet catch. I suspect the Windows CI images will upgrade to LLVM 19 tools in the next month or so.