### PR TITLE
Fixed audio engine attempting to read data from previously destroyed objects

### DIFF
--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -315,6 +315,14 @@ void AudioDevice::unregisterResource(AudioDevice::ResourceEntryIter resourceEntr
 
 
 ////////////////////////////////////////////////////////////
+void AudioDevice::waitForReadingComplete()
+{
+    // Once we can lock the reading mutex it means the engine read cycle has been completed
+    const std::lock_guard lock(getInstance()->m_readingDataMutex);
+}
+
+
+////////////////////////////////////////////////////////////
 void AudioDevice::setGlobalVolume(float volume)
 {
     // Store the volume in case no audio device exists yet
@@ -488,6 +496,7 @@ bool AudioDevice::initialize()
 
         if (audioDevice.m_engine)
         {
+            const std::lock_guard lock(audioDevice.m_readingDataMutex);
             if (const auto result = ma_engine_read_pcm_frames(&*audioDevice.m_engine, output, frameCount, nullptr);
                 result != MA_SUCCESS)
                 err() << "Failed to read PCM frames from audio engine: " << ma_result_description(result) << std::endl;

--- a/src/SFML/Audio/AudioDevice.hpp
+++ b/src/SFML/Audio/AudioDevice.hpp
@@ -180,6 +180,16 @@ public:
     static void unregisterResource(ResourceEntryIter resourceEntry);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Wait for device reading to complete
+    ///
+    /// This is primarily used to ensure changes to the engine
+    /// node graph have been applied so the next read cycle does
+    /// not read from objects that have already been destroyed.
+    ///
+    ////////////////////////////////////////////////////////////
+    static void waitForReadingComplete();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Change the global volume of all the sounds and musics
     ///
     /// The volume is a number between 0 and 100; it is combined with
@@ -370,12 +380,13 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::optional<ma_log>     m_log;            //!< The miniaudio log
-    std::optional<ma_context> m_context;        //!< The miniaudio context
-    std::optional<ma_device>  m_playbackDevice; //!< The miniaudio playback device
-    std::optional<ma_engine>  m_engine;         //!< The miniaudio engine (used for effects and spatialization)
-    ResourceEntryList         m_resources;      //!< Registered resources
-    std::mutex                m_resourcesMutex; //!< The mutex guarding the registered resources
+    std::optional<ma_log>     m_log;              //!< The miniaudio log
+    std::optional<ma_context> m_context;          //!< The miniaudio context
+    std::optional<ma_device>  m_playbackDevice;   //!< The miniaudio playback device
+    std::optional<ma_engine>  m_engine;           //!< The miniaudio engine (used for effects and spatialization)
+    ResourceEntryList         m_resources;        //!< Registered resources
+    std::mutex                m_resourcesMutex;   //!< The mutex guarding the registered resources
+    std::mutex                m_readingDataMutex; //!< The mutex guarding data reading cycles by the audio engine
 };
 
 } // namespace sf::priv

--- a/src/SFML/Audio/Sound.cpp
+++ b/src/SFML/Audio/Sound.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Audio/AudioDevice.hpp>
 #include <SFML/Audio/MiniaudioUtils.hpp>
 #include <SFML/Audio/Sound.hpp>
 #include <SFML/Audio/SoundBuffer.hpp>
@@ -256,6 +257,7 @@ void Sound::stop()
     {
         setPlayingOffset(Time::Zero);
         m_impl->status = Status::Stopped;
+        priv::AudioDevice::waitForReadingComplete();
     }
 }
 

--- a/src/SFML/Audio/SoundStream.cpp
+++ b/src/SFML/Audio/SoundStream.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Audio/AudioDevice.hpp>
 #include <SFML/Audio/MiniaudioUtils.hpp>
 #include <SFML/Audio/SoundStream.hpp>
 
@@ -312,6 +313,7 @@ void SoundStream::stop()
     {
         setPlayingOffset(Time::Zero);
         m_impl->status = Status::Stopped;
+        priv::AudioDevice::waitForReadingComplete();
     }
 }
 


### PR DESCRIPTION
miniaudio organizes audio objects as nodes in a node graph. Audio data flows from source nodes to sink nodes. The audio device is usually the sink node but since we are using the audio engine functionality for spatialization it serves as our main sink node. When miniaudio needs audio sample data to forward to the operating system sound driver it traverses the node graph from the sink back to the sources. The sources in our case are typically `sf::Sound` and `sf::Music` or any user-defined type derived from `sf::SoundStream`. Because audio data processing is a real-time process, this traversal of the node graph happens on a dedicated audio thread that is managed by miniaudio.

The miniaudio node graph is documented here: https://miniaud.io/docs/manual/index.html#NodeGraph

The way `sf::SoundStream` works, `onGetData` will ultimately get called from the audio thread to retrieve new sample data. This works well in general. A problem only arises when `sf::SoundStream` objects are destroyed.

In the past, when using OpenAL, each `sf::SoundStream` object would spawn its own thread to handle among other things calling `onGetData`. When `stop()` is called in the destructor of e.g. `sf::Music` or any other derived class, the internal thread would be stopped and there was no risk of `onGetData` being called after the object was already destroyed.

Now that we are using miniaudio, there is only a single audio thread that handles pulling data from all objects. Until the miniaudio audio device itself is stopped, this thread will keep traversing the node graph at regular intervals to pull in audio data.

One might think that the call to `sf::SoundStream::stop()` is enough to prevent the audio thread from attempting to pull in audio data from that object from that point onward, however for performance reasons any changes to the node graph traversal are only made visible to the audio thread only after it completes its reading cycle. This means that if `stop()` is called while the audio thread is already on its way reading in data for the current cycle, `onGetData` of the object to be destroyed will still be called for the current cycle.

In order to prevent this use-after-free bug we have to block destruction of the `sf::SoundStream` derived object until after the reading cycle is complete. Because historically calling `stop()` from the destructor of the derived class would be sufficient to prevent any data races, the call to wait for the audio read cycle to complete was placed there. This means that any call to `stop()` would always wait for reading to complete, even calls to `stop()` that did not involve destroying the object. Performance measurements show that there is little to no performance impact of doing so. I assume this has to do with the fact that due to the nature that audio data processing has to be done in a low-latency manner, the lock contention and thus waiting that has to be done in a typical scenario is very minimal.

A use-after-free can be reproduced with the following code:
```cpp
#include <SFML/Audio.hpp>

#include <atomic>
#include <iostream>
#include <thread>
#include <vector>

#include <cassert>

int main()
{
    struct Test : sf::SoundStream
    {
        bool alive = true; // Helps us assert on use-after-frees

        Test()
        {
            initialize(1, 44100, {sf::SoundChannel::Mono});
            play();
            while (getStatus() != sf::SoundStream::Status::Playing)
                ;
        }

        ~Test()
        {
            stop();
            alive = false;
        }

        bool onGetData(Chunk& data) override
        {
            assert(alive);
            static const std::int16_t sample{};
            data.samples     = &sample;
            data.sampleCount = 1;
            return true;
        }

        void onSeek(sf::Time) override
        {
        }
    };

    Test dummy; // To keep audio device alive

    std::vector<std::thread> threads;

    static std::atomic<std::int32_t> count;

    for (auto i = 0u; i < std::thread::hardware_concurrency(); ++i)
        threads.emplace_back(
            []
            {
                while (1)
                {
                    Test test;
                    count.fetch_add(1, std::memory_order_relaxed);
                }
            });

    while (1)
    {
        std::cout << count.exchange(0, std::memory_order_relaxed) << "\n";
        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
    }
}
```
When running the above code (optionally with address sanitizer enabled), it will eventually lead to abnormal termination of the program due to one of several reasons:
- The runtime detecting a call to a pure virtual function (i.e. `onGetData` being called after the Test destructor already completed but the `sf::SoundStream` destructor has not)
- The assert being triggered when building with asserts enabled
- ASAN detecting a memory error
- Something else terminating the program due to undefined behaviour

Initially I used the example provided in #3503 however, as the author said, that example is not able to reliably reproduce an error on all systems. On my test system I had to run the program for at least 10 hours before it terminated due to an error. In contrast, the code provided above should terminate almost immediately.

The changes in this PR should prevent any use-after-frees in this context. The code above continued to run even after several hours.

Closes #3503