### PR TITLE
Block window creation on android until async process finishes

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.hpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.hpp
@@ -268,7 +268,6 @@ private:
     static char32_t getUnicode(AInputEvent* event);
 
     Vector2u m_size;
-    bool     m_windowBeingCreated{};
     bool     m_windowBeingDestroyed{};
     bool     m_hasFocus{};
 };

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -164,12 +164,8 @@ EglContext::EglContext(EglContext*                        shared,
     // Create EGL context
     createContext(shared);
 
-#if !defined(SFML_SYSTEM_ANDROID)
-    // Create EGL surface (except on Android because the window is created
-    // asynchronously, its activity manager will call it for us)
-    createSurface(owner.getNativeHandle());
-
-#endif
+    // Create EGL surface
+    createSurface(static_cast<EGLNativeWindowType>(owner.getNativeHandle()));
 }
 
 


### PR DESCRIPTION
fixes #3521 

Creating a window on android is an async process, and with the current implementation the native window is likely to not exist after you've created the `sf::Window` object so if you do anything with it before polling events it is likely to crash, this can be seen with the openGL example which will crash before it gets to the first poll event

This change waits until the window is actually created inside the constructor, so you're guaranteed to have a valid window after creation