### PR TITLE
Use default cmake output paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,6 @@ if(SFML_ENABLE_STDLIB_ASSERTIONS)
     endif()
 endif()
 
-# set the output directory for SFML DLLs and executables
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
-
 # enable project folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -380,7 +380,10 @@ macro(sfml_add_example target)
     endif()
 
     if(SFML_OS_WINDOWS AND SFML_USE_MESA3D)
-        add_dependencies(${target} "install-mesa3d")
+        add_custom_command(TARGET ${target} POST_BUILD 
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${MESA3D_FILE_LIST} $<TARGET_FILE_DIR:${target}>
+            COMMENT "Copying Mesa3D dlls"
+            COMMAND_EXPAND_LISTS)
     endif()
 
     # Enable support for UTF-8 characters in source code
@@ -388,10 +391,10 @@ macro(sfml_add_example target)
         target_compile_options(${target} PRIVATE /utf-8)
     endif()
 
-    if(WIN32 AND BUILD_SHARED_LIBS)
-        # Copy runtime dependencies to the output
+    if(SFML_OS_WINDOWS AND BUILD_SHARED_LIBS)
         add_custom_command(TARGET ${target} POST_BUILD 
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}> 
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}>
+            COMMENT "Copying dependencies"
             COMMAND_EXPAND_LISTS)
     endif()
 endmacro()
@@ -444,7 +447,10 @@ function(sfml_add_test target SOURCES DEPENDS)
     endif()
 
     if(SFML_OS_WINDOWS AND SFML_USE_MESA3D)
-        add_dependencies(${target} "install-mesa3d")
+        add_custom_command(TARGET ${target} POST_BUILD 
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${MESA3D_FILE_LIST} $<TARGET_FILE_DIR:${target}>
+            COMMENT "Copying Mesa3D dlls"
+            COMMAND_EXPAND_LISTS)
     endif()
 
     # Delay test registration when cross compiling to avoid running crosscompiled app on host OS
@@ -473,7 +479,7 @@ function(sfml_add_test target SOURCES DEPENDS)
         target_compile_options(${target} PRIVATE /utf-8)
     endif()
 
-    if(WIN32 AND BUILD_SHARED_LIBS)
+    if(SFML_OS_WINDOWS AND BUILD_SHARED_LIBS)
         # Copy runtime dependencies to the output
         add_custom_command(TARGET ${target} POST_BUILD 
             COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}> 

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -387,6 +387,13 @@ macro(sfml_add_example target)
     if(SFML_COMPILER_MSVC)
         target_compile_options(${target} PRIVATE /utf-8)
     endif()
+
+    if(WIN32)
+        # Copy runtime dependencies to the output
+        add_custom_command(TARGET ${target} POST_BUILD 
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}> 
+            COMMAND_EXPAND_LISTS)
+    endif()
 endmacro()
 
 # add a new target which is a SFML test
@@ -464,6 +471,13 @@ function(sfml_add_test target SOURCES DEPENDS)
     # Enable support for UTF-8 characters in source code
     if(SFML_COMPILER_MSVC)
         target_compile_options(${target} PRIVATE /utf-8)
+    endif()
+
+    if(WIN32)
+        # Copy runtime dependencies to the output
+        add_custom_command(TARGET ${target} POST_BUILD 
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}> 
+            COMMAND_EXPAND_LISTS)
     endif()
 
     # Add the test

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -388,7 +388,7 @@ macro(sfml_add_example target)
         target_compile_options(${target} PRIVATE /utf-8)
     endif()
 
-    if(WIN32)
+    if(WIN32 AND BUILD_SHARED_LIBS)
         # Copy runtime dependencies to the output
         add_custom_command(TARGET ${target} POST_BUILD 
             COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}> 
@@ -473,7 +473,7 @@ function(sfml_add_test target SOURCES DEPENDS)
         target_compile_options(${target} PRIVATE /utf-8)
     endif()
 
-    if(WIN32)
+    if(WIN32 AND BUILD_SHARED_LIBS)
         # Copy runtime dependencies to the output
         add_custom_command(TARGET ${target} POST_BUILD 
             COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target}> $<TARGET_FILE_DIR:${target}> 

--- a/cmake/Mesa3D.cmake
+++ b/cmake/Mesa3D.cmake
@@ -1,8 +1,8 @@
 set(MESA3D_URL "https://github.com/pal1000/mesa-dist-win/releases/download/25.2.0/mesa3d-25.2.0-release-msvc.7z")
 set(MESA3D_SHA256 "67e76e9844206c71cf313e09409303af9c01d7561c5f57d7e152771e2408aafe")
 
-get_filename_component(MESA3D_ARCHIVE "${MESA3D_URL}" NAME)
-get_filename_component(MESA3D_ARCHIVE_DIRECTORY "${MESA3D_URL}" NAME_WLE)
+cmake_path(GET MESA3D_URL FILENAME MESA3D_ARCHIVE)
+cmake_path(GET MESA3D_URL STEM LAST_ONLY MESA3D_ARCHIVE_DIRECTORY)
 
 if(ARCH_X64)
     set(MESA3D_ARCH "x64")
@@ -44,45 +44,6 @@ if(SFML_OS_WINDOWS AND SFML_USE_MESA3D)
         file(REMOVE "${MESA3D_ARCHIVE_PATH}")
     endif()
 
-    # add the files as file dependencies to a custom target that we can add as a dependency to executable/test targets
-    file(GLOB MESA3D_FILE_LIST "${MESA3D_ARCH_PATH}/*")
-
-    get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-
-    foreach(MESA3D_FILE ${MESA3D_FILE_LIST})
-        get_filename_component(MESA3D_FILE_NAME "${MESA3D_FILE}" NAME)
-
-        list(APPEND MESA3D_INSTALLED_FILES "${PROJECT_BINARY_DIR}/bin/$<IF:$<BOOL:${IS_MULTI_CONFIG}>,$<CONFIG>/,>${MESA3D_FILE_NAME}")
-    endforeach()
-
-    # if files are missing from the target directory of the configuration being built, copy them over
-    add_custom_command(OUTPUT ${MESA3D_INSTALLED_FILES} COMMAND "${CMAKE_COMMAND}" ARGS -E copy_if_different ${MESA3D_FILE_LIST} "${PROJECT_BINARY_DIR}/bin$<IF:$<BOOL:${IS_MULTI_CONFIG}>,/$<CONFIG>,>")
-
-    add_custom_target(install-mesa3d DEPENDS ${MESA3D_INSTALLED_FILES})
-
-    set_target_properties(install-mesa3d PROPERTIES EXCLUDE_FROM_ALL ON)
-elseif(SFML_OS_WINDOWS AND MESA3D_ARCH AND EXISTS "${MESA3D_ARCH_PATH}")
-    # we are removing the files
-
-    # compile a list of file names that we have to remove
-    file(GLOB MESA3D_FILE_LIST "${MESA3D_ARCH_PATH}/*")
-
-    foreach(MESA3D_FILE ${MESA3D_FILE_LIST})
-        get_filename_component(MESA3D_FILE_NAME "${MESA3D_FILE}" NAME)
-
-        list(APPEND MESA3D_FILE_NAMES "${MESA3D_FILE_NAME}")
-    endforeach()
-
-    # recursively go through all files in bin and remove files that match the file name of a Mesa 3D file
-    file(GLOB_RECURSE BINARY_FILE_LIST "${PROJECT_BINARY_DIR}/bin/*")
-
-    foreach(BINARY_FILE ${BINARY_FILE_LIST})
-        get_filename_component(BINARY_FILE_NAME "${BINARY_FILE}" NAME)
-
-        list(FIND MESA3D_FILE_NAMES "${BINARY_FILE_NAME}" INDEX)
-
-        if(NOT INDEX EQUAL -1)
-            file(REMOVE "${BINARY_FILE}")
-        endif()
-    endforeach()
+    # Create a list of dll's that can be copied where needed
+    file(GLOB MESA3D_FILE_LIST "${MESA3D_ARCH_PATH}/*.dll")
 endif()


### PR DESCRIPTION
Overriding the global `CMAKE_RUNTIME_OUTPUT_DIRECTORY` variable so that every binary goes into the same folder is intrusive, unintuitive, and can cause a variety of unnecessary complications

My understanding is this was only done so that windows dlls can be loaded for the examples/tests, but it's simple enough to do that in a target and platform specific way that leaves the standard output structure untouched.

Had to modify the mesa3d stuff to accommodate this, which also removed the functionality to remove the mesa3d dlls when disabling the option, but given it's just a workaround for CI jobs (where this behaviour would never be used) I think the impact of this is negligible - I _could_ make it work with some more hacks but in my opinion it's not worth it for something that maintaners/developers may only do once in a blue moon (you can just do a clean build instead when disabling the option)

A big motivation for this is mobile/console ports, where the output is often more than just a simple binary, and involves specific folder structures that are difficult (or impossible) to manage when every target is trying to work with the same output folder