### PR TITLE
Enable cmake policy CMP0168

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ if(POLICY CMP0141)
     cmake_policy(SET CMP0141 NEW)
 endif()
 
+# When configuring with `--fresh`, also do a fresh configure for fetched dependencies
+if(POLICY CMP0168)
+    cmake_policy(SET CMP0168 NEW)
+endif()
+
 # determine whether to create a debug or release build
 sfml_set_option(CMAKE_BUILD_TYPE Release STRING "Choose the type of build (Debug or Release)")
 sfml_set_option(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" STRING "The minimal iOS version that will be able to run the built binaries. Cannot be lower than 13.0")


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/policy/CMP0168.html

The issue this causes in practice is if you require a fresh configure (e.g. for changing generator or toolchain) it will fail as the dependencies won't do a fresh configure, which this policy fixes