### PR TITLE
Set cmake_policy in SFMLConfig.cmake

### DIFF
--- a/cmake/SFMLConfig.cmake.in
+++ b/cmake/SFMLConfig.cmake.in
@@ -63,6 +63,8 @@
 #   add_executable(myapp ...)
 #   target_link_libraries(myapp PRIVATE SFML::Graphics SFML::Audio)
 
+cmake_policy(VERSION 3.22...3.31)
+
 if(NOT SFML_FIND_COMPONENTS)
     message(FATAL_ERROR "find_package(SFML) called with no component")
 endif()


### PR DESCRIPTION
`SFMLConfig.cmake` uses the `if(... IN_LIST` feature which requires policy `CMP0057` to be enabled (added in CMake 3.3). If an application uses `find_package(SFML)` with a minimum CMake version set to less than `3.3`, the `IN_LIST` lines cause a CMake error.

Fix this by setting the minimum CMake policy we require in `SFMLConfig.cmake`. CMake keeps a policy stack so this does not affect the application's policy.
