### PR TITLE
[Backport] Fixed wrong sample count being reported for certain ogg audio files. Fixes #3578

### DIFF
--- a/src/SFML/Audio/SoundFileReaderOgg.cpp
+++ b/src/SFML/Audio/SoundFileReaderOgg.cpp
@@ -127,7 +127,7 @@ bool SoundFileReaderOgg::open(InputStream& stream, Info& info)
     if (ov_raw_seek(&m_vorbis, 0) < 0)
     {
         err() << "Failed to seek to start of Vorbis file" << std::endl;
-        return std::nullopt;
+        return false;
     }
 
     info.channelCount = static_cast<unsigned int>(vorbisInfo->channels);


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [x] Have you provided some example/test code for your changes?
-   [x] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

This PR is a backport of #3579 and is related to the issue #3578

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

The test case is similar to the one provided in issue #3578 but only concerns the ogg files provided.

```cpp
#include <SFML/Audio.hpp>

int main()
{
    std::string path_Ogg_NotWorking = "audio-test-files/Sample_Ogg_NotWorking.ogg";
    std::string path_Ogg_Working = "audio-test-files/Sample_Ogg_Working.ogg";

    sf::SoundBuffer buffer_Ogg_NotWorking;
    sf::SoundBuffer buffer_Ogg_Working;

    bool result_Ogg_NotWorking = buffer_Ogg_NotWorking.loadFromFile(path_Ogg_NotWorking);
    bool result_Ogg_Working = buffer_Ogg_Working.loadFromFile(path_Ogg_Working);
}
```
