### PR TITLE
Fix backspace TextEntered event for android

### DIFF
--- a/src/SFML/Window/Android/WindowImplAndroid.cpp
+++ b/src/SFML/Window/Android/WindowImplAndroid.cpp
@@ -831,6 +831,12 @@ char32_t WindowImplAndroid::getUnicode(AInputEvent* event)
     const jint  flags     = AKeyEvent_getFlags(event);
     const jint  source    = AInputEvent_getSource(event);
 
+    // Backspace doesn't have a unicode char, so we generate '\b' for consistency with other platforms
+    if (code == AKEYCODE_DEL)
+    {
+        return '\b';
+    }
+
     // Construct a KeyEvent object from the event data
     jclass    classKeyEvent       = lJNIEnv->FindClass("android/view/KeyEvent");
     jmethodID keyEventConstructor = lJNIEnv->GetMethodID(classKeyEvent, "<init>", "(JJIIIIIIII)V");


### PR DESCRIPTION
Fixes #2272 

Per discussion on issue - There are no native TextEntered events on android, so we simulate them by handling key release events and calling `getUnicodeChar`, but as that understandably doesn't return anything for the backspace key, we simulate it ourselves