### PR TITLE
16 KB page sizes for Android

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -222,6 +222,9 @@ macro(sfml_add_library module)
         # Always use position-independent code on Android, even when linking statically.
         # This is needed because all c++ code is placed in a shared library on Android.
         set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+        # Google Play requires all new apps to support 16 KB page sizes.
+        target_link_options(${target} PRIVATE "-Wl,-z,max-page-size=16384")
     endif()
 
     if(BUILD_SHARED_LIBS)
@@ -333,6 +336,9 @@ macro(sfml_add_example target)
         # Executables on android are shared libraries loaded by the native activity
         add_library(${target} SHARED ${target_input})
         target_link_libraries(${target} PRIVATE SFML::Main)
+
+        # Google Play requires all new apps to support 16 KB page sizes.
+        target_link_options(${target} PRIVATE "-Wl,-z,max-page-size=16384")
     else()
         add_executable(${target} ${target_input})
     endif()

--- a/examples/android/app/src/main/jni/CMakeLists.txt
+++ b/examples/android/app/src/main/jni/CMakeLists.txt
@@ -17,3 +17,6 @@ target_link_libraries(sfml-example PUBLIC
   SFML::Main
   -Wl,--no-whole-archive
 )
+
+# Google Play requires all new apps to support 16 KB page sizes.
+target_link_options(sfml-example PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

This PR is related to the issue https://github.com/SFML/SFML/issues/3654

This should work for any NDK between 23 and 27, I've tested with 25 and 27.
As mentioned in the issue, I'm not sure how many people would nowadays upload SFML 2 apps on Google Play. Porting this to SFML 2 would require recompilation of OpenAL or increasing the version to where this was fixed.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [X] Tested on Android

## How to test this PR?

https://developer.android.com/guide/practices/page-sizes#auto-checks