### PR TITLE
Fix issue with Re-creation of Windows on Android

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -70,11 +70,16 @@ m_size(mode.size)
     if (state == State::Fullscreen)
         states.fullscreen = true;
 
+    const bool shouldCreateSurface = (states.window != nullptr) && (WindowImplAndroid::singleInstance == nullptr);
+
     WindowImplAndroid::singleInstance = this;
     states.forwardEvent               = forwardEvent;
 
     // Register process event callback
     states.processEvent = processEvent;
+
+    if (shouldCreateSurface)
+        states.forwardEvent(sf::Event::FocusGained{});
 
     states.initialized = true;
 }


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

This PR fixes an issue with SFML on Android, where it is not possible to close and re-create a Window (unless the user paused and resumed the application).
This happened due to the fact that for Surface creation, SFML waited for the onNativeWindowCreated callback to be called. However, the required callback before that one (onNativeWindowDestroyed) isn't called if you close the window from within the program itself.

To fix that, a call to create the Surface is added, which only happens if onNativeWindowCreated has already been called (and onNativeWindowDestroyed has not been called yet).

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [X] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->
Use the basic Android example, and add to it the ability to recreate the window (so call create a second time).

One could make it so recreating the window can be triggered by either holding the touchscreen for a set amount of time, or by touching the top half of the screen.