### PR TITLE
Remove deprecated VS2019 CI jobs & update Ubuntu image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
         platform:
         - { name: Windows VS2022,       os: windows-2022 }
         - { name: Windows VS2022 Clang, os: windows-2022, flags: -T ClangCL }
-        - { name: Linux GCC,            os: ubuntu-20.04 }
-        - { name: Linux Clang,          os: ubuntu-20.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
-        - { name: Linux GCC OpenGL ES,  os: ubuntu-20.04, flags: -DSFML_OPENGL_ES=ON }
+        - { name: Linux GCC,            os: ubuntu-22.04 }
+        - { name: Linux Clang,          os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: Linux GCC OpenGL ES,  os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON }
         - { name: macOS x64,            os: macos-13 }
         - { name: macOS arm64,          os: macos-14 }
         - { name: iOS,                  os: macos-13, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
@@ -35,17 +35,17 @@ jobs:
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
         - platform: { name: macOS, os: macos-13 }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }
-        - platform: { name: Android, os: ubuntu-20.04 }
+        - platform: { name: Android, os: ubuntu-22.04 }
           config: { name: x86, flags: -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Android, os: ubuntu-20.04 }
+        - platform: { name: Android, os: ubuntu-22.04 }
           config: { name: armeabi-v7a, flags: -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Android, os: ubuntu-20.04 }
+        - platform: { name: Android, os: ubuntu-22.04 }
           config: { name: arm64-v8a, flags: -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-ndk-r18b/build/cmake/android.toolchain.cmake -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Android, os: ubuntu-20.04 }
+        - platform: { name: Android, os: ubuntu-22.04 }
           config: { name: x86_64, flags: -DCMAKE_ANDROID_ARCH_ABI=x86_64 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-ndk-r18b/build/cmake/android.toolchain.cmake -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Linux GCC, os: ubuntu-20.04 }
+        - platform: { name: Linux GCC, os: ubuntu-22.04 }
           config: { name: Static DRM, flags: -DBUILD_SHARED_LIBS=FALSE -DSFML_USE_DRM=TRUE }
-        - platform: { name: Linux GCC, os: ubuntu-20.04 }
+        - platform: { name: Linux GCC, os: ubuntu-22.04 }
           config: { name: Shared DRM, flags: -DBUILD_SHARED_LIBS=TRUE -DSFML_USE_DRM=TRUE }
     steps:
     - name: Checkout Code


### PR DESCRIPTION
## Description

Microsoft will be removing these images on June 30th. Between now and it then it will be performing brownouts so let's remove these jobs before those brownouts hit in a few days.

Ubuntu 20.04 has already been removed.

See also #3517