### PR TITLE
Add Vector3u type alias for consistency.

### DIFF
--- a/include/SFML/System/Vector3.hpp
+++ b/include/SFML/System/Vector3.hpp
@@ -303,6 +303,7 @@ template <typename T>
 
 // Aliases for the most common types
 using Vector3i = Vector3<int>;
+using Vector3u = Vector3<unsigned int>;
 using Vector3f = Vector3<float>;
 
 } // namespace sf


### PR DESCRIPTION
It is a bit weird that Vector3i exists, yet Vector3u doesn't despite Vector3i's non-usage. To be consistent, we should either not have Vector3i, or copy Vector2's implementation and provide a Vector3u.

Opted for providing a Vector3u as it would be easier to justify adding new API features instead of removing API which is (of course) breaking.