### PR TITLE
Update all runner images to their latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2022,       os: windows-2022 }
-        - { name: Windows VS2022 Clang, os: windows-2022, flags: -T ClangCL }
-        - { name: Windows VS2022 arm64, os: windows-2022, flags: -A arm64 -DSFML_BUILD_TEST_SUITE=FALSE }
-        - { name: Linux GCC,            os: ubuntu-22.04 }
-        - { name: Linux Clang,          os: ubuntu-22.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
-        - { name: Linux GCC OpenGL ES,  os: ubuntu-22.04, flags: -DSFML_OPENGL_ES=ON }
-        - { name: macOS x64,            os: macos-13 }
-        - { name: macOS arm64,          os: macos-14 }
-        - { name: iOS,                  os: macos-13, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
-        - { name: iOS Xcode,            os: macos-13, suffix: -- CODE_SIGNING_ALLOWED=NO, flags: -DCMAKE_SYSTEM_NAME=iOS -GXcode }
+        - { name: Windows VS2022,       os: windows-2025 }
+        - { name: Windows VS2022 Clang, os: windows-2025, flags: -T ClangCL }
+        - { name: Windows VS2022 arm64, os: windows-2025, flags: -A arm64 -DSFML_BUILD_TEST_SUITE=FALSE }
+        - { name: Linux GCC,            os: ubuntu-24.04 }
+        - { name: Linux Clang,          os: ubuntu-24.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
+        - { name: Linux GCC OpenGL ES,  os: ubuntu-24.04, flags: -DSFML_OPENGL_ES=ON }
+        - { name: macOS x64,            os: macos-15, flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 }
+        - { name: macOS arm64,          os: macos-15, flags: -DCMAKE_OSX_ARCHITECTURES=arm64 }
+        - { name: iOS,                  os: macos-15, flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
+        - { name: iOS Xcode,            os: macos-15, suffix: -- CODE_SIGNING_ALLOWED=NO, flags: -DCMAKE_SYSTEM_NAME=iOS -GXcode }
         config:
         - { name: Shared, flags: -DBUILD_SHARED_LIBS=TRUE }
         - { name: Static, flags: -DBUILD_SHARED_LIBS=FALSE }
@@ -32,21 +32,21 @@ jobs:
             config: { name: Shared }
 
         include:
-        - platform: { name: Windows VS2022, os: windows-2022 }
+        - platform: { name: Windows VS2022, os: windows-2025 }
           config: { name: Unity, flags: -DBUILD_SHARED_LIBS=TRUE -DCMAKE_UNITY_BUILD=ON }
-        - platform: { name: macOS, os: macos-13 }
+        - platform: { name: macOS, os: macos-15 }
           config: { name: Frameworks, flags: -DSFML_BUILD_FRAMEWORKS=TRUE }
-        - platform: { name: Android, os: ubuntu-22.04 }
+        - platform: { name: Android, os: ubuntu-24.04 }
           config: { name: x86, flags: -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Android, os: ubuntu-22.04 }
+        - platform: { name: Android, os: ubuntu-24.04 }
           config: { name: armeabi-v7a, flags: -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Android, os: ubuntu-22.04 }
+        - platform: { name: Android, os: ubuntu-24.04 }
           config: { name: arm64-v8a, flags: -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-ndk-r18b/build/cmake/android.toolchain.cmake -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Android, os: ubuntu-22.04 }
+        - platform: { name: Android, os: ubuntu-24.04 }
           config: { name: x86_64, flags: -DCMAKE_ANDROID_ARCH_ABI=x86_64 -DCMAKE_SYSTEM_NAME=Android -DSFML_BUILD_TEST_SUITE=FALSE -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-ndk-r18b/build/cmake/android.toolchain.cmake -DCMAKE_ANDROID_NDK=$GITHUB_WORKSPACE/android-ndk-r18b -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_STL_TYPE=c++_shared -DCMAKE_ANDROID_API=26 }
-        - platform: { name: Linux GCC, os: ubuntu-22.04 }
+        - platform: { name: Linux GCC, os: ubuntu-24.04 }
           config: { name: Static DRM, flags: -DBUILD_SHARED_LIBS=FALSE -DSFML_USE_DRM=TRUE }
-        - platform: { name: Linux GCC, os: ubuntu-22.04 }
+        - platform: { name: Linux GCC, os: ubuntu-24.04 }
           config: { name: Shared DRM, flags: -DBUILD_SHARED_LIBS=TRUE -DSFML_USE_DRM=TRUE }
     steps:
     - name: Checkout Code
@@ -54,7 +54,7 @@ jobs:
 
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev
+      run: sudo apt-get update && sudo apt-get install libxrandr-dev libxcursor-dev libudev-dev libopenal-dev libflac-dev libvorbis-dev libfreetype-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev
 
 
     - name: Install Android Components


### PR DESCRIPTION
## Description

`macos-13` has been removed. Additionally, it makes sense to update everything else to the latest image version to ensure that it remains compatible for a while longer.

## How to test this PR?

CI should pass (except the LLVM builds which will be fixed with #3592 )