### PR TITLE
Support static libraries on android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,6 @@ include(cmake/Config.cmake)
 # https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
 include(GNUInstallDirs)
 
-# disable static libraries on Android
-if(SFML_OS_ANDROID)
-    set(BUILD_SHARED_LIBS ON)
-endif()
-
 # add options to select which modules to build
 sfml_set_option(SFML_BUILD_WINDOW ON BOOL "ON to build SFML's Window module. This setting is ignored, if the graphics module is built.")
 sfml_set_option(SFML_BUILD_GRAPHICS ON BOOL "ON to build SFML's Graphics module.")

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -73,13 +73,8 @@ if(SFML_USE_SYSTEM_DEPS)
     find_package(FLAC REQUIRED)
 else()
     # use an immediately invoked function to scope option variables we have to set
-    function(sfml_add_audio_dependencies)
+    block()
         include(FetchContent)
-
-        # remember whether we are building SFML as a shared library
-        if(BUILD_SHARED_LIBS)
-            set(SFML_BUILD_SHARED_LIBS ON)
-        endif()
 
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
         set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
@@ -127,12 +122,6 @@ else()
         FetchContent_MakeAvailable(ogg flac vorbis)
 
         set_target_properties(ogg FLAC vorbis vorbisenc vorbisfile PROPERTIES FOLDER "Dependencies")
-
-        # if building SFML as a shared library and linking our dependencies in
-        # as static libraries we need to build them with -fPIC
-        if(SFML_BUILD_SHARED_LIBS)
-            set_target_properties(ogg FLAC vorbis vorbisenc vorbisfile PROPERTIES POSITION_INDEPENDENT_CODE ON)
-        endif()
 
         # build using unity build and exclude files that cause issues
         set_target_properties(ogg FLAC vorbis vorbisenc vorbisfile PROPERTIES UNITY_BUILD ON UNITY_BUILD_BATCH_SIZE 256)
@@ -188,8 +177,13 @@ else()
         add_library(Vorbis::vorbis ALIAS vorbis)
         add_library(Vorbis::vorbisenc ALIAS vorbisenc)
         add_library(Vorbis::vorbisfile ALIAS vorbisfile)
-    endfunction()
-    sfml_add_audio_dependencies()
+    endblock()
+
+    # if building SFML as a shared library or on android (where exes are shared libs) and linking our dependencies in
+    # as static libraries we need to build them with -fPIC
+    if(BUILD_SHARED_LIBS OR SFML_OS_ANDROID)
+        set_target_properties(ogg FLAC vorbis vorbisenc vorbisfile PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endif()
 endif()
 
 find_package(Threads REQUIRED)

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -193,9 +193,9 @@ else()
 
     set_target_properties(freetype harfbuzz PROPERTIES FOLDER "Dependencies" SYSTEM ON)
 
-    # if building SFML as a shared library and linking our dependencies in
+    # if building SFML as a shared library or on android (where exes are shared libs) and linking our dependencies in
     # as static libraries we need to build them with -fPIC
-    if(BUILD_SHARED_LIBS)
+    if(BUILD_SHARED_LIBS OR SFML_OS_ANDROID)
         set_target_properties(freetype harfbuzz PROPERTIES POSITION_INDEPENDENT_CODE ON)
     endif()
 
@@ -266,9 +266,9 @@ target_include_directories(sfml-graphics SYSTEM PRIVATE "${SheenBidi_SOURCE_DIR}
 # Disable all warnings
 target_compile_options(SheenBidi PRIVATE -w)
 
-# if building SFML as a shared library and linking our dependencies in
+# if building SFML as a shared library or on android (where exes are shared libs) and linking our dependencies in
 # as static libraries we need to build them with -fPIC
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS OR SFML_OS_ANDROID)
     set_target_properties(SheenBidi PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 

--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -23,9 +23,6 @@ set_target_properties(sfml-main PROPERTIES
                       RELWITHDEBINFO_POSTFIX "")
 
 if(SFML_OS_ANDROID)
-    # ensure that linking into shared libraries doesn't fail
-    set_target_properties(sfml-main PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
     # glad sources
     target_include_directories(sfml-main SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/glad/include")
 
@@ -34,6 +31,8 @@ if(SFML_OS_ANDROID)
 
     # Ensure this method is not stripped
     target_link_options(sfml-main PUBLIC -u ANativeActivity_onCreate)
+
+    target_link_libraries(sfml-main PUBLIC SFML::System)
 elseif(SFML_OS_IOS)
     target_link_libraries(sfml-main PUBLIC SFML::Window)
 endif()

--- a/src/SFML/Main/MainAndroid.cpp
+++ b/src/SFML/Main/MainAndroid.cpp
@@ -50,9 +50,6 @@
 #include <cassert>
 #include <cstring>
 
-#define SF_GLAD_EGL_IMPLEMENTATION
-#include <glad/egl.h>
-
 
 extern int main(int argc, char* argv[]);
 
@@ -326,9 +323,6 @@ void onDestroy(ANativeActivity* activity)
 
     states.mutex.unlock();
 
-    // Terminate EGL display
-    eglTerminate(states.display);
-
     // Delete our allocated states
     delete &states;
 
@@ -498,9 +492,6 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
     for (auto& isButtonPressed : states->isButtonPressed)
         isButtonPressed = false;
 
-    gladLoaderLoadEGL(EGL_DEFAULT_DISPLAY);
-    states->display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-
     if (savedState != nullptr)
     {
         const auto* begin = static_cast<const std::byte*>(savedState);
@@ -544,9 +535,6 @@ JNIEXPORT void ANativeActivity_onCreate(ANativeActivity* activity, void* savedSt
 
     // Keep the screen turned on and bright
     ANativeActivity_setWindowFlags(activity, AWINDOW_FLAG_KEEP_SCREEN_ON, AWINDOW_FLAG_KEEP_SCREEN_ON);
-
-    // Initialize the display
-    eglInitialize(states->display, nullptr, nullptr);
 
     getScreenSizeInPixels(*activity, states->screenSize.x, states->screenSize.y);
     getFullScreenSizeInPixels(*activity, states->fullScreenSize.x, states->fullScreenSize.y);

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -80,9 +80,9 @@ else()
 
     set_target_properties(mbedtls mbedcrypto mbedx509 PROPERTIES FOLDER "Dependencies" SYSTEM ON)
 
-    # if building SFML as a shared library and linking our dependencies in
+    # if building SFML as a shared library or on android (where exes are shared libs) and linking our dependencies in
     # as static libraries we need to build them with -fPIC
-    if(BUILD_SHARED_LIBS)
+    if(BUILD_SHARED_LIBS OR SFML_OS_ANDROID)
         set_target_properties(mbedtls mbedcrypto mbedx509 PROPERTIES POSITION_INDEPENDENT_CODE ON)
     endif()
 

--- a/src/SFML/System/Android/Activity.hpp
+++ b/src/SFML/System/Android/Activity.hpp
@@ -65,7 +65,6 @@ struct ActivityStates
     AInputQueue*    inputQueue{};
     AConfiguration* config{};
 
-    EGLDisplay  display{};
     EglContext* context{};
 
     std::vector<std::byte> savedState;

--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -282,8 +282,12 @@ if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR SFML_OS_NETBSD)
 endif()
 target_link_libraries(sfml-window PUBLIC SFML::System)
 
-# glad sources
-target_include_directories(sfml-window SYSTEM PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/glad/include")
+# glad sources, must be public for android as the system module includes EglContext.hpp  which includes glad
+set(GLAD_INCLUDE_PATH "${PROJECT_SOURCE_DIR}/extlibs/headers/glad/include")
+if (SFML_OS_ANDROID)
+    target_include_directories(sfml-window SYSTEM PUBLIC $<BUILD_INTERFACE:${GLAD_INCLUDE_PATH}>)
+endif()
+target_include_directories(sfml-window SYSTEM PRIVATE ${GLAD_INCLUDE_PATH})
 
 # When static linking on macOS, we need to add this flag for objective C to work
 # https://developer.apple.com/library/archive/qa/qa1490/_index.html

--- a/src/SFML/Window/EglContext.cpp
+++ b/src/SFML/Window/EglContext.cpp
@@ -60,16 +60,6 @@ namespace EglContextImpl
 {
 EGLDisplay getInitializedDisplay()
 {
-#if defined(SFML_SYSTEM_ANDROID)
-
-    // On Android, its native activity handles this for us
-    sf::priv::ActivityStates& states = sf::priv::getActivity();
-    const std::lock_guard     lock(states.mutex);
-
-    return states.display;
-
-#endif
-
     static EGLDisplay display = EGL_NO_DISPLAY;
 
     if (display == EGL_NO_DISPLAY)


### PR DESCRIPTION
Fixes #3533 

The main change here is to remove the egl context initialisation from the Main activity creation so that it's consistent with other platforms and happens during SFML's window creation. I'm not entirely sure what the use-case would be for that, perhaps it allowed people to use SFML to hook into a native activity with an egl context set up but I don't know why we would support that as they should just be creating a window, as you do on every other platform, especially as the system module already (secretly) depends on the window module so it's not like you can use it separately anyway

This also makes the hidden dependency of main -> system -> window explicit.

As cmake defaults to static libs, the CI checks for the examples will now be using static libraries to cover this