### PR TITLE
Fix static install package config - Export custom openAL module so it can be found properly

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -442,4 +442,9 @@ function(sfml_export_targets)
                   "${CMAKE_CURRENT_BINARY_DIR}/SFMLConfigVersion.cmake"
             DESTINATION ${config_package_location}
             COMPONENT devel)
+
+    # Install custom openal find module
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindOpenAL.cmake"
+            DESTINATION ${config_package_location}/Modules
+            COMPONENT devel)
 endfunction()

--- a/cmake/SFMLConfigDependencies.cmake.in
+++ b/cmake/SFMLConfigDependencies.cmake.in
@@ -75,7 +75,6 @@ if(SFML_STATIC_LIBRARIES)
     # sfml-audio
     list(FIND SFML_FIND_COMPONENTS "audio" FIND_SFML_AUDIO_COMPONENT_INDEX)
     if(FIND_SFML_AUDIO_COMPONENT_INDEX GREATER -1)
-        sfml_bind_dependency(TARGET OpenAL FRIENDLY_NAME "OpenAL" SEARCH_NAMES "OpenAL" "openal" "openal32")
         if (NOT FIND_SFML_OS_IOS)
             sfml_bind_dependency(TARGET VORBIS FRIENDLY_NAME "VorbisFile" SEARCH_NAMES "vorbisfile")
             sfml_bind_dependency(TARGET VORBIS FRIENDLY_NAME "VorbisEnc" SEARCH_NAMES "vorbisenc")
@@ -83,6 +82,12 @@ if(SFML_STATIC_LIBRARIES)
         sfml_bind_dependency(TARGET VORBIS FRIENDLY_NAME "Vorbis" SEARCH_NAMES "vorbis")
         sfml_bind_dependency(TARGET VORBIS FRIENDLY_NAME "Ogg" SEARCH_NAMES "ogg")
         sfml_bind_dependency(TARGET FLAC FRIENDLY_NAME "FLAC" SEARCH_NAMES "FLAC")
+
+        # For OpenAL targets use our custom find module so runtime dependencies are properly propagated
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules/")
+        list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}/../..") # For it to find our packaged openAL library
+        set(OPENAL_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../include") # Include dir isn't needed but find module will error out if not set
+        find_package(OpenAL REQUIRED)
     endif()
 
     if (FIND_SFML_DEPENDENCIES_NOTFOUND)


### PR DESCRIPTION
Fixes #3308 

It's actually an issue on all platforms when installing static SFML libraries and trying to find them, and an oversight when we added the custom openAL find module to use imported targets

As the imported targets aren't (and can't be) exported via SFML, we must export the custom find module and use that in our exported config

Had some trouble reproducing locally (likely why I missed it when testing the original change) but chucked the install interface tests we have on master into a 2.6.x branch and it reproduces there: https://github.com/JonnyPtn/SFML/actions/runs/21354108466

And with this fix on that branch: https://github.com/JonnyPtn/SFML/actions/runs/21354620272 Not sure why it still has some errors about finding the main sfml config file but think that's unrelated