### PR TITLE
Define character traits for sf::Uint8, sf::Uint16, and sf::Uint32

### DIFF
--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -38,6 +38,118 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
+/// \brief Character traits for std::uint8_t
+///
+////////////////////////////////////////////////////////////
+struct SFML_SYSTEM_API U8StringCharTraits
+{
+    typedef unsigned char                           char_type;
+    typedef std::char_traits<char>::int_type        int_type;
+    typedef std::char_traits<char>::off_type        off_type;
+    typedef std::char_traits<char>::pos_type        pos_type;
+    typedef std::char_traits<char>::state_type      state_type;
+
+    static void             assign(char_type& c1, char_type c2);
+    static char_type*       assign(char_type* s, std::size_t n, char_type c);
+    static bool             eq(char_type c1, char_type c2);
+    static bool             lt(char_type c1, char_type c2);
+    static char_type*       move(char_type* s1, const char_type* s2, std::size_t n);
+    static char_type*       copy(char_type* s1, const char_type* s2, std::size_t n);
+    static int              compare(const char_type* s1, const char_type* s2, std::size_t n);
+    static std::size_t      length(const char_type* s);
+    static const char_type* find(const char_type* s, std::size_t n, const char_type& c);
+    static char_type        to_char_type(int_type i);
+    static int_type         to_int_type(char_type c);
+    static bool             eq_int_type(int_type i1, int_type i2);
+    static int_type         eof();
+    static int_type         not_eof(int_type i);
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Portable replacement for std::basic_string<std::uint8_t>
+///
+/// While all major C++ implementations happen to define this
+/// as of early 2024, this specialization is not strictly speaking
+/// standard C++. Thus we can't depend on its continued existence.
+///
+////////////////////////////////////////////////////////////
+typedef std::basic_string<unsigned char, U8StringCharTraits> U8String;
+
+////////////////////////////////////////////////////////////
+/// \brief Character traits for std::uint16_t (unsigned short)
+///
+////////////////////////////////////////////////////////////
+struct SFML_SYSTEM_API Uint16CharTraits
+{
+    typedef unsigned short                          char_type;
+    typedef std::char_traits<char16_t>::int_type    int_type;
+    typedef std::char_traits<char16_t>::off_type    off_type;
+    typedef std::char_traits<char16_t>::pos_type    pos_type;
+    typedef std::char_traits<char16_t>::state_type  state_type;
+
+    static void             assign(char_type& c1, char_type c2);
+    static char_type*       assign(char_type* s, std::size_t n, char_type c);
+    static bool             eq(char_type c1, char_type c2);
+    static bool             lt(char_type c1, char_type c2);
+    static char_type*       move(char_type* s1, const char_type* s2, std::size_t n);
+    static char_type*       copy(char_type* s1, const char_type* s2, std::size_t n);
+    static int              compare(const char_type* s1, const char_type* s2, std::size_t n);
+    static std::size_t      length(const char_type* s);
+    static const char_type* find(const char_type* s, std::size_t n, const char_type& c);
+    static char_type        to_char_type(int_type i);
+    static int_type         to_int_type(char_type c);
+    static bool             eq_int_type(int_type i1, int_type i2);
+    static int_type         eof();
+    static int_type         not_eof(int_type i);
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Portable replacement for std::basic_string<Uint16>
+///
+/// While std::u16string exists, it uses char16_t which is not
+/// compatible with Uint16 (unsigned short) on all platforms.
+///
+////////////////////////////////////////////////////////////
+typedef std::basic_string<unsigned short, Uint16CharTraits> Utf16String;
+
+////////////////////////////////////////////////////////////
+/// \brief Character traits for std::uint32_t (unsigned int)
+///
+////////////////////////////////////////////////////////////
+struct SFML_SYSTEM_API Uint32CharTraits
+{
+    typedef unsigned int                            char_type;
+    typedef std::char_traits<char32_t>::int_type    int_type;
+    typedef std::char_traits<char32_t>::off_type    off_type;
+    typedef std::char_traits<char32_t>::pos_type    pos_type;
+    typedef std::char_traits<char32_t>::state_type  state_type;
+
+    static void             assign(char_type& c1, char_type c2);
+    static char_type*       assign(char_type* s, std::size_t n, char_type c);
+    static bool             eq(char_type c1, char_type c2);
+    static bool             lt(char_type c1, char_type c2);
+    static char_type*       move(char_type* s1, const char_type* s2, std::size_t n);
+    static char_type*       copy(char_type* s1, const char_type* s2, std::size_t n);
+    static int              compare(const char_type* s1, const char_type* s2, std::size_t n);
+    static std::size_t      length(const char_type* s);
+    static const char_type* find(const char_type* s, std::size_t n, const char_type& c);
+    static char_type        to_char_type(int_type i);
+    static int_type         to_int_type(char_type c);
+    static bool             eq_int_type(int_type i1, int_type i2);
+    static int_type         eof();
+    static int_type         not_eof(int_type i);
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Portable replacement for std::basic_string<Uint32>
+///
+/// While std::u32string exists, it uses char32_t which may not
+/// be compatible with Uint32 (unsigned int) on all platforms.
+///
+////////////////////////////////////////////////////////////
+typedef std::basic_string<unsigned int, Uint32CharTraits> Utf32String;
+
+////////////////////////////////////////////////////////////
 /// \brief Utility string class that automatically handles
 ///        conversions between types and encodings
 ///
@@ -49,8 +161,8 @@ public:
     ////////////////////////////////////////////////////////////
     // Types
     ////////////////////////////////////////////////////////////
-    typedef std::basic_string<Uint32>::iterator       Iterator;      //!< Iterator type
-    typedef std::basic_string<Uint32>::const_iterator ConstIterator; //!< Read-only iterator type
+    typedef Utf32String::iterator       Iterator;      //!< Iterator type
+    typedef Utf32String::const_iterator ConstIterator; //!< Read-only iterator type
 
     ////////////////////////////////////////////////////////////
     // Static member data
@@ -147,7 +259,7 @@ public:
     /// \param utf32String UTF-32 string to assign
     ///
     ////////////////////////////////////////////////////////////
-    String(const std::basic_string<Uint32>& utf32String);
+    String(const Utf32String& utf32String);
 
     ////////////////////////////////////////////////////////////
     /// \brief Copy constructor
@@ -190,7 +302,7 @@ public:
     ///
     /// This function is provided for consistency, it is equivalent to
     /// using the constructors that takes a const sf::Uint32* or
-    /// a std::basic_string<sf::Uint32>.
+    /// a sf::Utf32String.
     ///
     /// \param begin Forward iterator to the beginning of the UTF-32 sequence
     /// \param end   Forward iterator to the end of the UTF-32 sequence
@@ -273,7 +385,7 @@ public:
     /// \see toUtf16, toUtf32
     ///
     ////////////////////////////////////////////////////////////
-    std::basic_string<Uint8> toUtf8() const;
+    sf::U8String toUtf8() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-16 string
@@ -283,7 +395,7 @@ public:
     /// \see toUtf8, toUtf32
     ///
     ////////////////////////////////////////////////////////////
-    std::basic_string<Uint16> toUtf16() const;
+    Utf16String toUtf16() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-32 string
@@ -296,7 +408,7 @@ public:
     /// \see toUtf8, toUtf16
     ///
     ////////////////////////////////////////////////////////////
-    std::basic_string<Uint32> toUtf32() const;
+    Utf32String toUtf32() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Overload of assignment operator
@@ -524,7 +636,7 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::basic_string<Uint32> m_string; //!< Internal string of UTF-32 characters
+    Utf32String m_string; //!< Internal string of UTF-32 characters
 };
 
 ////////////////////////////////////////////////////////////

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -34,7 +34,351 @@
 namespace sf
 {
 ////////////////////////////////////////////////////////////
-const std::size_t String::InvalidPos = std::basic_string<Uint32>::npos;
+void U8StringCharTraits::assign(char_type& c1, char_type c2)
+{
+    c1 = c2;
+}
+
+
+////////////////////////////////////////////////////////////
+U8StringCharTraits::char_type* U8StringCharTraits::assign(char_type* s, std::size_t n, char_type c)
+{
+    return reinterpret_cast<U8StringCharTraits::char_type*>(
+        std::char_traits<char>::assign(reinterpret_cast<char*>(s), n, static_cast<char>(c)));
+}
+
+
+////////////////////////////////////////////////////////////
+bool U8StringCharTraits::eq(char_type c1, char_type c2)
+{
+    return c1 == c2;
+}
+
+
+////////////////////////////////////////////////////////////
+bool U8StringCharTraits::lt(char_type c1, char_type c2)
+{
+    return c1 < c2;
+}
+
+
+////////////////////////////////////////////////////////////
+U8StringCharTraits::char_type* U8StringCharTraits::move(char_type* s1, const char_type* s2, std::size_t n)
+{
+    std::memmove(s1, s2, n);
+    return s1;
+}
+
+
+////////////////////////////////////////////////////////////
+U8StringCharTraits::char_type* U8StringCharTraits::copy(char_type* s1, const char_type* s2, std::size_t n)
+{
+    std::memcpy(s1, s2, n);
+    return s1;
+}
+
+
+////////////////////////////////////////////////////////////
+int U8StringCharTraits::compare(const char_type* s1, const char_type* s2, std::size_t n)
+{
+    return std::memcmp(s1, s2, n);
+}
+
+
+////////////////////////////////////////////////////////////
+std::size_t U8StringCharTraits::length(const char_type* s)
+{
+    return std::strlen(reinterpret_cast<const char*>(s));
+}
+
+
+////////////////////////////////////////////////////////////
+const U8StringCharTraits::char_type* U8StringCharTraits::find(const char_type* s, std::size_t n, const char_type& c)
+{
+    return reinterpret_cast<const U8StringCharTraits::char_type*>(
+        std::char_traits<char>::find(reinterpret_cast<const char*>(s), n, static_cast<char>(c)));
+}
+
+
+////////////////////////////////////////////////////////////
+U8StringCharTraits::char_type U8StringCharTraits::to_char_type(int_type i)
+{
+    return static_cast<U8StringCharTraits::char_type>(std::char_traits<char>::to_char_type(i));
+}
+
+
+////////////////////////////////////////////////////////////
+U8StringCharTraits::int_type U8StringCharTraits::to_int_type(char_type c)
+{
+    return std::char_traits<char>::to_int_type(static_cast<char>(c));
+}
+
+
+////////////////////////////////////////////////////////////
+bool U8StringCharTraits::eq_int_type(int_type i1, int_type i2)
+{
+    return i1 == i2;
+}
+
+
+////////////////////////////////////////////////////////////
+U8StringCharTraits::int_type U8StringCharTraits::eof()
+{
+    return std::char_traits<char>::eof();
+}
+
+
+////////////////////////////////////////////////////////////
+U8StringCharTraits::int_type U8StringCharTraits::not_eof(int_type i)
+{
+    return std::char_traits<char>::not_eof(i);
+}
+
+
+////////////////////////////////////////////////////////////
+void Uint16CharTraits::assign(char_type& c1, char_type c2)
+{
+    c1 = c2;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint16CharTraits::char_type* Uint16CharTraits::assign(char_type* s, std::size_t n, char_type c)
+{
+    for (std::size_t i = 0; i < n; ++i)
+        s[i] = c;
+    return s;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Uint16CharTraits::eq(char_type c1, char_type c2)
+{
+    return c1 == c2;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Uint16CharTraits::lt(char_type c1, char_type c2)
+{
+    return c1 < c2;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint16CharTraits::char_type* Uint16CharTraits::move(char_type* s1, const char_type* s2, std::size_t n)
+{
+    if (n == 0)
+        return s1;
+    std::memmove(s1, s2, n * sizeof(char_type));
+    return s1;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint16CharTraits::char_type* Uint16CharTraits::copy(char_type* s1, const char_type* s2, std::size_t n)
+{
+    if (n == 0)
+        return s1;
+    std::memcpy(s1, s2, n * sizeof(char_type));
+    return s1;
+}
+
+
+////////////////////////////////////////////////////////////
+int Uint16CharTraits::compare(const char_type* s1, const char_type* s2, std::size_t n)
+{
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        if (s1[i] < s2[i])
+            return -1;
+        if (s1[i] > s2[i])
+            return 1;
+    }
+    return 0;
+}
+
+
+////////////////////////////////////////////////////////////
+std::size_t Uint16CharTraits::length(const char_type* s)
+{
+    std::size_t len = 0;
+    while (s[len] != 0)
+        ++len;
+    return len;
+}
+
+
+////////////////////////////////////////////////////////////
+const Uint16CharTraits::char_type* Uint16CharTraits::find(const char_type* s, std::size_t n, const char_type& c)
+{
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        if (s[i] == c)
+            return s + i;
+    }
+    return nullptr;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint16CharTraits::char_type Uint16CharTraits::to_char_type(int_type i)
+{
+    return static_cast<char_type>(i);
+}
+
+
+////////////////////////////////////////////////////////////
+Uint16CharTraits::int_type Uint16CharTraits::to_int_type(char_type c)
+{
+    return static_cast<int_type>(c);
+}
+
+
+////////////////////////////////////////////////////////////
+bool Uint16CharTraits::eq_int_type(int_type i1, int_type i2)
+{
+    return i1 == i2;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint16CharTraits::int_type Uint16CharTraits::eof()
+{
+    return static_cast<int_type>(-1);
+}
+
+
+////////////////////////////////////////////////////////////
+Uint16CharTraits::int_type Uint16CharTraits::not_eof(int_type i)
+{
+    return (i == eof()) ? 0 : i;
+}
+
+
+////////////////////////////////////////////////////////////
+void Uint32CharTraits::assign(char_type& c1, char_type c2)
+{
+    c1 = c2;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint32CharTraits::char_type* Uint32CharTraits::assign(char_type* s, std::size_t n, char_type c)
+{
+    for (std::size_t i = 0; i < n; ++i)
+        s[i] = c;
+    return s;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Uint32CharTraits::eq(char_type c1, char_type c2)
+{
+    return c1 == c2;
+}
+
+
+////////////////////////////////////////////////////////////
+bool Uint32CharTraits::lt(char_type c1, char_type c2)
+{
+    return c1 < c2;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint32CharTraits::char_type* Uint32CharTraits::move(char_type* s1, const char_type* s2, std::size_t n)
+{
+    if (n == 0)
+        return s1;
+    std::memmove(s1, s2, n * sizeof(char_type));
+    return s1;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint32CharTraits::char_type* Uint32CharTraits::copy(char_type* s1, const char_type* s2, std::size_t n)
+{
+    if (n == 0)
+        return s1;
+    std::memcpy(s1, s2, n * sizeof(char_type));
+    return s1;
+}
+
+
+////////////////////////////////////////////////////////////
+int Uint32CharTraits::compare(const char_type* s1, const char_type* s2, std::size_t n)
+{
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        if (s1[i] < s2[i])
+            return -1;
+        if (s1[i] > s2[i])
+            return 1;
+    }
+    return 0;
+}
+
+
+////////////////////////////////////////////////////////////
+std::size_t Uint32CharTraits::length(const char_type* s)
+{
+    std::size_t len = 0;
+    while (s[len] != 0)
+        ++len;
+    return len;
+}
+
+
+////////////////////////////////////////////////////////////
+const Uint32CharTraits::char_type* Uint32CharTraits::find(const char_type* s, std::size_t n, const char_type& c)
+{
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        if (s[i] == c)
+            return s + i;
+    }
+    return nullptr;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint32CharTraits::char_type Uint32CharTraits::to_char_type(int_type i)
+{
+    return static_cast<char_type>(i);
+}
+
+
+////////////////////////////////////////////////////////////
+Uint32CharTraits::int_type Uint32CharTraits::to_int_type(char_type c)
+{
+    return static_cast<int_type>(c);
+}
+
+
+////////////////////////////////////////////////////////////
+bool Uint32CharTraits::eq_int_type(int_type i1, int_type i2)
+{
+    return i1 == i2;
+}
+
+
+////////////////////////////////////////////////////////////
+Uint32CharTraits::int_type Uint32CharTraits::eof()
+{
+    return static_cast<int_type>(-1);
+}
+
+
+////////////////////////////////////////////////////////////
+Uint32CharTraits::int_type Uint32CharTraits::not_eof(int_type i)
+{
+    return (i == eof()) ? 0 : i;
+}
+
+
+////////////////////////////////////////////////////////////
+const std::size_t String::InvalidPos = Utf32String::npos;
 
 
 ////////////////////////////////////////////////////////////
@@ -119,7 +463,7 @@ String::String(const Uint32* utf32String)
 
 
 ////////////////////////////////////////////////////////////
-String::String(const std::basic_string<Uint32>& utf32String) :
+String::String(const Utf32String& utf32String) :
 m_string(utf32String)
 {
 }
@@ -175,10 +519,10 @@ std::wstring String::toWideString() const
 
 
 ////////////////////////////////////////////////////////////
-std::basic_string<Uint8> String::toUtf8() const
+sf::U8String String::toUtf8() const
 {
     // Prepare the output string
-    std::basic_string<Uint8> output;
+    sf::U8String output;
     output.reserve(m_string.length());
 
     // Convert
@@ -189,10 +533,10 @@ std::basic_string<Uint8> String::toUtf8() const
 
 
 ////////////////////////////////////////////////////////////
-std::basic_string<Uint16> String::toUtf16() const
+Utf16String String::toUtf16() const
 {
     // Prepare the output string
-    std::basic_string<Uint16> output;
+    Utf16String output;
     output.reserve(m_string.length());
 
     // Convert
@@ -203,7 +547,7 @@ std::basic_string<Uint16> String::toUtf16() const
 
 
 ////////////////////////////////////////////////////////////
-std::basic_string<Uint32> String::toUtf32() const
+Utf32String String::toUtf32() const
 {
     return m_string;
 }

--- a/src/SFML/Window/OSX/ClipboardImpl.mm
+++ b/src/SFML/Window/OSX/ClipboardImpl.mm
@@ -53,7 +53,7 @@ String ClipboardImpl::getString()
 void ClipboardImpl::setString(const String& text)
 {
     AutoreleasePool pool;
-    std::basic_string<Uint8> utf8 = text.toUtf8();
+    U8String utf8 = text.toUtf8();
     NSString* data = [[NSString alloc] initWithBytes:utf8.data()
                                               length:utf8.length()
                                             encoding:NSUTF8StringEncoding];

--- a/src/SFML/Window/Unix/ClipboardImpl.cpp
+++ b/src/SFML/Window/Unix/ClipboardImpl.cpp
@@ -344,7 +344,7 @@ void ClipboardImpl::processEvent(XEvent& windowEvent)
                 {
                     // Respond to a request for conversion to a UTF-8 string
                     // or an encoding of our choosing (we always choose UTF-8)
-                    std::basic_string<Uint8> data = m_clipboardContents.toUtf8();
+                    U8String data = m_clipboardContents.toUtf8();
 
                     XChangeProperty(
                         m_display,

--- a/src/SFML/Window/Unix/WindowImplX11.cpp
+++ b/src/SFML/Window/Unix/WindowImplX11.cpp
@@ -895,7 +895,7 @@ void WindowImplX11::setTitle(const String& title)
     // There is however an option to tell the window manager your Unicode title via hints.
 
     // Convert to UTF-8 encoding.
-    std::basic_string<Uint8> utf8Title;
+    U8String utf8Title;
     Utf32::toUtf8(title.begin(), title.end(), std::back_inserter(utf8Title));
 
     Atom useUtf8 = getAtom("UTF8_STRING", false);

--- a/src/SFML/Window/iOS/ClipboardImpl.mm
+++ b/src/SFML/Window/iOS/ClipboardImpl.mm
@@ -57,7 +57,7 @@ String ClipboardImpl::getString()
 ////////////////////////////////////////////////////////////
 void ClipboardImpl::setString(const String& text)
 {
-    std::basic_string<Uint8> utf8 = text.toUtf8();
+    U8String utf8 = text.toUtf8();
     NSString* data = [[NSString alloc] initWithBytes:utf8.data()
                                               length:utf8.length()
                                             encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
This is a SFML 2 backport of #2885, see also #2670

This is on the surface a breaking change, but LLVM is essentially forcing us to provide the workaround.

Character traits are only standardized for character types of which sf::Uint8 is not. All major C++ implementations happen to define this specialization but because it is not standard C++ they are allowed to remove it as LLVM has done by deprecating this specialization in LLVM 18. It is removed in LLVM 19.

