### PR TITLE
docs: sf::Text - clarify setPosition behavior and offsets

### DIFF
--- a/include/SFML/Graphics/Transformable.hpp
+++ b/include/SFML/Graphics/Transformable.hpp
@@ -62,6 +62,17 @@ public:
     /// See the move function to apply an offset based on the previous position instead.
     /// The default position of a transformable object is (0, 0).
     ///
+    /// **Note on offsets:**
+    /// `sf::Text` may appear offset when positioned.
+    /// This is because its local bounds are influenced by font metrics (e.g., tallest characters),
+    /// so `getGlobalBounds()` may not match the position you set.
+    ///
+    /// To remove this offset, adjust the origin manually:
+    /// \code
+    /// text.setOrigin(text.getLocalBounds().position.x, text.getLocalBounds().position.y);
+    /// text.setPosition(position);
+    /// \endcode
+    ///
     /// \param position New position
     ///
     /// \see `move`, `getPosition`


### PR DESCRIPTION
- Added note explaining why sf::Text may appear offset.
- Showed how to fix offset by adjusting origin.

<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to be ticked, but the more the better!)

-   [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php?topic=33803.0) or in an issue before?
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [x] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

This PR updates the Doxygen documentation for `sf::Text::setPosition` to clarify its behavior regarding text offsets caused by font metrics. It explains why `getGlobalBounds()` may not match the set position and demonstrates how to remove the offset by adjusting the origin.  

This PR closes GitHub issue #2172
## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

You can test by generating Doxygen documentation from the updated header and checking the `setPosition` description.  

<img width="1167" height="509" alt="image" src="https://github.com/user-attachments/assets/aae247d9-5354-4221-96c3-6a861cb60c5e" />
