### PR TITLE
Prevent copy of shaper by moving the shared_ptr

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -239,7 +239,7 @@ struct Text::ShaperImpl
             else
             {
                 if (shaper->fontId == fontId && shaper->characterSize == characterSize)
-                    result = shaper;
+                    result = std::move(shaper);
 
                 // Don't break even if we find a match since we want to finish cleaning up
                 ++iter;


### PR DESCRIPTION
## Description

Reported by [Coverity](https://scan9.scan.coverity.com/#/project-view/11820/10261?selectedIssue=548489)

This originates from the complex text layout change #3543 

## How to test this PR?

Run the text example