### PR TITLE
Add missing cast between NSWindow and SFOpenGLView

### DIFF
--- a/src/SFML/Window/macOS/InputImpl.mm
+++ b/src/SFML/Window/macOS/InputImpl.mm
@@ -58,12 +58,12 @@ SFOpenGLView* getSFOpenGLViewFromSFMLWindow(const sf::WindowBase& window)
     const id nsHandle = static_cast<id>(window.getNativeHandle());
 
     // Get our SFOpenGLView from ...
-    SFOpenGLView* view = nil;
+    SFOpenGLView* _Nullable view = nil;
 
     if ([nsHandle isKindOfClass:[NSWindow class]])
     {
         // If system handle is a window then from its content view.
-        view = [nsHandle contentView];
+        view = static_cast<SFOpenGLView*>([nsHandle contentView]);
 
         // Subview doesn't match ?
         if (![view isKindOfClass:[SFOpenGLView class]])


### PR DESCRIPTION
## Description

Looks like something changed in Xcode 26 which leads to failure of the implicit cast between `NSWindow*` and `SFOpenGLView*`.

```
src/SFML/Window/macOS/InputImpl.mm:66:16: error: incompatible pointer types assigning to 'SFOpenGLView *' from 'NSView * _Nullable' [-Werror,-Wincompatible-pointer-types]
   66 |         view = [nsHandle contentView];
      |                ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [src/SFML/Window/CMakeFiles/sfml-window.dir/macOS/InputImpl.mm.o] Error 1
```

https://ci.sfml-dev.org/#/builders/16/builds/2751

## Tasks

-   [x] Tested on macOS

## How to test this PR?

The getPosition should call the affected conversion function.

The expected outcome is that the rectangle moves with the mouse position relative to the window.

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    auto shape = sf::RectangleShape({10.f, 10.f});
    shape.setFillColor(sf::Color::Green);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        auto position = sf::Mouse::getPosition(window);
        shape.setPosition(sf::Vector2f(position));

        window.clear();
        window.draw(shape);
        window.display();
    }
}
```
