### PR TITLE
Use CGWarpMouseCursorPosition to set mouse position on macOS

### DIFF
--- a/src/SFML/Window/macOS/InputImpl.mm
+++ b/src/SFML/Window/macOS/InputImpl.mm
@@ -212,13 +212,7 @@ void setMousePosition(Vector2i position)
     const CGPoint pos   = CGPointMake(position.x / scale, position.y / scale);
 
     // Place the cursor.
-    CGEventRef event = CGEventCreateMouseEvent(nullptr,
-                                               kCGEventMouseMoved,
-                                               pos,
-                                               /* we don't care about this: */ kCGMouseButtonLeft);
-    CGEventPost(kCGHIDEventTap, event);
-    CFRelease(event);
-    // This is a workaround to deprecated CGSetLocalEventsSuppressionInterval.
+    CGWarpMouseCursorPosition(pos);
 }
 
 


### PR DESCRIPTION
Fixes #1574 

Posting an event as the current implementation does will only update the position once the event has been processed, so if you call `getPosition` immediately after `setPosition` it will return a value different to what you set

Using `CGWarpMouseCursorPosition` as suggested on the issue fixes this behaviour and is what other libraries (SDL, glfw) do

Also added a test which fails on master but passes with this change