### PR TITLE
Add build output to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,28 @@
 .vs/
 .vscode/
 build/
-cmake-build-*/
-CMakeUserPresets.json
 .DS_Store
+compile_commands.json
+
+# CMake files
+CMakeUserPresets.json
+CMakeCache.txt
+CMakeFiles
+cmake_install.cmake
+CPack*.cmake
+CTest*.cmake
+_deps
+SFMLConfig.cmake
+SFMLConfigVersion.cmake
+
+# Ninja build files
+*.Ninja*
+
+# Binary output
+*.a
+*.so
+bin
+
+# Test/coverage files
+*include.cmake
+patch_coverage.cmake


### PR DESCRIPTION
#2648  removed a bunch of stuff from the gitignore as it was deemed irrelevant. While they may be irrelevant to some people, they were relevant to many people, and weren't causing any harm

One of the justifications was:

> We know that the SFML build won't produce files with any of these patterns outside of the binary dir

Which isn't true, and assumes everybody will be using the same binary dir which also isn't true. Developers (and IDE's/tools) tend to have their own preferences about how to structure cmake output, so we shouldn't force everybody building SFML to use a specific structure when there is no real benefit

Currently just the files I needed to ignore for an android build (especially relevant as some of the output paths from android studio aren't easy to control) 