### PR TITLE
Remove redundant cmake policy setting, since minimum cmake version was updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,6 @@ endmacro()
 
 # these options have to be set before CMake detects/configures the toolchain
 
-# use new MSVC debug information format specification mechanism if available
-# we use this mechanism to embed debug information into the object file to allow ccache to cache it
-if(POLICY CMP0141)
-    cmake_policy(SET CMP0141 NEW)
-endif()
-
 # When configuring with `--fresh`, also do a fresh configure for fetched dependencies
 if(POLICY CMP0168)
     cmake_policy(SET CMP0168 NEW)


### PR DESCRIPTION
Policy is already enabled in cmake 3.25+ (We require 3.28)