### PR TITLE
Graphics/Text: add optional rounding for letter and line spacing

### DIFF
--- a/include/SFML/Graphics/Text.hpp
+++ b/include/SFML/Graphics/Text.hpp
@@ -433,7 +433,7 @@ public:
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] float getLineSpacing() const;
-    
+
     ////////////////////////////////////////////////////////////
     /// \brief Tell whether line and letter spacing rounding is enabled
     ///
@@ -820,16 +820,16 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    String                m_string;                                      //!< String to display
-    const Font*           m_font{};                                      //!< Font used to display the string
-    unsigned int          m_characterSize{30};                           //!< Base size of characters, in pixels
-    float                 m_letterSpacingFactor{1.f};                    //!< Spacing factor between letters
-    float                 m_lineSpacingFactor{1.f};                      //!< Spacing factor between lines
-    bool                  m_roundTextSpacing = false;                    //!< Does the letter and line spacing need to be rounded?
-    std::uint32_t         m_style{Regular};                              //!< Text style (see Style enum)
-    Color                 m_fillColor{Color::White};                     //!< Text fill color
-    Color                 m_outlineColor{Color::Black};                  //!< Text outline color
-    float                 m_outlineThickness{0.f};                       //!< Thickness of the text's outline
+    String                m_string;                     //!< String to display
+    const Font*           m_font{};                     //!< Font used to display the string
+    unsigned int          m_characterSize{30};          //!< Base size of characters, in pixels
+    float                 m_letterSpacingFactor{1.f};   //!< Spacing factor between letters
+    float                 m_lineSpacingFactor{1.f};     //!< Spacing factor between lines
+    bool                  m_roundTextSpacing = false;   //!< Does the letter and line spacing need to be rounded?
+    std::uint32_t         m_style{Regular};             //!< Text style (see Style enum)
+    Color                 m_fillColor{Color::White};    //!< Text fill color
+    Color                 m_outlineColor{Color::Black}; //!< Text outline color
+    float                 m_outlineThickness{0.f};      //!< Thickness of the text's outline
     LineAlignment         m_lineAlignment{LineAlignment::Default};       //!< Line alignment for a multi-line text
     TextOrientation       m_textOrientation{TextOrientation::Default};   //!< Text orientation
     ClusterGrouping       m_clusterGrouping{ClusterGrouping::Character}; //!< Cluster grouping algorithm

--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -466,9 +466,9 @@ void Text::setLineSpacing(float spacingFactor)
 ////////////////////////////////////////////////////////////
 void Text::setTextSpacingRounding(bool enabled)
 {
-    if(m_roundTextSpacing != enabled)
+    if (m_roundTextSpacing != enabled)
     {
-        m_roundTextSpacing = enabled;
+        m_roundTextSpacing   = enabled;
         m_geometryNeedUpdate = true;
     }
 }
@@ -802,18 +802,18 @@ void Text::ensureGeometryUpdate() const
 
     // Precompute the variables needed by the algorithm
     const float whitespaceWidth = m_font->getGlyph(U' ', m_characterSize, isBold).advance;
-    float letterSpacing = (whitespaceWidth / 3.0f) * (m_letterSpacingFactor - 1.0f);
-    float lineSpacing = m_font->getLineSpacing(m_characterSize) * m_lineSpacingFactor;
+    float       letterSpacing   = (whitespaceWidth / 3.0f) * (m_letterSpacingFactor - 1.0f);
+    float       lineSpacing     = m_font->getLineSpacing(m_characterSize) * m_lineSpacingFactor;
 
     // Round line and letter spacing if round text spacing is enabled
-    if(m_roundTextSpacing)
+    if (m_roundTextSpacing)
     {
         letterSpacing = std::round(letterSpacing);
-        lineSpacing = std::round(lineSpacing);
+        lineSpacing   = std::round(lineSpacing);
     }
 
-    float       x               = 0.0f;
-    auto        y = (m_textOrientation == TextOrientation::Default) ? static_cast<float>(m_characterSize) : 0.0f;
+    float x = 0.0f;
+    auto  y = (m_textOrientation == TextOrientation::Default) ? static_cast<float>(m_characterSize) : 0.0f;
 
     // Variables used to compute bounds
     auto minX = static_cast<float>(m_characterSize);


### PR DESCRIPTION
This pull request introduces optional pixel rounding for text letter spacing and line spacing in sf::Text.

When using fractional spacing factors (e.g. setLetterSpacing(1.1f)), glyph positions may fall on sub-pixel coordinates, which can lead to blurred text due to texture filtering and rasterization behavior. This PR adds a way to opt into pixel-aligned spacing without changing the existing default behavior.

What’s new:
- Added setLetterSpacingRounding(bool) / getLetterSpacingRounding()
- Added setLineSpacingRounding(bool) / getLineSpacingRounding()
- When enabled, rounding is applied during geometry generation only
- Default behavior remains unchanged (rounding disabled)

This allows users to choose between:
- Exact mathematical spacing (current default)
- Sharper text rendering when using fractional spacing values

Related issue:
Fixes #3595

Checklist:
- Has this change been discussed in an issue before: Yes
- Does the code follow the SFML Code Style Guide: Yes
- Have you provided example/test code for your changes: Yes

Tasks:
 - Tested on macOS

How to test this PR?
The effect is most visible when using fractional spacing values.

Minimal example:
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({800, 600}), "Text spacing rounding test");
    window.setFramerateLimit(60);

    sf::Font font;
    font.openFromFile("font.ttf");

    sf::Text text(font);
    text.setString("SFML TEXT SPACING TEST\nThe quick brown fox jumps over the lazy dog");
    text.setCharacterSize(24);
    text.setLetterSpacing(1.1f);
    text.setLineSpacing(1.1f);

    // New API
    text.setLetterSpacingRounding(true);
    text.setLineSpacingRounding(true);

    text.setPosition({50.f, 50.f});

    while (window.isOpen())
    {
        while (const auto event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        window.clear(sf::Color(36, 36, 71));
        window.draw(text);
        window.display();
    }
}

Without Rounding:
<img width="873" height="387" alt="Screenshot 2026-01-14 at 1 30 11 PM" src="https://github.com/user-attachments/assets/8add26fb-272e-4cc2-a7b5-4dc3e94aadc1" />

With Rounding:
<img width="764" height="345" alt="Screenshot 2026-01-14 at 1 32 04 PM" src="https://github.com/user-attachments/assets/b6492bee-480c-49b3-b6d1-90b3d69b05f2" />

Compare the output with rounding enabled vs disabled to clearly see the difference in sharpness.