### PR TITLE
Fix special comments for clang-format and issue tracker URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,5 +13,5 @@ contact_links:
       url: https://github.com/SFML/CSFML/issues/new
       about: Use the dedicated CSFML issue tracker
     - name: Report a bug or request a feature for SFML.Net
-      url: https://github.com/SFML/CSFML/issues/new
+      url: https://github.com/SFML/SFML.Net/issues/new
       about: Use the dedicated SFML.Net issue tracker

--- a/include/SFML/Graphics/Transform.hpp
+++ b/include/SFML/Graphics/Transform.hpp
@@ -273,7 +273,7 @@ private:
                                    0.f, 1.f, 0.f, 0.f,
                                    0.f, 0.f, 1.f, 0.f,
                                    0.f, 0.f, 0.f, 1.f}; //!< 4x4 matrix defining the transformation
-    // clang-format off
+    // clang-format on
 };
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

This PR is straightforward and doesn't have a corresponding open issue. It fixes the following two problems:

- Fix special comments for clang-format so that clang-format will be enabled after that comment according to [Disabling Formatting on a Piece of Code](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code).
- Fix issue tracker URL for SFML.Net related issues in .github/ISSUE_TEMPLATE/config.yml.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

