### PR TITLE
Update docs for `operator bool`

### DIFF
--- a/include/SFML/Network/Packet.hpp
+++ b/include/SFML/Network/Packet.hpp
@@ -191,10 +191,6 @@ public:
     /// }
     /// \endcode
     ///
-    /// Don't focus on the return type, it's equivalent to bool but
-    /// it disallows unwanted implicit conversions to integer or
-    /// pointer types.
-    ///
     /// \return `true` if last data extraction from packet was successful
     ///
     /// \see `endOfPacket`


### PR DESCRIPTION
This comment was because it used the safe bool idiom which is no longer necessary with C++11 explicit conversion operators