### PR TITLE
Feature: Android joystick support

### DIFF
--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -81,8 +81,8 @@ struct ActivityStates
     Vector2i                                           mousePosition;
     EnumArray<Mouse::Button, bool, Mouse::ButtonCount> isButtonPressed{};
 
-    std::map<uint32_t, EnumArray<Joystick::Axis, float, Joystick::AxisCount>> joyAxii;
-    std::map<uint32_t, std::array<bool, Joystick::ButtonCount>> isJoystickButtonPressed{};
+    EnumArray<Joystick::Axis, float, Joystick::AxisCount> joyAxii;
+    std::array<bool, Joystick::ButtonCount> isJoystickButtonPressed{};
 
     bool mainOver{};
 

--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/EglContext.hpp>
 #include <SFML/Window/Event.hpp>
+#include <SFML/Window/Android/JoystickButton.hpp>
 
 #include <SFML/System/EnumArray.hpp>
 
@@ -40,6 +41,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <map>
 
 #include <cstddef>
 
@@ -78,6 +80,9 @@ struct ActivityStates
     std::unordered_map<int, Vector2i>                  touchEvents;
     Vector2i                                           mousePosition;
     EnumArray<Mouse::Button, bool, Mouse::ButtonCount> isButtonPressed{};
+
+    std::map<uint32_t, EnumArray<Joystick::Axis, float, Joystick::AxisCount>> joyAxii;
+    std::map<uint32_t, std::array<bool, Joystick::ButtonCount>> isJoystickButtonPressed{};
 
     bool mainOver{};
 

--- a/src/SFML/Window/Android/JoystickButton.hpp
+++ b/src/SFML/Window/Android/JoystickButton.hpp
@@ -1,0 +1,56 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2013 Jonathan De Wachter (dewachter.jonathan@gmail.com)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace sf::Joystick
+{
+////////////////////////////////////////////////////////////
+/// \brief Abstract names for Joystick button codes
+///
+////////////////////////////////////////////////////////////
+enum class Button : size_t
+{
+    A = 0,
+    B,
+    C,
+    X,
+    Y,
+    Z,
+    L1,
+    R1,
+    L2,
+    R2,
+    L3,
+    R3,
+    Start,
+    Select,
+    Capture,
+    DpadUp,
+    DpadDown,
+    DpadLeft,
+    DpadRight,
+    DpadCenter,
+};
+}

--- a/src/SFML/Window/Android/JoystickImpl.cpp
+++ b/src/SFML/Window/Android/JoystickImpl.cpp
@@ -29,16 +29,166 @@
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Android/Activity.hpp>
 
-static std::string javaStringToStd(JNIEnv* lJNIEnv, jstring str)
+static std::string javaStringToStd(JNIEnv* env, jstring str)
 {
-    const char* utfChars = lJNIEnv->GetStringUTFChars(str, nullptr);
+    const char* utfChars = env->GetStringUTFChars(str, nullptr);
     std::string result(utfChars);
-    lJNIEnv->ReleaseStringUTFChars(str, utfChars);
+    env->ReleaseStringUTFChars(str, utfChars);
     return result;
 }
 
+template<class T>
+class JniArray {
+public:
+    JniArray(JNIEnv* env, jintArray array)
+        : env(env)
+        , array(array)
+        , length(env->GetArrayLength(array))
+        , data(env->GetIntArrayElements(array, nullptr))
+    {}
+
+    JniArray(JniArray&& other)
+    {
+        std::swap(env, other.env);
+        std::swap(array, other.array);
+        std::swap(length, other.length);
+        std::swap(data, other.data);
+    }
+
+    ~JniArray()
+    {
+        if (data)
+            env->ReleaseIntArrayElements(array, data, 0);
+    }
+
+public:
+    T operator[](ssize_t idx)
+    {
+        assert(0 <= idx && idx <= length);
+        return data[idx];
+    }
+
+    const T operator[](ssize_t idx) const
+    {
+        assert(0 <= idx && idx <= length);
+        return data[idx];
+    }
+
+    ssize_t getLength() const noexcept
+    {
+        return length;
+    }
+
+private:
+    JNIEnv * env = nullptr;
+    jintArray array = nullptr;
+    ssize_t length = 0;
+    T* data = nullptr;
+};
+
 namespace sf::priv
 {
+class JniInputDevice
+{
+public:
+    JniInputDevice(
+        JNIEnv* env,
+        jobject inputDevice,
+        jmethodID getNameMethod,
+        jmethodID getVendorIdMethod,
+        jmethodID getProductIdMethod,
+        jmethodID supportsSourceMethod)
+        : env(env)
+        , inputDevice(inputDevice)
+        , getNameMethod(getNameMethod)
+        , getVendorIdMethod(getVendorIdMethod)
+        , getProductIdMethod(getProductIdMethod)
+        , supportsSourceMethod(supportsSourceMethod)
+    {}
+
+public:
+    static std::optional<JniArray<jint>> getDeviceIds(JNIEnv *env, jclass inputDeviceClass)
+    {
+        jmethodID getDeviceIdsMethod = env->GetStaticMethodID(inputDeviceClass, "getDeviceIds", "()[I");
+        if (!getDeviceIdsMethod)
+        {
+            err() << "Could not locate InputDevice.getDeviceIds method" << std::endl;
+            return std::nullopt;
+        }
+
+        jintArray deviceIdsArray = (jintArray)env->CallStaticObjectMethod(inputDeviceClass, getDeviceIdsMethod);
+        if (deviceIdsArray == nullptr)
+        {
+            err() << "No input devices found." << std::endl;
+            return std::nullopt;
+        }
+
+        return JniArray<jint>(env, deviceIdsArray);
+    }
+
+    static std::optional<JniInputDevice> getDevice(JNIEnv *env, jclass inputDeviceClass, jint idx)
+    {
+        jmethodID getDeviceMethod = env->GetStaticMethodID(inputDeviceClass, "getDevice", "(I)Landroid/view/InputDevice;");
+        jmethodID getNameMethod = env->GetMethodID(inputDeviceClass, "getName", "()Ljava/lang/String;");
+        jmethodID getVendorIdMethod = env->GetMethodID(inputDeviceClass, "getVendorId", "()I");
+        jmethodID getProductIdMethod = env->GetMethodID(inputDeviceClass, "getProductId", "()I");
+        jmethodID supportsSourceMethod = env->GetMethodID(inputDeviceClass, "supportsSource", "(I)Z");
+
+        if (!getDeviceMethod || !getNameMethod || !getVendorIdMethod || !getProductIdMethod || !supportsSourceMethod)
+        {
+            err() << "Could not locate required InputDevice methods" << std::endl;
+            return std::nullopt;
+        }
+
+        jobject inputDevice = env->CallStaticObjectMethod(inputDeviceClass, getDeviceMethod, idx);
+        if (!inputDevice)
+        {
+            // Can happen normally, no log needed
+            return std::nullopt;
+        }
+
+        return JniInputDevice(
+                env,
+                inputDevice,
+                getNameMethod,
+                getVendorIdMethod,
+                getProductIdMethod,
+                supportsSourceMethod);
+    }
+
+    unsigned getVendorId() const
+    {
+        return (unsigned)env->CallIntMethod(inputDevice, getVendorIdMethod);
+    }
+
+    unsigned getProductId() const
+    {
+        return (unsigned)env->CallIntMethod(inputDevice, getProductIdMethod);
+    }
+
+    std::string getName() const
+    {
+        return javaStringToStd(
+            env,
+            (jstring)env->CallObjectMethod(
+                inputDevice,
+                getNameMethod));
+    }
+
+    bool supportsSource(size_t sourceFlags) const
+    {
+        return env->CallBooleanMethod(inputDevice, supportsSourceMethod, jint(sourceFlags));
+    }
+
+private:
+    JNIEnv* env;
+    jobject inputDevice;
+    jmethodID getNameMethod;
+    jmethodID getVendorIdMethod;
+    jmethodID getProductIdMethod;
+    jmethodID supportsSourceMethod;
+};
+
 ////////////////////////////////////////////////////////////
 void JoystickImpl::initialize()
 {
@@ -54,38 +204,18 @@ void JoystickImpl::cleanup()
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::isConnected(unsigned int /* index */)
+bool JoystickImpl::isConnected(unsigned int index)
 {
-    // To implement
-    return true;
+    // This is called as a prefilter before open, but it
+    // would just duplicate the logic of open. Furthermore
+    // how many physical devices are you going to attach to
+    // an android device?
+    return index == 0;
 }
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::open(unsigned int /* index */)
-{
-    // To implement
-    return true;
-}
-
-
-////////////////////////////////////////////////////////////
-void JoystickImpl::close()
-{
-    // To implement
-}
-
-
-////////////////////////////////////////////////////////////
-JoystickCaps JoystickImpl::getCapabilities() const
-{
-    // To implement
-    return {};
-}
-
-
-////////////////////////////////////////////////////////////
-Joystick::Identification JoystickImpl::getIdentification() const
+bool JoystickImpl::open(unsigned int joy_index)
 {
     // Retrieve activity states
     ActivityStates&       states = getActivity();
@@ -106,55 +236,66 @@ Joystick::Identification JoystickImpl::getIdentification() const
     lResult = lJavaVM->AttachCurrentThread(&lJNIEnv, &lJavaVMAttachArgs);
 
     if (lResult == JNI_ERR)
-        err() << "Failed to initialize JNI, couldn't get the Unicode value" << std::endl;
+        err() << "Failed to initialize JNI" << std::endl;
 
     jclass inputDeviceClass = lJNIEnv->FindClass("android/view/InputDevice");
     if (inputDeviceClass == nullptr) {
         err() << "Failed to find InputDevice class." << std::endl;
-        return m_identification;
+        return false;
     }
 
-    // Locate required InputDevice methods
-    jmethodID getDeviceIdsMethod = lJNIEnv->GetStaticMethodID(inputDeviceClass, "getDeviceIds", "()[I");
-    jmethodID getDeviceMethod = lJNIEnv->GetStaticMethodID(inputDeviceClass, "getDevice", "(I)Landroid/view/InputDevice;");
-    jmethodID getNameMethod = lJNIEnv->GetMethodID(inputDeviceClass, "getName", "()Ljava/lang/String;");
-    jmethodID getVendorIdMethod = lJNIEnv->GetMethodID(inputDeviceClass, "getVendorId", "()I");
-    jmethodID getProductIdMethod = lJNIEnv->GetMethodID(inputDeviceClass, "getProductId", "()I");
-    jmethodID supportsSourceMethod = lJNIEnv->GetMethodID(inputDeviceClass, "supportsSource", "(I)Z");
+    auto deviceIds = JniInputDevice::getDeviceIds(lJNIEnv, inputDeviceClass);
+    if (!deviceIds) return false;
 
-    if (!getDeviceIdsMethod || !getDeviceMethod || !getNameMethod || !getVendorIdMethod || !getProductIdMethod || !supportsSourceMethod) {
-        err() << "Failed to locate required methods from android/view/InputDevice" << std::endl;
-        return m_identification;
-    }
-
-    // Call getDeviceIds() to get the array of device IDs
-    jintArray deviceIdsArray = (jintArray)lJNIEnv->CallStaticObjectMethod(inputDeviceClass, getDeviceIdsMethod);
-    if (deviceIdsArray == nullptr) {
-        err() << "No input devices found." << std::endl;
-        return m_identification;
-    }
-
-    // Get the array length and elements
-    jsize arrayLength = lJNIEnv->GetArrayLength(deviceIdsArray);
-    jint* deviceIds = lJNIEnv->GetIntArrayElements(deviceIdsArray, nullptr);
-
-    for (jsize i = 0; i < arrayLength; ++i) {
-        jobject inputDevice = lJNIEnv->CallStaticObjectMethod(inputDeviceClass, getDeviceMethod, deviceIds[i]);
+    for (jsize i = 0; i < deviceIds->getLength(); ++i) {
+        auto inputDevice = JniInputDevice::getDevice(lJNIEnv, inputDeviceClass, (*deviceIds)[i]);
         if (!inputDevice) continue;
 
-        jboolean supportsGamepad = lJNIEnv->CallBooleanMethod(inputDevice, supportsSourceMethod, jint(AINPUT_SOURCE_GAMEPAD | AINPUT_SOURCE_JOYSTICK));
-        if (!(bool)supportsGamepad) continue;
+        if (!inputDevice->supportsSource(AINPUT_SOURCE_GAMEPAD | AINPUT_SOURCE_JOYSTICK)) continue;
+
+        // Get state of nth gamepad
+        if (joy_index > 0)
+        {
+            --joy_index;
+            continue;
+        }
 
         m_identification = Joystick::Identification{
-            javaStringToStd(lJNIEnv, (jstring)lJNIEnv->CallObjectMethod(inputDevice, getNameMethod)),
-            (unsigned)lJNIEnv->CallIntMethod(inputDevice, getVendorIdMethod),
-            (unsigned)lJNIEnv->CallIntMethod(inputDevice, getProductIdMethod),
+                inputDevice->getName(),
+                inputDevice->getVendorId(),
+                inputDevice->getProductId(),
         };
+
+        m_currentDeviceIdx = int(i);
+
+        return true;
     }
 
-    // Release the array elements
-    lJNIEnv->ReleaseIntArrayElements(deviceIdsArray, deviceIds, 0);
+    return false;
+}
 
+
+////////////////////////////////////////////////////////////
+void JoystickImpl::close()
+{
+    // To implement
+}
+
+
+////////////////////////////////////////////////////////////
+JoystickCaps JoystickImpl::getCapabilities() const
+{
+    // To implement
+    return JoystickCaps{
+        Joystick::ButtonCount,
+        EnumArray<Joystick::Axis, bool, Joystick::AxisCount>{ true }
+    };
+}
+
+
+////////////////////////////////////////////////////////////
+Joystick::Identification JoystickImpl::getIdentification() const
+{
     return m_identification;
 }
 

--- a/src/SFML/Window/Android/JoystickImpl.cpp
+++ b/src/SFML/Window/Android/JoystickImpl.cpp
@@ -261,9 +261,9 @@ bool JoystickImpl::open(unsigned int joy_index)
         }
 
         m_identification = Joystick::Identification{
-                inputDevice->getName(),
-                inputDevice->getVendorId(),
-                inputDevice->getProductId(),
+            inputDevice->getName(),
+            inputDevice->getVendorId(),
+            inputDevice->getProductId(),
         };
 
         m_currentDeviceIdx = int(i);
@@ -303,8 +303,16 @@ Joystick::Identification JoystickImpl::getIdentification() const
 ////////////////////////////////////////////////////////////
 JoystickState JoystickImpl::update()
 {
+    // Retrieve activity states
+    ActivityStates&       states = getActivity();
+    const std::lock_guard lock(states.mutex);
+
     // To implement
-    return {};
+    return {
+        true,
+        {},
+        states.isJoystickButtonPressed[0]
+    };
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/Android/JoystickImpl.cpp
+++ b/src/SFML/Window/Android/JoystickImpl.cpp
@@ -26,7 +26,16 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/JoystickImpl.hpp>
+#include <SFML/System/Err.hpp>
+#include <SFML/System/Android/Activity.hpp>
 
+static std::string javaStringToStd(JNIEnv* lJNIEnv, jstring str)
+{
+    const char* utfChars = lJNIEnv->GetStringUTFChars(str, nullptr);
+    std::string result(utfChars);
+    lJNIEnv->ReleaseStringUTFChars(str, utfChars);
+    return result;
+}
 
 namespace sf::priv
 {
@@ -48,7 +57,7 @@ void JoystickImpl::cleanup()
 bool JoystickImpl::isConnected(unsigned int /* index */)
 {
     // To implement
-    return false;
+    return true;
 }
 
 
@@ -56,7 +65,7 @@ bool JoystickImpl::isConnected(unsigned int /* index */)
 bool JoystickImpl::open(unsigned int /* index */)
 {
     // To implement
-    return false;
+    return true;
 }
 
 
@@ -78,6 +87,74 @@ JoystickCaps JoystickImpl::getCapabilities() const
 ////////////////////////////////////////////////////////////
 Joystick::Identification JoystickImpl::getIdentification() const
 {
+    // Retrieve activity states
+    ActivityStates&       states = getActivity();
+    const std::lock_guard lock(states.mutex);
+
+    // Initializes JNI
+    jint lResult = 0;
+
+    // TODO: extract to common method also used in windowimpl
+    JavaVM* lJavaVM = states.activity->vm;
+    JNIEnv* lJNIEnv = states.activity->env;
+
+    JavaVMAttachArgs lJavaVMAttachArgs;
+    lJavaVMAttachArgs.version = JNI_VERSION_1_6;
+    lJavaVMAttachArgs.name    = "NativeThread";
+    lJavaVMAttachArgs.group   = nullptr;
+
+    lResult = lJavaVM->AttachCurrentThread(&lJNIEnv, &lJavaVMAttachArgs);
+
+    if (lResult == JNI_ERR)
+        err() << "Failed to initialize JNI, couldn't get the Unicode value" << std::endl;
+
+    jclass inputDeviceClass = lJNIEnv->FindClass("android/view/InputDevice");
+    if (inputDeviceClass == nullptr) {
+        err() << "Failed to find InputDevice class." << std::endl;
+        return m_identification;
+    }
+
+    // Locate required InputDevice methods
+    jmethodID getDeviceIdsMethod = lJNIEnv->GetStaticMethodID(inputDeviceClass, "getDeviceIds", "()[I");
+    jmethodID getDeviceMethod = lJNIEnv->GetStaticMethodID(inputDeviceClass, "getDevice", "(I)Landroid/view/InputDevice;");
+    jmethodID getNameMethod = lJNIEnv->GetMethodID(inputDeviceClass, "getName", "()Ljava/lang/String;");
+    jmethodID getVendorIdMethod = lJNIEnv->GetMethodID(inputDeviceClass, "getVendorId", "()I");
+    jmethodID getProductIdMethod = lJNIEnv->GetMethodID(inputDeviceClass, "getProductId", "()I");
+    jmethodID supportsSourceMethod = lJNIEnv->GetMethodID(inputDeviceClass, "supportsSource", "(I)Z");
+
+    if (!getDeviceIdsMethod || !getDeviceMethod || !getNameMethod || !getVendorIdMethod || !getProductIdMethod || !supportsSourceMethod) {
+        err() << "Failed to locate required methods from android/view/InputDevice" << std::endl;
+        return m_identification;
+    }
+
+    // Call getDeviceIds() to get the array of device IDs
+    jintArray deviceIdsArray = (jintArray)lJNIEnv->CallStaticObjectMethod(inputDeviceClass, getDeviceIdsMethod);
+    if (deviceIdsArray == nullptr) {
+        err() << "No input devices found." << std::endl;
+        return m_identification;
+    }
+
+    // Get the array length and elements
+    jsize arrayLength = lJNIEnv->GetArrayLength(deviceIdsArray);
+    jint* deviceIds = lJNIEnv->GetIntArrayElements(deviceIdsArray, nullptr);
+
+    for (jsize i = 0; i < arrayLength; ++i) {
+        jobject inputDevice = lJNIEnv->CallStaticObjectMethod(inputDeviceClass, getDeviceMethod, deviceIds[i]);
+        if (!inputDevice) continue;
+
+        jboolean supportsGamepad = lJNIEnv->CallBooleanMethod(inputDevice, supportsSourceMethod, jint(AINPUT_SOURCE_GAMEPAD | AINPUT_SOURCE_JOYSTICK));
+        if (!(bool)supportsGamepad) continue;
+
+        m_identification = Joystick::Identification{
+            javaStringToStd(lJNIEnv, (jstring)lJNIEnv->CallObjectMethod(inputDevice, getNameMethod)),
+            (unsigned)lJNIEnv->CallIntMethod(inputDevice, getVendorIdMethod),
+            (unsigned)lJNIEnv->CallIntMethod(inputDevice, getProductIdMethod),
+        };
+    }
+
+    // Release the array elements
+    lJNIEnv->ReleaseIntArrayElements(deviceIdsArray, deviceIds, 0);
+
     return m_identification;
 }
 

--- a/src/SFML/Window/Android/JoystickImpl.hpp
+++ b/src/SFML/Window/Android/JoystickImpl.hpp
@@ -100,7 +100,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    Joystick::Identification m_identification; ///< Joystick identification
+    mutable Joystick::Identification m_identification; ///< Joystick identification
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/Android/JoystickImpl.hpp
+++ b/src/SFML/Window/Android/JoystickImpl.hpp
@@ -100,7 +100,8 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    mutable Joystick::Identification m_identification; ///< Joystick identification
+    Joystick::Identification m_identification; ///< Joystick identification
+    int32_t m_currentDeviceIdx = -1;
 };
 
 } // namespace sf::priv

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -407,16 +407,37 @@ int WindowImplAndroid::processScrollEvent(AInputEvent* inputEvent, ActivityState
 
 
 ////////////////////////////////////////////////////////////
-int WindowImplAndroid::processKeyEvent(AInputEvent* inputEvent, ActivityStates& /* states */)
+int WindowImplAndroid::processKeyEvent(AInputEvent* inputEvent, ActivityStates& states)
 {
     const std::int32_t action = AKeyEvent_getAction(inputEvent);
-
     const std::int32_t key     = AKeyEvent_getKeyCode(inputEvent);
     const std::int32_t metakey = AKeyEvent_getMetaState(inputEvent);
+    const auto sfCode = androidKeyToSF(key);
 
+    if (std::holds_alternative<Keyboard::Key>(sfCode))
+    {
+        return processKeyboardKeyEvent(
+            inputEvent,
+            action,
+            std::get<Keyboard::Key>(sfCode),
+            metakey
+        );
+    }
+    else
+    {
+        return processJoystickButtonEvent(
+            action,
+            std::get<Joystick::Button>(sfCode),
+            states);
+    }
+}
+
+////////////////////////////////////////////////////////////
+int WindowImplAndroid::processKeyboardKeyEvent(AInputEvent* inputEvent, std::int32_t action, sf::Keyboard::Key key, std::int32_t metakey)
+{
     const auto forwardKeyEvent = [&](auto keyEvent)
     {
-        keyEvent.code  = androidKeyToSF(key);
+        keyEvent.code  = key;
         keyEvent.alt   = metakey & AMETA_ALT_ON;
         keyEvent.shift = metakey & AMETA_SHIFT_ON;
         forwardEvent(keyEvent);
@@ -439,11 +460,9 @@ int WindowImplAndroid::processKeyEvent(AInputEvent* inputEvent, ActivityStates& 
             forwardKeyEvent(Event::KeyPressed{});
             forwardKeyEvent(Event::KeyReleased{});
 
-            // This requires some special treatment, since this might represent
-            // a repetition of key presses or a complete sequence
-            if (key == AKEYCODE_UNKNOWN)
+            if (key == Keyboard::Key::Unknown)
             {
-                // This is a unique sequence, which is not yet exposed in the NDK
+                // This related to a very old issue that hasn't been resolved in over a decade
                 // https://code.google.com/p/android/issues/detail?id=33998
                 return 0;
             }
@@ -461,6 +480,14 @@ int WindowImplAndroid::processKeyEvent(AInputEvent* inputEvent, ActivityStates& 
     return 0;
 }
 
+////////////////////////////////////////////////////////////
+int WindowImplAndroid::processJoystickButtonEvent(std::int32_t action, Joystick::Button button, ActivityStates& states)
+{
+    auto joyIdx = 0u;
+    auto buttonIdx = static_cast<std::underlying_type_t<decltype(button)>>(button);
+    states.isJoystickButtonPressed[joyIdx][buttonIdx] = action == AKEY_EVENT_ACTION_DOWN;
+    return 1;
+}
 
 ////////////////////////////////////////////////////////////
 int WindowImplAndroid::processMotionEvent(AInputEvent* inputEvent, ActivityStates& states)
@@ -552,7 +579,8 @@ int WindowImplAndroid::processPointerEvent(bool isDown, AInputEvent* inputEvent,
 
 
 ////////////////////////////////////////////////////////////
-Keyboard::Key WindowImplAndroid::androidKeyToSF(std::int32_t key)
+std::variant<Keyboard::Key, Joystick::Button>
+WindowImplAndroid::androidKeyToSF(std::int32_t key)
 {
     // clang-format off
     switch (key)
@@ -575,12 +603,12 @@ Keyboard::Key WindowImplAndroid::androidKeyToSF(std::int32_t key)
         case AKEYCODE_8:                  return Keyboard::Key::Num8;
         case AKEYCODE_9:                  return Keyboard::Key::Num9;
         case AKEYCODE_STAR:
-        case AKEYCODE_POUND:
-        case AKEYCODE_DPAD_UP:
-        case AKEYCODE_DPAD_DOWN:
-        case AKEYCODE_DPAD_LEFT:
-        case AKEYCODE_DPAD_RIGHT:
-        case AKEYCODE_DPAD_CENTER:
+        case AKEYCODE_POUND:              return Keyboard::Key::Unknown;
+        case AKEYCODE_DPAD_UP:            return Joystick::Button::DpadUp;
+        case AKEYCODE_DPAD_DOWN:          return Joystick::Button::DpadDown;
+        case AKEYCODE_DPAD_LEFT:          return Joystick::Button::DpadLeft;
+        case AKEYCODE_DPAD_RIGHT:         return Joystick::Button::DpadRight;
+        case AKEYCODE_DPAD_CENTER:        return Joystick::Button::DpadCenter;
         case AKEYCODE_VOLUME_UP:
         case AKEYCODE_VOLUME_DOWN:
         case AKEYCODE_POWER:
@@ -653,22 +681,22 @@ Keyboard::Key WindowImplAndroid::androidKeyToSF(std::int32_t key)
         case AKEYCODE_PAGE_UP:            return Keyboard::Key::PageUp;
         case AKEYCODE_PAGE_DOWN:          return Keyboard::Key::PageDown;
         case AKEYCODE_PICTSYMBOLS:
-        case AKEYCODE_SWITCH_CHARSET:
-        case AKEYCODE_BUTTON_A:
-        case AKEYCODE_BUTTON_B:
-        case AKEYCODE_BUTTON_C:
-        case AKEYCODE_BUTTON_X:
-        case AKEYCODE_BUTTON_Y:
-        case AKEYCODE_BUTTON_Z:
-        case AKEYCODE_BUTTON_L1:
-        case AKEYCODE_BUTTON_R1:
-        case AKEYCODE_BUTTON_L2:
-        case AKEYCODE_BUTTON_R2:
-        case AKEYCODE_BUTTON_THUMBL:
-        case AKEYCODE_BUTTON_THUMBR:
-        case AKEYCODE_BUTTON_START:
-        case AKEYCODE_BUTTON_SELECT:
-        case AKEYCODE_BUTTON_MODE:
+        case AKEYCODE_SWITCH_CHARSET:     return Keyboard::Key::Unknown;
+        case AKEYCODE_BUTTON_A:           return Joystick::Button::A;
+        case AKEYCODE_BUTTON_B:           return Joystick::Button::B;
+        case AKEYCODE_BUTTON_C:           return Joystick::Button::C;
+        case AKEYCODE_BUTTON_X:           return Joystick::Button::X;
+        case AKEYCODE_BUTTON_Y:           return Joystick::Button::Y;
+        case AKEYCODE_BUTTON_Z:           return Joystick::Button::Z;
+        case AKEYCODE_BUTTON_L1:          return Joystick::Button::L1;
+        case AKEYCODE_BUTTON_R1:          return Joystick::Button::R1;
+        case AKEYCODE_BUTTON_L2:          return Joystick::Button::L2;
+        case AKEYCODE_BUTTON_R2:          return Joystick::Button::R2;
+        case AKEYCODE_BUTTON_THUMBL:      return Joystick::Button::L3;
+        case AKEYCODE_BUTTON_THUMBR:      return Joystick::Button::R3;
+        case AKEYCODE_BUTTON_START:       return Joystick::Button::Start;
+        case AKEYCODE_BUTTON_SELECT:      return Joystick::Button::Select;
+        case AKEYCODE_BUTTON_MODE:        return Joystick::Button::Capture;
         default:                          return Keyboard::Key::Unknown;
     }
     // clang-format on

--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -483,9 +483,8 @@ int WindowImplAndroid::processKeyboardKeyEvent(AInputEvent* inputEvent, std::int
 ////////////////////////////////////////////////////////////
 int WindowImplAndroid::processJoystickButtonEvent(std::int32_t action, Joystick::Button button, ActivityStates& states)
 {
-    auto joyIdx = 0u;
-    auto buttonIdx = static_cast<std::underlying_type_t<decltype(button)>>(button);
-    states.isJoystickButtonPressed[joyIdx][buttonIdx] = action == AKEY_EVENT_ACTION_DOWN;
+    const auto buttonIdx = static_cast<std::underlying_type_t<decltype(button)>>(button);
+    states.isJoystickButtonPressed[buttonIdx] = action == AKEY_EVENT_ACTION_DOWN;
     return 1;
 }
 
@@ -518,6 +517,17 @@ int WindowImplAndroid::processMotionEvent(AInputEvent* inputEvent, ActivityState
             forwardEvent(touchMoved);
 
             states.touchEvents[id] = touchMoved.position;
+        }
+        else if (static_cast<std::uint32_t>(device) & AINPUT_SOURCE_JOYSTICK)
+        {
+            states.joyAxii[Joystick::Axis::X] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_X, p);
+            states.joyAxii[Joystick::Axis::Y] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_Y, p);
+            states.joyAxii[Joystick::Axis::Z] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_Z, p);
+            states.joyAxii[Joystick::Axis::R] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_RTRIGGER, p);
+            states.joyAxii[Joystick::Axis::U] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_LTRIGGER, p);
+            states.joyAxii[Joystick::Axis::V] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_RZ, p);
+            states.joyAxii[Joystick::Axis::PovX] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_HAT_X, p);
+            states.joyAxii[Joystick::Axis::PovY] = AMotionEvent_getAxisValue(inputEvent, AMOTION_EVENT_AXIS_HAT_Y, p);
         }
     }
 

--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -29,12 +29,14 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/EglContext.hpp>
 #include <SFML/Window/Event.hpp>
+#include <SFML/Window/Android/JoystickButton.hpp>
 #include <SFML/Window/WindowImpl.hpp>
 
 #include <SFML/System/Android/Activity.hpp>
 
 #include <android/input.h>
 
+#include <variant>
 
 namespace sf::priv
 {
@@ -228,18 +230,20 @@ private:
 
     static int processScrollEvent(AInputEvent* inputEvent, ActivityStates& states);
     static int processKeyEvent(AInputEvent* inputEvent, ActivityStates& states);
+    static int processKeyboardKeyEvent(AInputEvent* inputEvent, std::int32_t action, sf::Keyboard::Key key, std::int32_t metakey);
+    static int processJoystickButtonEvent(std::int32_t action, Joystick::Button button, ActivityStates& states);
     static int processMotionEvent(AInputEvent* inputEvent, ActivityStates& states);
     static int processPointerEvent(bool isDown, AInputEvent* event, ActivityStates& states);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Convert a Android key to SFML key code
+    /// \brief Convert a Android key to SFML key code / joy button code
     ///
     /// \param symbol Android key to convert
     ///
-    /// \return Corresponding SFML key code
+    /// \return Corresponding SFML key code or joystick button code
     ///
     ////////////////////////////////////////////////////////////
-    static Keyboard::Key androidKeyToSF(std::int32_t key);
+    static std::variant<Keyboard::Key, Joystick::Button> androidKeyToSF(std::int32_t key);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get Unicode decoded from the input event


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

This PR adds the support for physical gamepads on Android devices through sf::Joystick API. The implementation is limited to only one physical device with layout of a standard Xbox/Playstation gamepad.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [X] Tested on Android
- [x] Tested with Backbone One
- [x] Tested with íPega-9167
- [ ] Tested with Xbox One (wired) controller
- [ ] Fix implementation not noticing disconnected controller
- [ ] Make sure axii bindings are alinged with Windows behavior

## How to test this PR?

Download the attached zipfile and unpack it somewhere.

1) In the root dir, create `_build` directory and run command `cmake ..` in it. This will generate AppManifest, gradle config and local properties in the `bin-android` folder.
2) Edit `bin-android/cppcore/CMakeLists.txt` so the `add_subdirectory` call on line 5 points to cloned repo from this branch (or just FetchContent on this branch)
3) Open `bin-android` as a project in Android Studio and build/run the project.

[_ControllerTest.zip](https://github.com/user-attachments/files/19966191/_ControllerTest.zip)

The application will print identification for all 4 controller slots (only the first one is supported) and all axii/button values for the first controller. If you connect a controller, the app should immediately recognize it. If you press buttons / sticks, you should see immediate changes to displayed values.

I've tested this with Backbone One, íPega-9167

