### PR TITLE
Use const ref instead of cloning channelMap

### DIFF
--- a/include/SFML/Audio/SoundBuffer.hpp
+++ b/include/SFML/Audio/SoundBuffer.hpp
@@ -291,7 +291,7 @@ public:
     /// \see `getSampleRate`, `getChannelCount`, `getDuration`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::vector<SoundChannel> getChannelMap() const;
+    [[nodiscard]] const std::vector<SoundChannel>& getChannelMap() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the total duration of the sound

--- a/include/SFML/Audio/SoundStream.hpp
+++ b/include/SFML/Audio/SoundStream.hpp
@@ -146,7 +146,7 @@ public:
     /// \return Map of position in sample frame to sound channel
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::vector<SoundChannel> getChannelMap() const;
+    [[nodiscard]] const std::vector<SoundChannel>& getChannelMap() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the current status of the stream (stopped, paused, playing)

--- a/src/SFML/Audio/SoundBuffer.cpp
+++ b/src/SFML/Audio/SoundBuffer.cpp
@@ -213,7 +213,7 @@ unsigned int SoundBuffer::getChannelCount() const
 
 
 ////////////////////////////////////////////////////////////
-std::vector<SoundChannel> SoundBuffer::getChannelMap() const
+const std::vector<SoundChannel>& SoundBuffer::getChannelMap() const
 {
     return m_channelMap;
 }

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -331,7 +331,7 @@ unsigned int SoundStream::getSampleRate() const
 
 
 ////////////////////////////////////////////////////////////
-std::vector<SoundChannel> SoundStream::getChannelMap() const
+const std::vector<SoundChannel>& SoundStream::getChannelMap() const
 {
     return m_impl->channelMap;
 }


### PR DESCRIPTION
getChannelMap was cloning the data unnecessarily. It wasn't building the data in the function, so I saw no reason why it had to pass by value instead of simply passing by const reference.

This is just a proposal, so nothing too serious. The one major benefit is simply being more consistent. There are other uses of the `getChannelMap` (such as in SoundRecorder and InputSoundFile) that was passing by const reference instead of cloning the data.

This may also improve the CSFML code. I see that ya'll are cloning the data in the CSFML layer because of this.

Looks like there is some proof that it was mistakenly forgotten:
https://github.com/SFML/SFML/pull/2749#discussion_r1478634083

There is an initiative to use the const references :)