### PR TITLE
Win32 Xbox XInput Controller Fix (Revised)

### DIFF
--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -187,6 +187,22 @@ public:
     ////////////////////////////////////////////////////////////
     [[nodiscard]] JoystickState updateDInputPolled();
 
+    ////////////////////////////////////////////////////////////
+    /// \brief Updates the joystick and gets its new state (XInput)
+    ///
+    /// \return Joystick state
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] JoystickState updateXInput();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Notifies that there has been a device change
+    ///
+    /// \return Joystick state
+    ///
+    ////////////////////////////////////////////////////////////
+    static void invalidateDevices();
+
 private:
     ////////////////////////////////////////////////////////////
     /// \brief Device enumeration callback function passed to EnumDevices in updateConnections
@@ -219,6 +235,8 @@ private:
     DIDEVCAPS             m_deviceCaps{};                         //!< DirectInput device capabilities
     EnumArray<Joystick::Axis, int, Joystick::AxisCount> m_axes{}; //!< Offsets to the bytes containing the axes states, -1 if not available
     std::array<int, Joystick::ButtonCount> m_buttons{}; //!< Offsets to the bytes containing the button states, -1 if not available
+    bool                     m_useXInput{};
+    DWORD                    m_xInputIndex{0xFFFFFFFF};
     Joystick::Identification m_identification; //!< Joystick identification
     JoystickState            m_state;          //!< Buffered joystick state
     bool                     m_buffered{}; //!< `true` if the device uses buffering, `false` if the device uses polling


### PR DESCRIPTION
## Description
This PR fixes issue https://github.com/SFML/SFML/issues/2428 (#2428) by adding XInput filtering and support in addition to the current DirectInput functionality.

## How to test this PR?
Test this PR on Windows by launching the Joystick demo with a controller and playing around, using the left and right triggers of an Xbox controller, in particular.

Other information: 

`WM_DEVICECHANGE` is inappropriate place to perform COM interop in order to determine if the Xbox controller is an XInput device or not. As such, the device-change procedure has been moved away from when the window message occurs and onto when the update routine is called. This was identified as a problem and advice was given to move the functionality away from `WM_DEVICECHANGE` in the DirectX Discord. 

No further linking targets were added as MinGW builds were failing on that - instead the procedures for XInput are loaded dynamically. `wbemuuid.lib` was also similarly avoided as a link target to avoid build errors with MinGW, instead hardcoding the relevant UUIDs for the IID and CLSID directly, following the conventions already present for the UUIDs involved in DirectInput. 