### PR TITLE
Make Unicode conversions more robust against invalid data

### DIFF
--- a/examples/event_handling/EventHandling.cpp
+++ b/examples/event_handling/EventHandling.cpp
@@ -67,12 +67,12 @@ public:
                 application.m_handlerText.setString("Current Handler: Overload");
             }
 
-            return "Key Pressed: " + sf::Keyboard::getDescription(keyPress.scancode);
+            return "Key Pressed: " + sf::Keyboard::getDescription(keyPress.scancode).toAnsiString();
         }
 
         std::optional<std::string> operator()(const sf::Event::KeyReleased& keyRelease)
         {
-            return "Key Released: " + sf::Keyboard::getDescription(keyRelease.scancode);
+            return "Key Released: " + sf::Keyboard::getDescription(keyRelease.scancode).toAnsiString();
         }
 
         std::optional<std::string> operator()(const sf::Event::MouseMoved& mouseMoved)
@@ -139,7 +139,8 @@ public:
 
                     if (const auto* keyPress = event->getIf<sf::Event::KeyPressed>())
                     {
-                        m_log.emplace_back("Key Pressed: " + sf::Keyboard::getDescription(keyPress->scancode));
+                        m_log.emplace_back(
+                            "Key Pressed: " + sf::Keyboard::getDescription(keyPress->scancode).toAnsiString());
 
                         // When the enter key is pressed, switch to the next handler type
                         if (keyPress->code == sf::Keyboard::Key::Enter)
@@ -150,7 +151,8 @@ public:
                     }
                     else if (const auto* keyRelease = event->getIf<sf::Event::KeyReleased>())
                     {
-                        m_log.emplace_back("Key Released: " + sf::Keyboard::getDescription(keyRelease->scancode));
+                        m_log.emplace_back(
+                            "Key Released: " + sf::Keyboard::getDescription(keyRelease->scancode).toAnsiString());
                     }
                     else if (const auto* mouseMoved = event->getIf<sf::Event::MouseMoved>())
                     {
@@ -198,7 +200,8 @@ public:
                                       [&](const sf::Event::KeyPressed& keyPress)
                                       {
                                           m_log.emplace_back(
-                                              "Key Pressed: " + sf::Keyboard::getDescription(keyPress.scancode));
+                                              "Key Pressed: " +
+                                              sf::Keyboard::getDescription(keyPress.scancode).toAnsiString());
 
                                           // When the enter key is pressed, switch to the next handler type
                                           if (keyPress.code == sf::Keyboard::Key::Enter)
@@ -209,7 +212,8 @@ public:
                                       },
                                       [&](const sf::Event::KeyReleased& keyRelease) {
                                           m_log.emplace_back(
-                                              "Key Released: " + sf::Keyboard::getDescription(keyRelease.scancode));
+                                              "Key Released: " +
+                                              sf::Keyboard::getDescription(keyRelease.scancode).toAnsiString());
                                       },
                                       [&](const sf::Event::MouseMoved& mouseMoved)
                                       { m_log.emplace_back("Mouse Moved: " + vec2ToString(mouseMoved.position)); },
@@ -240,7 +244,8 @@ public:
                         }
                         else if constexpr (std::is_same_v<T, sf::Event::KeyPressed>)
                         {
-                            m_log.emplace_back("Key Pressed: " + sf::Keyboard::getDescription(event.scancode));
+                            m_log.emplace_back(
+                                "Key Pressed: " + sf::Keyboard::getDescription(event.scancode).toAnsiString());
 
                             // When the enter key is pressed, switch to the next handler type
                             if (event.code == sf::Keyboard::Key::Enter)
@@ -251,7 +256,8 @@ public:
                         }
                         else if constexpr (std::is_same_v<T, sf::Event::KeyReleased>)
                         {
-                            m_log.emplace_back("Key Released: " + sf::Keyboard::getDescription(event.scancode));
+                            m_log.emplace_back(
+                                "Key Released: " + sf::Keyboard::getDescription(event.scancode).toAnsiString());
                         }
                         else if constexpr (std::is_same_v<T, sf::Event::MouseMoved>)
                         {
@@ -325,7 +331,7 @@ public:
 
     void handle(const sf::Event::KeyPressed& keyPress)
     {
-        m_log.emplace_back("Key Pressed: " + sf::Keyboard::getDescription(keyPress.scancode));
+        m_log.emplace_back("Key Pressed: " + sf::Keyboard::getDescription(keyPress.scancode).toAnsiString());
 
         // When the enter key is pressed, switch to the next handler type
         if (keyPress.code == sf::Keyboard::Key::Enter)
@@ -337,7 +343,7 @@ public:
 
     void handle(const sf::Event::KeyReleased& keyRelease)
     {
-        m_log.emplace_back("Key Released: " + sf::Keyboard::getDescription(keyRelease.scancode));
+        m_log.emplace_back("Key Released: " + sf::Keyboard::getDescription(keyRelease.scancode).toAnsiString());
     }
 
     void handle(const sf::Event::MouseMoved& mouseMoved)

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -32,6 +32,7 @@
 #include <SFML/System/Utf.hpp>
 
 #include <locale>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -234,8 +235,9 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Create a new `sf::String` from a UTF-8 encoded string
     ///
-    /// \param begin Forward iterator to the beginning of the UTF-8 sequence
-    /// \param end   Forward iterator to the end of the UTF-8 sequence
+    /// \param begin       Forward iterator to the beginning of the UTF-8 sequence
+    /// \param end         Forward iterator to the end of the UTF-8 sequence
+    /// \param replacement Replacement for characters not convertible from UTF-8 (use nullopt to skip them)
     ///
     /// \return A `sf::String` containing the source string
     ///
@@ -243,13 +245,14 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
-    [[nodiscard]] static String fromUtf8(T begin, T end);
+    [[nodiscard]] static String fromUtf8(T begin, T end, std::optional<char32_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new `sf::String` from a UTF-16 encoded string
     ///
-    /// \param begin Forward iterator to the beginning of the UTF-16 sequence
-    /// \param end   Forward iterator to the end of the UTF-16 sequence
+    /// \param begin       Forward iterator to the beginning of the UTF-16 sequence
+    /// \param end         Forward iterator to the end of the UTF-16 sequence
+    /// \param replacement Replacement for characters not convertible from UTF-16 (use nullopt to skip them)
     ///
     /// \return A `sf::String` containing the source string
     ///
@@ -257,7 +260,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename T>
-    [[nodiscard]] static String fromUtf16(T begin, T end);
+    [[nodiscard]] static String fromUtf16(T begin, T end, std::optional<char32_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create a new `sf::String` from a UTF-32 encoded string
@@ -292,7 +295,7 @@ public:
     /// \see `toAnsiString`, `operator std::wstring`
     ///
     ////////////////////////////////////////////////////////////
-    operator std::string() const;
+    [[deprecated("Use toAnsiString() instead")]] operator std::string() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Implicit conversion operator to `std::wstring` (wide string)
@@ -307,57 +310,60 @@ public:
     /// \see `toWideString`, `operator std::string`
     ///
     ////////////////////////////////////////////////////////////
-    operator std::wstring() const;
+    [[deprecated("Use toWideString() instead")]] operator std::wstring() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to an ANSI string
     ///
     /// The UTF-32 string is converted to an ANSI string in
     /// the encoding defined by `locale`.
-    /// Characters that do not fit in the target encoding are
-    /// discarded from the returned string.
     ///
-    /// \param locale Locale to use for conversion
+    /// \param locale      Locale to use for conversion
+    /// \param replacement Replacement for characters not convertible to ANSI (use nullopt to skip them)
     ///
     /// \return Converted ANSI string
     ///
     /// \see `toWideString`, `operator std::string`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::string toAnsiString(const std::locale& locale = {}) const;
+    [[nodiscard]] std::string toAnsiString(const std::locale&  locale      = {},
+                                           std::optional<char> replacement = std::nullopt) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a wide string
     ///
-    /// Characters that do not fit in the target encoding are
-    /// discarded from the returned string.
+    /// \param replacement Replacement for characters not convertible to wide char (use nullopt to skip them)
     ///
     /// \return Converted wide string
     ///
     /// \see `toAnsiString`, `operator std::wstring`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::wstring toWideString() const;
+    [[nodiscard]] std::wstring toWideString(std::optional<wchar_t> replacement = std::nullopt) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-8 string
+    ///
+    /// \param replacement Replacement for characters not convertible to UTF-8 (use nullopt to skip them)
     ///
     /// \return Converted UTF-8 string
     ///
     /// \see `toUtf16`, `toUtf32`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] sf::U8String toUtf8() const;
+    [[nodiscard]] sf::U8String toUtf8(std::optional<std::uint8_t> replacement = std::nullopt) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-16 string
+    ///
+    /// \param replacement Replacement for characters not convertible to UTF-16 (use nullopt to skip them)
     ///
     /// \return Converted UTF-16 string
     ///
     /// \see `toUtf8`, `toUtf32`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] std::u16string toUtf16() const;
+    [[nodiscard]] std::u16string toUtf16(std::optional<std::uint16_t> replacement = std::nullopt) const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert the Unicode string to a UTF-32 string

--- a/include/SFML/System/String.inl
+++ b/include/SFML/System/String.inl
@@ -34,20 +34,20 @@ namespace sf
 {
 ////////////////////////////////////////////////////////////
 template <typename T>
-String String::fromUtf8(T begin, T end)
+String String::fromUtf8(T begin, T end, std::optional<char32_t> replacement)
 {
     String string;
-    Utf8::toUtf32(begin, end, std::back_inserter(string.m_string));
+    Utf8::toUtf32(begin, end, std::back_inserter(string.m_string), replacement);
     return string;
 }
 
 
 ////////////////////////////////////////////////////////////
 template <typename T>
-String String::fromUtf16(T begin, T end)
+String String::fromUtf16(T begin, T end, std::optional<char32_t> replacement)
 {
     String string;
-    Utf16::toUtf32(begin, end, std::back_inserter(string.m_string));
+    Utf16::toUtf32(begin, end, std::back_inserter(string.m_string), replacement);
     return string;
 }
 

--- a/include/SFML/System/Utf.hpp
+++ b/include/SFML/System/Utf.hpp
@@ -31,6 +31,7 @@
 
 #include <array>
 #include <locale>
+#include <optional>
 
 #include <cstdint>
 #include <cstdlib>
@@ -64,7 +65,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static In decode(In begin, In end, char32_t& output, char32_t replacement = 0);
+    static In decode(In begin, In end, char32_t& output, std::optional<char32_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-8 character
@@ -74,13 +75,13 @@ public:
     ///
     /// \param input       Codepoint to encode as UTF-8
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to UTF-8 (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to UTF-8 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encode(char32_t input, Out output, std::uint8_t replacement = 0);
+    static Out encode(char32_t input, Out output, std::optional<std::uint8_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Advance to the next UTF-8 character
@@ -165,14 +166,18 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to ANSI (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to ANSI (use nullopt to skip them)
     /// \param locale      Locale to use for conversion
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toAnsi(In begin, In end, Out output, char replacement = 0, const std::locale& locale = {});
+    static Out toAnsi(In                  begin,
+                      In                  end,
+                      Out                 output,
+                      std::optional<char> replacement = std::nullopt,
+                      const std::locale&  locale      = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert an UTF-8 characters range to wide characters
@@ -180,13 +185,13 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to wide (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toWide(In begin, In end, Out output, wchar_t replacement = 0);
+    static Out toWide(In begin, In end, Out output, std::optional<wchar_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert an UTF-8 characters range to latin-1 (ISO-5589-1) characters
@@ -194,13 +199,13 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to latin-1 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toLatin1(In begin, In end, Out output, char replacement = 0);
+    static Out toLatin1(In begin, In end, Out output, std::optional<char> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-8 characters range to UTF-8
@@ -210,41 +215,44 @@ public:
     /// specializations of the `sf::Utf<>` template, and allow
     /// generic code to be written on top of it.
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Unused, kept to stay compatible with other specializations
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf8(In begin, In end, Out output);
+    static Out toUtf8(In begin, In end, Out output, std::optional<std::uint8_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-8 characters range to UTF-16
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-16 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf16(In begin, In end, Out output);
+    static Out toUtf16(In begin, In end, Out output, std::optional<char16_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-8 characters range to UTF-32
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-32 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf32(In begin, In end, Out output);
+    static Out toUtf32(In begin, In end, Out output, std::optional<char32_t> replacement = std::nullopt);
 };
 
 ////////////////////////////////////////////////////////////
@@ -270,7 +278,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static In decode(In begin, In end, char32_t& output, char32_t replacement = 0);
+    static In decode(In begin, In end, char32_t& output, std::optional<char32_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-16 character
@@ -280,13 +288,13 @@ public:
     ///
     /// \param input       Codepoint to encode as UTF-16
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to UTF-16 (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to UTF-16 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encode(char32_t input, Out output, char16_t replacement = 0);
+    static Out encode(char32_t input, Out output, std::optional<char16_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Advance to the next UTF-16 character
@@ -371,14 +379,18 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to ANSI (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to ANSI (use nullopt to skip them)
     /// \param locale      Locale to use for conversion
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toAnsi(In begin, In end, Out output, char replacement = 0, const std::locale& locale = {});
+    static Out toAnsi(In                  begin,
+                      In                  end,
+                      Out                 output,
+                      std::optional<char> replacement = std::nullopt,
+                      const std::locale&  locale      = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert an UTF-16 characters range to wide characters
@@ -386,13 +398,13 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to wide (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toWide(In begin, In end, Out output, wchar_t replacement = 0);
+    static Out toWide(In begin, In end, Out output, std::optional<wchar_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert an UTF-16 characters range to latin-1 (ISO-5589-1) characters
@@ -400,26 +412,27 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to latin-1 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toLatin1(In begin, In end, Out output, char replacement = 0);
+    static Out toLatin1(In begin, In end, Out output, std::optional<char> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-16 characters range to UTF-8
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-8 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf8(In begin, In end, Out output);
+    static Out toUtf8(In begin, In end, Out output, std::optional<std::uint8_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-16 characters range to UTF-16
@@ -429,28 +442,30 @@ public:
     /// specializations of the `sf::Utf<>` template, and allow
     /// generic code to be written on top of it.
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Unused, kept to stay compatible with other specializations
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf16(In begin, In end, Out output);
+    static Out toUtf16(In begin, In end, Out output, std::optional<char16_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-16 characters range to UTF-32
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-32 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf32(In begin, In end, Out output);
+    static Out toUtf32(In begin, In end, Out output, std::optional<char32_t> replacement = std::nullopt);
 };
 
 ////////////////////////////////////////////////////////////
@@ -477,7 +492,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     template <typename In>
-    static In decode(In begin, In end, char32_t& output, char32_t replacement = 0);
+    static In decode(In begin, In end, char32_t& output, std::optional<char32_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-32 character
@@ -488,13 +503,13 @@ public:
     ///
     /// \param input       Codepoint to encode as UTF-32
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to UTF-32 (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to UTF-32 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encode(char32_t input, Out output, char32_t replacement = 0);
+    static Out encode(char32_t input, Out output, std::optional<char32_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Advance to the next UTF-32 character
@@ -578,14 +593,18 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to ANSI (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to ANSI (use nullopt to skip them)
     /// \param locale      Locale to use for conversion
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toAnsi(In begin, In end, Out output, char replacement = 0, const std::locale& locale = {});
+    static Out toAnsi(In                  begin,
+                      In                  end,
+                      Out                 output,
+                      std::optional<char> replacement = std::nullopt,
+                      const std::locale&  locale      = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert an UTF-32 characters range to wide characters
@@ -593,13 +612,13 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to wide (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toWide(In begin, In end, Out output, wchar_t replacement = 0);
+    static Out toWide(In begin, In end, Out output, std::optional<wchar_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert an UTF-16 characters range to latin-1 (ISO-5589-1) characters
@@ -607,39 +626,41 @@ public:
     /// \param begin       Iterator pointing to the beginning of the input sequence
     /// \param end         Iterator pointing to the end of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    /// \param replacement Replacement for characters not convertible to latin-1 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toLatin1(In begin, In end, Out output, char replacement = 0);
+    static Out toLatin1(In begin, In end, Out output, std::optional<char> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-32 characters range to UTF-8
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-8 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf8(In begin, In end, Out output);
+    static Out toUtf8(In begin, In end, Out output, std::optional<std::uint8_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-32 characters range to UTF-16
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-16 (use nullopt to skip them)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf16(In begin, In end, Out output);
+    static Out toUtf16(In begin, In end, Out output, std::optional<char16_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Convert a UTF-32 characters range to UTF-32
@@ -649,15 +670,16 @@ public:
     /// specializations of the `sf::Utf<>` template, and allow
     /// generic code to be written on top of it.
     ///
-    /// \param begin  Iterator pointing to the beginning of the input sequence
-    /// \param end    Iterator pointing to the end of the input sequence
-    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Unused, kept to stay compatible with other specializations
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename In, typename Out>
-    static Out toUtf32(In begin, In end, Out output);
+    static Out toUtf32(In begin, In end, Out output, std::optional<char32_t> replacement = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Decode a single ANSI character to UTF-32
@@ -699,14 +721,17 @@ public:
     ///
     /// \param codepoint   Iterator pointing to the beginning of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement if the input character is not convertible to ANSI (use 0 to skip it)
+    /// \param replacement Replacement if the input character is not convertible to ANSI (use nullopt to skip it)
     /// \param locale      Locale to use for conversion
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encodeAnsi(char32_t codepoint, Out output, char replacement = 0, const std::locale& locale = {});
+    static Out encodeAnsi(char32_t            codepoint,
+                          Out                 output,
+                          std::optional<char> replacement = std::nullopt,
+                          const std::locale&  locale      = {});
 
     ////////////////////////////////////////////////////////////
     /// \brief Encode a single UTF-32 character to wide
@@ -717,13 +742,13 @@ public:
     ///
     /// \param codepoint   Iterator pointing to the beginning of the input sequence
     /// \param output      Iterator pointing to the beginning of the output sequence
-    /// \param replacement Replacement if the input character is not convertible to wide (use 0 to skip it)
+    /// \param replacement Replacement if the input character is not convertible to wide (use nullopt to skip it)
     ///
     /// \return Iterator to the end of the output sequence which has been written
     ///
     ////////////////////////////////////////////////////////////
     template <typename Out>
-    static Out encodeWide(char32_t codepoint, Out output, wchar_t replacement = 0);
+    static Out encodeWide(char32_t codepoint, Out output, std::optional<wchar_t> replacement = std::nullopt);
 };
 
 // Make type aliases to get rid of the template syntax

--- a/src/SFML/System/String.cpp
+++ b/src/SFML/System/String.cpp
@@ -249,56 +249,56 @@ String::operator std::wstring() const
 
 
 ////////////////////////////////////////////////////////////
-std::string String::toAnsiString(const std::locale& locale) const
+std::string String::toAnsiString(const std::locale& locale, std::optional<char> replacement) const
 {
     // Prepare the output string
     std::string output;
     output.reserve(m_string.length() + 1);
 
     // Convert
-    Utf32::toAnsi(m_string.begin(), m_string.end(), std::back_inserter(output), 0, locale);
+    Utf32::toAnsi(m_string.begin(), m_string.end(), std::back_inserter(output), replacement, locale);
 
     return output;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::wstring String::toWideString() const
+std::wstring String::toWideString(std::optional<wchar_t> replacement) const
 {
     // Prepare the output string
     std::wstring output;
     output.reserve(m_string.length() + 1);
 
     // Convert
-    Utf32::toWide(m_string.begin(), m_string.end(), std::back_inserter(output), 0);
+    Utf32::toWide(m_string.begin(), m_string.end(), std::back_inserter(output), replacement);
 
     return output;
 }
 
 
 ////////////////////////////////////////////////////////////
-U8String String::toUtf8() const
+U8String String::toUtf8(std::optional<std::uint8_t> replacement) const
 {
     // Prepare the output string
     U8String output;
     output.reserve(m_string.length());
 
     // Convert
-    Utf32::toUtf8(m_string.begin(), m_string.end(), std::back_inserter(output));
+    Utf32::toUtf8(m_string.begin(), m_string.end(), std::back_inserter(output), replacement);
 
     return output;
 }
 
 
 ////////////////////////////////////////////////////////////
-std::u16string String::toUtf16() const
+std::u16string String::toUtf16(std::optional<std::uint16_t> replacement) const
 {
     // Prepare the output string
     std::u16string output;
     output.reserve(m_string.length());
 
     // Convert
-    Utf32::toUtf16(m_string.begin(), m_string.end(), std::back_inserter(output));
+    Utf32::toUtf16(m_string.begin(), m_string.end(), std::back_inserter(output), replacement);
 
     return output;
 }

--- a/test/System/String.test.cpp
+++ b/test/System/String.test.cpp
@@ -10,6 +10,13 @@
 
 #include <cassert>
 
+// Allow testing deprecated functions
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 namespace
 {
 // Return either argument depending on whether wchar_t is 16 or 32 bits
@@ -305,9 +312,9 @@ TEST_CASE("[System] sf::String")
         {
             {
                 const sf::String string = L'ú';
-                CHECK(std::string(string) == select("\xFA"s, "\0"s));
+                CHECK(std::string(string) == select("\xFA"s, ""s));
                 CHECK(std::wstring(string) == L"ú"s);
-                CHECK(string.toAnsiString() == select("\xFA"s, "\0"s));
+                CHECK(string.toAnsiString() == select("\xFA"s, ""s));
                 CHECK(string.toWideString() == L"ú"s);
                 CHECK(string.toUtf8() == sf::U8String{0xC3, 0xBA});
                 CHECK(string.toUtf16() == u"ú"s);
@@ -318,9 +325,9 @@ TEST_CASE("[System] sf::String")
             }
             {
                 const sf::String string = L'Ǻ';
-                CHECK(std::string(string) == "\0"s);
+                CHECK(std::string(string).empty());
                 CHECK(std::wstring(string) == L"Ǻ"s);
-                CHECK(string.toAnsiString() == "\0"s);
+                CHECK(string.toAnsiString().empty());
                 CHECK(string.toWideString() == L"Ǻ"s);
                 CHECK(string.toUtf8() == sf::U8String{0xC7, 0xBA});
                 CHECK(string.toUtf16() == u"Ǻ"s);
@@ -348,9 +355,9 @@ TEST_CASE("[System] sf::String")
             }
             {
                 const sf::String string = L"Улитка";
-                CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+                CHECK(std::string(string).empty());
                 CHECK(std::wstring(string) == L"Улитка"s);
-                CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+                CHECK(string.toAnsiString().empty());
                 CHECK(string.toWideString() == L"Улитка"s);
                 CHECK(string.toUtf8() ==
                       sf::U8String{0xD0, 0xA3, 0xD0, 0xBB, 0xD0, 0xB8, 0xD1, 0x82, 0xD0, 0xBA, 0xD0, 0xB0});
@@ -365,9 +372,9 @@ TEST_CASE("[System] sf::String")
         SECTION("Wide string constructor")
         {
             const sf::String string = L"Полжав"s;
-            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::string(string).empty());
             CHECK(std::wstring(string) == L"Полжав"s);
-            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toAnsiString().empty());
             CHECK(string.toWideString() == L"Полжав"s);
             CHECK(string.toUtf8() == sf::U8String{0xD0, 0x9F, 0xD0, 0xBE, 0xD0, 0xBB, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB2});
             CHECK(string.toUtf16() == u"Полжав"s);
@@ -380,9 +387,9 @@ TEST_CASE("[System] sf::String")
         SECTION("Wide string view constructor")
         {
             const sf::String string = L"Полжав"sv;
-            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::string(string).empty());
             CHECK(std::wstring(string) == L"Полжав"s);
-            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toAnsiString().empty());
             CHECK(string.toWideString() == L"Полжав"s);
             CHECK(string.toUtf8() == sf::U8String{0xD0, 0x9F, 0xD0, 0xBE, 0xD0, 0xBB, 0xD0, 0xB6, 0xD0, 0xB0, 0xD0, 0xB2});
             CHECK(string.toUtf16() == u"Полжав"s);
@@ -395,9 +402,9 @@ TEST_CASE("[System] sf::String")
         SECTION("UTF-32 character constructor")
         {
             const sf::String string = U'🐌';
-            CHECK(std::string(string) == "\0"s);
+            CHECK(std::string(string).empty());
             CHECK(std::wstring(string) == select(L""s, L"🐌"s));
-            CHECK(string.toAnsiString() == "\0"s);
+            CHECK(string.toAnsiString().empty());
             CHECK(string.toWideString() == select(L""s, L"🐌"s));
             CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C});
             CHECK(string.toUtf16() == u"🐌"s);
@@ -424,9 +431,9 @@ TEST_CASE("[System] sf::String")
             }
             {
                 const sf::String string = U"カタツムリ";
-                CHECK(std::string(string) == "\0\0\0\0\0"s);
+                CHECK(std::string(string).empty());
                 CHECK(std::wstring(string) == L"カタツムリ"s);
-                CHECK(string.toAnsiString() == "\0\0\0\0\0"s);
+                CHECK(string.toAnsiString().empty());
                 CHECK(string.toWideString() == L"カタツムリ"s);
                 CHECK(string.toUtf8() ==
                       sf::U8String{0xE3, 0x82, 0xAB, 0xE3, 0x82, 0xBF, 0xE3, 0x83, 0x84, 0xE3, 0x83, 0xA0, 0xE3, 0x83, 0xAA});
@@ -438,9 +445,9 @@ TEST_CASE("[System] sf::String")
             }
             {
                 const sf::String string = U"🐌🐚";
-                CHECK(std::string(string) == "\0\0"s);
+                CHECK(std::string(string).empty());
                 CHECK(std::wstring(string) == select(L""s, L"🐌🐚"s));
-                CHECK(string.toAnsiString() == "\0\0"s);
+                CHECK(string.toAnsiString().empty());
                 CHECK(string.toWideString() == select(L""s, L"🐌🐚"s));
                 CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C, 0xF0, 0x9F, 0x90, 0x9A});
                 CHECK(string.toUtf16() == u"🐌🐚"s);
@@ -454,9 +461,9 @@ TEST_CASE("[System] sf::String")
         SECTION("UTF-32 string constructor")
         {
             const sf::String string = U"گھونگا"s;
-            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::string(string).empty());
             CHECK(std::wstring(string) == L"گھونگا"s);
-            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toAnsiString().empty());
             CHECK(string.toWideString() == L"گھونگا"s);
             CHECK(string.toUtf8() == sf::U8String{0xDA, 0xAF, 0xDA, 0xBE, 0xD9, 0x88, 0xD9, 0x86, 0xDA, 0xAF, 0xD8, 0xA7});
             CHECK(string.toUtf16() == u"گھونگا"s);
@@ -469,9 +476,9 @@ TEST_CASE("[System] sf::String")
         SECTION("UTF-32 string view constructor")
         {
             const sf::String string = U"گھونگا"sv;
-            CHECK(std::string(string) == "\0\0\0\0\0\0"s);
+            CHECK(std::string(string).empty());
             CHECK(std::wstring(string) == L"گھونگا"s);
-            CHECK(string.toAnsiString() == "\0\0\0\0\0\0"s);
+            CHECK(string.toAnsiString().empty());
             CHECK(string.toWideString() == L"گھونگا"s);
             CHECK(string.toUtf8() == sf::U8String{0xDA, 0xAF, 0xDA, 0xBE, 0xD9, 0x88, 0xD9, 0x86, 0xDA, 0xAF, 0xD8, 0xA7});
             CHECK(string.toUtf16() == u"گھونگا"s);
@@ -487,8 +494,13 @@ TEST_CASE("[System] sf::String")
         {
             constexpr std::array<std::uint8_t, 1> characters{251};
             const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
+            CHECK(string.isEmpty());
+        }
+        {
+            constexpr std::array<std::uint8_t, 1> characters{251};
+            const sf::String string = sf::String::fromUtf8(characters.begin(), characters.end(), '?');
             CHECK(string.getSize() == 1);
-            CHECK(string[0] == 0);
+            CHECK(string[0] == '?');
         }
         {
             constexpr std::array<std::uint8_t, 4> characters{'w', 'x', 'y', 'z'};
@@ -507,9 +519,9 @@ TEST_CASE("[System] sf::String")
         {
             constexpr std::array<std::uint8_t, 4> characters{0xF0, 0x9F, 0x90, 0x8C};
             const sf::String                      string = sf::String::fromUtf8(characters.begin(), characters.end());
-            CHECK(std::string(string) == "\0"s);
+            CHECK(std::string(string).empty());
             CHECK(std::wstring(string) == select(L""s, L"🐌"s));
-            CHECK(string.toAnsiString() == "\0"s);
+            CHECK(string.toAnsiString().empty());
             CHECK(string.toWideString() == select(L""s, L"🐌"s));
             CHECK(string.toUtf8() == sf::U8String{0xF0, 0x9F, 0x90, 0x8C});
             CHECK(string.toUtf16() == u"🐌"s);
@@ -522,6 +534,28 @@ TEST_CASE("[System] sf::String")
 
     SECTION("fromUtf16()")
     {
+        {
+            constexpr std::array<char16_t, 1> characters{0xD800};
+            const sf::String                  string = sf::String::fromUtf16(characters.begin(), characters.end());
+            CHECK(string.isEmpty());
+        }
+        {
+            constexpr std::array<char16_t, 1> characters{0xD800};
+            const sf::String                  string = sf::String::fromUtf16(characters.begin(), characters.end(), '?');
+            CHECK(string.getSize() == 1);
+            CHECK(string[0] == '?');
+        }
+        {
+            constexpr std::array<char16_t, 2> characters{0xD800, 0xD800};
+            const sf::String                  string = sf::String::fromUtf16(characters.begin(), characters.end());
+            CHECK(string.isEmpty());
+        }
+        {
+            constexpr std::array<char16_t, 2> characters{0xD800, 0xD800};
+            const sf::String                  string = sf::String::fromUtf16(characters.begin(), characters.end(), '?');
+            CHECK(string.getSize() == 2);
+            CHECK(string[0] == '?');
+        }
         {
             constexpr std::u16string_view characters = u"SFML!"sv;
             const sf::String              string     = sf::String::fromUtf16(characters.begin(), characters.end());
@@ -541,11 +575,11 @@ TEST_CASE("[System] sf::String")
             const sf::String              string     = sf::String::fromUtf16(characters.begin(), characters.end());
             CHECK(std::string(string) == select("pi\xF1"
                                                 "ata"s,
-                                                "pi\0ata"s));
+                                                "piata"s));
             CHECK(std::wstring(string) == L"piñata"s);
             CHECK(string.toAnsiString() == select("pi\xF1"
                                                   "ata"s,
-                                                  "pi\0ata"s));
+                                                  "piata"s));
             CHECK(string.toWideString() == L"piñata"s);
             CHECK(string.toUtf8() == sf::U8String{'p', 'i', 0xC3, 0xB1, 'a', 't', 'a'});
             CHECK(string.toUtf16() == u"piñata"s);
@@ -557,9 +591,9 @@ TEST_CASE("[System] sf::String")
         {
             constexpr std::u16string_view characters = u"달팽이"sv;
             const sf::String              string     = sf::String::fromUtf16(characters.begin(), characters.end());
-            CHECK(std::string(string) == "\0\0\0"s);
+            CHECK(std::string(string).empty());
             CHECK(std::wstring(string) == L"달팽이"s);
-            CHECK(string.toAnsiString() == "\0\0\0"s);
+            CHECK(string.toAnsiString().empty());
             CHECK(string.toWideString() == L"달팽이"s);
             CHECK(string.toUtf8() == sf::U8String{0xEB, 0x8B, 0xAC, 0xED, 0x8C, 0xBD, 0xEC, 0x9D, 0xB4});
             CHECK(string.toUtf16() == u"달팽이"s);
@@ -574,9 +608,9 @@ TEST_CASE("[System] sf::String")
     {
         constexpr std::u32string_view characters = U"👍+👎=🤷"sv;
         const sf::String              string     = sf::String::fromUtf32(characters.begin(), characters.end());
-        CHECK(std::string(string) == "\0+\0=\0"s);
+        CHECK(std::string(string) == "+="s);
         CHECK(std::wstring(string) == select(L"+="s, L"👍+👎=🤷"s));
-        CHECK(string.toAnsiString() == "\0+\0=\0"s);
+        CHECK(string.toAnsiString() == "+="s);
         CHECK(string.toWideString() == select(L"+="s, L"👍+👎=🤷"s));
         CHECK(string.toUtf8() ==
               sf::U8String{0xF0, 0x9F, 0x91, 0x8D, '+', 0xF0, 0x9F, 0x91, 0x8E, '=', 0xF0, 0x9F, 0xA4, 0xB7});

--- a/test/System/Utf.test.cpp
+++ b/test/System/Utf.test.cpp
@@ -1,7 +1,13 @@
+// Some versions of GCC produce a false positive maybe-uninitialized warning when building this file in release
+#if (!defined(SFML_DEBUG) && defined(__GNUC__) && !defined(__clang__))
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
 #include <SFML/System/Utf.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <array>
 #include <string_view>
 
 namespace
@@ -32,17 +38,161 @@ using u8string_view = std::basic_string_view<decltype(u8' ')>;
 TEST_CASE("[System] sf::Utf8")
 {
     static constexpr auto utf8 = u8"SFML 🐌"sv;
+    static_assert(utf8.length() == 9);
 
     SECTION("decode")
     {
-        std::u32string output;
-        for (auto begin = utf8.cbegin(); begin < utf8.cend();)
+        SECTION("Valid sequence")
         {
-            char32_t character = 0;
-            begin              = sf::Utf8::decode(begin, utf8.cend(), character);
-            output.push_back(character);
+            SECTION("Complete sequence")
+            {
+                std::u32string output;
+                for (auto begin = utf8.cbegin(); begin < utf8.cend();)
+                {
+                    char32_t character = 0;
+                    begin              = sf::Utf8::decode(begin, utf8.cend(), character);
+                    output.push_back(character);
+                }
+                CHECK(output == U"SFML 🐌"sv);
+            }
+
+            SECTION("Complete codepoint")
+            {
+                SECTION("1 Byte")
+                {
+                    // Ensure ASCII (0x00-0x7F) is decoded 1:1
+                    for (auto i = 0x00; i <= 0x7F; ++i)
+                    {
+                        char32_t   character = 0;
+                        const auto c         = static_cast<std::uint8_t>(i);
+                        const auto next      = sf::Utf8::decode(&c, &c + 1, character);
+                        CHECK(character == static_cast<char32_t>(c));
+                        CHECK(next == (&c + 1));
+                    }
+                }
+
+                SECTION("2 Bytes")
+                {
+                    {
+                        static constexpr auto sequence = u8"\u0080"sv;
+                        static_assert(sequence.length() == 2);
+                        char32_t   character = 0;
+                        const auto next      = sf::Utf8::decode(sequence.cbegin(), sequence.cend(), character);
+                        CHECK(character == U'\u0080');
+                        CHECK(next == sequence.cend());
+                    }
+
+                    {
+                        static constexpr auto sequence = u8"\u07FF"sv;
+                        static_assert(sequence.length() == 2);
+                        char32_t   character = 0;
+                        const auto next      = sf::Utf8::decode(sequence.cbegin(), sequence.cend(), character);
+                        CHECK(character == U'\u07FF');
+                        CHECK(next == sequence.cend());
+                    }
+                }
+
+                SECTION("3 Bytes")
+                {
+                    {
+                        static constexpr auto sequence = u8"\u0800"sv;
+                        static_assert(sequence.length() == 3);
+                        char32_t   character = 0;
+                        const auto next      = sf::Utf8::decode(sequence.cbegin(), sequence.cend(), character);
+                        CHECK(character == U'\u0800');
+                        CHECK(next == sequence.cend());
+                    }
+
+                    {
+                        static constexpr auto sequence = u8"\uFFFF"sv;
+                        static_assert(sequence.length() == 3);
+                        char32_t   character = 0;
+                        const auto next      = sf::Utf8::decode(sequence.cbegin(), sequence.cend(), character);
+                        CHECK(character == U'\uFFFF');
+                        CHECK(next == sequence.cend());
+                    }
+                }
+
+                SECTION("4 Bytes")
+                {
+                    {
+                        static constexpr auto sequence = u8"\U00010000"sv;
+                        static_assert(sequence.length() == 4);
+                        char32_t   character = 0;
+                        const auto next      = sf::Utf8::decode(sequence.cbegin(), sequence.cend(), character);
+                        CHECK(character == U'\U00010000');
+                        CHECK(next == sequence.cend());
+                    }
+
+                    {
+                        static constexpr auto sequence = u8"\U0010FFFF"sv;
+                        static_assert(sequence.length() == 4);
+                        char32_t   character = 0;
+                        const auto next      = sf::Utf8::decode(sequence.cbegin(), sequence.cend(), character);
+                        CHECK(character == U'\U0010FFFF');
+                        CHECK(next == sequence.cend());
+                    }
+                }
+            }
         }
-        CHECK(output == U"SFML 🐌"sv);
+
+        SECTION("Invalid sequence")
+        {
+            SECTION("Incomplete sequence")
+            {
+                const auto end = utf8.cend() - 1;
+
+                SECTION("Default replacement character")
+                {
+                    std::u32string output;
+                    for (auto begin = utf8.cbegin(); begin < end;)
+                    {
+                        char32_t character = 0;
+                        begin              = sf::Utf8::decode(begin, end, character);
+                        output.push_back(character);
+                    }
+                    CHECK(output == U"SFML \0\0\0"sv);
+                }
+
+                SECTION("Custom replacement character")
+                {
+                    std::u32string output;
+                    for (auto begin = utf8.cbegin(); begin < end;)
+                    {
+                        char32_t character = 0;
+                        begin              = sf::Utf8::decode(begin, end, character, '?');
+                        output.push_back(character);
+                    }
+                    CHECK(output == U"SFML ???"sv);
+                }
+            }
+
+            SECTION("Invalid leading byte")
+            {
+                static constexpr std::array<unsigned char, 13>
+                    invalid{0xC0, 0xC1, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF};
+
+                for (auto begin = invalid.cbegin(); begin < invalid.cend(); ++begin)
+                {
+                    char32_t   character = 0;
+                    const auto next      = sf::Utf8::decode(begin, begin + 1, character);
+                    CHECK(character == '\0');
+                    CHECK(next == begin + 1);
+                }
+            }
+
+            SECTION("Leading continuation byte")
+            {
+                for (auto i = 0x80; i <= 0xBF; ++i)
+                {
+                    char32_t   character = 0;
+                    const auto c         = static_cast<std::uint8_t>(i);
+                    const auto next      = sf::Utf8::decode(&c, &c + 1, character);
+                    CHECK(character == '\0');
+                    CHECK(next == (&c + 1));
+                }
+            }
+        }
     }
 
     SECTION("encode")
@@ -90,11 +240,13 @@ TEST_CASE("[System] sf::Utf8")
 
     SECTION("count")
     {
+        // Attempting to read an incomplete byte sequence should result in each byte
+        // of the incomplete sequence being replaced by the replacement character
         REQUIRE(utf8.size() == 9);
         CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cend()) == 6);
         CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 9) == 6);
-        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 8) == 6);
-        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 7) == 6);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 8) == 8);
+        CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 7) == 7);
         CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 6) == 6);
         CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 5) == 5);
         CHECK(sf::Utf8::count(utf8.cbegin(), utf8.cbegin() + 4) == 4);
@@ -135,9 +287,15 @@ TEST_CASE("[System] sf::Utf8")
     {
         std::string output;
 
-        SECTION("Default replacement character")
+        SECTION("No replacement character")
         {
             sf::Utf8::toAnsi(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+            CHECK(output == "SFML "sv);
+        }
+
+        SECTION("NULL replacement character")
+        {
+            sf::Utf8::toAnsi(utf8.cbegin(), utf8.cend(), std::back_inserter(output), '\0');
             CHECK(output == "SFML \0"sv);
         }
 
@@ -169,9 +327,15 @@ TEST_CASE("[System] sf::Utf8")
     {
         std::string output;
 
-        SECTION("Default replacement character")
+        SECTION("No replacement character")
         {
             sf::Utf8::toLatin1(utf8.cbegin(), utf8.cend(), std::back_inserter(output));
+            CHECK(output == "SFML "sv);
+        }
+
+        SECTION("NULL replacement character")
+        {
+            sf::Utf8::toLatin1(utf8.cbegin(), utf8.cend(), std::back_inserter(output), '\0');
             CHECK(output == "SFML \0"sv);
         }
 
@@ -308,9 +472,15 @@ TEST_CASE("[System] sf::Utf16")
     {
         std::string output;
 
-        SECTION("Default replacement character")
+        SECTION("No replacement character")
         {
             sf::Utf16::toAnsi(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+            CHECK(output == "SFML "sv);
+        }
+
+        SECTION("NULL replacement character")
+        {
+            sf::Utf16::toAnsi(utf16.cbegin(), utf16.cend(), std::back_inserter(output), '\0');
             CHECK(output == "SFML \0"sv);
         }
 
@@ -342,9 +512,15 @@ TEST_CASE("[System] sf::Utf16")
     {
         std::string output;
 
-        SECTION("Default replacement character")
+        SECTION("No replacement character")
         {
             sf::Utf16::toLatin1(utf16.cbegin(), utf16.cend(), std::back_inserter(output));
+            CHECK(output == "SFML "sv);
+        }
+
+        SECTION("NULL replacement character")
+        {
+            sf::Utf16::toLatin1(utf16.cbegin(), utf16.cend(), std::back_inserter(output), '\0');
             CHECK(output == "SFML \0\0"sv);
         }
 
@@ -463,9 +639,15 @@ TEST_CASE("[System] sf::Utf32")
     {
         std::string output;
 
-        SECTION("Default replacement character")
+        SECTION("No replacement character")
         {
             sf::Utf32::toAnsi(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+            CHECK(output == "SFML "sv);
+        }
+
+        SECTION("NULL replacement character")
+        {
+            sf::Utf32::toAnsi(utf32.cbegin(), utf32.cend(), std::back_inserter(output), '\0');
             CHECK(output == "SFML \0"sv);
         }
 
@@ -486,6 +668,12 @@ TEST_CASE("[System] sf::Utf32")
             CHECK(output == select(L"SFML "sv, L"SFML 🐌"sv));
         }
 
+        SECTION("NULL replacement character")
+        {
+            sf::Utf32::toWide(utf32.cbegin(), utf32.cend(), std::back_inserter(output), L'\0');
+            CHECK(output == select(L"SFML \0"sv, L"SFML 🐌"sv));
+        }
+
         SECTION("Custom replacement character")
         {
             sf::Utf32::toWide(utf32.cbegin(), utf32.cend(), std::back_inserter(output), L'_');
@@ -497,9 +685,15 @@ TEST_CASE("[System] sf::Utf32")
     {
         std::string output;
 
-        SECTION("Default replacement character")
+        SECTION("No replacement character")
         {
             sf::Utf32::toLatin1(utf32.cbegin(), utf32.cend(), std::back_inserter(output));
+            CHECK(output == "SFML "sv);
+        }
+
+        SECTION("NULL replacement character")
+        {
+            sf::Utf32::toLatin1(utf32.cbegin(), utf32.cend(), std::back_inserter(output), '\0');
             CHECK(output == "SFML \0"sv);
         }
 
@@ -553,7 +747,7 @@ TEST_CASE("[System] sf::Utf32")
     {
         std::string output;
 
-        SECTION("Default replacement character")
+        SECTION("No replacement character")
         {
             sf::Utf32::encodeAnsi(U' ', std::back_inserter(output));
             CHECK(output == " "sv);
@@ -562,6 +756,18 @@ TEST_CASE("[System] sf::Utf32")
             sf::Utf32::encodeAnsi(U'a', std::back_inserter(output));
             CHECK(output == " _a"sv);
             sf::Utf32::encodeAnsi(U'🐌', std::back_inserter(output));
+            CHECK(output == " _a"sv);
+        }
+
+        SECTION("NULL replacement character")
+        {
+            sf::Utf32::encodeAnsi(U' ', std::back_inserter(output), '\0');
+            CHECK(output == " "sv);
+            sf::Utf32::encodeAnsi(U'_', std::back_inserter(output), '\0');
+            CHECK(output == " _"sv);
+            sf::Utf32::encodeAnsi(U'a', std::back_inserter(output), '\0');
+            CHECK(output == " _a"sv);
+            sf::Utf32::encodeAnsi(U'🐌', std::back_inserter(output), '\0');
             CHECK(output == " _a\0"sv);
         }
 


### PR DESCRIPTION
Title.

These changes are intended to make Unicode (UTF-8/16) conversions more robust against invalid sequences. Previously, feeding the conversions invalid sequences could result in those bytes being copied 1:1 to the UTF-32 output without proper validation. This resulted in confusion when attempting to decode non-UTF-8-encoded data as UTF-8 because the resulting `sf::String` would be filled with codepoints which did not correspond to the source data in its original encoding. An example of this can be seen in #2985.

The decoding and encoding functions already provided a parameter to specify a replacement codepoint to be inserted into the resulting data stream if decoding encountered an invalid sequence. Because validation was not performed correctly the replacement codepoint would not always be inserted when it had to be. This change also exposes the replacement parameter to all functions that call the decoding functions so the user has the possibility of specifying their own replacement codepoint when e.g. decoding UTF-8 directly into an `sf::String`. Not being able to do so would mean they are forced to use the default behaviour which would be to discard invalid sequences without replacing them.

Because silent conversion errors can be hard to detect and lead to many other unwanted effects, warning messages are output in debug builds to notify the user that conversion errors occurred so they can investigate.

Long term we should consider adding conversion functions that return the result of a conversion so the user can handle conversion errors from within the code itself.

We should also consider a mechanism to allow `'\0'` to be a replacement character. Currently this value is interpreted as an indication that invalid sequences should be discarded.