### PR TITLE
Remove keyboard example on iOS

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -46,7 +46,10 @@ if(SFML_BUILD_GRAPHICS)
 endif()
 if(SFML_BUILD_GRAPHICS AND SFML_BUILD_AUDIO)
     add_subdirectory(tennis)
-    add_subdirectory(keyboard)
+
+    if(NOT SFML_OS_IOS)
+        add_subdirectory(keyboard)
+    endif()
 
     if(NOT SFML_OPENGL_ES)
         add_subdirectory(sound_effects)


### PR DESCRIPTION
I did take a brief look at if it could work wiht the virtual keyboard, but as far as I can tell the virtual keyboard on iOS doesn't work anyway