### PR TITLE
Catch backup stringifier

### DIFF
--- a/test/Audio/SoundFileFactory.test.cpp
+++ b/test/Audio/SoundFileFactory.test.cpp
@@ -100,10 +100,10 @@ TEST_CASE("[Audio] sf::SoundFileFactory")
 
         SECTION("Valid file")
         {
-            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/ding.flac"));
-            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/ding.mp3"));
-            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/doodle_pop.ogg"));
-            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/killdeer.wav"));
+            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/ding.flac").get());
+            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/ding.mp3").get());
+            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/doodle_pop.ogg").get());
+            CHECK(sf::SoundFileFactory::createReaderFromFilename("Audio/killdeer.wav").get());
         }
     }
 
@@ -131,7 +131,7 @@ TEST_CASE("[Audio] sf::SoundFileFactory")
             REQUIRE(stream.open("Audio/killdeer.wav"));
         }
 
-        CHECK(sf::SoundFileFactory::createReaderFromStream(stream));
+        CHECK(sf::SoundFileFactory::createReaderFromStream(stream).get());
     }
 
     SECTION("createWriterFromFilename()")
@@ -143,10 +143,10 @@ TEST_CASE("[Audio] sf::SoundFileFactory")
 
         SECTION("Valid extension")
         {
-            CHECK(sf::SoundFileFactory::createWriterFromFilename("file.flac"));
+            CHECK(sf::SoundFileFactory::createWriterFromFilename("file.flac").get());
             CHECK(!sf::SoundFileFactory::createWriterFromFilename("file.mp3")); // Mp3 writing not yet implemented
-            CHECK(sf::SoundFileFactory::createWriterFromFilename("file.ogg"));
-            CHECK(sf::SoundFileFactory::createWriterFromFilename("file.wav"));
+            CHECK(sf::SoundFileFactory::createWriterFromFilename("file.ogg").get());
+            CHECK(sf::SoundFileFactory::createWriterFromFilename("file.wav").get());
         }
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(sfml-test-main STATIC
 )
 target_include_directories(sfml-test-main PUBLIC TestUtilities)
 target_link_libraries(sfml-test-main PUBLIC SFML::System Catch2::Catch2WithMain)
+target_compile_definitions(sfml-test-main PUBLIC CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS)
 set_target_warnings(sfml-test-main)
 
 # set the target flags to use the appropriate C++ standard library

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(sfml-test-main STATIC
 )
 target_include_directories(sfml-test-main PUBLIC TestUtilities)
 target_link_libraries(sfml-test-main PUBLIC SFML::System Catch2::Catch2WithMain)
-target_compile_definitions(sfml-test-main PUBLIC CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS)
+target_compile_definitions(sfml-test-main PUBLIC CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS CATCH_CONFIG_FALLBACK_STRINGIFIER=toString)
 set_target_warnings(sfml-test-main)
 
 # set the target flags to use the appropriate C++ standard library

--- a/test/Graphics/RenderTarget.test.cpp
+++ b/test/Graphics/RenderTarget.test.cpp
@@ -3,7 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include <SystemUtil.hpp>
+#include <GraphicsUtil.hpp>
 #include <type_traits>
 
 class RenderTarget : public sf::RenderTarget

--- a/test/Graphics/Sprite.test.cpp
+++ b/test/Graphics/Sprite.test.cpp
@@ -5,6 +5,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <GraphicsUtil.hpp>
 #include <WindowUtil.hpp>
 #include <type_traits>
 

--- a/test/Graphics/StencilMode.test.cpp
+++ b/test/Graphics/StencilMode.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <GraphicsUtil.hpp>
 #include <type_traits>
 
 TEST_CASE("[Graphics] sf::StencilMode")

--- a/test/Network/Ftp.test.cpp
+++ b/test/Network/Ftp.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <SystemUtil.hpp>
 #include <type_traits>
 
 TEST_CASE("[Network] sf::Ftp")

--- a/test/Network/Http.test.cpp
+++ b/test/Network/Http.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <SystemUtil.hpp>
 #include <type_traits>
 
 TEST_CASE("[Network] sf::Http")

--- a/test/Network/Packet.test.cpp
+++ b/test/Network/Packet.test.cpp
@@ -5,6 +5,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <SystemUtil.hpp>
 #include <array>
 #include <limits>
 #include <type_traits>

--- a/test/Network/TcpListener.test.cpp
+++ b/test/Network/TcpListener.test.cpp
@@ -5,6 +5,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <SystemUtil.hpp>
 #include <type_traits>
 
 TEST_CASE("[Network] sf::TcpListener")

--- a/test/Network/UdpSocket.test.cpp
+++ b/test/Network/UdpSocket.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <SystemUtil.hpp>
 #include <type_traits>
 
 TEST_CASE("[Network] sf::UdpSocket")

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -2,10 +2,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <GraphicsUtil.hpp>
+#include <SystemUtil.hpp>
 #include <array>
-#include <iomanip>
-#include <sstream>
 #include <type_traits>
 
 #include <cassert>
@@ -25,37 +23,7 @@ auto select(const std::basic_string<T>& string16, const std::basic_string<T>& st
     else
         return string32;
 }
-
-auto toHex(const char32_t character)
-{
-    std::ostringstream stream;
-    stream << "[\\x" << std::uppercase << std::hex << std::uint32_t{character} << ']';
-    return stream.str();
-}
 } // namespace
-
-// Specialize StringMaker for alternative std::basic_string<T> specializations
-// std::string's string conversion cannot be specialized but all other string types get special treatment
-// https://github.com/catchorg/Catch2/blob/devel/docs/tostring.md#catchstringmaker-specialisation
-namespace Catch
-{
-template <>
-struct StringMaker<sf::U8String>
-{
-    static std::string convert(const sf::U8String& string)
-    {
-        std::ostringstream output;
-        for (const auto character : string)
-        {
-            if (character >= 32 && character < 127)
-                output << std::string(1, static_cast<char>(character));
-            else
-                output << toHex(character);
-        }
-        return output.str();
-    }
-};
-} // namespace Catch
 
 TEST_CASE("[System] sf::U8StringCharTraits")
 {

--- a/test/System/Utf.test.cpp
+++ b/test/System/Utf.test.cpp
@@ -2,6 +2,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <SystemUtil.hpp>
 #include <string_view>
 
 namespace
@@ -85,7 +86,7 @@ TEST_CASE("[System] sf::Utf8")
         next = sf::Utf8::next(next, utf8.cend());
         CHECK(u8string_view(&*next, 4) == u8"🐌"sv);
         next = sf::Utf8::next(next, utf8.cend());
-        CHECK(next == utf8.cend());
+        CHECK(std::distance(next, utf8.cend()) == 0);
     }
 
     SECTION("count")
@@ -260,7 +261,7 @@ TEST_CASE("[System] sf::Utf16")
         next = sf::Utf16::next(next, utf16.cend());
         CHECK(std::u16string_view(&*next, 2) == u"🐌"sv);
         next = sf::Utf16::next(next, utf16.cend());
-        CHECK(next == utf16.cend());
+        CHECK(std::distance(next, utf16.cend()) == 0);
     }
 
     SECTION("count")
@@ -416,7 +417,7 @@ TEST_CASE("[System] sf::Utf32")
         next = sf::Utf32::next(next, utf32.cend());
         CHECK(*next == U'🐌');
         next = sf::Utf32::next(next, utf32.cend());
-        CHECK(next == utf32.cend());
+        CHECK(std::distance(next, utf32.cend()) == 0);
     }
 
     SECTION("count")

--- a/test/TestUtilities/SystemUtil.cpp
+++ b/test/TestUtilities/SystemUtil.cpp
@@ -8,7 +8,6 @@
 
 #include <SystemUtil.hpp>
 #include <fstream>
-#include <iomanip>
 #include <limits>
 
 #include <cassert>
@@ -59,6 +58,31 @@ template std::ostream& operator<<(std::ostream&, const Vector3<int>&);
 template std::ostream& operator<<(std::ostream&, const Vector3<unsigned int>&);
 template std::ostream& operator<<(std::ostream&, const Vector3<float>&);
 } // namespace sf
+
+namespace Catch
+{
+std::string StringMaker<sf::String>::convert(const sf::String& string)
+{
+    return '"' + string.toAnsiString() + '"';
+}
+
+#ifdef __cpp_char8_t
+std::string StringMaker<char8_t>::convert(char8_t char8)
+{
+    return std::to_string(char8);
+}
+#endif
+
+std::string StringMaker<char16_t>::convert(char16_t char16)
+{
+    return std::to_string(char16);
+}
+
+std::string StringMaker<char32_t>::convert(char32_t char32)
+{
+    return std::to_string(char32);
+}
+} // namespace Catch
 
 bool operator==(const float& lhs, const Approx<float>& rhs)
 {

--- a/test/TestUtilities/SystemUtil.hpp
+++ b/test/TestUtilities/SystemUtil.hpp
@@ -5,13 +5,33 @@
 
 #pragma once
 
+#include <catch2/catch_tostring.hpp>
+
 #include <filesystem>
-#include <iosfwd>
+#include <ios>
+#include <sstream>
 #include <vector>
 
 #include <cstddef>
 
 // String conversions for Catch2
+template <typename CharT>
+[[nodiscard]] std::string toString(std::basic_string_view<CharT> string)
+{
+    std::ostringstream out;
+    out << "{ " << std::hex;
+    for (std::size_t i = 0; i + 1 < string.size(); ++i)
+        out << "\\x" << std::uint32_t{string[i]} << ", ";
+    out << "\\x" << std::uint32_t{string.back()} << " }";
+    return out.str();
+}
+
+template <typename CharT>
+[[nodiscard]] std::string toString(const std::basic_string<CharT>& string)
+{
+    return toString(std::basic_string_view<CharT>(string));
+}
+
 namespace sf
 {
 class Angle;
@@ -36,6 +56,44 @@ std::ostream& operator<<(std::ostream& os, Vector2<T> vector);
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const Vector3<T>& vector);
 } // namespace sf
+
+namespace Catch
+{
+template <typename Enum>
+struct StringMaker<Enum, std::enable_if_t<std::is_enum_v<Enum>>>
+{
+    static std::string convert(Enum e)
+    {
+        return std::to_string(static_cast<int>(e));
+    }
+};
+
+template <>
+struct StringMaker<sf::String>
+{
+    static std::string convert(const sf::String& string);
+};
+
+#ifdef __cpp_char8_t
+template <>
+struct StringMaker<char8_t>
+{
+    static std::string convert(char8_t char8);
+};
+#endif
+
+template <>
+struct StringMaker<char16_t>
+{
+    static std::string convert(char16_t char16);
+};
+
+template <>
+struct StringMaker<char32_t>
+{
+    static std::string convert(char32_t char32);
+};
+} // namespace Catch
 
 ////////////////////////////////////////////////////////////
 /// Class template for creating custom approximate comparisons.

--- a/test/Window/Cursor.test.cpp
+++ b/test/Window/Cursor.test.cpp
@@ -58,24 +58,24 @@ TEST_CASE("[Window] sf::Cursor", runDisplayTests())
         CHECK(!sf::Cursor::createFromPixels(nullptr, {}, {}));
         CHECK(!sf::Cursor::createFromPixels(pixels.data(), {0, 1}, {}));
         CHECK(!sf::Cursor::createFromPixels(pixels.data(), {1, 0}, {}));
-        CHECK(sf::Cursor::createFromPixels(pixels.data(), {1, 1}, {}));
+        CHECK(sf::Cursor::createFromPixels(pixels.data(), {1, 1}, {}).has_value());
     }
 
     SECTION("loadFromSystem()")
     {
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Hand));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeHorizontal));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeVertical));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeLeft));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeRight));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTop));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottom));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTopLeft));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTopRight));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottomLeft));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottomRight));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Cross));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Help));
-        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::NotAllowed));
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Hand).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeHorizontal).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeVertical).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeLeft).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeRight).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTop).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottom).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTopLeft).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeTopRight).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottomLeft).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::SizeBottomRight).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Cross).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::Help).has_value());
+        CHECK(sf::Cursor::createFromSystem(sf::Cursor::Type::NotAllowed).has_value());
     }
 }

--- a/test/Window/Joystick.test.cpp
+++ b/test/Window/Joystick.test.cpp
@@ -3,6 +3,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
 
+#include <SystemUtil.hpp>
+
 TEST_CASE("[Window] sf::Joystick")
 {
     SECTION("Constants")

--- a/test/Window/WindowBase.test.cpp
+++ b/test/Window/WindowBase.test.cpp
@@ -152,7 +152,7 @@ TEST_CASE("[Window] sf::WindowBase", runDisplayTests())
             REQUIRE(elapsed < (timeout + sf::milliseconds(100)).toDuration());
 
             if (elapsed <= timeout.toDuration())
-                CHECK(event);
+                CHECK(event.has_value());
             else
                 CHECK(!event);
         }


### PR DESCRIPTION
## Description

https://github.com/SFML/SFML/pull/3452 revealed a very ugly ODR violation which led to `sf::Vector2`s not being corrected printed in the tests. In the Event.test.cpp translation unit, we forgot the header for formatting vectors which led to Catch2 using the backup stringifier which simply prints `{?}`. In other translation units the correct headers were included but this discrepancy led to an ODR violation that caused other translation units that _did_ include the correct header to behave incorrectly. Spooky action at a distance.

This PR systematically fixes that problem by forcing Catch2 to find a stringifier function. If one is not found due to for example forgetting `#include <SystemUtil.hpp>` then compilation fails. This guarantees that such an ODR violation cannot happen again.