### PR TITLE
Fix pkg-config when SFML_PKGCONFIG_INSTALL_DIR is unset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,9 +201,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
 
-# add the subdirectories
-add_subdirectory(src/SFML)
-
 # on Linux and BSD-like OS, install pkg-config files by default
 set(SFML_INSTALL_PKGCONFIG_DEFAULT OFF)
 
@@ -247,6 +244,9 @@ endif()
 if(SFML_ENABLE_PCH AND SFML_OS_MACOS)
     message(FATAL_ERROR "Precompiled headers are currently not supported in macOS builds")
 endif()
+
+# add the subdirectories
+add_subdirectory(src/SFML)
 
 # setup the install rules
 if(NOT SFML_BUILD_FRAMEWORKS)


### PR DESCRIPTION
Commit e5127715e64a ("Install pkgconfig only if module is built") attempted to move the pkg-config installation rules into `sfml_add_library`, but this fails if `SFML_PKGCONFIG_INSTALL_DIR` is unset because this code is run before the default value is set in `CMakeLists.txt`.

Fix by moving the `add_subdirectory(src/SFML)` line below the pkg-config setup code.

Closes: #3504