### PR TITLE
Prevent in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.28)
 
+# Prevent in-source builds
+if("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+    message(FATAL_ERROR "In-source builds are not permitted! Make sure to use a separate build directory")
+endif ()
+
 # define a macro that helps defining an option
 macro(sfml_set_option var default type docstring)
     if(NOT DEFINED ${var})


### PR DESCRIPTION
We already recommend against them here: https://www.sfml-dev.org/tutorials/3.0/getting-started/build-from-source/#configuring-your-sfml-build

freetype also prevents them, so it's already a configuration error unless you are using system deps, which we could add a condition if we still wanted to support it, but I don't believe we should. 

It's also strongly recommended against in the [cmake docs](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Getting%20Started.html): 

> Out-of-source builds, where the source and binary directories are different, are strongly encouraged. In-source builds where the source and binary directories are the same are supported but should be avoided if possible.