### PR TITLE
Use viewWillTransitionToSize to handle orientation changes on iOS

### DIFF
--- a/src/SFML/Window/iOS/SFAppDelegate.hpp
+++ b/src/SFML/Window/iOS/SFAppDelegate.hpp
@@ -102,22 +102,6 @@
 - (void)notifyCharacter:(char32_t)character;
 
 ////////////////////////////////////////////////////////////
-/// \brief Tells if the dimensions of the current window must be flipped when switching to a given orientation
-///
-/// \param orientation the device has changed to
-///
-////////////////////////////////////////////////////////////
-- (bool)needsToFlipFrameForOrientation:(UIDeviceOrientation)orientation;
-
-////////////////////////////////////////////////////////////
-/// \brief Tells if app and view support a requested device orientation or not
-///
-/// \param orientation the device has changed to
-///
-////////////////////////////////////////////////////////////
-- (bool)supportsOrientation:(UIDeviceOrientation)orientation;
-
-////////////////////////////////////////////////////////////
 /// \brief Initializes the factor which is required to convert from points to pixels and back
 ///
 ////////////////////////////////////////////////////////////

--- a/src/SFML/Window/iOS/SFViewController.hpp
+++ b/src/SFML/Window/iOS/SFViewController.hpp
@@ -37,26 +37,13 @@
 @interface SFViewController : UIViewController
 
 ////////////////////////////////////////////////////////////
-/// \brief Tells if the controller supports auto-rotation (iOS < 6)
+/// \brief Called when the UI orientation changes
 ///
-/// \param interfaceOrientation Orientation to check
-///
-/// \return `true` if auto-rotation is supported, `false` otherwise
-///
-////////////////////////////////////////////////////////////
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
-
-////////////////////////////////////////////////////////////
-/// \brief Tells if the controller supports auto-rotation (iOS >= 6)
-///
-/// \return `true` if auto-rotation is supported, `false` otherwise
+/// \param size The new size
+/// \param coordinator The transition coordinator
 ///
 ////////////////////////////////////////////////////////////
-- (BOOL)shouldAutorotate;
-
-////////////////////////////////////////////////////////////
-// Member data
-////////////////////////////////////////////////////////////
-@property(nonatomic) bool orientationCanChange; ///< Tells whether the controller's view can rotate or not
+- (void)viewWillTransitionToSize:(CGSize)size
+       withTransitionCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)coordinator;
 
 @end

--- a/src/SFML/Window/iOS/SFViewController.mm
+++ b/src/SFML/Window/iOS/SFViewController.mm
@@ -25,25 +25,23 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/iOS/SFAppDelegate.hpp>
 #include <SFML/Window/iOS/SFViewController.hpp>
 
 
 @implementation SFViewController
 
-@synthesize orientationCanChange;
-
-
 ////////////////////////////////////////////////////////////
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+- (void)viewWillTransitionToSize:(CGSize)size
+       withTransitionCoordinator:(nonnull id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    return self.orientationCanChange;
-}
-
-
-////////////////////////////////////////////////////////////
-- (BOOL)shouldAutorotate
-{
-    return self.orientationCanChange;
+    if ([SFAppDelegate getInstance].sfWindow)
+    {
+        [SFAppDelegate getInstance].sfWindow->forwardEvent(
+            sf::Event::Resized{{static_cast<unsigned int>(size.width), static_cast<unsigned int>(size.height)}});
+    }
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 }
 
 @end

--- a/src/SFML/Window/iOS/WindowImplUIKit.mm
+++ b/src/SFML/Window/iOS/WindowImplUIKit.mm
@@ -73,10 +73,9 @@ WindowImplUIKit::WindowImplUIKit(VideoMode mode,
     [m_view resignFirstResponder];
 
     // Create the view controller
-    m_viewController                      = [SFViewController alloc];
-    m_viewController.view                 = m_view;
-    m_viewController.orientationCanChange = style & Style::Resize;
-    m_window.rootViewController           = m_viewController;
+    m_viewController            = [SFViewController alloc];
+    m_viewController.view       = m_view;
+    m_window.rootViewController = m_viewController;
 
     // Make it the current window
     [m_window makeKeyAndVisible];


### PR DESCRIPTION
Fixes #3241

Currently we register for device orientation changes, but as we already have our own view controller in the responder chain it can take care of most of the business for us (working out the new size, app orientation restrictions, only sending events when the orientation actually changes)

As part of this I've removed the functionality which tried to prevent orientation changes if `Style::Resize` is not set on the window. It should be technically possible to maintain this behaviour but I've chosen not to because:
- It's undocumented
- Android doesn't do it
- It doesn't work on newer iOS versions (I don't have a device on <16 to test, so it may have worked there?) so the window still rotates but SFML thinks it hasn't
- Even if it all worked, it effectively locks the orientation to whichever one the app is started with, which seems completely unintuitive and not a behaviour I can imagine anybody needing

This change also means users won't get resize events when the orientation isn't supported, which they do currently