### PR TITLE
replaces `<iosfwd>` with `<ostream>`

### DIFF
--- a/include/SFML/System/Err.hpp
+++ b/include/SFML/System/Err.hpp
@@ -29,7 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/System/Export.hpp>
 
-#include <iosfwd>
+#include <ostream>
 
 
 namespace sf


### PR DESCRIPTION


<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

[`<iosfwd>` only declares the standard library's stream types][1]. This means that writing a string literal to `sf::err()` can cause a compile-time error when `<ostream>` isn't included by the file that imports `<SFML/System/Err.hpp>`.

This can change from implementation to implementation. For example, libc++ is very strict about which symbols are exported from headers. Building SFML with libc++ causes a compile-time error in `src/SFML/Audio/OutputSoundFile.cpp` because `errs() << "message";` can't find the appropriate `operator<<` overload.

As functional use of `err()` depends on including `<ostream>`, swapping `<iosfwd>` with `<ostream>` should improve user experience.

[1]: https://en.cppreference.com/w/cpp/header/iosfwd.html

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Testing this PR will be covered by CI. If reproducing the error is required, then you'll need to use a relatively recent version of libc++, and configure with the following:
```
$ cmake -GNinja -S. -Bbuild          \
    -DCMAKE_C_COMPILER=clang         \
    -DCMAKE_CXX_COMPILER=clang++     \
    -DCMAKE_CXX_FLAGS=-stdlib=libc++ \
    -DSFML_USE_SYSTEM_DEPS=No
$ ninja -C build
```
