### PR TITLE
Disable warnings in 3rd party code

### DIFF
--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -177,6 +177,13 @@ else()
             target_compile_definitions(FLAC PRIVATE _FILE_OFFSET_BITS=32)
         endif()
 
+        # Disable all warnings
+        if(SFML_COMPILER_MSVC)
+            target_compile_options(FLAC PRIVATE /w)
+        elseif(SFML_COMPILER_GCC OR SFML_COMPILER_CLANG)
+            target_compile_options(FLAC PRIVATE -w)
+        endif()
+
         # aliases were introduced only after 1.3.7 was released
         add_library(Vorbis::vorbis ALIAS vorbis)
         add_library(Vorbis::vorbisenc ALIAS vorbisenc)

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -227,6 +227,13 @@ else()
             target_compile_options(harfbuzz PRIVATE -Wa,-mbig-obj)
         endif()
 
+        # Disable all warnings
+        if(SFML_COMPILER_MSVC)
+            target_compile_options(freetype PRIVATE /w)
+        elseif(SFML_COMPILER_GCC OR SFML_COMPILER_CLANG)
+            target_compile_options(freetype PRIVATE -w)
+        endif()
+
         add_library(Freetype::Freetype ALIAS freetype)
         add_library(HarfBuzz::HarfBuzz ALIAS harfbuzz)
     endfunction()


### PR DESCRIPTION
Freetype and FLAC trigger some compiler warnings even at the default warning level. In newer Clang releases, this actually causes a build error because one of those default warnings is now treated as an error by default.