### PR TITLE
Migrate away from macos-13 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
         - { name: Linux Clang,                    os: ubuntu-24.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: Linux GCC DRM,                  os: ubuntu-24.04, flags: -DSFML_USE_DRM=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
         - { name: Linux GCC OpenGL ES,            os: ubuntu-24.04, flags: -DSFML_OPENGL_ES=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
-        - { name: macOS x64,                      os: macos-13, flags: -GNinja }
-        - { name: macOS x64 Xcode,                os: macos-13, flags: -GXcode }
+        - { name: macOS x64,                      os: macos-15, flags: -GNinja -DCMAKE_OSX_ARCHITECTURES=x86_64 }
+        - { name: macOS x64 Xcode,                os: macos-15, flags: -GXcode -DCMAKE_OSX_ARCHITECTURES=x86_64 }
         - { name: macOS arm64,                    os: macos-15, flags: -GNinja -DSFML_RUN_AUDIO_DEVICE_TESTS=OFF }
         - { name: iOS Xcode,                      os: macos-15, flags: -DCMAKE_SYSTEM_NAME=iOS -GXcode -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO }
         config:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         - { name: Windows MinGW x86,  os: windows-2025, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
         - { name: Windows MinGW x64,  os: windows-2025, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
         - { name: Linux GCC,          os: ubuntu-24.04 }
-        - { name: macOS x64,          os: macos-13 }
+        - { name: macOS x64,          os: macos-15,     flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 }
         - { name: macOS arm64,        os: macos-15 }
         config:
         - { name: Shared, flags: -DBUILD_SHARED_LIBS=ON }
@@ -33,8 +33,8 @@ jobs:
         - { name: Release, flags: -DCMAKE_BUILD_TYPE=Release }
         - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug }
         include:
-        - platform: { name: macOS x64, os: macos-13 }
-          config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=ON -DBUILD_SHARED_LIBS=ON }
+        - platform: { name: macOS x64, os: macos-15 }
+          config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64 }
           type: { name: Release }
         - platform: { name: macOS arm64, os: macos-15 }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=ON -DBUILD_SHARED_LIBS=ON }
@@ -279,7 +279,7 @@ jobs:
         - { name: Windows MinGW x86,  os: windows-2025 }
         - { name: Windows MinGW x64,  os: windows-2025 }
         - { name: Linux GCC,          os: ubuntu-24.04 }
-        - { name: macOS x64,          os: macos-13 }
+        - { name: macOS x64,          os: macos-15 }
         - { name: macOS arm64,        os: macos-15 }
 
     steps:


### PR DESCRIPTION
## Description

macOS 13 has been marked as Tier 3 configuration in Homebrew, which leads to a lot of tooling being built from source, including LLVM, taking hours to complete.

>  Warning: You are using macOS 13.
> We (and Apple) do not provide support for this old version.
> 
> This is a Tier 3 configuration:
>   https://docs.brew.sh/Support-Tiers#tier-3
> You can report Tier 3 unrelated issues to Homebrew/* repositories!
> Read the above document instead before opening any issues or PRs.

See also: https://docs.brew.sh/Support-Tiers#tier-3

https://github.com/SFML/SFML/actions/runs/18176221812/job/51742608567?pr=3545

## How to test this PR?

- CI should pass
- Previous macOS 13 (x64) builds should still target x64