### PR TITLE
Build dependencies using unity build.

### DIFF
--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -134,8 +134,34 @@ else()
             set_target_properties(ogg FLAC vorbis vorbisenc vorbisfile PROPERTIES POSITION_INDEPENDENT_CODE ON)
         endif()
 
-        # disable building dependencies as part of a unity build, they don't support it
-        set_target_properties(ogg FLAC vorbis vorbisenc vorbisfile PROPERTIES UNITY_BUILD OFF)
+        # build using unity build and exclude files that cause issues
+        set_target_properties(ogg FLAC vorbis vorbisenc vorbisfile PROPERTIES UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 256)
+        set_source_files_properties(
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/fixed.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/format.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/fixed_intrin_sse2.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/fixed_intrin_ssse3.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/fixed_intrin_sse42.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/lpc.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/metadata_object.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/stream_decoder.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/stream_encoder.c"
+            "${FETCHCONTENT_BASE_DIR}/flac-src/src/libFLAC/window.c"
+            TARGET_DIRECTORY FLAC
+            PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+        )
+        set_source_files_properties(
+            "${FETCHCONTENT_BASE_DIR}/vorbis-src/lib/floor1.c"
+            "${FETCHCONTENT_BASE_DIR}/vorbis-src/lib/sharedbook.c"
+            "${FETCHCONTENT_BASE_DIR}/vorbis-src/lib/vorbisenc.c"
+            TARGET_DIRECTORY vorbis
+            PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+        )
+        set_source_files_properties(
+            "${FETCHCONTENT_BASE_DIR}/vorbis-src/lib/vorbisenc.c"
+            TARGET_DIRECTORY vorbisenc
+            PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+        )
 
         sfml_set_stdlib(ogg)
         sfml_set_stdlib(FLAC)

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -144,8 +144,16 @@ else()
             set_target_properties(freetype PROPERTIES POSITION_INDEPENDENT_CODE ON)
         endif()
 
-        # disable building dependencies as part of a unity build, they don't support it
-        set_target_properties(freetype PROPERTIES UNITY_BUILD OFF)
+        # build using unity build and exclude files that cause issues
+        set_target_properties(freetype PROPERTIES UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 256)
+        set_source_files_properties(
+            "${FETCHCONTENT_BASE_DIR}/freetype-src/src/pfr/pfr.c"
+            "${FETCHCONTENT_BASE_DIR}/freetype-src/src/smooth/smooth.c"
+            "${FETCHCONTENT_BASE_DIR}/freetype-src/builds/windows/ftsystem.c"
+            "${FETCHCONTENT_BASE_DIR}/freetype-src/builds/windows/ftdebug.c"
+            TARGET_DIRECTORY freetype
+            PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+        )
 
         sfml_set_stdlib(freetype)
         add_library(Freetype::Freetype ALIAS freetype)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ include(Catch)
 target_compile_features(Catch2 PRIVATE cxx_std_17)
 
 # Ensure that Catch2 sources and headers are not analyzed by any tools
-set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF)
+set_target_properties(Catch2 PROPERTIES COMPILE_OPTIONS "" EXPORT_COMPILE_COMMANDS OFF UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 256)
 set_target_properties(Catch2WithMain PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
 set_target_properties(Catch2 Catch2WithMain PROPERTIES FOLDER "Dependencies")
 get_target_property(CATCH2_INCLUDE_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
This change enables always building dependencies using unity build.

This has the following benefits:
- Reduced build time in certain cases especially where compiler invocation and process start up takes more time e.g. on Windows
- Reduced output from building dependencies in build logs, this makes it easier to analyse them for our own warnings/errors
- Since unity build makes all source files visible to the compiler at the same time there could be a potential performance increase from this "poor man's link time optimization"

Because none of our C dependencies were really written to be built this way, some files had to be excluded from the unity build due to ODR violations and other errors. If anyone wants to know how these files were selected: trial and error.