### PR TITLE
Linux DRM - Fix issues with current implementation

### DIFF
--- a/src/SFML/Window/DRM/DRMContext.cpp
+++ b/src/SFML/Window/DRM/DRMContext.cpp
@@ -68,11 +68,6 @@ int             contextCount   = 0;
 EGLDisplay      display        = EGL_NO_DISPLAY;
 int             waitingForFlip = 0;
 
-bool isEglLoaded()
-{
-    return eglLoaded;
-}
-
 void pageFlipHandler(int /* fd */, unsigned int /* frame */, unsigned int /* sec */, unsigned int /* usec */, void* data)
 {
     int* temp = static_cast<int*>(data);
@@ -555,7 +550,7 @@ DRMContext::DRMContext(DRMContext* shared)
 
     // Get the initialized EGL display
     m_display = getInitializedDisplay();
-    if (!isEglLoaded())
+    if (!eglLoaded)
         return;
 
     // Get the best EGL config matching the default video settings
@@ -583,7 +578,7 @@ DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, cons
 
     // Get the initialized EGL display
     m_display = getInitializedDisplay();
-    if (!isEglLoaded())
+    if (!eglLoaded)
         return;
 
     // Get the best EGL config matching the requested video settings
@@ -608,7 +603,7 @@ DRMContext::DRMContext(DRMContext* shared, const ContextSettings& settings, Vect
 
     // Get the initialized EGL display
     m_display = getInitializedDisplay();
-    if (!isEglLoaded())
+    if (!eglLoaded)
         return;
 
     // Get the best EGL config matching the requested video settings
@@ -860,7 +855,7 @@ void DRMContext::updateSettings()
 ////////////////////////////////////////////////////////////
 GlFunctionPointer DRMContext::getFunction(const char* name)
 {
-    if (!isEglLoaded())
+    if (!eglLoaded)
         return nullptr;
     return reinterpret_cast<GlFunctionPointer>(eglGetProcAddress(name));
 }


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [X] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->
This PR fixes three issues I noticed while testing the DRM setup by myself:
- A segmentation fault if the initDrm function fails (i.e. due to the file specified being the wrong one).
- A segmentation fault if libEgl is not loaded (the program will still not work properly, to be clear... But at least now the user will be able to know why. Before this PR, SFML said nothing to the user, and it just crashed)
- The lack of the ability to select which screen the program should target.

The first two points are fixed thanks to the new function inside DRMContext.cpp: getEglLoaded(), which returns whether Egl was dynamically loaded correctly.
The last point is solved by adding the SFML_DRM_CONNECTOR_ID environment variable, which SFML checks at runtime. If this variable is set, it will specify the ID for the connector (and the screen that is plugged into said connector).

## Tasks

-   [X] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->
To test this, a Linux environment without a Desktop active is required.
This can be achieved by using certain combinations on some devices, like CTRL + Alt + F3.

For point 1, to test this, simply set SFML_DRM_DEVICE to a bad file value (anything will work). It shouldn't crash inside DRMContext.

For point 2, launch a program in an environment without libegl1. I used a Raspberry Pi loaded with the Raspbian OS Lite image, with libgm1 and libgl1 installed, but without libegl1 installed. Again, the result is that it shouldn't crash inside DRMContext.
A helpful error message should also get printed.

For point 3, it requires a second monitor. Check the ID of the connector via the drm_info command, and then the user should be able to change the screen on which the application is displayed on.

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        window.clear();
        window.display();
    }
}
```
