### PR TITLE
When using xcode discover tests before test to avoid running unsigned code

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -435,7 +435,9 @@ function(sfml_add_test target SOURCES DEPENDS)
     endif()
 
     # Delay test registration when cross compiling to avoid running crosscompiled app on host OS
-    if(CMAKE_CROSSCOMPILING)
+    # Do the same when using Xcode, as otherwise it runs as a post-build step before codesigning and fails
+    # see https://gitlab.kitware.com/cmake/cmake/-/issues/21845
+    if(CMAKE_CROSSCOMPILING OR XCODE)
         set(CMAKE_CATCH_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
 
         # When running tests on Android, use a custom shell script to invoke commands using adb shell


### PR DESCRIPTION
Currently building the unit tests with Xcode 15+ will fail, as catch_discover_tests tries to run the test as a post-build step which is before it's. been codesigned, see https://gitlab.kitware.com/cmake/cmake/-/issues/21845

I can't explain why this works on the GitHub runners, as far as I can tell the commands are the same. I would guess they may have gatekeeper disabled but I can't find anything to verify this

I don't believe it's any particular setting on my machine, but would be good for someone else to double check (@Rosme / @ChrisThrasher ?) - should reproduce if you just generate sfml projects for Xcode and try to build a test target