### PR TITLE
Remove NSOpenGLPFAAccelerated attribute to allow mac software renderer

### DIFF
--- a/src/SFML/Window/macOS/SFContext.mm
+++ b/src/SFML/Window/macOS/SFContext.mm
@@ -203,9 +203,6 @@ void SFContext::createContext(SFContext* shared, unsigned int bitsPerPixel, cons
         // Antialiasing level
         attrs.push_back(NSOpenGLPFASamples);
         attrs.push_back(static_cast<NSOpenGLPixelFormatAttribute>(m_settings.antiAliasingLevel));
-
-        // No software renderer - only hardware renderer
-        attrs.push_back(NSOpenGLPFAAccelerated);
     }
 
     // Support for OpenGL 3.2 on Mac OS X Lion and later:


### PR DESCRIPTION
Fixes #1640 

Per docs, hardware acceleration is still preferred.

Don't think we're explicit about which macOS versions we support outside of `CMAKE_OSX_DEPLOYMENT_TARGET` which we set to 13, I don't see any harm in supporting older versions with this change, and it may also be useful for software rendering on newer versions (e.g. some virtual/headless environments)