### PR TITLE
Assert positive size and in-bounds position for area

### DIFF
--- a/src/SFML/Graphics/Texture.cpp
+++ b/src/SFML/Graphics/Texture.cpp
@@ -394,6 +394,10 @@ bool Texture::loadFromImage(const Image& image, bool sRgb, const IntRect& area)
     }
 
     // Load a sub-area of the image
+    assert(area.size.x > 0 && "Area size x cannot be negative");
+    assert(area.size.y > 0 && "Area size y cannot be negative");
+    assert(area.position.x < size.x && "Area position x is out of image bounds");
+    assert(area.position.y < size.y && "Area position y is out of image bounds");
 
     // Adjust the rectangle to the size of the image
     IntRect rectangle    = area;


### PR DESCRIPTION
## Description

Added asserts to handle negative size and out of bounds position for the image sub-area in Texture::loadFromImage. 

Size: assert strictly positive sizes, as zero sizes are already handled earlier and are invalid as well.
Position: assert positions strictly less than the image size, ensuring the remaining space is non-zero.

This PR is related to the issue #3539

For reference, negative positions are adjusted to 0. So maybe we should consider asserting on negative positions as well, or consistently adjust size and position for uniform behavior.

## Tasks

-   [ ] Tested on Linux
-   [X] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    const sf::Image image(sf::Vector2u(10, 15));
    const sf::Texture position_out_of_bounds(image, false, {{20, 20}, {5, 10}}); // assertion
    const sf::Texture negative_size(image, false, {{20, 20}, {-5, 10}}); // assertion
}
```
