### PR TITLE
[Backport] Fix pkg-config when SFML_PKGCONFIG_INSTALL_DIR is unset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,9 +201,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
 
-# add the subdirectories
-add_subdirectory(src/SFML)
-
 # on Linux and BSD-like OS, install pkg-config files by default
 set(SFML_INSTALL_PKGCONFIG_DEFAULT OFF)
 
@@ -247,6 +244,9 @@ endif()
 if(SFML_ENABLE_PCH AND SFML_OS_MACOS)
     message(FATAL_ERROR "Precompiled headers are currently not supported in macOS builds")
 endif()
+
+# add the subdirectories
+add_subdirectory(src/SFML)
 
 # setup the install rules
 if(NOT SFML_BUILD_FRAMEWORKS)


### PR DESCRIPTION
This is just commit a87763becbc4672b38f1021418ed94caa0f6540a grafted to the 3.0.x branch, so it can generate the .pc scripts on the first run of cmake.