### PR TITLE
Added boolean return value to sf::Http::setHost. Added test to sf::Http::setHost. Made sf::Http::sendRequest const.

### DIFF
--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -374,6 +374,7 @@ public:
     ///
     /// This function just stores the host address and port, it
     /// doesn't actually connect to it until you send a request.
+    /// It does however try to resolve the address.
     /// The port has a default value of 0, which means that the
     /// HTTP client will use the right port according to the
     /// protocol used (80 for HTTP). You should leave it like
@@ -383,8 +384,10 @@ public:
     /// \param host Web server to connect to
     /// \param port Port to use for connection
     ///
+    /// \return `true` if the host has been resolved and is valid, `false` otherwise
+    ///
     ////////////////////////////////////////////////////////////
-    void setHost(const std::string& host, unsigned short port = 0);
+    bool setHost(const std::string& host, unsigned short port = 0);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a HTTP request and return the server's response.
@@ -405,17 +408,16 @@ public:
     /// \return Server's response
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] Response sendRequest(const Request& request, Time timeout = Time::Zero, bool verifyServer = true);
+    [[nodiscard]] Response sendRequest(const Request& request, Time timeout = Time::Zero, bool verifyServer = true) const;
 
 private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    TcpSocket                m_connection; //!< Connection to the host
-    std::optional<IpAddress> m_host;       //!< Web host address
-    std::string              m_hostName;   //!< Web host name
-    unsigned short           m_port{};     //!< Port used for connection with host
-    bool                     m_https{};    //!< Use HTTPS
+    std::optional<IpAddress> m_host;     //!< Web host address
+    std::string              m_hostName; //!< Web host name
+    unsigned short           m_port{};   //!< Port used for connection with host
+    bool                     m_https{};  //!< Use HTTPS
 };
 
 } // namespace sf

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -298,7 +298,7 @@ Http::Http(const std::string& host, unsigned short port)
 
 
 ////////////////////////////////////////////////////////////
-void Http::setHost(const std::string& host, unsigned short port)
+bool Http::setHost(const std::string& host, unsigned short port)
 {
     // Check the protocol
     if (toLower(host.substr(0, 7)) == "http://")
@@ -326,11 +326,12 @@ void Http::setHost(const std::string& host, unsigned short port)
         m_hostName.erase(m_hostName.size() - 1);
 
     m_host = IpAddress::resolve(m_hostName);
+    return m_host.has_value();
 }
 
 
 ////////////////////////////////////////////////////////////
-Http::Response Http::sendRequest(const Http::Request& request, Time timeout, bool verifyServer)
+Http::Response Http::sendRequest(const Http::Request& request, Time timeout, bool verifyServer) const
 {
     // First make sure that the request is valid -- add missing mandatory fields
     Request toSend(request);
@@ -364,11 +365,11 @@ Http::Response Http::sendRequest(const Http::Request& request, Time timeout, boo
     // Prepare the response
     Response received;
 
+    TcpSocket connection;
     // Connect the socket to the host
-    if (m_host.has_value() && m_connection.connect(m_host.value(), m_port, timeout) == Socket::Status::Done)
+    if (m_host.has_value() && connection.connect(m_host.value(), m_port, timeout) == Socket::Status::Done)
     {
-        if (m_https &&
-            (m_connection.setupTlsClient(m_hostName, verifyServer) != sf::TcpSocket::TlsStatus::HandshakeComplete))
+        if (m_https && (connection.setupTlsClient(m_hostName, verifyServer) != sf::TcpSocket::TlsStatus::HandshakeComplete))
             return received;
 
         // Convert the request to string and send it through the connected socket
@@ -377,7 +378,7 @@ Http::Response Http::sendRequest(const Http::Request& request, Time timeout, boo
         if (!requestStr.empty())
         {
             // Send it through the socket
-            if (m_connection.send(requestStr.c_str(), requestStr.size()) == Socket::Status::Done)
+            if (connection.send(requestStr.c_str(), requestStr.size()) == Socket::Status::Done)
             {
                 // Wait for the server's response
                 std::string            receivedStr;
@@ -389,7 +390,7 @@ Http::Response Http::sendRequest(const Http::Request& request, Time timeout, boo
                 // When these messages are received the receive function will return Socket::Status::Partial
                 // In this case We just continue to call receive until actual payload
                 // data is available, the connection is closed or an error occurs
-                auto result = m_connection.receive(buffer.data(), buffer.size(), size);
+                auto result = connection.receive(buffer.data(), buffer.size(), size);
 
                 while ((result == Socket::Status::Done) || (result == Socket::Status::Partial))
                 {
@@ -397,7 +398,7 @@ Http::Response Http::sendRequest(const Http::Request& request, Time timeout, boo
                     if (result == Socket::Status::Done)
                         receivedStr.append(buffer.data(), buffer.data() + size);
 
-                    result = m_connection.receive(buffer.data(), buffer.size(), size);
+                    result = connection.receive(buffer.data(), buffer.size(), size);
                 }
 
                 // Build the Response object from the received data
@@ -406,7 +407,7 @@ Http::Response Http::sendRequest(const Http::Request& request, Time timeout, boo
         }
 
         // Close the connection
-        m_connection.disconnect();
+        connection.disconnect();
     }
 
     return received;

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -175,7 +175,7 @@ std::optional<IpAddress> IpAddress::getPublicAddress(Time timeout)
     // and parse the result to extract our IP address
     // (not very hard: the web page contains only our IP address).
 
-    Http                 server("www.sfml-dev.org");
+    const Http           server("www.sfml-dev.org");
     const Http::Request  request("/ip-provider.php", Http::Request::Method::Get);
     const Http::Response page = server.sendRequest(request, timeout);
 

--- a/test/Network/Http.test.cpp
+++ b/test/Network/Http.test.cpp
@@ -15,6 +15,31 @@ TEST_CASE("[Network] sf::Http")
         STATIC_CHECK(!std::is_nothrow_move_assignable_v<sf::Http>);
     }
 
+    SECTION("setHost")
+    {
+        sf::Http http;
+
+        SECTION("Valid host w/ prefix")
+        {
+            CHECK(http.setHost("http://google.com"));
+        }
+
+        SECTION("Valid host w/o prefix")
+        {
+            CHECK(http.setHost("google.com"));
+        }
+
+        SECTION("Invalid host w/ prefix")
+        {
+            CHECK(!http.setHost("http://dummy"));
+        }
+
+        SECTION("Invalid host w/o prefix")
+        {
+            CHECK(!http.setHost("dummy"));
+        }
+    }
+
     SECTION("Request")
     {
         SECTION("Type traits")
@@ -52,7 +77,7 @@ TEST_CASE("[Network] sf::Http Connection", runConnectionTests())
 {
     SECTION("HTTP Connection")
     {
-        sf::Http http("http://github.com");
+        const sf::Http http("http://github.com");
 
         SECTION("Request Index")
         {


### PR DESCRIPTION
## Description

Continuation of the accidentally closed #3542 PR by @Rosme 

This PR has no related issue. It was discussed in Discord as a nice to have.

## Tasks

-   [x] Tested on Linux
-   [x] Tested on Windows
-   [x] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

This PR does not add any side effect. It provide the result of setHost. Existing code will still work.
Unit tests have been added for the result of setHost with both a http prefix and not, both for a valid and a non valid host.

```cpp
#include <SFML/Network.hpp>

int main()
{
    sf::Http http;
    if(!http.setHost("dummy"))
    {
        sf::err() << "Failed to set host";
    }
}
```