### PR TITLE
Only change output dir if we're top_level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,8 +191,11 @@ if(SFML_ENABLE_STDLIB_ASSERTIONS)
     endif()
 endif()
 
-# set the output directory for SFML DLLs and executables
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+# only change the directory if we're the top level project
+if(${PROJECT_IS_TOP_LEVEL})
+    # set the output directory for SFML DLLs and executables
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+endif()
 
 # enable project folders
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
## Description

SFML should only change the runtime output directory if it is the top level project. Otherwise, it should defer to the top level project to determine the output directory.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Build SFML as a top level project and not a top level project.

## Other

I can do the testing if it's absolutely necessary, but as I haven't changed any of the code I didn't run the tests.

Thank you for your understanding.