### PR TITLE
Add missing `<ostream>` include in `OutputSoundFile.cpp`

### DIFF
--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -32,6 +32,8 @@
 #include <SFML/System/Err.hpp>
 #include <SFML/System/Exception.hpp>
 
+#include <ostream>
+
 #include <cassert>
 
 


### PR DESCRIPTION
Fixes #3499.