### PR TITLE
Prevent copy of message by moving the string

### DIFF
--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -456,7 +456,7 @@ Ftp::Response Ftp::getResponse()
                                                length - static_cast<std::size_t>(in.tellg()));
 
                         // Return the response code and message
-                        return Response(static_cast<Response::Status>(code), message);
+                        return Response(static_cast<Response::Status>(code), std::move(message));
                     }
 
                     // The line we just read was actually not a response,


### PR DESCRIPTION
## Description

Performance fix / improvement

Reported by [Coverity](https://scan9.scan.coverity.com/#/project-view/11820/10261?selectedIssue=535666)

## How to test this PR?

Run the ftp example