### PR TITLE
Silence warning about default DirectInput version

### DIFF
--- a/src/SFML/Window/Win32/JoystickImpl.hpp
+++ b/src/SFML/Window/Win32/JoystickImpl.hpp
@@ -30,6 +30,10 @@
 #include <SFML/System/EnumArray.hpp>
 #include <SFML/System/Win32/WindowsHeader.hpp>
 
+#ifndef DIRECTINPUT_VERSION
+#define DIRECTINPUT_VERSION 0x0800
+#endif
+
 #include <dinput.h>
 #include <mmsystem.h>
 


### PR DESCRIPTION
## Description

Ever since the use of DirectInput VS produces warnings about the default version selection during build time:

```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\dinput.h: DIRECTINPUT_VERSION undefined. Defaulting to version 0x0800
```

Selecting the default explicitly, should silence the warning.

## Tasks

-   [x] Tested on Windows

## How to test this PR?

CI should complete and no warning should be shown in Windows builds