### PR TITLE
Add explicit cast for charN_t conversion

### DIFF
--- a/include/SFML/System/Utf.inl
+++ b/include/SFML/System/Utf.inl
@@ -388,7 +388,7 @@ In Utf<16>::decode(In begin, In end, char32_t& output, char32_t replacement)
     else
     {
         // We can make a direct copy
-        output = first;
+        output = static_cast<char32_t>(first);
     }
 
     return begin;


### PR DESCRIPTION
The llvm 21 release adds a new on by default warning for charN_t implicit conversion and comparison. This adds a static cast to get around that.
Relevant PR: https://github.com/llvm/llvm-project/issues/138526
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->


## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Build with clang 21 or newer
