### PR TITLE
Don't suppress brew failures in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
 
     env:
       CMAKE_CXX_COMPILER_LAUNCHER: ccache # Use ccache to cache C++ compiler output
-      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1" # Work around Homebrew errors within coverallsapp/github-action@v2
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Recently gcovr 8.5 was released with an issue that affected us causing CI to fail - In testing the fix I changed the CI to use the head version of the brew packages and ran the jobs. 

As the jobs passed I thought that confirmed the fix, however what actually happened was brew failed to install the head version and used the cached previous version which passed.

Links to the jobs for the original instability these supposedly worked around are all dead so I can't really make more educated guesses on whether they are still present or now, but generally speaking I think hiding instabilities in CI is a bad practice, and if it does turn out brew/coveralls are unreliable we should find alternatives

This also raises the question about if/how we should pin versions for these things to improve stability, but that's best left for another discussion.