### PR TITLE
Move joystick example code around to support multiple controllers

### DIFF
--- a/examples/joystick/Joystick.cpp
+++ b/examples/joystick/Joystick.cpp
@@ -16,68 +16,157 @@ struct JoystickObject
 {
     sf::Text label;
     sf::Text value;
+
+    void draw(sf::RenderWindow& window, const sf::RenderStates& states = sf::RenderStates::Default) const
+    {
+        window.draw(label, states);
+        window.draw(value, states);
+    }
 };
 
-using Texts = std::unordered_map<std::string, JoystickObject>;
-Texts              texts;
-std::ostringstream sstr;
-float              threshold = 0.1f;
+[[nodiscard]] auto getStream()
+{
+    std::ostringstream sstr;
+    // Set up our string conversion parameters
+    sstr.precision(2);
+    sstr.setf(std::ios::fixed | std::ios::boolalpha);
+    return sstr;
+}
 
 // Axes labels in as strings
 const std::array<std::string, 8> axislabels = {"X", "Y", "Z", "R", "U", "V", "PovX", "PovY"};
 
-// Helper to set text entries to a specified value
-template <typename T>
-void set(const std::string& label, const T& value)
+class JoystickDisplay
 {
-    sstr.str("");
-    sstr << value;
-    texts.at(label).value.setString(sstr.str());
-}
+public:
+    JoystickDisplay() = default;
 
-// Update joystick identification
-void updateIdentification(unsigned int index)
-{
-    sstr.str("");
-    sstr << "Joystick " << index << ":";
-    auto& [label, value] = texts.at("ID");
-    label.setString(sstr.str());
-    value.setString(sf::Joystick::getIdentification(index).name);
-}
-
-// Update joystick axes
-void updateAxes(unsigned int index)
-{
-    for (unsigned int j = 0; j < sf::Joystick::AxisCount; ++j)
+    JoystickDisplay(unsigned int idx, const sf::Font& font) : m_index(idx)
     {
-        if (sf::Joystick::hasAxis(index, static_cast<sf::Joystick::Axis>(j)))
-            set(axislabels[j], sf::Joystick::getAxisPosition(index, static_cast<sf::Joystick::Axis>(j)));
-    }
-}
+        {
+            const auto [it, success] = m_texts.try_emplace("ID", JoystickObject{{font, "<Not Connected>"}, {font}});
+            auto& [label, value]     = it->second;
+            label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
+            value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
+        }
 
-// Update joystick buttons
-void updateButtons(unsigned int index)
-{
-    for (unsigned int j = 0; j < sf::Joystick::getButtonCount(index); ++j)
+        for (unsigned int i = 0; i < sf::Joystick::AxisCount; ++i)
+        {
+            const auto [it, success] = m_texts.try_emplace(axislabels[i],
+                                                           JoystickObject{{font, axislabels[i] + ":"}, {font, "N/A"}});
+            auto& [label, value]     = it->second;
+            label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
+            value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
+        }
+
+        auto sstr = getStream();
+        for (unsigned int i = 0; i < sf::Joystick::ButtonCount; ++i)
+        {
+            sstr.str("");
+            sstr << "Button " << i;
+            const auto [it, success] = m_texts.try_emplace(sstr.str(),
+                                                           JoystickObject{{font, sstr.str() + ":"}, {font, "N/A"}});
+            auto& [label, value]     = it->second;
+            label.setPosition({5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
+            value.setPosition({80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
+        }
+
+        for (auto& [label, joystickObject] : m_texts)
+        {
+            joystickObject.label.setCharacterSize(14);
+            joystickObject.value.setCharacterSize(14);
+        }
+    }
+
+    [[nodiscard]] bool isPresent() const
+    {
+        return m_present;
+    }
+
+    // Helper to set text entries to a specified value
+    template <typename T>
+    void set(const std::string& label, const T& value, std::ostringstream& sstr)
     {
         sstr.str("");
-        sstr << "Button " << j;
-
-        set(sstr.str(), sf::Joystick::isButtonPressed(index, j));
+        sstr << value;
+        m_texts.at(label).value.setString(sstr.str());
     }
-}
 
-// Helper to update displayed joystick values
-void updateValues(unsigned int index)
-{
-    if (sf::Joystick::isConnected(index))
+    // Update joystick identification
+    void updateIdentification()
     {
-        // Update the label-value sf::Text objects based on the current joystick state
-        updateIdentification(index);
-        updateAxes(index);
-        updateButtons(index);
+        auto sstr = getStream();
+        sstr << "Joystick " << m_index << ":";
+        auto& [label, value] = m_texts.at("ID");
+        label.setString(sstr.str());
+        value.setString(sf::Joystick::getIdentification(m_index).name);
     }
-}
+
+    // Update joystick axes
+    void updateAxes()
+    {
+        auto sstr = getStream();
+        for (unsigned int j = 0; j < sf::Joystick::AxisCount; ++j)
+        {
+            if (sf::Joystick::hasAxis(m_index, static_cast<sf::Joystick::Axis>(j)))
+                set(axislabels[j], sf::Joystick::getAxisPosition(m_index, static_cast<sf::Joystick::Axis>(j)), sstr);
+        }
+    }
+
+    // Update joystick buttons
+    void updateButtons()
+    {
+        auto sstr = getStream();
+        for (unsigned int j = 0; j < sf::Joystick::getButtonCount(m_index); ++j)
+        {
+            sstr.str("");
+            sstr << "Button " << j;
+
+            auto buttonName = sstr.str();
+            set(buttonName, sf::Joystick::isButtonPressed(m_index, j), sstr);
+        }
+    }
+
+    void updateValues()
+    {
+        m_present = sf::Joystick::isConnected(m_index);
+        if (m_present)
+        {
+            // Update the label-value sf::Text objects based on the current joystick state
+            updateIdentification();
+            updateAxes();
+            updateButtons();
+        }
+    }
+
+    void clearValues()
+    {
+        m_present = false;
+
+        // Reset displayed joystick values to empty
+        for (auto& [label, joystickObject] : m_texts)
+            joystickObject.value.setString("N/A");
+
+        auto& [label, value] = m_texts.at("ID");
+        label.setString("<Not Connected>");
+        value.setString("");
+    }
+
+    void draw(sf::RenderWindow& window, const sf::RenderStates& states = sf::RenderStates::Default) const
+    {
+        for (const auto& [_, joystickObject] : m_texts)
+            joystickObject.draw(window, states);
+    }
+
+private:
+    using Texts = std::unordered_map<std::string, JoystickObject>;
+
+    unsigned int m_index{};
+    bool         m_present{};
+    Texts        m_texts;
+};
+
+std::array<JoystickDisplay, sf::Joystick::Count> joysticks;
 } // namespace
 
 
@@ -96,64 +185,23 @@ int main()
     // Open the text font
     const sf::Font font("resources/tuffy.ttf");
 
-    // Set up our string conversion parameters
-    sstr.precision(2);
-    sstr.setf(std::ios::fixed | std::ios::boolalpha);
-
-    // Set up our joystick identification sf::Text objects
-    {
-        const auto [it, success] = texts.try_emplace("ID", JoystickObject{{font, "<Not Connected>"}, {font}});
-        auto& [label, value]     = it->second;
-        label.setPosition({5.f, 5.f});
-        value.setPosition({80.f, 5.f});
-    }
-
-    // Set up our threshold sf::Text objects
-    sstr.str("");
-    sstr << threshold << "  (Change with up/down arrow keys)";
-    {
-        const auto [it, success] = texts.emplace("Threshold", JoystickObject{{font, "Threshold:"}, {font, sstr.str()}});
-        auto& [label, value]     = it->second;
-        label.setPosition({5.f, 5.f + 2 * font.getLineSpacing(14)});
-        value.setPosition({80.f, 5.f + 2 * font.getLineSpacing(14)});
-    }
-
-    // Set up our label-value sf::Text objects
-    for (unsigned int i = 0; i < sf::Joystick::AxisCount; ++i)
-    {
-        const auto [it, success] = texts.try_emplace(axislabels[i],
-                                                     JoystickObject{{font, axislabels[i] + ":"}, {font, "N/A"}});
-        auto& [label, value]     = it->second;
-        label.setPosition({5.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
-        value.setPosition({80.f, 5.f + (static_cast<float>(i + 4) * font.getLineSpacing(14))});
-    }
-
-    for (unsigned int i = 0; i < sf::Joystick::ButtonCount; ++i)
-    {
-        sstr.str("");
-        sstr << "Button " << i;
-        const auto [it,
-                    success] = texts.try_emplace(sstr.str(), JoystickObject{{font, sstr.str() + ":"}, {font, "N/A"}});
-        auto& [label, value] = it->second;
-        label.setPosition({5.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
-        value.setPosition({80.f, 5.f + (static_cast<float>(sf::Joystick::AxisCount + i + 4) * font.getLineSpacing(14))});
-    }
-
-    for (auto& [label, joystickObject] : texts)
-    {
-        joystickObject.label.setCharacterSize(14);
-        joystickObject.value.setCharacterSize(14);
-    }
+    float          threshold = 0.1f;
+    JoystickObject thresholdDisplay{{font, "Threshold:"}, {font, ""}};
+    thresholdDisplay.label.setPosition({5.f, 5.f});
+    thresholdDisplay.value.setPosition({80.f, 5.f});
+    thresholdDisplay.label.setCharacterSize(14);
+    thresholdDisplay.value.setCharacterSize(14);
 
     // Update initially displayed joystick values if a joystick is already connected on startup
+    unsigned int joysticksPresent = 0;
     for (unsigned int i = 0; i < sf::Joystick::Count; ++i)
     {
-        if (sf::Joystick::isConnected(i))
-        {
-            updateValues(i);
-            break;
-        }
+        joysticks[i] = JoystickDisplay{i, font};
+        joysticks[i].updateValues();
+        if (joysticks[i].isPresent())
+            ++joysticksPresent;
     }
+    window.setSize({400 * std::max(joysticksPresent, 1u), 775});
 
     while (window.isOpen())
     {
@@ -168,41 +216,29 @@ int main()
                 window.close();
                 break;
             }
-
-            if (const auto* joystickButtonPressed = event->getIf<sf::Event::JoystickButtonPressed>())
+            if (const auto* resized = event->getIf<sf::Event::Resized>())
             {
-                // Update displayed joystick values
-                updateValues(joystickButtonPressed->joystickId);
+                window.setView(sf::View(sf::FloatRect({}, sf::Vector2f(resized->size))));
+            }
+            else if (const auto* joystickButtonPressed = event->getIf<sf::Event::JoystickButtonPressed>())
+            {
+                joysticks[joystickButtonPressed->joystickId].updateValues();
             }
             else if (const auto* joystickButtonReleased = event->getIf<sf::Event::JoystickButtonReleased>())
             {
-                // Update displayed joystick values
-                updateValues(joystickButtonReleased->joystickId);
+                joysticks[joystickButtonReleased->joystickId].updateValues();
             }
             else if (const auto* joystickMoved = event->getIf<sf::Event::JoystickMoved>())
             {
-                // Update displayed joystick values
-                updateValues(joystickMoved->joystickId);
+                joysticks[joystickMoved->joystickId].updateValues();
             }
             else if (const auto* joystickConnected = event->getIf<sf::Event::JoystickConnected>())
             {
-                // Update displayed joystick values
-                updateValues(joystickConnected->joystickId);
+                joysticks[joystickConnected->joystickId].updateValues();
             }
-            else if (event->is<sf::Event::JoystickDisconnected>())
+            else if (const auto* joystickDisconnected = event->getIf<sf::Event::JoystickDisconnected>())
             {
-                // Reset displayed joystick values to empty
-                for (auto& [label, joystickObject] : texts)
-                    joystickObject.value.setString("N/A");
-
-                auto& [label, value] = texts.at("ID");
-                label.setString("<Not Connected>");
-                value.setString("");
-
-                sstr.str("");
-                sstr << threshold << "  (Change with up/down arrow keys)";
-
-                texts.at("Threshold").value.setString(sstr.str());
+                joysticks[joystickDisconnected->joystickId].clearValues();
             }
         }
 
@@ -217,25 +253,53 @@ int main()
 
         newThreshold = std::clamp(newThreshold, 0.1f, 100.0f);
 
-        if (newThreshold != threshold)
+        // Update the threshold if it has changed, or if this is the first time
+        if (newThreshold != threshold || thresholdDisplay.value.getString().isEmpty())
         {
             threshold = newThreshold;
             window.setJoystickThreshold(threshold);
 
-            sstr.str("");
+            auto sstr = getStream();
             sstr << threshold << "  (Change with up/down arrow keys)";
 
-            texts.at("Threshold").value.setString(sstr.str());
+            thresholdDisplay.value.setString(sstr.str());
         }
 
         // Clear the window
         window.clear();
 
-        // Draw the label-value sf::Text objects
-        for (const auto& [label, joystickObject] : texts)
+        // Display the current threshold
+        thresholdDisplay.draw(window);
+
+        unsigned int  newJoysticksPresent = 0;
+        sf::Transform transform           = sf::Transform::Identity;
+        for (auto& joystick : joysticks)
         {
-            window.draw(joystickObject.label);
-            window.draw(joystickObject.value);
+            if (joystick.isPresent())
+            {
+                // Draw the values from this joystick
+                joystick.draw(window, transform);
+
+                // Move the transform to the right for the next joystick
+                transform.translate(sf::Vector2f(400, 0));
+
+                // Keep track of the number of joysticks that we found
+                ++newJoysticksPresent;
+            }
+        }
+
+        // Did the number of joysticks change?
+        if (newJoysticksPresent != joysticksPresent)
+        {
+            // Yep, resize the window to take the new number of joysticks into account
+            joysticksPresent = newJoysticksPresent;
+            window.setSize({400 * std::max(joysticksPresent, 1u), 775});
+        }
+
+        // If no joystick is present, draw the first one
+        if (joysticksPresent == 0)
+        {
+            joysticks[0].draw(window);
         }
 
         // Display things on screen


### PR DESCRIPTION
Keep a state per joystick, so that we can display all of them at once. The window is simply resized for the number of controllers, so it might get fairly wide.

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Connect multiple controllers, and enjoy!

> [!NOTE]
> Currently (as of 15-apr-2025) devices that are enabled before starting the application will only be 'discovered' after receiving inputs from them.
> This is being worked on in #3477 

Example screenshots:
No controller:
![No controller](https://github.com/user-attachments/assets/5aa731ae-b375-4c6d-bcf2-680aa4a2bc20)

1 controller:
![1 controller](https://github.com/user-attachments/assets/56c530f1-b5b2-4645-ab3f-1fa702acca86)

3 controllers:
![3 controllers](https://github.com/user-attachments/assets/a9675d55-e81c-40fb-9359-61486c8c0140)

