### PR TITLE
Install Xcode 16.0 for macos-15 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,12 @@ jobs:
       if: contains(matrix.config.name, 'System Deps')
       run: brew install flac libvorbis || true
 
+    - name: Install old Xcode version
+      if: matrix.platform.os == 'macos-15' && contains(matrix.platform.name, 'iOS')
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode_version: '16.0'
+
     # In addition to installing a known working version of CCache, this action also takes care of saving and restoring the cache for us
     # Additionally it outputs information at the end of each job that helps us to verify if the cache is working properly
     - name: Setup CCache


### PR DESCRIPTION
## Description

> Platform tools (SDK and simulator runtimes) will only be available for the three most recently installed versions of Xcode, including beta and pre-release versions for macOS-15-based and later images.

https://github.com/actions/runner-images/issues/12541

This PR installs Xcode 16.0 again for `macos-15` images via https://github.com/maxim-lobanov/setup-xcode 

## How to test this PR?

CI should pass