### PR TITLE
Require two-step initialization of `sf::priv::ResourceStream`

### DIFF
--- a/src/SFML/Graphics/Font.cpp
+++ b/src/SFML/Graphics/Font.cpp
@@ -154,24 +154,21 @@ bool Font::openFromFile(const std::filesystem::path& filename)
     // Cleanup the previous resources
     cleanup();
 
-#ifndef SFML_SYSTEM_ANDROID
-
     // Create the input stream and open the file
+#ifndef SFML_SYSTEM_ANDROID
     const auto stream = std::make_shared<FileInputStream>();
     const auto type   = "file"sv;
+#else
+    const auto stream = std::make_shared<priv::ResourceStream>();
+    const auto type   = "Android resource stream"sv;
+#endif
+
     if (!stream->open(filename))
     {
         err() << "Failed to load font (failed to open file): " << std::strerror(errno) << '\n'
               << formatDebugPathInfo(filename) << std::endl;
         return false;
     }
-
-#else
-
-    const auto stream = std::make_shared<priv::ResourceStream>(filename);
-    const auto type   = "Android resource stream"sv;
-
-#endif
 
     // Open the font, and if succesful save the stream to keep it alive
     if (openFromStreamImpl(*stream, type))

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -204,7 +204,9 @@ bool Image::loadFromFile(const std::filesystem::path& filename)
 
     if (priv::getActivityStatesPtr() != nullptr)
     {
-        priv::ResourceStream stream(filename);
+        priv::ResourceStream stream;
+        if (!stream.open(filename))
+            return false;
         return loadFromStream(stream);
     }
 

--- a/src/SFML/System/Android/ResourceStream.cpp
+++ b/src/SFML/System/Android/ResourceStream.cpp
@@ -34,20 +34,20 @@
 
 namespace sf::priv
 {
-
 ////////////////////////////////////////////////////////////
-ResourceStream::ResourceStream(const std::filesystem::path& filename)
+bool ResourceStream::open(const std::filesystem::path& filename)
 {
     ActivityStates&       states = getActivity();
     const std::lock_guard lock(states.mutex);
     m_file.reset(AAssetManager_open(states.activity->assetManager, filename.c_str(), AASSET_MODE_UNKNOWN));
-    assert(m_file && "Failed to initialize ResourceStream file");
+    return m_file != nullptr;
 }
 
 
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> ResourceStream::read(void* data, std::size_t size)
 {
+    assert(m_file && "ResourceStream::read() cannot be called when file is not initialized");
     const auto numBytesRead = AAsset_read(m_file.get(), data, size);
     if (numBytesRead < 0)
         return std::nullopt;
@@ -58,6 +58,7 @@ std::optional<std::size_t> ResourceStream::read(void* data, std::size_t size)
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> ResourceStream::seek(std::size_t position)
 {
+    assert(m_file && "ResourceStream::seek() cannot be called when file is not initialized");
     const auto newPosition = AAsset_seek(m_file.get(), static_cast<off_t>(position), SEEK_SET);
     if (newPosition < 0)
         return std::nullopt;
@@ -68,6 +69,7 @@ std::optional<std::size_t> ResourceStream::seek(std::size_t position)
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> ResourceStream::tell()
 {
+    assert(m_file && "ResourceStream::tell() cannot be called when file is not initialized");
     return getSize().value() - static_cast<std::size_t>(AAsset_getRemainingLength(m_file.get()));
 }
 
@@ -75,6 +77,7 @@ std::optional<std::size_t> ResourceStream::tell()
 ////////////////////////////////////////////////////////////
 std::optional<std::size_t> ResourceStream::getSize()
 {
+    assert(m_file && "ResourceStream::getSize() cannot be called when file is not initialized");
     return AAsset_getLength(m_file.get());
 }
 

--- a/src/SFML/System/Android/ResourceStream.hpp
+++ b/src/SFML/System/Android/ResourceStream.hpp
@@ -52,7 +52,17 @@ public:
     /// \param filename Filename of the asset
     ///
     ////////////////////////////////////////////////////////////
-    ResourceStream(const std::filesystem::path& filename);
+    ResourceStream() = default;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open the stream from a file path
+    ///
+    /// \param filename Name of the file to open
+    ///
+    /// \return `true` on success, `false` on error
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool open(const std::filesystem::path& filename);
 
     ////////////////////////////////////////////////////////////
     /// \brief Read data from the asset

--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -75,7 +75,9 @@ bool FileInputStream::open(const std::filesystem::path& filename)
 #ifdef SFML_SYSTEM_ANDROID
     if (priv::getActivityStatesPtr() != nullptr)
     {
-        m_androidFile = std::make_unique<priv::ResourceStream>(filename);
+        m_androidFile = std::make_unique<priv::ResourceStream>();
+        if (!m_androidFile->open(filename))
+            return false;
         return m_androidFile->tell().has_value();
     }
 #endif


### PR DESCRIPTION
## Description

Closes #3473

The fix is basically to just make `ResourceStream` behave like `FileInputStream`. Frankly I'm not sure why we directly use `ResourceStream` when `FileInputStream` already uses `ResourceStream` under the hood, but regardless this PR should fix the issue without otherwise changing any behavior.