### PR TITLE
gitignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build/
 cmake-build-*/
 CMakeUserPresets.json
+.DS_Store


### PR DESCRIPTION
These are files generated by macOS when indexing folders and should never go into source control