### PR TITLE
docs: Add macOS Accessibility permission warning to Mouse::setPosition

### DIFF
--- a/include/SFML/Window/Mouse.hpp
+++ b/include/SFML/Window/Mouse.hpp
@@ -113,6 +113,10 @@ enum class Wheel
 ///
 /// \param position New position of the mouse
 ///
+/// \warning On macOS the OS API used for `setPosition` requires granting
+///     of Accessibility permission for your application.
+///     See also: https://support.apple.com/guide/mac-help/allow-accessibility-apps-to-access-your-mac-mh43185/
+///
 ////////////////////////////////////////////////////////////
 SFML_WINDOW_API void setPosition(Vector2i position);
 
@@ -124,6 +128,10 @@ SFML_WINDOW_API void setPosition(Vector2i position);
 ///
 /// \param position New position of the mouse
 /// \param relativeTo Reference window
+///
+/// \warning On macOS the OS API used for `setPosition` requires granting
+///     of Accessibility permission for your application.
+///     See also: https://support.apple.com/guide/mac-help/allow-accessibility-apps-to-access-your-mac-mh43185/
 ///
 ////////////////////////////////////////////////////////////
 SFML_WINDOW_API void setPosition(Vector2i position, const WindowBase& relativeTo);


### PR DESCRIPTION
Adds the necessary warning about macOS 'Accessibility' permission requirements for the setPosition functions, addressing the remaining part of issue #3532.

<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

This PR adds the missing documentation warning about the 'Accessibility' permission requirement for sf::Mouse::setPosition on macOS.

This change completes the work discussed in issue #3532, as the warning for sf::Keyboard::isKeyPressed was already present in the codebase.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

Note: As this is a documentation-only change for a macOS-specific issue and I do not have access to a macOS device, I was unable to perform live testing.

## How to test this PR?

This is a documentation-only change. The test is to review the added Doxygen comments in the include/SFML/Window/Mouse.hpp file for clarity and correctness.
