### PR TITLE
Disable more dependency warnings and remove redundancy

### DIFF
--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -178,11 +178,11 @@ else()
         endif()
 
         # Disable all warnings
-        if(SFML_COMPILER_MSVC)
-            target_compile_options(FLAC PRIVATE /w)
-        elseif(SFML_COMPILER_GCC OR SFML_COMPILER_CLANG)
-            target_compile_options(FLAC PRIVATE -w)
-        endif()
+        target_compile_options(ogg PRIVATE -w)
+        target_compile_options(FLAC PRIVATE -w)
+        target_compile_options(vorbis PRIVATE -w)
+        target_compile_options(vorbisenc PRIVATE -w)
+        target_compile_options(vorbisfile PRIVATE -w)
 
         # aliases were introduced only after 1.3.7 was released
         add_library(Vorbis::vorbis ALIAS vorbis)

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -228,11 +228,7 @@ else()
         endif()
 
         # Disable all warnings
-        if(SFML_COMPILER_MSVC)
-            target_compile_options(freetype PRIVATE /w)
-        elseif(SFML_COMPILER_GCC OR SFML_COMPILER_CLANG)
-            target_compile_options(freetype PRIVATE -w)
-        endif()
+        target_compile_options(freetype PRIVATE -w)
 
         add_library(Freetype::Freetype ALIAS freetype)
         add_library(HarfBuzz::HarfBuzz ALIAS harfbuzz)


### PR DESCRIPTION
Some dependencies are still emitting warnings, and we don't need a separate flag for MSVC as it accepts either `/` or `-`