### PR TITLE
Add support for IPv6 and more types of DNS queries

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -28,7 +28,7 @@ jobs:
         - { name: Linux OpenGL ES, os: ubuntu-24.04, flags: -DSFML_OPENGL_ES=ON }
         - { name: macOS,           os: macos-14 }
         - { name: iOS,             os: macos-14,     flags: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 }
-        - { name: Android,         os: ubuntu-24.04, flags: -DCMAKE_ANDROID_ARCH_ABI=x86_64 -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=21 -DCMAKE_ANDROID_NDK=$ANDROID_NDK -DCMAKE_ANDROID_STL_TYPE=c++_shared }
+        - { name: Android,         os: ubuntu-24.04, flags: -DCMAKE_ANDROID_ARCH_ABI=x86_64 -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=22 -DCMAKE_ANDROID_NDK=$ANDROID_NDK -DCMAKE_ANDROID_STL_TYPE=c++_shared }
 
     steps:
     - name: Checkout Code
@@ -59,7 +59,7 @@ jobs:
         echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
 
     - name: Configure
-      run: cmake --preset dev ${{ matrix.platform.name != 'Android' && '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' || ''}} -DCMAKE_UNITY_BUILD=ON ${{matrix.platform.flags}}
+      run: cmake --preset dev ${{ matrix.platform.name != 'Android' && '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' || ''}} -DCMAKE_UNITY_BUILD=ON -DSFML_RUN_IPV4_LINK_TESTS=ON -DSFML_RUN_IPV4_INTERNET_TESTS=ON -DSFML_RUN_IPV6_LINK_TESTS=ON ${{matrix.platform.flags}}
 
     - name: Analyze Code
       run: cmake --build build --target tidy
@@ -92,7 +92,7 @@ jobs:
         sudo apt-get install xorg-dev libharfbuzz-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev libmbedtls-dev xvfb fluxbox
 
     - name: Configure
-      run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_BUILD_EXAMPLES=OFF -DSFML_ENABLE_SANITIZERS=ON ${{matrix.platform.flags}}
+      run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_BUILD_EXAMPLES=OFF -DSFML_ENABLE_SANITIZERS=ON -DSFML_RUN_IPV4_LINK_TESTS=ON -DSFML_RUN_IPV4_INTERNET_TESTS=ON -DSFML_RUN_IPV6_LINK_TESTS=ON ${{matrix.platform.flags}}
 
     - name: Build
       run: cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,10 @@ jobs:
           config: { name: System Deps, flags: -GNinja -DBUILD_SHARED_LIBS=ON -DSFML_USE_SYSTEM_DEPS=ON }
         - platform: { name: Android, os: ubuntu-24.04 }
           config:
-            name: x86 (API 21)
-            flags: -GNinja -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=21 -DCMAKE_ANDROID_NDK=$ANDROID_NDK_ROOT -DBUILD_SHARED_LIBS=ON -DCMAKE_ANDROID_STL_TYPE=c++_shared -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_RUN_AUDIO_DEVICE_TESTS=OFF
+            name: x86 (API 22)
+            flags: -GNinja -DCMAKE_ANDROID_ARCH_ABI=x86 -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=22 -DCMAKE_ANDROID_NDK=$ANDROID_NDK_ROOT -DBUILD_SHARED_LIBS=ON -DCMAKE_ANDROID_STL_TYPE=c++_shared -DSFML_RUN_DISPLAY_TESTS=OFF -DSFML_RUN_AUDIO_DEVICE_TESTS=OFF
             arch: x86
-            api: 21
+            api: 22
           type: { name: Release }
         - platform: { name: Android, os: ubuntu-24.04 }
           config:
@@ -193,7 +193,7 @@ jobs:
         cmake --version
 
     - name: Configure CMake
-      run: cmake --preset dev -DCMAKE_VERBOSE_MAKEFILE=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
+      run: cmake --preset dev -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_RUN_IPV4_LINK_TESTS=ON -DSFML_RUN_IPV4_INTERNET_TESTS=ON -DSFML_RUN_IPV6_LINK_TESTS=ON ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
 
     - name: Build
       run: cmake --build build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install

--- a/examples/sockets/TCP.cpp
+++ b/examples/sockets/TCP.cpp
@@ -113,7 +113,10 @@ void runTcpClient(unsigned short port, bool tls)
     do
     {
         std::cout << "Type the address or name of the server to connect to: ";
-        std::cin >> server;
+        std::string hostname;
+        std::cin >> hostname;
+        if (const auto addresses = sf::Dns::resolve(hostname); addresses.has_value() && !addresses->empty())
+            server = addresses->front();
     } while (!server.has_value());
 
     // Create a socket for communicating with the server

--- a/examples/sockets/UDP.cpp
+++ b/examples/sockets/UDP.cpp
@@ -55,7 +55,10 @@ void runUdpClient(unsigned short port)
     do
     {
         std::cout << "Type the address or name of the server to connect to: ";
-        std::cin >> server;
+        std::string hostname;
+        std::cin >> hostname;
+        if (const auto addresses = sf::Dns::resolve(hostname); addresses.has_value() && !addresses->empty())
+            server = addresses->front();
     } while (!server.has_value());
 
     // Create a socket for communicating with the server

--- a/examples/voip/Client.cpp
+++ b/examples/voip/Client.cpp
@@ -126,7 +126,10 @@ void doClient(unsigned short port)
     do
     {
         std::cout << "Type address or name of the server to connect to: ";
-        std::cin >> server;
+        std::string hostname;
+        std::cin >> hostname;
+        if (const auto addresses = sf::Dns::resolve(hostname); addresses.has_value() && !addresses->empty())
+            server = addresses->front();
     } while (!server.has_value());
 
     // Create an instance of our custom recorder

--- a/include/SFML/Network.hpp
+++ b/include/SFML/Network.hpp
@@ -28,6 +28,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 
+#include <SFML/Network/Dns.hpp>
 #include <SFML/Network/Ftp.hpp>
 #include <SFML/Network/Http.hpp>
 #include <SFML/Network/IpAddress.hpp>

--- a/include/SFML/Network/Dns.hpp
+++ b/include/SFML/Network/Dns.hpp
@@ -1,0 +1,214 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2025 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+
+#include <SFML/Network/IpAddress.hpp>
+
+#include <SFML/System/String.hpp>
+#include <SFML/System/Time.hpp>
+
+#include <optional>
+#include <vector>
+
+#include <cstdint>
+
+
+////////////////////////////////////////////////////////////
+/// \brief Perform Domain Name System queries to lookup
+///        DNS records for various purposes
+///
+////////////////////////////////////////////////////////////
+namespace sf::Dns
+{
+////////////////////////////////////////////////////////////
+/// \brief Resolve a hostname into a list of IP addresses
+///
+/// \param hostname Hostname to resolve
+/// \param servers  The list of servers to query, if empty use the default servers
+/// \param timeout  Query timeout if using a provided list of servers, `std::nullopt` to wait forever
+///
+/// \return List of IP addresses the given hostname resolves to, `std::nullopt` is returned if name resolution fails, an empty list is returned if the hostname could not be resolved to any address
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_NETWORK_API std::optional<std::vector<IpAddress>> resolve(
+    const sf::String&                 hostname,
+    const std::vector<sf::IpAddress>& servers = {},
+    std::optional<sf::Time>           timeout = sf::seconds(1));
+
+////////////////////////////////////////////////////////////
+/// \brief Query NS records for a hostname
+///
+/// \param hostname Hostname to query NS records for
+/// \param servers  The list of servers to query, if empty use the default servers
+/// \param timeout  Query timeout if using a provided list of servers, `std::nullopt` to wait forever
+///
+/// \return List of NS record strings, an empty list is returned if there are no NS records for the hostname
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_NETWORK_API std::vector<sf::String> queryNs(const sf::String&                 hostname,
+                                                               const std::vector<sf::IpAddress>& servers = {},
+                                                               std::optional<sf::Time> timeout = sf::seconds(1));
+
+////////////////////////////////////////////////////////////
+/// \brief A DNS MX record
+///
+////////////////////////////////////////////////////////////
+struct MxRecord
+{
+    sf::String    exchange;     //!< Host willing to act as mail exchange
+    std::uint16_t preference{}; //!< Preference of this record among others, lower values are preferred
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Query MX records for a hostname
+///
+/// \param hostname Hostname to query MX records for
+/// \param servers  The list of servers to query, if empty use the default servers
+/// \param timeout  Query timeout if using a provided list of servers, `std::nullopt` to wait forever
+///
+/// \return List of MX records, an empty list is returned if there are no MX records for the hostname
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_NETWORK_API std::vector<MxRecord> queryMx(const sf::String&                 hostname,
+                                                             const std::vector<sf::IpAddress>& servers = {},
+                                                             std::optional<sf::Time> timeout = sf::seconds(1));
+
+////////////////////////////////////////////////////////////
+/// \brief A DNS SRV record
+///
+////////////////////////////////////////////////////////////
+struct SrvRecord
+{
+    sf::String    target; //!< The domain name of the target host
+    std::uint16_t port{}; //!< The port on the target host of the service
+    std::uint16_t weight{}; //!< Server selection mechanism, larger weights should be given a proportionately higher probability of being selected
+    std::uint16_t priority{}; //!< The priority of the target host, a client must attempt to contact the target host with the lowest-numbered priority it can reach
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Query SRV records for a hostname
+///
+/// \param hostname Hostname to query SRV records for
+/// \param servers  The list of servers to query, if empty use the default servers
+/// \param timeout  Query timeout if using a provided list of servers, `std::nullopt` to wait forever
+///
+/// \return List of SRV records, an empty list is returned if there are no SRV records for the hostname
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_NETWORK_API std::vector<SrvRecord> querySrv(const sf::String&                 hostname,
+                                                               const std::vector<sf::IpAddress>& servers = {},
+                                                               std::optional<sf::Time> timeout = sf::seconds(1));
+
+////////////////////////////////////////////////////////////
+/// \brief Query TXT records for a hostname
+///
+/// \param hostname Hostname to query TXT records for
+/// \param servers  The list of servers to query, if empty use the default servers
+/// \param timeout  Query timeout if using a provided list of servers, `std::nullopt` to wait forever
+///
+/// \return List of TXT record string lists, an empty list is returned if there are no TXT records for the hostname
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_NETWORK_API std::vector<std::vector<sf::String>> queryTxt(
+    const sf::String&                 hostname,
+    const std::vector<sf::IpAddress>& servers = {},
+    std::optional<sf::Time>           timeout = sf::seconds(1));
+
+////////////////////////////////////////////////////////////
+/// \brief Get the computer's public address via DNS
+///
+/// The public address is the address of the computer from the
+/// point of view of the internet, i.e. something like 89.54.1.169
+/// or 2600:1901:0:13e0::1 as opposed to a private or local address
+/// like 192.168.1.56 or fe80::1234:5678:9abc.
+/// It is necessary for communication with hosts outside of the
+/// local network.
+///
+/// The only way to reliably get the public address is to send
+/// data to a host on the internet and see what the origin
+/// address is; as a consequence, this function depends on both
+/// your network connection and the server, and may be very slow.
+/// You should try to use it as little as possible. Because this
+/// function depends on the network connection and on a distant
+/// server, you can specify a time limit if you don't want your
+/// program to get stuck waiting in case there is a problem; this
+/// limit is deactivated by default.
+///
+/// This function makes use of DNS queries get the public address.
+///
+/// \param timeout Maximum time to wait, `std::nullopt` to wait forever
+/// \param type    The type of public address to get
+///
+/// \return Public IP address of the computer on success, `std::nullopt` otherwise
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_NETWORK_API std::optional<IpAddress> getPublicAddress(std::optional<Time> timeout = std::nullopt,
+                                                                         IpAddress::Type type = IpAddress::Type::IpV4);
+} // namespace sf::Dns
+
+
+////////////////////////////////////////////////////////////
+/// \namespace sf::Dns
+/// \ingroup network
+///
+/// The `sf::Dns` functions allow querying the Domain Name System.
+/// The Domain Name System contains many different kinds of
+/// records. The most common records are A and AAAA records
+/// used to resolve hostnames to IPv4 and IPv6 addresses
+/// respectively. Additionally, other kinds of records such
+/// as MX, SRV and TXT records can be queried.
+///
+/// Usage example:
+/// \code
+/// std::vector<sf::IpAddress> addresses0 = sf::Dns::resolve("127.0.0.1");            // the local host address
+/// std::vector<sf::IpAddress> addresses1 = sf::Dns::resolve("my_computer");          // a list of local addresses created from a network name
+/// std::vector<sf::IpAddress> addresses2 = sf::Dns::resolve("89.54.1.169");          // a distant IPv4 address
+/// std::vector<sf::IpAddress> addresses3 = sf::Dns::resolve("2606:4700:4700::1111"); // a distant IPv6 address
+/// std::vector<sf::IpAddress> addresses4 = sf::Dns::resolve("www.google.com");       // a list of distant address created from a network name
+///
+/// for (const sf::IpAddress& address : addresses4)
+/// {
+///     if (address.isV4())
+///     {
+///         // Do something with IPv4 address
+///     }
+///     else
+///     {
+///         // Do something with IPv6 address
+///     }
+/// }
+///
+/// std::vector<sf::String>              nsRecords  = sf::Dns::queryNs("sfml-dev.org");
+/// std::vector<sf::Dns::MxRecord>       mxRecords  = sf::Dns::queryMx("sfml-dev.org");
+/// std::vector<std::vector<sf::String>> txtRecords = sf::Dns::queryTxt("sfml-dev.org");
+/// std::vector<sf::Dns::SrvRecord>      srvRecords = sf::Dns::querySrv("_irc._tcp.sfml-dev.org");
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/include/SFML/Network/Http.hpp
+++ b/include/SFML/Network/Http.hpp
@@ -38,6 +38,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <vector>
 
 
 namespace sf
@@ -351,11 +352,12 @@ public:
     /// this unless you really need a port other than the
     /// standard one, or use an unknown protocol.
     ///
-    /// \param host Web server to connect to
-    /// \param port Port to use for connection
+    /// \param host        Web server to connect to
+    /// \param port        Port to use for the connection
+    /// \param addressType Address type to use for the connection, `std::nullopt` to specify no preference
     ///
     ////////////////////////////////////////////////////////////
-    Http(const std::string& host, unsigned short port = 0);
+    Http(const std::string& host, unsigned short port = 0, std::optional<IpAddress::Type> addressType = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Deleted copy constructor
@@ -381,13 +383,14 @@ public:
     /// this unless you really need a port other than the
     /// standard one, or use an unknown protocol.
     ///
-    /// \param host Web server to connect to
-    /// \param port Port to use for connection
+    /// \param host        Web server to connect to
+    /// \param port        Port to use for the connection
+    /// \param addressType Address type to use for the connection, `std::nullopt` to specify no preference
     ///
     /// \return `true` if the host has been resolved and is valid, `false` otherwise
     ///
     ////////////////////////////////////////////////////////////
-    bool setHost(const std::string& host, unsigned short port = 0);
+    bool setHost(const std::string& host, unsigned short port = 0, std::optional<IpAddress::Type> addressType = std::nullopt);
 
     ////////////////////////////////////////////////////////////
     /// \brief Send a HTTP request and return the server's response.
@@ -414,10 +417,11 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::optional<IpAddress> m_host;     //!< Web host address
-    std::string              m_hostName; //!< Web host name
-    unsigned short           m_port{};   //!< Port used for connection with host
-    bool                     m_https{};  //!< Use HTTPS
+    std::vector<IpAddress>         m_hosts;       //!< Web host addresses
+    std::optional<IpAddress::Type> m_addressType; //!< Address type
+    std::string                    m_hostName;    //!< Web host name
+    unsigned short                 m_port{};      //!< Port used for connection with host
+    bool                           m_https{};     //!< Use HTTPS
 };
 
 } // namespace sf

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -31,10 +31,12 @@
 
 #include <SFML/System/Time.hpp>
 
+#include <array>
 #include <iosfwd>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <variant>
 
 #include <cstdint>
 
@@ -49,20 +51,33 @@ class SFML_NETWORK_API IpAddress
 {
 public:
     ////////////////////////////////////////////////////////////
+    /// \brief Type of IP address
+    ///
+    ////////////////////////////////////////////////////////////
+    enum class Type
+    {
+        IpV4, //!< IPv4 address
+        IpV6  //!< IPv6 address
+    };
+
+    ////////////////////////////////////////////////////////////
     /// \brief Construct the address from a null-terminated string view
     ///
     /// Here \a address can be either a decimal address
     /// (ex: "192.168.1.56") or a network name (ex: "localhost").
+    ///
+    /// This function will only resolve to an IPv4 address.
+    /// Use Dns::resolve() to resolve to IPv6 addresses as well.
     ///
     /// \param address IP address or network name
     ///
     /// \return Address if provided argument was valid, otherwise `std::nullopt`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<IpAddress> resolve(std::string_view address);
+    [[deprecated("Use Dns::resolve() instead")]] [[nodiscard]] static std::optional<IpAddress> resolve(std::string_view address);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Construct the address from 4 bytes
+    /// \brief Construct an IPv4 address from 4 bytes
     ///
     /// Calling `IpAddress(a, b, c, d)` is equivalent to calling
     /// `IpAddress::resolve("a.b.c.d")`, but safer as it doesn't
@@ -77,14 +92,14 @@ public:
     IpAddress(std::uint8_t byte0, std::uint8_t byte1, std::uint8_t byte2, std::uint8_t byte3);
 
     ////////////////////////////////////////////////////////////
-    /// \brief Construct the address from a 32-bits integer
+    /// \brief Construct an IPv4 address from a 32-bit integer
     ///
     /// This constructor uses the internal representation of
     /// the address directly. It should be used for optimization
     /// purposes, and only if you got that representation from
     /// `IpAddress::toInteger()`.
     ///
-    /// \param address 4 bytes of the address packed into a 32-bits integer
+    /// \param address 4 bytes of the address packed into a 32-bit integer
     ///
     /// \see `toInteger`
     ///
@@ -92,21 +107,62 @@ public:
     explicit IpAddress(std::uint32_t address);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Construct an IPv6 address from 16 bytes
+    ///
+    /// \param bytes Array of 16 bytes containing the address
+    ///
+    ////////////////////////////////////////////////////////////
+    IpAddress(std::array<std::uint8_t, 16> bytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Try to construct an address from its string representation
+    ///
+    /// The string should contain either a valid representation of an
+    /// IPv4 address in dotted-decimal notation or a valid representation
+    /// of an IPv6 address in internet standard notation.
+    ///
+    /// Examples:
+    ///   - 192.168.1.56
+    ///   - FEDC:BA98:7654:3210:FEDC:BA98:7654:3210
+    ///   - fedc:ba98:7654:3210:fedc:ba98:7654:3210
+    ///   - 1080:0:0:0:8:800:200C:417A
+    ///   - 1080::8:800:200C:417A
+    ///   - FF01::101
+    ///   - ::1
+    ///   - ::
+    ///   - 0:0:0:0:0:0:13.1.68.3
+    ///   - ::13.1.68.3
+    ///   - 0:0:0:0:0:FFFF:129.144.52.38
+    ///   - ::FFFF:129.144.52.38
+    ///
+    /// \param address String representation of the address
+    ///
+    /// \return Address if provided argument was a valid string represenation of an IP address, otherwise `std::nullopt`
+    ///
+    /// \see `toString`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] static std::optional<IpAddress> fromString(std::string_view address);
+
+    ////////////////////////////////////////////////////////////
     /// \brief Get a string representation of the address
     ///
     /// The returned string is the decimal representation of the
-    /// IP address (like "192.168.1.56"), even if it was constructed
-    /// from a host name.
+    /// IP address (like "192.168.1.56" or "FF01::101"), even if
+    /// it was constructed from a host name.
     ///
     /// \return String representation of the address
     ///
-    /// \see `toInteger`
+    /// \see `fromString`, `toInteger`
     ///
     ////////////////////////////////////////////////////////////
     [[nodiscard]] std::string toString() const;
 
     ////////////////////////////////////////////////////////////
     /// \brief Get an integer representation of the address
+    ///
+    /// This function can only be called if this is an IPv4
+    /// address. Check with isV4() before calling this function.
     ///
     /// The returned number is the internal representation of the
     /// address, and should be used for optimization purposes only
@@ -122,6 +178,53 @@ public:
     [[nodiscard]] std::uint32_t toInteger() const;
 
     ////////////////////////////////////////////////////////////
+    /// \brief Get an array of bytes representing the address
+    ///
+    /// This function can only be called if this is an IPv6
+    /// address. Check with isV6() before calling this function.
+    ///
+    /// The returned array is the internal representation of the
+    /// address, and should be used for optimization purposes only
+    /// (like sending the address through a socket).
+    /// The array produced by this function can then be converted
+    /// back to a `sf::IpAddress` with the proper constructor.
+    ///
+    /// \return 16-byte array representation of the address
+    ///
+    /// \see `toString`
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] std::array<std::uint8_t, 16> toBytes() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the type of this IP address
+    ///
+    /// \return The type of this IP address (IPv4 or IPv6)
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] Type getType() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if this IP address is an IPv4 address
+    ///
+    /// Equivalent to getType() == Type::IPv4
+    ///
+    /// \return true if this is an IPv4 address, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool isV4() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if this IP address is an IPv6 address
+    ///
+    /// Equivalent to getType() == Type::IPv6
+    ///
+    /// \return true if this is an IPv6 address, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool isV6() const;
+
+    ////////////////////////////////////////////////////////////
     /// \brief Get the computer's local address
     ///
     /// The local address is the address of the computer from the
@@ -130,44 +233,63 @@ public:
     /// Unlike getPublicAddress, this function is fast and may be
     /// used safely anywhere.
     ///
+    /// \param type Type of local address
+    ///
     /// \return Local IP address of the computer on success, `std::nullopt` otherwise
     ///
     /// \see `getPublicAddress`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<IpAddress> getLocalAddress();
+    [[nodiscard]] static std::optional<IpAddress> getLocalAddress(Type type = Type::IpV4);
 
     ////////////////////////////////////////////////////////////
     /// \brief Get the computer's public address
     ///
     /// The public address is the address of the computer from the
-    /// internet point of view, i.e. something like 89.54.1.169.
-    /// It is necessary for communications over the world wide web.
-    /// The only way to get a public address is to ask it to a
-    /// distant website; as a consequence, this function depends on
-    /// both your network connection and the server, and may be
-    /// very slow. You should use it as few as possible. Because
-    /// this function depends on the network connection and on a distant
-    /// server, you may use a time limit if you don't want your program
-    /// to be possibly stuck waiting in case there is a problem; this
+    /// point of view of the internet, i.e. something like 89.54.1.169
+    /// or 2600:1901:0:13e0::1 as opposed to a private or local address
+    /// like 192.168.1.56 or fe80::1234:5678:9abc.
+    /// It is necessary for communication with hosts outside of the
+    /// local network.
+    ///
+    /// The only way to reliably get the public address is to send
+    /// data to a host on the internet and see what the origin
+    /// address is; as a consequence, this function depends on both
+    /// your network connection and the server, and may be very slow.
+    /// You should try to use it as little as possible. Because this
+    /// function depends on the network connection and on a distant
+    /// server, you can specify a time limit if you don't want your
+    /// program to get stuck waiting in case there is a problem; this
     /// limit is deactivated by default.
     ///
+    /// If tamper resistance is required, setting `secure` to `true`
+    /// will make use of verified HTTPS connections to get the address.
+    ///
     /// \param timeout Maximum time to wait
+    /// \param type    The type of public address to get, `std::nullopt` to specify no preference
+    /// \param secure  true to retrieve the public address via a secure HTTPS connection, false to retrieve via DNS or an insecure connection
     ///
     /// \return Public IP address of the computer on success, `std::nullopt` otherwise
     ///
     /// \see `getLocalAddress`
     ///
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] static std::optional<IpAddress> getPublicAddress(Time timeout = Time::Zero);
+    [[nodiscard]] static std::optional<IpAddress> getPublicAddress(Time                timeout = Time::Zero,
+                                                                   std::optional<Type> type    = Type::IpV4,
+                                                                   bool                secure  = false);
 
     ////////////////////////////////////////////////////////////
     // Static member data
     ////////////////////////////////////////////////////////////
     // NOLINTBEGIN(readability-identifier-naming)
-    static const IpAddress Any;       //!< Value representing any address (0.0.0.0)
-    static const IpAddress LocalHost; //!< The "localhost" address (for connecting a computer to itself locally)
-    static const IpAddress Broadcast; //!< The "broadcast" address (for sending UDP messages to everyone on a local network)
+    static const IpAddress Any;         //!< The same as AnyV4
+    static const IpAddress LocalHost;   //!< The same as LocalHostV4
+    static const IpAddress Broadcast;   //!< The same as BroadcastV4
+    static const IpAddress AnyV4;       //!< Value representing any IPv4 address (0.0.0.0)
+    static const IpAddress LocalHostV4; //!< The "localhost" IPv4 address (for connecting a computer to itself locally)
+    static const IpAddress BroadcastV4; //!< The "broadcast" IPv4 address (for sending UDP messages to everyone on a local network)
+    static const IpAddress AnyV6;       //!< Value representing any IPv6 address (::)
+    static const IpAddress LocalHostV6; //!< The "localhost" IPv6 address (for connecting a computer to itself locally)
     // NOLINTEND(readability-identifier-naming)
 
 private:
@@ -180,7 +302,9 @@ private:
     ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    std::uint32_t m_address; //!< Address stored as an unsigned 32 bit integer
+    using V4Data = std::uint32_t;
+    using V6Data = std::array<std::uint8_t, 16>;
+    std::variant<V4Data, V6Data> m_address; //!< Address stored as an unsigned 32 bit integer or array of 16 bytes
 };
 
 ////////////////////////////////////////////////////////////
@@ -252,6 +376,10 @@ private:
 ////////////////////////////////////////////////////////////
 /// \brief Overload of `operator>>` to extract an IP address from an input stream
 ///
+/// This will only create an IP address from a string
+/// representation of an IP address. In order to resolve
+/// hostnames to IP addresses use the Dns::resolve() function.
+///
 /// \param stream  Input stream
 /// \param address IP address to extract
 ///
@@ -285,17 +413,20 @@ SFML_NETWORK_API std::ostream& operator<<(std::ostream& stream, IpAddress addres
 ///
 /// Usage example:
 /// \code
-/// auto a2 = sf::IpAddress::resolve("127.0.0.1");      // the local host address
-/// auto a3 = sf::IpAddress::Broadcast;                 // the broadcast address
-/// sf::IpAddress a4(192, 168, 1, 56);                  // a local address
-/// auto a5 = sf::IpAddress::resolve("my_computer");    // a local address created from a network name
-/// auto a6 = sf::IpAddress::resolve("89.54.1.169");    // a distant address
-/// auto a7 = sf::IpAddress::resolve("www.google.com"); // a distant address created from a network name
-/// auto a8 = sf::IpAddress::getLocalAddress();         // my address on the local network
-/// auto a9 = sf::IpAddress::getPublicAddress();        // my address on the internet
+/// auto a0  = sf::IpAddress::fromString("127.0.0.1");                                                                  // the local host IPv4 address
+/// auto a1  = sf::IpAddress::fromString("::1");                                                                        // the local host IPv6 address
+/// auto a2  = sf::IpAddress::Broadcast;                                                                                // the broadcast address
+/// sf::IpAddress a3(192, 168, 1, 56);                                                                                  // a local IPv4 address
+/// sf::IpAddress a4({0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5d, 0x58, 0x84, 0xef, 0xc1, 0x34, 0xfd}); // a local IPv6 address
+/// auto a5  = sf::IpAddress::fromString("89.54.1.169");                                                                // a distant IPv4 address
+/// auto a6  = sf::IpAddress::fromString("2606:4700:4700::1111");                                                       // a distant IPv6 address
+/// auto a7  = sf::IpAddress::getLocalAddress(sf::IpAddress::Type::IpV4);                                               // my IPv4 address on the local network
+/// auto a8  = sf::IpAddress::getLocalAddress(sf::IpAddress::Type::IpV6);                                               // my IPv6 address on the local network
+/// auto a9  = sf::IpAddress::getPublicAddress(sf::Time::Zero, sf::IpAddress::Type::IpV4);                              // my IPv4 address on the internet
+/// auto a10 = sf::IpAddress::getPublicAddress(sf::Time::Zero, sf::IpAddress::Type::IpV6);                              // my IPv6 address on the internet
 /// \endcode
 ///
-/// Note that `sf::IpAddress` currently doesn't support IPv6
-/// nor other types of network addresses.
+/// To resolve hostnames to IP addresses, use the
+/// sf::Dns::resolve() function.
 ///
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Network/Socket.hpp
+++ b/include/SFML/Network/Socket.hpp
@@ -29,6 +29,7 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Network/Export.hpp>
 
+#include <SFML/Network/IpAddress.hpp>
 #include <SFML/Network/SocketHandle.hpp>
 
 
@@ -158,8 +159,10 @@ protected:
     ///
     /// This function can only be accessed by derived classes.
     ///
+    /// \param addressType The address type of the socket
+    ///
     ////////////////////////////////////////////////////////////
-    void create();
+    void create(IpAddress::Type addressType = IpAddress::Type::IpV4);
 
     ////////////////////////////////////////////////////////////
     /// \brief Create the internal representation of the socket

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -3,6 +3,8 @@ set(SRCROOT ${PROJECT_SOURCE_DIR}/src/SFML/Network)
 
 # all source files
 set(SRC
+    ${SRCROOT}/Dns.cpp
+    ${INCROOT}/Dns.hpp
     ${INCROOT}/Export.hpp
     ${SRCROOT}/Ftp.cpp
     ${INCROOT}/Ftp.hpp
@@ -47,7 +49,9 @@ sfml_add_library(Network
 # setup dependencies
 target_link_libraries(sfml-network PUBLIC SFML::System)
 if(SFML_OS_WINDOWS)
-    target_link_libraries(sfml-network PRIVATE Crypt32 ws2_32)
+    target_link_libraries(sfml-network PRIVATE Crypt32 ws2_32 Dnsapi)
+elseif(SFML_OS_LINUX OR SFML_OS_IOS OR SFML_OS_MACOS)
+    target_link_libraries(sfml-network PRIVATE resolv)
 endif()
 
 if(SFML_USE_SYSTEM_DEPS)

--- a/src/SFML/Network/Dns.cpp
+++ b/src/SFML/Network/Dns.cpp
@@ -1,0 +1,983 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2025 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Dns.hpp>
+#include <SFML/Network/SocketImpl.hpp>
+#include <SFML/Network/SocketSelector.hpp>
+#include <SFML/Network/UdpSocket.hpp>
+
+#include <SFML/System/Clock.hpp>
+#include <SFML/System/Utils.hpp>
+
+#if defined(SFML_SYSTEM_WINDOWS)
+#include <windns.h>
+#else
+#include <arpa/inet.h>
+#include <arpa/nameser.h>
+#include <netdb.h>
+#include <resolv.h>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include <cassert>
+#include <cstring>
+
+using namespace std::string_literals;
+
+
+namespace
+{
+const std::vector
+    cloudflareAddresses{sf::IpAddress(1, 1, 1, 1),
+                        sf::IpAddress(1, 0, 0, 1),
+                        sf::IpAddress(
+                            {0x26, 0x06, 0x47, 0x00, 0x47, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x11}),
+                        sf::IpAddress(
+                            {0x26, 0x06, 0x47, 0x00, 0x47, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x01})};
+const std::vector
+    quad9Addresses{sf::IpAddress(9, 9, 9, 9),
+                   sf::IpAddress(149, 112, 112, 112),
+                   sf::IpAddress(
+                       {0x26, 0x20, 0x00, 0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfe}),
+                   sf::IpAddress(
+                       {0x26, 0x20, 0x00, 0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09})};
+const std::vector
+    googleAddresses{sf::IpAddress(8, 8, 8, 8),
+                    sf::IpAddress(8, 8, 4, 4),
+                    sf::IpAddress(
+                        {0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x88}),
+                    sf::IpAddress(
+                        {0x20, 0x01, 0x48, 0x60, 0x48, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x88, 0x44})};
+const std::vector
+    opendnsAddresses{sf::IpAddress(208, 67, 222, 222),
+                     sf::IpAddress(208, 67, 222, 220),
+                     sf::IpAddress(
+                         {0x26, 0x20, 0x01, 0x19, 0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x35}),
+                     sf::IpAddress(
+                         {0x26, 0x20, 0x01, 0x19, 0x00, 0x53, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x53})};
+
+#if defined(SFML_SYSTEM_ANDROID)
+const std::vector<sf::IpAddress>& getAndroidServers()
+{
+    static const auto servers = []
+    {
+        std::vector<sf::IpAddress> theServers;
+        theServers.insert(theServers.end(), cloudflareAddresses.begin(), cloudflareAddresses.end());
+        theServers.insert(theServers.end(), quad9Addresses.begin(), quad9Addresses.end());
+        theServers.insert(theServers.end(), googleAddresses.begin(), googleAddresses.end());
+        theServers.insert(theServers.end(), opendnsAddresses.begin(), opendnsAddresses.end());
+        return theServers;
+    }();
+    return servers;
+}
+#endif
+
+#if defined(SFML_SYSTEM_WINDOWS)
+struct RecordsDeleter
+{
+    void operator()(DNS_RECORDW* ptr) const
+    {
+        DnsFree(ptr, DnsFreeRecordList);
+    }
+};
+
+std::unique_ptr<DNS_RECORDW, RecordsDeleter> getRecords(const std::string& hostname, WORD type)
+{
+    // The Win32 DnsQuery API can be a bit misleading
+    // There are 3 variants of DnsQuery: DnsQuery_A, DnsQuery_W and DnsQuery_UTF8
+    // Depending on which variant is used, the hostname has to be provided in the corresponding encoding
+    // The problem is that they all return records in a DNS_RECORD* which when
+    // UNICODE is defined is DNS_RECORDW* regardless of which variant of DnsQuery is used
+    // Depending on the type of query, DNS_RECORDW can contain pointers to strings
+    // These strings are encoded in the encoding specified by the variant of DnsQuery that was called
+    // This means that calling DnsQuery_A would return a DNS_RECORDW* that contains wide-string pointers pointing to ASCII strings
+    // Those wide-string pointers would have to be interpreted as ASCII in order to prevent data corruption
+    // Because of this, the fact that UNICODE being defined forces us to use DNS_RECORDW
+    // and that means that in order to not have to interpret wide-string pointers as ASCII data
+    // we have to use DnsQuery_W here even though the hostname is passed as a possibly punycode encoded ASCII
+    // Using DnsQuery_W ensures that the data pointed to by wide-string pointers in DNS_RECORDW is actually wide-string data
+    DNS_RECORDW* recordsPtr{};
+    const auto result = DnsQuery_W(sf::String(hostname).toWideString().c_str(), type, DNS_QUERY_STANDARD, nullptr, &recordsPtr, nullptr);
+    std::unique_ptr<DNS_RECORDW, RecordsDeleter> records{recordsPtr};
+
+    if (result != DNS_RCODE_NOERROR)
+        return {};
+
+    return records;
+}
+#else
+template <typename RecordHandler>
+void getRecords(const std::string& hostname, int type, const RecordHandler& recordHandler)
+{
+#if defined(SFML_SYSTEM_ANDROID)
+    // This implementation will not work on Android due to their
+    // deliberate decision to implement their own dialect of the resolv API
+    // The API we use here doesn't prevent building on Android but
+    // calling any of the functions will always result in an error
+    // A working Android implementation would have to make use of
+    // android_res_nquery() and android_res_nresult() instead
+    // https://developer.android.com/ndk/reference/group/networking
+    // If the user wants to perform advanced DNS queries we currently
+    // have to perform it ourselves using our own manual resolver
+    assert(false && "Advanced DNS queries cannot be made through res_search");
+#endif
+
+    std::array<unsigned char, NS_PACKETSZ> answer{};
+
+    const auto length = res_search(hostname.c_str(), ns_c_in, type, answer.data(), answer.size());
+
+    if (length < 0)
+        return;
+
+    ns_msg handle{};
+    ns_initparse(answer.data(), length, &handle);
+
+    for (int i = 0; i < ns_msg_count(handle, ns_s_an); ++i)
+    {
+        ns_rr record{};
+
+        if (const auto result = ns_parserr(&handle, ns_s_an, i, &record); result < 0)
+            continue;
+
+        if (const auto recordType = ns_rr_type(record); recordType != type)
+            continue;
+
+        recordHandler(handle, record);
+    }
+}
+#endif
+
+std::uint8_t readU8(const char*& ptr, const char* end)
+{
+    std::uint8_t x{};
+    if (ptr + 1 <= end)
+    {
+        std::memcpy(&x, ptr, 1);
+        ptr += 1;
+    }
+    return x;
+}
+
+std::uint16_t readU16(const char*& ptr, const char* end)
+{
+    std::uint16_t x{};
+    if (ptr + 2 <= end)
+    {
+        std::memcpy(&x, ptr, 2);
+        ptr += 2;
+    }
+    return ntohs(x);
+}
+
+std::uint32_t readU32(const char*& ptr, const char* end)
+{
+    std::uint32_t x{};
+    if (ptr + 4 <= end)
+    {
+        std::memcpy(&x, ptr, 4);
+        ptr += 4;
+    }
+    return ntohl(x);
+}
+
+std::string readName(const char*& ptr, const char* end, const char* begin)
+{
+    std::string name;
+    while (true)
+    {
+        const auto count = readU8(ptr, end);
+        if (count == 0)
+            break;
+        if (count & 0b11000000)
+        {
+            // Compressed data
+            const auto  offset     = (static_cast<int>(count & 0b00111111) << 8) + readU8(ptr, end);
+            const auto* messagePtr = begin + offset;
+            name += readName(messagePtr, end, begin);
+            break;
+        }
+        name += std::string(ptr, count) + '.';
+        ptr += count;
+    }
+    if (!name.empty() && (name.back() == '.'))
+        name.pop_back();
+    return name;
+}
+
+struct Query
+{
+    std::vector<sf::IpAddress> servers;
+    std::uint16_t              queryType;
+    std::uint16_t              queryClass;
+    std::string                name;
+};
+
+template <typename Handler>
+void queryDns(const Handler& handler, std::optional<sf::Time> timeout, const std::vector<Query>& queries)
+{
+    const auto hasIpV6 = std::any_of(queries.begin(),
+                                     queries.end(),
+                                     [](const auto& query) {
+                                         return std::any_of(query.servers.begin(),
+                                                            query.servers.end(),
+                                                            [](const auto& server) { return server.isV6(); });
+                                     });
+
+    sf::UdpSocket socket;
+    if (socket.bind(sf::Socket::AnyPort, hasIpV6 ? sf::IpAddress::AnyV6 : sf::IpAddress::AnyV4) != sf::Socket::Status::Done)
+        return;
+
+    static std::atomic_uint16_t nextTransactionId{1};
+    const auto                  transactionId = nextTransactionId.fetch_add(1);
+
+    const auto parseResponse = [&](const std::vector<char>& buffer)
+    {
+        const auto* begin = buffer.data();
+        const auto* ptr   = begin;
+        const auto* end   = ptr + buffer.size();
+
+        // Verify matching transaction ID
+        if (const auto responseTransactionId = readU16(ptr, end); responseTransactionId != transactionId)
+            return false;
+
+        // Ensure response and no error
+        if (const auto flags = readU16(ptr, end); !(flags & 0x8000) || (flags & 0x000F))
+            return false;
+
+        const auto questions = readU16(ptr, end);
+        const auto answers   = readU16(ptr, end);
+        readU16(ptr, end); // Authority RRs
+        readU16(ptr, end); // Additional RRs
+
+        for (auto i = 0u; (i < questions) && (ptr < end); ++i)
+        {
+            readName(ptr, end, begin);
+            readU16(ptr, end); // Type
+            readU16(ptr, end); // Class
+        }
+
+        auto handled = false;
+
+        for (auto i = 0u; (i < answers) && (ptr < end); ++i)
+        {
+            readU16(ptr, end); // Name
+            const auto responseType  = readU16(ptr, end);
+            const auto responseClass = readU16(ptr, end);
+            readU32(ptr, end); // TTL
+            const auto length = readU16(ptr, end);
+
+            if (length == 0)
+                continue;
+
+            if (ptr + length <= end)
+            {
+                handler(ptr, length, begin, responseType, responseClass);
+                handled = true;
+            }
+
+            ptr += length;
+        }
+
+        return handled;
+    };
+
+    auto sentQueries = 0;
+
+    for (const auto& query : queries)
+    {
+        if (query.name.empty() || query.servers.empty() || (query.name.size() > 255))
+            return;
+
+        std::string queryData;
+        queryData += static_cast<char>(transactionId >> 8);
+        queryData += static_cast<char>(transactionId & 0xFF);
+        queryData += "\1\0\0\1\0\0\0\0\0\0"s; // Standard recursive query, 1 question
+
+        // Convert name to lowercase and append '.' if necessary
+        auto lowerName = sf::toLower(query.name);
+
+        while (!lowerName.empty() && (lowerName.back() == '.'))
+            lowerName.pop_back();
+
+        while (!lowerName.empty() && (lowerName.front() == '.'))
+            lowerName.erase(0, 1);
+
+        if (lowerName.empty())
+            return;
+
+        lowerName += '.';
+
+        // Split name into labels and add to query
+        std::string label;
+
+        while (!lowerName.empty())
+        {
+            if (auto c = lowerName.front(); c == '.')
+            {
+                queryData += static_cast<char>(label.size());
+                queryData += label;
+                label.clear();
+            }
+            else
+            {
+                label += c;
+                if (label.size() > 63u)
+                {
+                    // Label length is not allowed to exceed 63 octets
+                    assert(false && "DNS hostname label length is not allowed to exceed 63 octets");
+                    return;
+                }
+            }
+
+            lowerName.erase(0, 1);
+        }
+
+        queryData += '\0';
+
+        // Query type and class
+        queryData += static_cast<char>(query.queryType >> 8);
+        queryData += static_cast<char>(query.queryType & 0xFF);
+        queryData += static_cast<char>(query.queryClass >> 8);
+        queryData += static_cast<char>(query.queryClass & 0xFF);
+
+        // Send the query to all provided servers
+        // Since this only consists of sending a single UDP datagram it is relatively cheap for us
+        // Once we receive the first response try to parse it and if successful return and ignore other responses
+        for (const auto& server : query.servers)
+        {
+            if (socket.send(queryData.data(), queryData.size(), server, 53) == sf::Socket::Status::Done)
+                ++sentQueries;
+        }
+    }
+
+    // Check if at least one send was successful
+    if (sentQueries > 0)
+    {
+        // At least one send was successful, now we wait for a response
+        sf::SocketSelector selector;
+        selector.add(socket);
+        const sf::Clock clock;
+
+        for (auto replyCount = 0; replyCount < sentQueries; ++replyCount)
+        {
+            if (timeout.has_value() && (clock.getElapsedTime() >= *timeout))
+                break;
+
+            if (selector.wait(timeout.has_value() ? (*timeout - clock.getElapsedTime()) : sf::Time::Zero))
+            {
+                std::vector<char>            buffer(1500);
+                std::size_t                  received{};
+                std::optional<sf::IpAddress> remote;
+                std::uint16_t                port{};
+
+                if (socket.receive(buffer.data(), buffer.size(), received, remote, port) == sf::Socket::Status::Done)
+                {
+                    buffer.resize(received);
+                    if (parseResponse(buffer))
+                        return;
+                }
+            }
+            else
+            {
+                // Timed out, no need to wait for more responses
+                break;
+            }
+        }
+    }
+}
+
+std::string encodeHostname(const sf::String& hostname)
+{
+    // TODO: Support proper Punycode conversion if there is a need for it
+    // https://datatracker.ietf.org/doc/html/rfc3492
+    return hostname.toAnsiString();
+}
+
+sf::String decodeHostname(const std::string& hostname)
+{
+    // TODO: Support proper Punycode conversion if there is a need for it
+    // https://datatracker.ietf.org/doc/html/rfc3492
+    return {hostname};
+}
+
+} // namespace
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+std::optional<std::vector<IpAddress>> Dns::resolve(const String&                 hostname,
+                                                   const std::vector<IpAddress>& servers,
+                                                   std::optional<Time>           timeout)
+{
+    std::vector<IpAddress> addresses;
+
+    if (hostname.isEmpty())
+        return std::nullopt;
+
+    // Check if the hostname is actually the string representation of an IP address
+    if (const auto address = IpAddress::fromString(hostname.toAnsiString()); address)
+    {
+        addresses.emplace_back(*address);
+        return addresses;
+    }
+
+    // Not a string representation of an IP address, do a full lookup
+
+    auto encoded = encodeHostname(hostname);
+
+    if (!servers.empty())
+    {
+        // Use user provided servers
+        auto querySuccess = false;
+
+        queryDns(
+            [&](const char* data, std::size_t length, const char*, std::uint16_t responseType, std::uint16_t responseClass)
+            {
+                querySuccess = true;
+
+                // AAAA, IN
+                if ((responseType != 28) || (responseClass != 1))
+                    return;
+
+                if (length == 16)
+                {
+                    std::array<std::uint8_t, 16> bytes{};
+                    std::memcpy(bytes.data(), data, 16);
+                    if (std::any_of(bytes.begin(), bytes.end(), [](auto b) { return b != 0; }))
+                        addresses.emplace_back(bytes);
+                }
+            },
+            timeout,
+            {{servers,
+              28, // AAAA
+              1,  // IN
+              encoded}});
+
+        queryDns(
+            [&](const char* data, std::size_t length, const char*, std::uint16_t responseType, std::uint16_t responseClass)
+            {
+                querySuccess = true;
+
+                // A, IN
+                if ((responseType != 1) || (responseClass != 1))
+                    return;
+
+                if (const auto bytes = readU32(data, data + length); bytes != 0)
+                    addresses.emplace_back(bytes);
+            },
+            timeout,
+            {{servers,
+              1, // A
+              1, // IN
+              encoded}});
+
+        // Return nullopt if we didn't get any response from the server (not even non-address responses)
+        if (!querySuccess)
+            return std::nullopt;
+
+        // We got at least one response but no addresses
+        return addresses;
+    }
+
+    const addrinfo hints{}; // AF_UNSPEC is the zero value for ai_family
+    addrinfo*      result      = nullptr;
+    const auto     queryResult = getaddrinfo(encoded.c_str(), nullptr, &hints, &result);
+
+    if ((queryResult == 0) && (result != nullptr))
+    {
+        for (auto* info = result; info; info = info->ai_next)
+        {
+            if (info->ai_family == AF_INET6)
+            {
+                // IPv6
+                sockaddr_in6 sin{};
+                std::memcpy(&sin, info->ai_addr, sizeof(sin));
+                const std::array<std::uint8_t, 16>
+                    bytes{sin.sin6_addr.s6_addr[0],
+                          sin.sin6_addr.s6_addr[1],
+                          sin.sin6_addr.s6_addr[2],
+                          sin.sin6_addr.s6_addr[3],
+                          sin.sin6_addr.s6_addr[4],
+                          sin.sin6_addr.s6_addr[5],
+                          sin.sin6_addr.s6_addr[6],
+                          sin.sin6_addr.s6_addr[7],
+                          sin.sin6_addr.s6_addr[8],
+                          sin.sin6_addr.s6_addr[9],
+                          sin.sin6_addr.s6_addr[10],
+                          sin.sin6_addr.s6_addr[11],
+                          sin.sin6_addr.s6_addr[12],
+                          sin.sin6_addr.s6_addr[13],
+                          sin.sin6_addr.s6_addr[14],
+                          sin.sin6_addr.s6_addr[15]};
+                addresses.emplace_back(bytes);
+            }
+            else if (info->ai_family == AF_INET)
+            {
+                // IPv4
+                sockaddr_in sin{};
+                std::memcpy(&sin, info->ai_addr, sizeof(sin));
+                addresses.emplace_back(ntohl(sin.sin_addr.s_addr));
+            }
+        }
+
+        freeaddrinfo(result);
+
+        return addresses;
+    }
+
+    // EAI_NODATA and EAI_NONAME indicate the server responded to the query but no addresses were returned
+    // On Windows EAI_NODATA and EAI_NONAME are the same value hence the required NOLINT
+    if ((queryResult == EAI_NODATA) || (queryResult == EAI_NONAME)) // NOLINT(misc-redundant-expression)
+        return addresses;
+
+    return std::nullopt;
+}
+
+
+////////////////////////////////////////////////////////////
+std::vector<sf::String> Dns::queryNs(const String& hostname, const std::vector<IpAddress>& servers, std::optional<Time> timeout)
+{
+    std::vector<sf::String> nsRecords;
+
+    if (hostname.isEmpty())
+        return nsRecords;
+
+    auto encoded = encodeHostname(hostname);
+
+    // On Android the libc provided resolv API doesn't work, we will have to do the work ourselves
+#if defined(SFML_SYSTEM_ANDROID)
+    const auto& serversToQuery = servers.empty() ? getAndroidServers() : servers;
+#else
+    const auto& serversToQuery = servers;
+#endif
+
+    if (!serversToQuery.empty())
+    {
+        queryDns(
+            [&](const char* data, std::size_t length, const char* messageBegin, std::uint16_t responseType, std::uint16_t responseClass)
+            {
+                // NS, IN
+                if ((responseType != 2) || (responseClass != 1))
+                    return;
+
+                if (auto nameserver = readName(data, data + length, messageBegin); !nameserver.empty())
+                    nsRecords.emplace_back(decodeHostname(nameserver));
+            },
+            timeout,
+            {{serversToQuery,
+              2, // NS
+              1, // IN
+              encoded}});
+
+        return nsRecords;
+    }
+
+#if defined(SFML_SYSTEM_WINDOWS)
+    const auto records = getRecords(encoded, DNS_TYPE_NS);
+    for (const auto* ptr = records.get(); ptr; ptr = ptr->pNext)
+    {
+        if ((ptr->wType == DNS_TYPE_NS) && (ptr->Data.NS.pNameHost != nullptr))
+            nsRecords.emplace_back(decodeHostname(sf::String(ptr->Data.NS.pNameHost).toAnsiString()));
+    }
+#else
+    getRecords(encoded,
+               ns_t_ns,
+               [&nsRecords](const ns_msg& handle, const ns_rr& record)
+               {
+                   std::array<char, NS_MAXCDNAME> nameserver{};
+
+                   if (const auto result = dn_expand(ns_msg_base(handle),
+                                                     ns_msg_end(handle),
+                                                     ns_rr_rdata(record),
+                                                     nameserver.data(),
+                                                     nameserver.size());
+                       result >= 0)
+                   {
+                       nameserver[NS_MAXCDNAME - 1] = '\0';
+                       nsRecords.emplace_back(decodeHostname(nameserver.data()));
+                   }
+               });
+#endif
+
+    return nsRecords;
+}
+
+
+////////////////////////////////////////////////////////////
+std::vector<Dns::MxRecord> Dns::queryMx(const String& hostname, const std::vector<IpAddress>& servers, std::optional<Time> timeout)
+{
+    std::vector<MxRecord> mxRecords;
+
+    if (hostname.isEmpty())
+        return mxRecords;
+
+    auto encoded = encodeHostname(hostname);
+
+    // On Android the libc provided resolv API doesn't work, we will have to do the work ourselves
+#if defined(SFML_SYSTEM_ANDROID)
+    const auto& serversToQuery = servers.empty() ? getAndroidServers() : servers;
+#else
+    const auto& serversToQuery = servers;
+#endif
+
+    if (!serversToQuery.empty())
+    {
+        queryDns(
+            [&](const char* data, std::size_t length, const char* messageBegin, std::uint16_t responseType, std::uint16_t responseClass)
+            {
+                // MX, IN
+                if ((responseType != 15) || (responseClass != 1))
+                    return;
+
+                const auto preference = readU16(data, data + length);
+                auto       exchange   = readName(data, data + length, messageBegin);
+
+                if (!exchange.empty())
+                    mxRecords.emplace_back(MxRecord{decodeHostname(exchange), preference});
+            },
+            timeout,
+            {{serversToQuery,
+              15, // MX
+              1,  // IN
+              encoded}});
+
+        return mxRecords;
+    }
+
+#if defined(SFML_SYSTEM_WINDOWS)
+    const auto records = getRecords(encoded, DNS_TYPE_MX);
+    for (const auto* ptr = records.get(); ptr; ptr = ptr->pNext)
+    {
+        if ((ptr->wType == DNS_TYPE_MX) && (ptr->Data.MX.pNameExchange != nullptr))
+        {
+            mxRecords.emplace_back(
+                MxRecord{decodeHostname(sf::String(ptr->Data.MX.pNameExchange).toAnsiString()), ptr->Data.MX.wPreference});
+        }
+    }
+#else
+    getRecords(encoded,
+               ns_t_mx,
+               [&mxRecords](const ns_msg& handle, const ns_rr& record)
+               {
+                   const auto preference = static_cast<std::uint16_t>(ns_get16(ns_rr_rdata(record) + 0 * NS_INT16SZ));
+
+                   std::array<char, NS_MAXCDNAME> exchange{};
+
+                   if (const auto result = dn_expand(ns_msg_base(handle),
+                                                     ns_msg_end(handle),
+                                                     ns_rr_rdata(record) + 1 * NS_INT16SZ,
+                                                     exchange.data(),
+                                                     exchange.size());
+                       result >= 0)
+                   {
+                       exchange[NS_MAXCDNAME - 1] = '\0';
+                       mxRecords.emplace_back(MxRecord{decodeHostname(exchange.data()), preference});
+                   }
+               });
+#endif
+
+    return mxRecords;
+}
+
+
+////////////////////////////////////////////////////////////
+std::vector<Dns::SrvRecord> Dns::querySrv(const String& hostname, const std::vector<IpAddress>& servers, std::optional<Time> timeout)
+{
+    std::vector<SrvRecord> srvRecords;
+
+    if (hostname.isEmpty())
+        return srvRecords;
+
+    auto encoded = encodeHostname(hostname);
+
+    // On Android the libc provided resolv API doesn't work, we will have to do the work ourselves
+#if defined(SFML_SYSTEM_ANDROID)
+    const auto& serversToQuery = servers.empty() ? getAndroidServers() : servers;
+#else
+    const auto& serversToQuery = servers;
+#endif
+
+    if (!serversToQuery.empty())
+    {
+        queryDns(
+            [&](const char* data, std::size_t length, const char* messageBegin, std::uint16_t responseType, std::uint16_t responseClass)
+            {
+                // SRV, IN
+                if ((responseType != 33) || (responseClass != 1))
+                    return;
+
+                const auto priority = readU16(data, data + length);
+                const auto weight   = readU16(data, data + length);
+                const auto port     = readU16(data, data + length);
+                auto       target   = readName(data, data + length, messageBegin);
+
+                if (!target.empty())
+                    srvRecords.emplace_back(SrvRecord{decodeHostname(target), port, weight, priority});
+            },
+            timeout,
+            {{serversToQuery,
+              33, // SRV
+              1,  // IN
+              encoded}});
+
+        return srvRecords;
+    }
+
+#if defined(SFML_SYSTEM_WINDOWS)
+    const auto records = getRecords(encoded, DNS_TYPE_SRV);
+    for (const auto* ptr = records.get(); ptr; ptr = ptr->pNext)
+    {
+        if ((ptr->wType == DNS_TYPE_SRV) && (ptr->Data.SRV.pNameTarget != nullptr))
+        {
+            srvRecords.emplace_back(SrvRecord{decodeHostname(sf::String(ptr->Data.SRV.pNameTarget).toAnsiString()),
+                                              ptr->Data.SRV.wPort,
+                                              ptr->Data.SRV.wWeight,
+                                              ptr->Data.SRV.wPriority});
+        }
+    }
+#else
+    getRecords(encoded,
+               ns_t_srv,
+               [&srvRecords](const ns_msg& handle, const ns_rr& record)
+               {
+                   const auto priority = static_cast<std::uint16_t>(ns_get16(ns_rr_rdata(record) + 0 * NS_INT16SZ));
+                   const auto weight   = static_cast<std::uint16_t>(ns_get16(ns_rr_rdata(record) + 1 * NS_INT16SZ));
+                   const auto port     = static_cast<std::uint16_t>(ns_get16(ns_rr_rdata(record) + 2 * NS_INT16SZ));
+
+                   std::array<char, NS_MAXCDNAME> target{};
+
+                   if (const auto result = dn_expand(ns_msg_base(handle),
+                                                     ns_msg_end(handle),
+                                                     ns_rr_rdata(record) + 3 * NS_INT16SZ,
+                                                     target.data(),
+                                                     target.size());
+                       result >= 0)
+                   {
+                       target[NS_MAXCDNAME - 1] = '\0';
+                       srvRecords.emplace_back(SrvRecord{decodeHostname(target.data()), port, weight, priority});
+                   }
+               });
+#endif
+
+    return srvRecords;
+}
+
+
+////////////////////////////////////////////////////////////
+std::vector<std::vector<sf::String>> Dns::queryTxt(const String&                 hostname,
+                                                   const std::vector<IpAddress>& servers,
+                                                   std::optional<Time>           timeout)
+{
+    std::vector<std::vector<sf::String>> txtRecords;
+
+    if (hostname.isEmpty())
+        return txtRecords;
+
+    auto encoded = encodeHostname(hostname);
+
+    // On Android the libc provided resolv API doesn't work, we will have to do the work ourselves
+#if defined(SFML_SYSTEM_ANDROID)
+    const auto& serversToQuery = servers.empty() ? getAndroidServers() : servers;
+#else
+    const auto& serversToQuery = servers;
+#endif
+
+    if (!serversToQuery.empty())
+    {
+        queryDns(
+            [&](const char* data, std::size_t length, const char*, std::uint16_t responseType, std::uint16_t responseClass)
+            {
+                // TXT, IN
+                if ((responseType != 16) || (responseClass != 1))
+                    return;
+
+                auto&             list  = txtRecords.emplace_back();
+                const auto*       begin = data;
+                const auto* const end   = begin + length;
+                std::string       buffer;
+                buffer.reserve(length);
+
+                while (begin < end)
+                {
+                    buffer.clear();
+                    std::uint8_t txtLength{};
+                    std::memcpy(&txtLength, begin++, 1);
+                    for (auto i = 0u; (i < txtLength) && (begin < end); ++i)
+                        buffer.push_back(*begin++);
+                    if (!buffer.empty())
+                        list.emplace_back(buffer);
+                }
+            },
+            timeout,
+            {{serversToQuery,
+              16, // TXT
+              1,  // IN
+              encoded}});
+
+        return txtRecords;
+    }
+
+#if defined(SFML_SYSTEM_WINDOWS)
+    const auto records = getRecords(encoded, DNS_TYPE_TEXT);
+    for (const auto* ptr = records.get(); ptr; ptr = ptr->pNext)
+    {
+        if (ptr->wType == DNS_TYPE_TEXT)
+        {
+            auto& list = txtRecords.emplace_back();
+            for (auto i = 0u; i < ptr->Data.TXT.dwStringCount; ++i)
+            {
+                if (ptr->Data.TXT.pStringArray[i])
+                    list.emplace_back(ptr->Data.TXT.pStringArray[i]);
+            }
+        }
+    }
+#else
+    getRecords(encoded,
+               ns_t_txt,
+               [&txtRecords](const ns_msg&, const ns_rr& record)
+               {
+                   auto&             list   = txtRecords.emplace_back();
+                   const auto        length = static_cast<std::size_t>(ns_rr_rdlen(record));
+                   const auto*       begin  = reinterpret_cast<const char*>(ns_rr_rdata(record));
+                   const auto* const end    = begin + length;
+                   std::string       buffer;
+                   buffer.reserve(length);
+
+                   while (begin < end)
+                   {
+                       buffer.clear();
+                       std::uint8_t txtLength{};
+                       std::memcpy(&txtLength, begin++, 1);
+                       for (auto i = 0u; (i < txtLength) && (begin < end); ++i)
+                           buffer.push_back(*begin++);
+                       if (!buffer.empty())
+                           list.emplace_back(buffer);
+                   }
+               });
+#endif
+
+    return txtRecords;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<IpAddress> Dns::getPublicAddress(std::optional<Time> timeout, IpAddress::Type type)
+{
+    std::optional<IpAddress> address;
+
+    const auto handler =
+        [&](const char* data, std::size_t length, const char*, std::uint16_t responseType, std::uint16_t responseClass)
+    {
+        // No need to handle this response if we already have an address
+        if (address.has_value())
+            return;
+
+        // AAAA, IN
+        if ((responseType == 28) && (responseClass == 1) && (length == 16))
+        {
+            std::array<std::uint8_t, 16> bytes{};
+            std::memcpy(bytes.data(), data, 16);
+            if (std::any_of(bytes.begin(), bytes.end(), [](auto b) { return b != 0; }))
+                address.emplace(bytes);
+        }
+
+        // A, IN
+        if ((responseType == 1) && (responseClass == 1))
+        {
+            if (const auto bytes = readU32(data, data + length); bytes != 0)
+                address.emplace(bytes);
+        }
+
+        // TXT, IN or CH
+        if ((responseType == 16) && ((responseClass == 1) || (responseClass == 3)))
+        {
+            if (const auto txtLength = readU8(data, data + length); (std::size_t{1} + txtLength) == length)
+            {
+                std::string str(data, txtLength);
+                str.erase(std::remove(str.begin(), str.end(), '"'), str.end()); // Remove quotes if any
+                if (const auto ipAddress = IpAddress::fromString(str); ipAddress)
+                    address.emplace(*ipAddress);
+            }
+        }
+    };
+
+    const auto filter = [&type](auto filteredAddresses)
+    {
+        filteredAddresses.erase(std::remove_if(filteredAddresses.begin(),
+                                               filteredAddresses.end(),
+                                               [&type](const auto& filteredAddress)
+                                               { return filteredAddress.getType() != type; }),
+                                filteredAddresses.end());
+        return filteredAddresses;
+    };
+
+    const auto addressQueryType = static_cast<std::uint16_t>((type == IpAddress::Type::IpV4) ? 1 : 28); // A/AAAA
+
+    std::vector<Query> queries;
+
+    // Attempt to query Cloudflare and OpenDNS first since those don't require their server hostnames to be looked up and resolved
+    queries.emplace_back(Query{filter(cloudflareAddresses), 16, 3, "whoami.cloudflare"});           // TXT, CH
+    queries.emplace_back(Query{filter(opendnsAddresses), addressQueryType, 1, "myip.opendns.com"}); // A/AAAA, IN
+
+    queryDns(handler, timeout, queries);
+
+    // If we already have an address no need to query Akamai and Google, return it here
+    if (address.has_value())
+        return address;
+
+    queries.clear();
+
+    static constexpr auto getAddresses = [](const char* provider)
+    {
+        std::vector<sf::IpAddress> providerAddresses;
+        for (const auto& nameserver : queryNs(provider))
+        {
+            if (const auto nameserverAddresses = resolve(nameserver); nameserverAddresses)
+                providerAddresses.insert(providerAddresses.end(), nameserverAddresses->begin(), nameserverAddresses->end());
+        }
+        return providerAddresses;
+    };
+
+    // Query Akamai and Google
+    const auto akamaiNameserverAddresses = getAddresses("akamaitech.net");
+    const auto googleNameserverAddresses = getAddresses("google.com");
+
+    queries.emplace_back(Query{filter(akamaiNameserverAddresses), addressQueryType, 1, "whoami.akamai.net"}); // A/AAAA, IN
+    queries.emplace_back(Query{filter(googleNameserverAddresses), 16, 1, "o-o.myaddr.l.google.com"});         // TXT, IN
+
+    queryDns(handler, timeout, queries);
+
+    return address;
+}
+
+} // namespace sf

--- a/src/SFML/Network/Ftp.cpp
+++ b/src/SFML/Network/Ftp.cpp
@@ -161,6 +161,12 @@ Ftp::~Ftp()
 ////////////////////////////////////////////////////////////
 Ftp::Response Ftp::connect(IpAddress server, unsigned short port, Time timeout)
 {
+    if (server.isV6())
+    {
+        err() << "FTP Error: Connecting to IPv6 servers is not supported" << std::endl;
+        return Response(Response::Status::ConnectionFailed);
+    }
+
     // Connect to the server
     if (m_commandSocket.connect(server, port, timeout) != Socket::Status::Done)
         return Response(Response::Status::ConnectionFailed);

--- a/src/SFML/Network/Http.cpp
+++ b/src/SFML/Network/Http.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+#include <SFML/Network/Dns.hpp>
 #include <SFML/Network/Http.hpp>
 
 #include <SFML/System/Err.hpp>
@@ -291,14 +292,14 @@ void Http::Response::parseFields(std::istream& in)
 
 
 ////////////////////////////////////////////////////////////
-Http::Http(const std::string& host, unsigned short port)
+Http::Http(const std::string& host, unsigned short port, std::optional<IpAddress::Type> addressType)
 {
-    setHost(host, port);
+    setHost(host, port, addressType);
 }
 
 
 ////////////////////////////////////////////////////////////
-bool Http::setHost(const std::string& host, unsigned short port)
+bool Http::setHost(const std::string& host, unsigned short port, std::optional<IpAddress::Type> addressType)
 {
     // Check the protocol
     if (toLower(host.substr(0, 7)) == "http://")
@@ -325,8 +326,10 @@ bool Http::setHost(const std::string& host, unsigned short port)
     if (!m_hostName.empty() && (*m_hostName.rbegin() == '/'))
         m_hostName.erase(m_hostName.size() - 1);
 
-    m_host = IpAddress::resolve(m_hostName);
-    return m_host.has_value();
+    m_hosts       = Dns::resolve(m_hostName).value_or(decltype(m_hosts){});
+    m_addressType = addressType;
+
+    return !m_hosts.empty();
 }
 
 
@@ -362,52 +365,78 @@ Http::Response Http::sendRequest(const Http::Request& request, Time timeout, boo
         toSend.setField("Connection", "close");
     }
 
+    auto hosts = m_hosts;
+
+    if (m_addressType == IpAddress::Type::IpV4)
+        hosts.erase(std::remove_if(hosts.begin(), hosts.end(), [](const auto& host) { return host.isV6(); }), hosts.end());
+
+    if (m_addressType == IpAddress::Type::IpV6)
+        hosts.erase(std::remove_if(hosts.begin(), hosts.end(), [](const auto& host) { return host.isV4(); }), hosts.end());
+
     // Prepare the response
     Response received;
 
-    TcpSocket connection;
-    // Connect the socket to the host
-    if (m_host.has_value() && connection.connect(m_host.value(), m_port, timeout) == Socket::Status::Done)
+    for (const auto& host : m_hosts)
     {
-        if (m_https && (connection.setupTlsClient(m_hostName, verifyServer) != sf::TcpSocket::TlsStatus::HandshakeComplete))
-            return received;
+        if ((m_addressType.has_value()) && (host.getType() != m_addressType))
+            continue;
 
-        // Convert the request to string and send it through the connected socket
-        const std::string requestStr = toSend.prepare();
+        TcpSocket connection;
 
-        if (!requestStr.empty())
+        // Connect the socket to the host
+        if (connection.connect(host, m_port, timeout) == Socket::Status::Done)
         {
-            // Send it through the socket
-            if (connection.send(requestStr.c_str(), requestStr.size()) == Socket::Status::Done)
+            if (m_https &&
+                (connection.setupTlsClient(m_hostName, verifyServer) != sf::TcpSocket::TlsStatus::HandshakeComplete))
+                continue;
+
+            // Convert the request to string and send it through the connected socket
+            const std::string requestStr = toSend.prepare();
+
+            if (!requestStr.empty())
             {
-                // Wait for the server's response
-                std::string            receivedStr;
-                std::size_t            size = 0;
-                std::array<char, 1024> buffer{};
-
-                // When the HTTPS connection makes use of TLS 1.3 new session ticket
-                // messages can be received by the client from the server at any time
-                // When these messages are received the receive function will return Socket::Status::Partial
-                // In this case We just continue to call receive until actual payload
-                // data is available, the connection is closed or an error occurs
-                auto result = connection.receive(buffer.data(), buffer.size(), size);
-
-                while ((result == Socket::Status::Done) || (result == Socket::Status::Partial))
+                // Send it through the socket
+                if (connection.send(requestStr.c_str(), requestStr.size()) == Socket::Status::Done)
                 {
-                    // Only append payload data when it has been completely received
-                    if (result == Socket::Status::Done)
-                        receivedStr.append(buffer.data(), buffer.data() + size);
+                    // Wait for the server's response
+                    std::string            receivedStr;
+                    std::size_t            size = 0;
+                    std::array<char, 1024> buffer{};
 
-                    result = connection.receive(buffer.data(), buffer.size(), size);
+                    // When the HTTPS connection makes use of TLS 1.3 new session ticket
+                    // messages can be received by the client from the server at any time
+                    // When these messages are received the receive function will return Socket::Status::Partial
+                    // In this case We just continue to call receive until actual payload
+                    // data is available, the connection is closed or an error occurs
+                    auto result = connection.receive(buffer.data(), buffer.size(), size);
+
+                    while ((result == Socket::Status::Done) || (result == Socket::Status::Partial))
+                    {
+                        // Only append payload data when it has been completely received
+                        if (result == Socket::Status::Done)
+                            receivedStr.append(buffer.data(), buffer.data() + size);
+
+                        result = connection.receive(buffer.data(), buffer.size(), size);
+                    }
+
+                    // Build the Response object from the received data
+                    received.parse(receivedStr);
+
+                    // If we received any data (even if it doesn't contain a HTTP 200 response)
+                    // we successfully found a host that we can connect to under the hostname
+                    // Stop attempting to connect to further addresses in this case
+                    if (!receivedStr.empty())
+                    {
+                        // Close the connection
+                        connection.disconnect();
+                        break;
+                    }
                 }
-
-                // Build the Response object from the received data
-                received.parse(receivedStr);
             }
-        }
 
-        // Close the connection
-        connection.disconnect();
+            // Close the connection
+            connection.disconnect();
+        }
     }
 
     return received;

--- a/src/SFML/Network/IpAddress.cpp
+++ b/src/SFML/Network/IpAddress.cpp
@@ -25,16 +25,29 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
+// MinGW defines _WIN32_WINNT to 0x0501 by default if it is not yet defined
+// If we don't set _WIN32_WINNT ourselves early here it will take precedence over
+// our own value thus preventing inet_pton and inet_ntop from being made available
+#include <SFML/Config.hpp>
+#if defined(SFML_SYSTEM_WINDOWS)
+#include <SFML/System/Win32/WindowsHeader.hpp>
+#endif
+
+#include <SFML/Network/Dns.hpp>
 #include <SFML/Network/Http.hpp>
 #include <SFML/Network/IpAddress.hpp>
 #include <SFML/Network/SocketImpl.hpp>
 
 #include <SFML/System/Err.hpp>
+#include <SFML/System/Utils.hpp>
 
+#include <algorithm>
 #include <istream>
 #include <ostream>
 
 #include <cstring>
+
+using namespace std::string_view_literals;
 
 
 namespace sf
@@ -43,50 +56,32 @@ namespace sf
 const IpAddress IpAddress::Any(0, 0, 0, 0);
 const IpAddress IpAddress::LocalHost(127, 0, 0, 1);
 const IpAddress IpAddress::Broadcast(255, 255, 255, 255);
+const IpAddress IpAddress::AnyV4(0, 0, 0, 0);
+const IpAddress IpAddress::LocalHostV4(127, 0, 0, 1);
+const IpAddress IpAddress::BroadcastV4(255, 255, 255, 255);
+const IpAddress IpAddress::AnyV6({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+const IpAddress IpAddress::LocalHostV6({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
 
 
 ////////////////////////////////////////////////////////////
 std::optional<IpAddress> IpAddress::resolve(std::string_view address)
 {
-    using namespace std::string_view_literals;
+    // For backwards compatibility try to convert from string representation first
+    if (const auto result = fromString(address); result)
+        return result;
 
-    if (address.empty())
+    // If not a string representation, resolve address
+    if (auto addresses = Dns::resolve(address); addresses.has_value() && !addresses->empty())
     {
-        // Not generating en error message here as resolution failure is a valid outcome.
-        return std::nullopt;
+        // Remove IPv6 addresses to stay backwards compatible
+        addresses
+            ->erase(std::remove_if(addresses->begin(), addresses->end(), [](const auto& entry) { return !entry.isV4(); }),
+                    addresses->end());
+
+        if (!addresses->empty())
+            return addresses->front();
     }
 
-    if (address == "255.255.255.255"sv)
-    {
-        // The broadcast address needs to be handled explicitly,
-        // because it is also the value returned by inet_addr on error
-        return Broadcast;
-    }
-
-    if (address == "0.0.0.0"sv)
-        return Any;
-
-    // Try to convert the address as a byte representation ("xxx.xxx.xxx.xxx")
-    if (const std::uint32_t ip = inet_addr(address.data()); ip != INADDR_NONE)
-        return IpAddress(ntohl(ip));
-
-    // Not a valid address, try to convert it as a host name
-    addrinfo hints{}; // Zero-initialize
-    hints.ai_family = AF_INET;
-
-    addrinfo* result = nullptr;
-    if (getaddrinfo(address.data(), nullptr, &hints, &result) == 0 && result != nullptr)
-    {
-        sockaddr_in sin{};
-        std::memcpy(&sin, result->ai_addr, sizeof(*result->ai_addr));
-
-        const std::uint32_t ip = sin.sin_addr.s_addr;
-        freeaddrinfo(result);
-
-        return IpAddress(ntohl(ip));
-    }
-
-    // Not generating en error message here as resolution failure is a valid outcome.
     return std::nullopt;
 }
 
@@ -105,41 +100,192 @@ IpAddress::IpAddress(std::uint32_t address) : m_address(address)
 
 
 ////////////////////////////////////////////////////////////
+IpAddress::IpAddress(std::array<std::uint8_t, 16> bytes) : m_address(bytes)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<IpAddress> IpAddress::fromString(std::string_view address)
+{
+    using namespace std::string_view_literals;
+
+    if (address.empty())
+        return std::nullopt;
+
+    // Optimizations for known address strings
+    if (address == "0.0.0.0"sv)
+        return AnyV4;
+
+    if (address == "127.0.0.1"sv)
+        return LocalHostV4;
+
+    if (address == "255.255.255.255"sv)
+        return BroadcastV4;
+
+    // Optimizations for known address strings
+    if (address == "::"sv)
+        return AnyV6;
+
+    if (address == "::1"sv)
+        return LocalHostV6;
+
+    // inet_pton expects the string to be null-terminated
+    const std::string addressString(address);
+
+    // Try to convert the address from dotted-decimal notation ("xxx.xxx.xxx.xxx")
+    if (in_addr addr{}; inet_pton(AF_INET, addressString.c_str(), &addr) == 1)
+        return IpAddress(ntohl(addr.s_addr));
+
+    // Try to convert the address from internet standard notation ("xxxx:xxxx::xxxx:xxxx")
+    if (in6_addr addr{}; inet_pton(AF_INET6, addressString.c_str(), &addr) == 1)
+        return IpAddress(
+            {addr.s6_addr[0],
+             addr.s6_addr[1],
+             addr.s6_addr[2],
+             addr.s6_addr[3],
+             addr.s6_addr[4],
+             addr.s6_addr[5],
+             addr.s6_addr[6],
+             addr.s6_addr[7],
+             addr.s6_addr[8],
+             addr.s6_addr[9],
+             addr.s6_addr[10],
+             addr.s6_addr[11],
+             addr.s6_addr[12],
+             addr.s6_addr[13],
+             addr.s6_addr[14],
+             addr.s6_addr[15]});
+
+    return std::nullopt;
+}
+
+
+////////////////////////////////////////////////////////////
 std::string IpAddress::toString() const
 {
-    in_addr address{};
-    address.s_addr = htonl(m_address);
+    if (const auto* addressV4 = std::get_if<V4Data>(&m_address); addressV4)
+    {
+        in_addr address{};
+        address.s_addr = htonl(*addressV4);
 
-    return inet_ntoa(address);
+        if (std::array<char, 32> buffer{}; inet_ntop(AF_INET, &address, buffer.data(), buffer.size()))
+            return buffer.data();
+    }
+    else if (const auto* addressV6 = std::get_if<V6Data>(&m_address); addressV6)
+    {
+        in6_addr address{};
+        static_assert(sizeof(address.s6_addr) == sizeof(*addressV6));
+        std::memcpy(address.s6_addr, addressV6->data(), addressV6->size());
+
+        if (std::array<char, 64> buffer{}; inet_ntop(AF_INET6, &address, buffer.data(), buffer.size()))
+            return buffer.data();
+    }
+
+    return "";
 }
 
 
 ////////////////////////////////////////////////////////////
 std::uint32_t IpAddress::toInteger() const
 {
-    return m_address;
+    assert(std::holds_alternative<V4Data>(m_address));
+    return std::get<V4Data>(m_address);
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<IpAddress> IpAddress::getLocalAddress()
+std::array<std::uint8_t, 16> IpAddress::toBytes() const
+{
+    assert(std::holds_alternative<V6Data>(m_address));
+    return std::get<V6Data>(m_address);
+}
+
+
+////////////////////////////////////////////////////////////
+IpAddress::Type IpAddress::getType() const
+{
+    return std::holds_alternative<V4Data>(m_address) ? Type::IpV4 : Type::IpV6;
+}
+
+
+////////////////////////////////////////////////////////////
+bool IpAddress::isV4() const
+{
+    return getType() == Type::IpV4;
+}
+
+
+////////////////////////////////////////////////////////////
+bool IpAddress::isV6() const
+{
+    return getType() == Type::IpV6;
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<IpAddress> IpAddress::getLocalAddress(Type type)
 {
     // The method here is to connect a UDP socket to a public ip,
     // and get the local socket address with the getsockname function.
     // UDP connection will not send anything to the network, so this function won't cause any overhead.
 
+    if (type == Type::IpV4)
+    {
+        // Create the socket
+        const SocketHandle sock = socket(PF_INET, SOCK_DGRAM, 0);
+        if (sock == priv::SocketImpl::invalidSocket())
+        {
+            err() << "Failed to retrieve local address (invalid socket)" << std::endl;
+            return std::nullopt;
+        }
+
+        // Connect the socket to a public ip (here 1.1.1.1) on any
+        // port. This will give the local address of the network interface
+        // used for default routing which is usually what we want.
+        sockaddr_in address = priv::SocketImpl::createAddress(0x01010101, 9);
+        if (connect(sock, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
+        {
+            priv::SocketImpl::close(sock);
+
+            err() << "Failed to retrieve local address (socket connection failure)" << std::endl;
+            return std::nullopt;
+        }
+
+        // Get the local address of the socket connection
+        priv::SocketImpl::AddrLength size = sizeof(address);
+        if (getsockname(sock, reinterpret_cast<sockaddr*>(&address), &size) == -1)
+        {
+            priv::SocketImpl::close(sock);
+
+            err() << "Failed to retrieve local address (socket local address retrieval failure)" << std::endl;
+            return std::nullopt;
+        }
+
+        // Close the socket
+        priv::SocketImpl::close(sock);
+
+        // Finally build the IP address
+        return IpAddress(ntohl(address.sin_addr.s_addr));
+    }
+
+    // If we get to this point the user wants to get the local IPv6 address
+
     // Create the socket
-    const SocketHandle sock = socket(PF_INET, SOCK_DGRAM, 0);
+    const SocketHandle sock = socket(PF_INET6, SOCK_DGRAM, 0);
     if (sock == priv::SocketImpl::invalidSocket())
     {
         err() << "Failed to retrieve local address (invalid socket)" << std::endl;
         return std::nullopt;
     }
 
-    // Connect the socket to a public ip (here 1.1.1.1) on any
+    // Connect the socket to a public ip (here 2a00::1) on any
     // port. This will give the local address of the network interface
     // used for default routing which is usually what we want.
-    sockaddr_in address = priv::SocketImpl::createAddress(0x01010101, 9);
+    sockaddr_in6 address = priv::SocketImpl::
+        createAddress(std::array<std::uint8_t,
+                                 16>{0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+                      9);
     if (connect(sock, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
     {
         priv::SocketImpl::close(sock);
@@ -162,30 +308,105 @@ std::optional<IpAddress> IpAddress::getLocalAddress()
     priv::SocketImpl::close(sock);
 
     // Finally build the IP address
-    return IpAddress(ntohl(address.sin_addr.s_addr));
+    return IpAddress(
+        {address.sin6_addr.s6_addr[0],
+         address.sin6_addr.s6_addr[1],
+         address.sin6_addr.s6_addr[2],
+         address.sin6_addr.s6_addr[3],
+         address.sin6_addr.s6_addr[4],
+         address.sin6_addr.s6_addr[5],
+         address.sin6_addr.s6_addr[6],
+         address.sin6_addr.s6_addr[7],
+         address.sin6_addr.s6_addr[8],
+         address.sin6_addr.s6_addr[9],
+         address.sin6_addr.s6_addr[10],
+         address.sin6_addr.s6_addr[11],
+         address.sin6_addr.s6_addr[12],
+         address.sin6_addr.s6_addr[13],
+         address.sin6_addr.s6_addr[14],
+         address.sin6_addr.s6_addr[15]});
 }
 
 
 ////////////////////////////////////////////////////////////
-std::optional<IpAddress> IpAddress::getPublicAddress(Time timeout)
+std::optional<IpAddress> IpAddress::getPublicAddress(Time timeout, std::optional<Type> type, bool secure)
 {
     // The trick here is more complicated, because the only way
     // to get our public IP address is to get it from a distant computer.
-    // Here we get the web page from http://www.sfml-dev.org/ip-provider.php
+
+    // Our own DNS implementation does not support DNSSEC, DNS-over-TLS or DNS-over-HTTPS
+    // Both DoT and DoH require communication over a TLS connection anyway
+    // so there is no advantage when using DNS to perform secure queries instead of HTTPS
+    if (!secure)
+    {
+        // Try first via DNS query
+        if (!type.has_value())
+        {
+            // No type preference, try IPv6 then IPv4
+            if (const auto addressViaDns = Dns::getPublicAddress(timeout, IpAddress::Type::IpV6); addressViaDns)
+                return addressViaDns;
+
+            if (const auto addressViaDns = Dns::getPublicAddress(timeout, IpAddress::Type::IpV4); addressViaDns)
+                return addressViaDns;
+        }
+        else
+        {
+            if (const auto addressViaDns = Dns::getPublicAddress(timeout, *type); addressViaDns)
+                return addressViaDns;
+        }
+    }
+
+    // DNS query wasn't successful, try via HTTP
+    // Here we get the web page from e.g. http://ifconfig.co/ip
     // and parse the result to extract our IP address
     // (not very hard: the web page contains only our IP address).
+    for (const auto provider : {"ifconfig.co"sv, "ifconfig.me"sv, "icanhazip.com"sv, "ipinfo.io"sv, "v6.ipinfo.io"sv})
+    {
+        if (type.has_value())
+        {
+            // Make sure the provider has addresses that match the query type
+            if (const auto providerAddresses = Dns::resolve(provider);
+                providerAddresses.has_value() &&
+                (std::find_if(providerAddresses->begin(),
+                              providerAddresses->end(),
+                              [&type](const auto& address) { return address.getType() == type; }) ==
+                 providerAddresses->end()))
+                continue;
+        }
 
-    const Http           server("www.sfml-dev.org");
-    const Http::Request  request("/ip-provider.php", Http::Request::Method::Get);
-    const Http::Response page = server.sendRequest(request, timeout);
+        const Http                   server((secure ? "https://" : "http://") + std::string(provider), 0, type);
+        const Http::Request          request("/ip", Http::Request::Method::Get);
+        const Http::Response         page   = server.sendRequest(request, timeout, secure);
+        const Http::Response::Status status = page.getStatus();
 
-    const Http::Response::Status status = page.getStatus();
+        if (status == Http::Response::Status::Ok)
+        {
+            static constexpr std::array charset = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
+                                                   'C', 'D', 'E', 'F', 'a', 'b', 'c', 'd', 'e', 'f', '.', ':'};
+            auto                        body    = page.getBody();
+            body.erase(std::remove_if(body.begin(),
+                                      body.end(),
+                                      [](char c) {
+                                          return std::none_of(charset.begin(),
+                                                              charset.end(),
+                                                              [&c](char cc) { return cc == c; });
+                                      }),
+                       body.end());
 
-    if (status == Http::Response::Status::Ok)
-        return IpAddress::resolve(page.getBody());
+            if (const auto address = IpAddress::fromString(body); address)
+            {
+                // If the user explicitly requested a specific type of
+                // address and we got the other type we skip it
+                if ((type == Type::IpV4) && address->isV6())
+                    continue;
 
-    err() << "Failed to retrieve public address from external IP resolution server (HTTP response status "
-          << static_cast<int>(status) << ")" << std::endl;
+                if ((type == Type::IpV6) && address->isV4())
+                    continue;
+
+                return address;
+            }
+        }
+    }
 
     return std::nullopt;
 }
@@ -238,7 +459,8 @@ std::istream& operator>>(std::istream& stream, std::optional<IpAddress>& address
 {
     std::string str;
     stream >> str;
-    address = IpAddress::resolve(str);
+
+    address = IpAddress::fromString(str);
 
     return stream;
 }

--- a/src/SFML/Network/Socket.cpp
+++ b/src/SFML/Network/Socket.cpp
@@ -100,12 +100,14 @@ SocketHandle Socket::getNativeHandle() const
 
 
 ////////////////////////////////////////////////////////////
-void Socket::create()
+void Socket::create(IpAddress::Type addressType)
 {
     // Don't create the socket if it already exists
     if (m_socket == priv::SocketImpl::invalidSocket())
     {
-        const SocketHandle handle = socket(PF_INET, m_type == Type::Tcp ? SOCK_STREAM : SOCK_DGRAM, 0);
+        const SocketHandle handle = socket(addressType == IpAddress::Type::IpV4 ? PF_INET : PF_INET6,
+                                           m_type == Type::Tcp ? SOCK_STREAM : SOCK_DGRAM,
+                                           0);
 
         if (handle == priv::SocketImpl::invalidSocket())
         {

--- a/src/SFML/Network/SocketImpl.hpp
+++ b/src/SFML/Network/SocketImpl.hpp
@@ -51,73 +51,82 @@
 
 #endif
 
+#include <array>
+
 #include <cstdint>
 
 
-namespace sf::priv
-{
 ////////////////////////////////////////////////////////////
-/// \brief Helper class implementing all the non-portable
+/// \brief Helper namespace implementing all the non-portable
 ///        socket stuff
 ///
 ////////////////////////////////////////////////////////////
-class SocketImpl
+namespace sf::priv::SocketImpl
 {
-public:
-    ////////////////////////////////////////////////////////////
-    // Types
-    ////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////
+// Types
+////////////////////////////////////////////////////////////
 #if defined(SFML_SYSTEM_WINDOWS)
-    using AddrLength = int;
-    using Size       = int;
+using AddrLength = int;
+using Size       = int;
 #else
-    using AddrLength = socklen_t;
-    using Size       = std::size_t;
+using AddrLength = socklen_t;
+using Size       = std::size_t;
 #endif
 
-    ////////////////////////////////////////////////////////////
-    /// \brief Create an internal sockaddr_in address
-    ///
-    /// \param address Target address
-    /// \param port    Target port
-    ///
-    /// \return sockaddr_in ready to be used by socket functions
-    ///
-    ////////////////////////////////////////////////////////////
-    static sockaddr_in createAddress(std::uint32_t address, unsigned short port);
+////////////////////////////////////////////////////////////
+/// \brief Create an internal sockaddr_in address
+///
+/// \param address Target address
+/// \param port    Target port
+///
+/// \return sockaddr_in ready to be used by socket functions
+///
+////////////////////////////////////////////////////////////
+sockaddr_in createAddress(std::uint32_t address, unsigned short port);
 
-    ////////////////////////////////////////////////////////////
-    /// \brief Return the value of the invalid socket
-    ///
-    /// \return Special value of the invalid socket
-    ///
-    ////////////////////////////////////////////////////////////
-    static SocketHandle invalidSocket();
+////////////////////////////////////////////////////////////
+/// \brief Create an internal sockaddr_in6 address
+///
+/// \param address Target address
+/// \param port    Target port
+///
+/// \return sockaddr_in6 ready to be used by socket functions
+///
+////////////////////////////////////////////////////////////
+sockaddr_in6 createAddress(std::array<std::uint8_t, 16> address, unsigned short port);
 
-    ////////////////////////////////////////////////////////////
-    /// \brief Close and destroy a socket
-    ///
-    /// \param sock Handle of the socket to close
-    ///
-    ////////////////////////////////////////////////////////////
-    static void close(SocketHandle sock);
+////////////////////////////////////////////////////////////
+/// \brief Return the value of the invalid socket
+///
+/// \return Special value of the invalid socket
+///
+////////////////////////////////////////////////////////////
+SocketHandle invalidSocket();
 
-    ////////////////////////////////////////////////////////////
-    /// \brief Set a socket as blocking or non-blocking
-    ///
-    /// \param sock  Handle of the socket
-    /// \param block New blocking state of the socket
-    ///
-    ////////////////////////////////////////////////////////////
-    static void setBlocking(SocketHandle sock, bool block);
+////////////////////////////////////////////////////////////
+/// \brief Close and destroy a socket
+///
+/// \param sock Handle of the socket to close
+///
+////////////////////////////////////////////////////////////
+void close(SocketHandle sock);
 
-    ////////////////////////////////////////////////////////////
-    /// Get the last socket error status
-    ///
-    /// \return Status corresponding to the last socket error
-    ///
-    ////////////////////////////////////////////////////////////
-    static Socket::Status getErrorStatus();
-};
+////////////////////////////////////////////////////////////
+/// \brief Set a socket as blocking or non-blocking
+///
+/// \param sock  Handle of the socket
+/// \param block New blocking state of the socket
+///
+////////////////////////////////////////////////////////////
+void setBlocking(SocketHandle sock, bool block);
 
-} // namespace sf::priv
+////////////////////////////////////////////////////////////
+/// Get the last socket error status
+///
+/// \return Status corresponding to the last socket error
+///
+////////////////////////////////////////////////////////////
+Socket::Status getErrorStatus();
+
+} // namespace sf::priv::SocketImpl

--- a/src/SFML/Network/TcpListener.cpp
+++ b/src/SFML/Network/TcpListener.cpp
@@ -33,6 +33,8 @@
 
 #include <ostream>
 
+#include <cstring>
+
 
 namespace sf
 {
@@ -48,11 +50,19 @@ unsigned short TcpListener::getLocalPort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the local end of the socket
-        sockaddr_in                  address{};
-        priv::SocketImpl::AddrLength size = sizeof(address);
-        if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+        sockaddr_in6                 addressV6{};
+        priv::SocketImpl::AddrLength size = sizeof(addressV6);
+        if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&addressV6), &size) != -1)
         {
-            return ntohs(address.sin_port);
+            if (addressV6.sin6_family == PF_INET6)
+                return ntohs(addressV6.sin6_port);
+
+            if (addressV6.sin6_family == PF_INET)
+            {
+                sockaddr_in addressV4{};
+                std::memcpy(&addressV4, &addressV6, sizeof(addressV4));
+                return ntohs(addressV4.sin_port);
+            }
         }
     }
 
@@ -67,16 +77,46 @@ Socket::Status TcpListener::listen(unsigned short port, IpAddress address)
     // Close the socket if it is already bound
     close();
 
-    // Create the internal socket if it doesn't exist
-    create();
-
     // Check if the address is valid
     if (address == IpAddress::Broadcast)
         return Status::Error;
 
     // Bind the socket to the specified port
-    sockaddr_in addr = priv::SocketImpl::createAddress(address.toInteger(), port);
-    if (bind(getNativeHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1)
+    sockaddr_in                  addressV4{};
+    sockaddr_in6                 addressV6{};
+    sockaddr*                    sockaddrPtr{};
+    priv::SocketImpl::AddrLength sockaddrSize{};
+
+    if (address.isV4())
+    {
+        addressV4    = priv::SocketImpl::createAddress(address.toInteger(), port);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV4);
+        sockaddrSize = sizeof(addressV4);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV4);
+    }
+    else if (address.isV6())
+    {
+        addressV6    = priv::SocketImpl::createAddress(address.toBytes(), port);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV6);
+        sockaddrSize = sizeof(addressV6);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV6);
+
+        // Disable IPv6 sockets only binding to IPv6 addresses,
+        // i.e. allow them to handle both IPv4 and IPv6 simultaneously
+        int no = 0;
+        if (setsockopt(getNativeHandle(), IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char*>(&no), sizeof(no)) == -1)
+        {
+            err() << "Failed to set socket option \"IPV6_V6ONLY\" ; "
+                  << "IPv6 sockets will only handle IPv6 packets" << std::endl;
+        }
+    }
+
+    // Bind the socket
+    if (::bind(getNativeHandle(), sockaddrPtr, sockaddrSize) == -1)
     {
         // Not likely to happen, but...
         err() << "Failed to bind listener socket to port " << port << std::endl;
@@ -114,7 +154,7 @@ Socket::Status TcpListener::accept(TcpSocket& socket)
     }
 
     // Accept a new connection
-    sockaddr_in                  address{};
+    sockaddr_in6                 address{};
     priv::SocketImpl::AddrLength length = sizeof(address);
     const SocketHandle           remote = ::accept(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &length);
 

--- a/src/SFML/Network/TcpSocket.cpp
+++ b/src/SFML/Network/TcpSocket.cpp
@@ -707,11 +707,19 @@ unsigned short TcpSocket::getLocalPort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the local end of the socket
-        sockaddr_in                  address{};
-        priv::SocketImpl::AddrLength size = sizeof(address);
-        if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+        sockaddr_in6                 addressV6{};
+        priv::SocketImpl::AddrLength size = sizeof(addressV6);
+        if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&addressV6), &size) != -1)
         {
-            return ntohs(address.sin_port);
+            if (addressV6.sin6_family == PF_INET6)
+                return ntohs(addressV6.sin6_port);
+
+            if (addressV6.sin6_family == PF_INET)
+            {
+                sockaddr_in addressV4{};
+                std::memcpy(&addressV4, &addressV6, sizeof(addressV4));
+                return ntohs(addressV4.sin_port);
+            }
         }
     }
 
@@ -725,12 +733,45 @@ std::optional<IpAddress> TcpSocket::getRemoteAddress() const
 {
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
-        // Retrieve information about the remote end of the socket
-        sockaddr_in                  address{};
+        // Get the address family of the socket
+        sockaddr_in6                 address{};
         priv::SocketImpl::AddrLength size = sizeof(address);
-        if (getpeername(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+
+        if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) == -1)
+            return std::nullopt;
+
+        // Retrieve information about the remote end of the socket
+        if (address.sin6_family == PF_INET)
         {
-            return IpAddress(ntohl(address.sin_addr.s_addr));
+            sockaddr_in                  addressV4{};
+            priv::SocketImpl::AddrLength sizeV4 = sizeof(address);
+            if (getpeername(getNativeHandle(), reinterpret_cast<sockaddr*>(&addressV4), &sizeV4) != -1)
+                return IpAddress(ntohl(addressV4.sin_addr.s_addr));
+        }
+        else if (address.sin6_family == PF_INET6)
+        {
+            sockaddr_in6                 addressV6{};
+            priv::SocketImpl::AddrLength sizeV6 = sizeof(addressV6);
+            if (getpeername(getNativeHandle(), reinterpret_cast<sockaddr*>(&addressV6), &sizeV6) != -1)
+            {
+                return IpAddress(
+                    {addressV6.sin6_addr.s6_addr[0],
+                     addressV6.sin6_addr.s6_addr[1],
+                     addressV6.sin6_addr.s6_addr[2],
+                     addressV6.sin6_addr.s6_addr[3],
+                     addressV6.sin6_addr.s6_addr[4],
+                     addressV6.sin6_addr.s6_addr[5],
+                     addressV6.sin6_addr.s6_addr[6],
+                     addressV6.sin6_addr.s6_addr[7],
+                     addressV6.sin6_addr.s6_addr[8],
+                     addressV6.sin6_addr.s6_addr[9],
+                     addressV6.sin6_addr.s6_addr[10],
+                     addressV6.sin6_addr.s6_addr[11],
+                     addressV6.sin6_addr.s6_addr[12],
+                     addressV6.sin6_addr.s6_addr[13],
+                     addressV6.sin6_addr.s6_addr[14],
+                     addressV6.sin6_addr.s6_addr[15]});
+            }
         }
     }
 
@@ -745,11 +786,19 @@ unsigned short TcpSocket::getRemotePort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the remote end of the socket
-        sockaddr_in                  address{};
-        priv::SocketImpl::AddrLength size = sizeof(address);
-        if (getpeername(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+        sockaddr_in6                 addressV6{};
+        priv::SocketImpl::AddrLength size = sizeof(addressV6);
+        if (getpeername(getNativeHandle(), reinterpret_cast<sockaddr*>(&addressV6), &size) != -1)
         {
-            return ntohs(address.sin_port);
+            if (addressV6.sin6_family == PF_INET6)
+                return ntohs(addressV6.sin6_port);
+
+            if (addressV6.sin6_family == PF_INET)
+            {
+                sockaddr_in addressV4{};
+                std::memcpy(&addressV4, &addressV6, sizeof(addressV4));
+                return ntohs(addressV4.sin_port);
+            }
         }
     }
 
@@ -764,18 +813,39 @@ Socket::Status TcpSocket::connect(IpAddress remoteAddress, unsigned short remote
     // Disconnect the socket if it is already connected
     disconnect();
 
-    // Create the internal socket if it doesn't exist
-    create();
-
     // Create the remote address
-    sockaddr_in address = priv::SocketImpl::createAddress(remoteAddress.toInteger(), remotePort);
+    sockaddr_in                  addressV4{};
+    sockaddr_in6                 addressV6{};
+    sockaddr*                    sockaddrPtr{};
+    priv::SocketImpl::AddrLength sockaddrSize{};
+
+    if (remoteAddress.isV4())
+    {
+        addressV4    = priv::SocketImpl::createAddress(remoteAddress.toInteger(), remotePort);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV4);
+        sockaddrSize = sizeof(addressV4);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV4);
+    }
+    else if (remoteAddress.isV6())
+    {
+        addressV6    = priv::SocketImpl::createAddress(remoteAddress.toBytes(), remotePort);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV6);
+        sockaddrSize = sizeof(addressV6);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV6);
+    }
+
+    assert(sockaddrPtr && sockaddrSize);
 
     if (timeout <= Time::Zero)
     {
         // ----- We're not using a timeout: just try to connect -----
 
         // Connect the socket
-        if (::connect(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) == -1)
+        if (::connect(getNativeHandle(), sockaddrPtr, sockaddrSize) == -1)
             return priv::SocketImpl::getErrorStatus();
 
         // Connection succeeded
@@ -792,7 +862,7 @@ Socket::Status TcpSocket::connect(IpAddress remoteAddress, unsigned short remote
         setBlocking(false);
 
     // Try to connect to the remote address
-    if (::connect(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), sizeof(address)) >= 0)
+    if (::connect(getNativeHandle(), sockaddrPtr, sockaddrSize) >= 0)
     {
         // We got instantly connected! (it may no happen a lot...)
         setBlocking(blocking);

--- a/src/SFML/Network/UdpSocket.cpp
+++ b/src/SFML/Network/UdpSocket.cpp
@@ -35,6 +35,7 @@
 #include <ostream>
 
 #include <cstddef>
+#include <cstring>
 
 
 namespace sf
@@ -51,11 +52,28 @@ unsigned short UdpSocket::getLocalPort() const
     if (getNativeHandle() != priv::SocketImpl::invalidSocket())
     {
         // Retrieve information about the local end of the socket
-        sockaddr_in                  address{};
-        priv::SocketImpl::AddrLength size = sizeof(address);
-        if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+        // We try first using sockaddr_in6 since it is the bigger structure
+        // If the sin6_family field indicates we have an IPv4 socket retry with sockaddr_in
         {
-            return ntohs(address.sin_port);
+            sockaddr_in6                 address{};
+            priv::SocketImpl::AddrLength size = sizeof(address);
+            if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+            {
+                if (address.sin6_family == PF_INET6)
+                    return ntohs(address.sin6_port);
+
+                // Give up if the socket isn't IPv4 either
+                if (address.sin6_family != PF_INET)
+                    return 0;
+            }
+        }
+
+        // Retry for IPv4
+        {
+            sockaddr_in                  address{};
+            priv::SocketImpl::AddrLength size = sizeof(address);
+            if (getsockname(getNativeHandle(), reinterpret_cast<sockaddr*>(&address), &size) != -1)
+                return ntohs(address.sin_port);
         }
     }
 
@@ -70,16 +88,46 @@ Socket::Status UdpSocket::bind(unsigned short port, IpAddress address)
     // Close the socket if it is already bound
     close();
 
-    // Create the internal socket if it doesn't exist
-    create();
-
     // Check if the address is valid
     if (address == IpAddress::Broadcast)
         return Status::Error;
 
+    // Create the remote address
+    sockaddr_in                  addressV4{};
+    sockaddr_in6                 addressV6{};
+    sockaddr*                    sockaddrPtr{};
+    priv::SocketImpl::AddrLength sockaddrSize{};
+
+    if (address.isV4())
+    {
+        addressV4    = priv::SocketImpl::createAddress(address.toInteger(), port);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV4);
+        sockaddrSize = sizeof(addressV4);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV4);
+    }
+    else if (address.isV6())
+    {
+        addressV6    = priv::SocketImpl::createAddress(address.toBytes(), port);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV6);
+        sockaddrSize = sizeof(addressV6);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV6);
+
+        // Disable IPv6 sockets only binding to IPv6 addresses,
+        // i.e. allow them to handle both IPv4 and IPv6 simultaneously
+        int no = 0;
+        if (setsockopt(getNativeHandle(), IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char*>(&no), sizeof(no)) == -1)
+        {
+            err() << "Failed to set socket option \"IPV6_V6ONLY\" ; "
+                  << "IPv6 sockets will only handle IPv6 packets" << std::endl;
+        }
+    }
+
     // Bind the socket
-    sockaddr_in addr = priv::SocketImpl::createAddress(address.toInteger(), port);
-    if (::bind(getNativeHandle(), reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1)
+    if (::bind(getNativeHandle(), sockaddrPtr, sockaddrSize) == -1)
     {
         err() << "Failed to bind socket to port " << port << std::endl;
         return Status::Error;
@@ -100,9 +148,6 @@ void UdpSocket::unbind()
 ////////////////////////////////////////////////////////////
 Socket::Status UdpSocket::send(const void* data, std::size_t size, IpAddress remoteAddress, unsigned short remotePort)
 {
-    // Create the internal socket if it doesn't exist
-    create();
-
     // Make sure that all the data will fit in one datagram
     if (size > MaxDatagramSize)
     {
@@ -111,8 +156,30 @@ Socket::Status UdpSocket::send(const void* data, std::size_t size, IpAddress rem
         return Status::Error;
     }
 
-    // Build the target address
-    sockaddr_in address = priv::SocketImpl::createAddress(remoteAddress.toInteger(), remotePort);
+    // Create the remote address
+    sockaddr_in                  addressV4{};
+    sockaddr_in6                 addressV6{};
+    sockaddr*                    sockaddrPtr{};
+    priv::SocketImpl::AddrLength sockaddrSize{};
+
+    if (remoteAddress.isV4())
+    {
+        addressV4    = priv::SocketImpl::createAddress(remoteAddress.toInteger(), remotePort);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV4);
+        sockaddrSize = sizeof(addressV4);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV4);
+    }
+    else if (remoteAddress.isV6())
+    {
+        addressV6    = priv::SocketImpl::createAddress(remoteAddress.toBytes(), remotePort);
+        sockaddrPtr  = reinterpret_cast<sockaddr*>(&addressV6);
+        sockaddrSize = sizeof(addressV6);
+
+        // Create the internal socket if it doesn't exist
+        create(IpAddress::Type::IpV6);
+    }
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuseless-cast"
@@ -122,8 +189,8 @@ Socket::Status UdpSocket::send(const void* data, std::size_t size, IpAddress rem
                static_cast<const char*>(data),
                static_cast<priv::SocketImpl::Size>(size),
                0,
-               reinterpret_cast<sockaddr*>(&address),
-               sizeof(address)));
+               sockaddrPtr,
+               sockaddrSize));
 #pragma GCC diagnostic pop
 
     // Check for errors
@@ -154,7 +221,7 @@ Socket::Status UdpSocket::receive(void*                     data,
     }
 
     // Data that will be filled with the other computer's address
-    sockaddr_in address = priv::SocketImpl::createAddress(INADDR_ANY, 0);
+    sockaddr_in6 address{};
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuseless-cast"
@@ -174,9 +241,36 @@ Socket::Status UdpSocket::receive(void*                     data,
         return priv::SocketImpl::getErrorStatus();
 
     // Fill the sender information
-    received      = static_cast<std::size_t>(sizeReceived);
-    remoteAddress = IpAddress(ntohl(address.sin_addr.s_addr));
-    remotePort    = ntohs(address.sin_port);
+    received = static_cast<std::size_t>(sizeReceived);
+
+    if (address.sin6_family == PF_INET6)
+    {
+        remoteAddress = IpAddress(
+            {address.sin6_addr.s6_addr[0],
+             address.sin6_addr.s6_addr[1],
+             address.sin6_addr.s6_addr[2],
+             address.sin6_addr.s6_addr[3],
+             address.sin6_addr.s6_addr[4],
+             address.sin6_addr.s6_addr[5],
+             address.sin6_addr.s6_addr[6],
+             address.sin6_addr.s6_addr[7],
+             address.sin6_addr.s6_addr[8],
+             address.sin6_addr.s6_addr[9],
+             address.sin6_addr.s6_addr[10],
+             address.sin6_addr.s6_addr[11],
+             address.sin6_addr.s6_addr[12],
+             address.sin6_addr.s6_addr[13],
+             address.sin6_addr.s6_addr[14],
+             address.sin6_addr.s6_addr[15]});
+        remotePort = ntohs(address.sin6_port);
+    }
+    else if (address.sin6_family == PF_INET)
+    {
+        sockaddr_in addressV4{};
+        std::memcpy(&addressV4, &address, sizeof(addressV4));
+        remoteAddress = IpAddress(ntohl(addressV4.sin_addr.s_addr));
+        remotePort    = ntohs(addressV4.sin_port);
+    }
 
     return Status::Done;
 }

--- a/src/SFML/Network/Unix/SocketImpl.cpp
+++ b/src/SFML/Network/Unix/SocketImpl.cpp
@@ -33,6 +33,7 @@
 #include <ostream>
 
 #include <cerrno>
+#include <cstring>
 
 
 namespace sf::priv
@@ -47,6 +48,23 @@ sockaddr_in SocketImpl::createAddress(std::uint32_t address, unsigned short port
 
 #if defined(SFML_SYSTEM_MACOS)
     addr.sin_len = sizeof(addr);
+#endif
+
+    return addr;
+}
+
+
+////////////////////////////////////////////////////////////
+sockaddr_in6 SocketImpl::createAddress(std::array<std::uint8_t, 16> address, unsigned short port)
+{
+    auto addr = sockaddr_in6();
+    static_assert(sizeof(addr.sin6_addr.s6_addr) == sizeof(address));
+    std::memcpy(addr.sin6_addr.s6_addr, address.data(), address.size());
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port   = htons(port);
+
+#if defined(SFML_SYSTEM_MACOS)
+    addr.sin6_len = sizeof(addr);
 #endif
 
     return addr;

--- a/src/SFML/Network/Win32/SocketImpl.cpp
+++ b/src/SFML/Network/Win32/SocketImpl.cpp
@@ -28,6 +28,7 @@
 #include <SFML/Network/SocketImpl.hpp>
 
 #include <cstdint>
+#include <cstring>
 
 
 namespace
@@ -62,6 +63,19 @@ sockaddr_in SocketImpl::createAddress(std::uint32_t address, unsigned short port
     addr.sin_addr.s_addr = htonl(address);
     addr.sin_family      = AF_INET;
     addr.sin_port        = htons(port);
+
+    return addr;
+}
+
+
+////////////////////////////////////////////////////////////
+sockaddr_in6 SocketImpl::createAddress(std::array<std::uint8_t, 16> address, unsigned short port)
+{
+    auto addr = sockaddr_in6();
+    static_assert(sizeof(addr.sin6_addr.s6_addr) == sizeof(address));
+    std::memcpy(addr.sin6_addr.s6_addr, address.data(), address.size());
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port   = htons(port);
 
     return addr;
 }

--- a/src/SFML/System/Win32/WindowsHeader.hpp
+++ b/src/SFML/System/Win32/WindowsHeader.hpp
@@ -33,15 +33,15 @@
 #endif
 
 #ifndef _WIN32_WINDOWS
-#define _WIN32_WINDOWS 0x0501 // NOLINT(bugprone-reserved-identifier)
+#define _WIN32_WINDOWS 0x0601 // NOLINT(bugprone-reserved-identifier) Windows 7
 #endif
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x0601 // Windows 7
 #endif
 
 #ifndef WINVER
-#define WINVER 0x0501
+#define WINVER 0x0601 // Windows 7
 #endif
 
 #ifndef UNICODE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(sfml-test-main STATIC
     TestUtilities/AudioUtil.cpp
 )
 target_include_directories(sfml-test-main PUBLIC TestUtilities)
-target_link_libraries(sfml-test-main PUBLIC SFML::System)
+target_link_libraries(sfml-test-main PUBLIC SFML::Network SFML::System)
 
 # Main is required on some platforms and is completely removed on others, so we can only depend on it when it exists
 if(TARGET SFML::Main)
@@ -47,19 +47,38 @@ sfml_set_stdlib(Catch2)
 sfml_set_stdlib(Catch2WithMain)
 sfml_set_stdlib(sfml-test-main)
 
-sfml_set_option(SFML_RUN_DISPLAY_TESTS ON BOOL "ON to run tests that require a display, OFF to ignore it")
+sfml_set_option(SFML_RUN_DISPLAY_TESTS ON BOOL "ON to run tests that require a display, OFF to ignore them")
 if(SFML_RUN_DISPLAY_TESTS)
     target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_DISPLAY_TESTS)
 endif()
 
-sfml_set_option(SFML_RUN_AUDIO_DEVICE_TESTS ON BOOL "ON to run tests that require an audio device, OFF to ignore it")
+sfml_set_option(SFML_RUN_AUDIO_DEVICE_TESTS ON BOOL "ON to run tests that require an audio device, OFF to ignore them")
 if(SFML_RUN_AUDIO_DEVICE_TESTS)
     target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_AUDIO_DEVICE_TESTS)
 endif()
 
 if(NOT SFML_OS_IOS)
-    target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_CONNECTION_TESTS)
     target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_LOOPBACK_TESTS)
+endif()
+
+sfml_set_option(SFML_RUN_IPV4_LINK_TESTS ON BOOL "ON to run tests that require an IPv4 link to be available, OFF to ignore them")
+if(SFML_RUN_IPV4_LINK_TESTS)
+    target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_IPV4_LINK_TESTS)
+endif()
+
+sfml_set_option(SFML_RUN_IPV4_INTERNET_TESTS OFF BOOL "ON to run tests that require an IPv4 route to the internet to be available, OFF to ignore them")
+if(SFML_RUN_IPV4_INTERNET_TESTS)
+    target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_IPV4_INTERNET_TESTS)
+endif()
+
+sfml_set_option(SFML_RUN_IPV6_LINK_TESTS OFF BOOL "ON to run tests that require an IPv6 link to be available, OFF to ignore them")
+if(SFML_RUN_IPV6_LINK_TESTS)
+    target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_IPV6_LINK_TESTS)
+endif()
+
+sfml_set_option(SFML_RUN_IPV6_INTERNET_TESTS OFF BOOL "ON to run tests that require an IPv6 route to the internet to be available, OFF to ignore them")
+if(SFML_RUN_IPV6_INTERNET_TESTS)
+    target_compile_definitions(sfml-test-main PRIVATE SFML_RUN_IPV6_INTERNET_TESTS)
 endif()
 
 add_subdirectory(Audio)

--- a/test/Network/CMakeLists.txt
+++ b/test/Network/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(NETWORK_SRC
+    Dns.test.cpp
     Ftp.test.cpp
     Http.test.cpp
     IpAddress.test.cpp
@@ -11,3 +12,6 @@ set(NETWORK_SRC
     UdpSocket.test.cpp
 )
 sfml_add_test(test-sfml-network "${NETWORK_SRC}" SFML::Network)
+if(SFML_RUN_IP_DISCOVERY_TESTS)
+    target_compile_definitions(test-sfml-network PRIVATE SFML_RUN_IP_DISCOVERY_TESTS)
+endif()

--- a/test/Network/Dns.test.cpp
+++ b/test/Network/Dns.test.cpp
@@ -1,0 +1,250 @@
+#include <SFML/Network/Dns.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <NetworkUtil.hpp>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+TEST_CASE("[Network] sf::Dns (IPv4)", runIpV4InternetTests())
+{
+    SECTION("Well known hosts")
+    {
+        const auto addresses = resolveV4("localhost");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() == sf::IpAddress::LocalHost);
+    }
+
+    SECTION("IP address strings")
+    {
+        const auto addresses = resolveV4("123.123.123.123");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() == sf::IpAddress(123, 123, 123, 123));
+    }
+
+    SECTION("www.sfml-dev.org")
+    {
+        const auto addresses = resolveV4("www.sfml-dev.org");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::Any);
+        CHECK(addresses.front() != sf::IpAddress::LocalHost);
+        CHECK(addresses.front() != sf::IpAddress::Broadcast);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("ci.sfml-dev.org")
+    {
+        const auto addresses = resolveV4("ci.sfml-dev.org");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::Any);
+        CHECK(addresses.front() != sf::IpAddress::LocalHost);
+        CHECK(addresses.front() != sf::IpAddress::Broadcast);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("microsoft.com")
+    {
+        const auto addresses = resolveV4("microsoft.com");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::Any);
+        CHECK(addresses.front() != sf::IpAddress::LocalHost);
+        CHECK(addresses.front() != sf::IpAddress::Broadcast);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("github.com")
+    {
+        const auto addresses = resolveV4("github.com");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::Any);
+        CHECK(addresses.front() != sf::IpAddress::LocalHost);
+        CHECK(addresses.front() != sf::IpAddress::Broadcast);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("google.com")
+    {
+        const auto addresses = resolveV4("google.com");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::Any);
+        CHECK(addresses.front() != sf::IpAddress::LocalHost);
+        CHECK(addresses.front() != sf::IpAddress::Broadcast);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("Public IP address")
+    {
+        const std::optional<sf::IpAddress> ipAddress = sf::Dns::getPublicAddress(sf::seconds(1), sf::IpAddress::Type::IpV4);
+        REQUIRE(ipAddress.has_value());
+        CHECK(ipAddress->isV4());
+        CHECK_FALSE(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "0.0.0.0");
+        CHECK(ipAddress->toInteger() != 0);
+    }
+}
+
+TEST_CASE("[Network] sf::Dns (IPv6)", runIpV6InternetTests())
+{
+    SECTION("Well known hosts")
+    {
+        // Some systems only provide an IPv6 address for ip6-localhost
+        // Try to resolve both localhost and ip6-localhost and check if one is successful
+        const auto addresses0 = resolveV6("localhost");
+        const auto addresses1 = resolveV6("ip6-localhost");
+        REQUIRE((!addresses0.empty() || !addresses1.empty()));
+        if (!addresses0.empty())
+            CHECK(addresses0.front() == sf::IpAddress::LocalHostV6);
+        if (!addresses1.empty())
+            CHECK(addresses1.front() == sf::IpAddress::LocalHostV6);
+    }
+
+    SECTION("IP address strings")
+    {
+        const auto addresses = resolveV6("0001:0203:0405:0607:0809:0A0B:0C0D:0E0F");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() ==
+              sf::IpAddress(
+                  {static_cast<std::uint8_t>(0x0),
+                   static_cast<std::uint8_t>(0x1),
+                   static_cast<std::uint8_t>(0x2),
+                   static_cast<std::uint8_t>(0x3),
+                   static_cast<std::uint8_t>(0x4),
+                   static_cast<std::uint8_t>(0x5),
+                   static_cast<std::uint8_t>(0x6),
+                   static_cast<std::uint8_t>(0x7),
+                   static_cast<std::uint8_t>(0x8),
+                   static_cast<std::uint8_t>(0x9),
+                   static_cast<std::uint8_t>(0xA),
+                   static_cast<std::uint8_t>(0xB),
+                   static_cast<std::uint8_t>(0xC),
+                   static_cast<std::uint8_t>(0xD),
+                   static_cast<std::uint8_t>(0xE),
+                   static_cast<std::uint8_t>(0xF)}));
+    }
+
+    SECTION("www.sfml-dev.org")
+    {
+        const auto addresses = resolveV6("www.sfml-dev.org");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::AnyV6);
+        CHECK(addresses.front() != sf::IpAddress::LocalHostV6);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("ci.sfml-dev.org")
+    {
+        const auto addresses = resolveV6("ci.sfml-dev.org");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::AnyV6);
+        CHECK(addresses.front() != sf::IpAddress::LocalHostV6);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("microsoft.com")
+    {
+        const auto addresses = resolveV6("microsoft.com");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::AnyV6);
+        CHECK(addresses.front() != sf::IpAddress::LocalHostV6);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("github.com")
+    {
+        // GitHub currently does not have IPv6 address records
+    }
+
+    SECTION("google.com")
+    {
+        const auto addresses = resolveV6("google.com");
+        REQUIRE_FALSE(addresses.empty());
+        CHECK(addresses.front() != sf::IpAddress::AnyV6);
+        CHECK(addresses.front() != sf::IpAddress::LocalHostV6);
+        CHECK_FALSE(addresses.front().toString().empty());
+    }
+
+    SECTION("Public IP address")
+    {
+        const std::optional<sf::IpAddress> ipAddress = sf::Dns::getPublicAddress(sf::seconds(1), sf::IpAddress::Type::IpV6);
+        REQUIRE(ipAddress.has_value());
+        CHECK_FALSE(ipAddress->isV4());
+        CHECK(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "::");
+        CHECK(ipAddress->toBytes() !=
+              std::array<std::uint8_t,
+                         16>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    }
+}
+
+TEST_CASE("[Network] sf::Dns (Advanced Queries)", runDnsTestsAdvanced())
+{
+    SECTION("NS records")
+    {
+        const auto records = sf::Dns::queryNs("sfml-dev.org");
+        REQUIRE_FALSE(records.empty());
+        CHECK_FALSE(records.empty());
+    }
+
+    SECTION("MX records")
+    {
+        const auto records = sf::Dns::queryMx("sfml-dev.org");
+        REQUIRE_FALSE(records.empty());
+        CHECK_FALSE(records.front().exchange.isEmpty());
+        CHECK(records.front().preference != 0);
+    }
+
+    SECTION("SRV records")
+    {
+        SECTION("_irc._tcp.sfml-dev.org")
+        {
+            const auto records = sf::Dns::querySrv("_irc._tcp.sfml-dev.org");
+            REQUIRE(records.size() == 1);
+            CHECK(records.front().target == "irc.sfml-dev.org");
+            CHECK(records.front().port == 6667);
+            CHECK(records.front().weight == 5);
+            CHECK(records.front().priority == 10);
+        }
+
+        SECTION("_ircs._tcp.sfml-dev.org")
+        {
+            const auto records = sf::Dns::querySrv("_ircs._tcp.sfml-dev.org");
+            REQUIRE(records.size() == 1);
+            CHECK(records.front().target == "irc.sfml-dev.org");
+            CHECK(records.front().port == 6697);
+            CHECK(records.front().weight == 5);
+            CHECK(records.front().priority == 5);
+        }
+    }
+
+    SECTION("TXT records")
+    {
+        SECTION("sfml-dev.org")
+        {
+            const auto records = sf::Dns::queryTxt("sfml-dev.org");
+            REQUIRE_FALSE(records.empty());
+            REQUIRE_FALSE(records.front().empty());
+            CHECK_FALSE(records.front().front().isEmpty());
+        }
+
+        SECTION("test-txt-short.sfml-dev.org")
+        {
+            const auto records = sf::Dns::queryTxt("test-txt-short.sfml-dev.org");
+            REQUIRE(records.size() == 1);
+            REQUIRE(records.front().size() == 1);
+            CHECK(records.front().front() == "AAAAAAAAAA");
+        }
+
+        SECTION("test-txt-long.sfml-dev.org")
+        {
+            const auto records = sf::Dns::queryTxt("test-txt-long.sfml-dev.org");
+            REQUIRE(records.size() == 1);
+            REQUIRE(records.front().size() == 2);
+            CHECK(records.front()[0] ==
+                  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+            CHECK(records.front()[1] == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        }
+    }
+}

--- a/test/Network/Http.test.cpp
+++ b/test/Network/Http.test.cpp
@@ -73,7 +73,7 @@ TEST_CASE("[Network] sf::Http")
     }
 }
 
-TEST_CASE("[Network] sf::Http Connection", runConnectionTests())
+TEST_CASE("[Network] sf::Http Connection", runIpV4InternetTests())
 {
     SECTION("HTTP Connection")
     {
@@ -92,22 +92,21 @@ TEST_CASE("[Network] sf::Http Connection", runConnectionTests())
 
         SECTION("Request Resource")
         {
-            const sf::Http::Response response = http.sendRequest(sf::Http::Request("SFML/SFML"), sf::milliseconds(1000));
+            const sf::Http::Response response = http.sendRequest(sf::Http::Request("sitemap"), sf::milliseconds(1000));
             const sf::Http::Response::Status status = response.getStatus();
 
             CHECK_FALSE(response.getMajorHttpVersion() == 0);
             CHECK(status == sf::Http::Response::Status::MovedPermanently);
-            CHECK(response.getField("Location") == "https://github.com/SFML/SFML");
-            CHECK(response.getField("location") == "https://github.com/SFML/SFML");
+            CHECK(response.getField("Location") == "https://github.com/sitemap");
+            CHECK(response.getField("location") == "https://github.com/sitemap");
         }
     }
 
     SECTION("HTTPS Connection")
     {
-        sf::Http http("https://github.com");
-
         SECTION("Request Index")
         {
+            const sf::Http                   http("https://github.com");
             const sf::Http::Response         response = http.sendRequest(sf::Http::Request{}, sf::milliseconds(1000));
             const sf::Http::Response::Status status   = response.getStatus();
 
@@ -122,23 +121,27 @@ TEST_CASE("[Network] sf::Http Connection", runConnectionTests())
 
         SECTION("Request Resource")
         {
-            const sf::Http::Response response = http.sendRequest(sf::Http::Request("SFML/SFML"), sf::milliseconds(1000));
+            const sf::Http           http("https://github.com");
+            const sf::Http::Response response = http.sendRequest(sf::Http::Request("sitemap"), sf::milliseconds(1000));
             const sf::Http::Response::Status status = response.getStatus();
 
             CHECK_FALSE(response.getMajorHttpVersion() == 0);
             CHECK(status == sf::Http::Response::Status::Ok);
             CHECK_FALSE(response.getField("Server").empty());
             CHECK_FALSE(response.getField("server").empty());
-            CHECK_FALSE(response.getField("Content-Type").empty());
-            CHECK_FALSE(response.getField("content-type").empty());
-            CHECK_FALSE(response.getBody().find("SFML") == std::string::npos);
+            CHECK_FALSE(response.getField("Content-Type").find("text/html") == std::string::npos);
+            CHECK_FALSE(response.getField("content-type").find("text/html") == std::string::npos);
+            CHECK(response.getField("Accept-Ranges") == "bytes");
+            CHECK(response.getField("accept-ranges") == "bytes");
+            CHECK_FALSE(response.getBody().find("GitHub") == std::string::npos);
         }
 
         SECTION("Request Non-Existant Resource")
         {
-            const sf::Http::Response response = http.sendRequest(sf::Http::Request("SFML/REPOSITORYTHATDOESNOTEXIST"),
+            const sf::Http                   http("https://github.com");
+            const sf::Http::Response         response = http.sendRequest(sf::Http::Request("RESOURCETHATDOESNOTEXIST"),
                                                                  sf::milliseconds(1000));
-            const sf::Http::Response::Status status = response.getStatus();
+            const sf::Http::Response::Status status   = response.getStatus();
 
             CHECK_FALSE(response.getMajorHttpVersion() == 0);
             CHECK(status == sf::Http::Response::Status::NotFound);
@@ -148,21 +151,21 @@ TEST_CASE("[Network] sf::Http Connection", runConnectionTests())
 
         SECTION("HEAD Request")
         {
-            http.setHost("https://codeload.github.com");
-
-            sf::Http::Request request("SFML/SFML/zip/refs/heads/master", sf::Http::Request::Method::Head);
+            const sf::Http    http("https://github.com");
+            sf::Http::Request request("/", sf::Http::Request::Method::Head);
             request.setHttpVersion(1, 1);
 
             const sf::Http::Response         response = http.sendRequest(request, sf::milliseconds(1000));
             const sf::Http::Response::Status status   = response.getStatus();
 
-            CHECK(response.getMajorHttpVersion() == 1);
-            CHECK(response.getMinorHttpVersion() == 1);
+            CHECK_FALSE(response.getMajorHttpVersion() == 0);
             CHECK(status == sf::Http::Response::Status::Ok);
-            CHECK(response.getField("Content-Type") == "application/zip");
-            CHECK(response.getField("content-type") == "application/zip");
-            CHECK_FALSE(response.getField("Content-Disposition").find("SFML-master.zip") == std::string::npos);
-            CHECK_FALSE(response.getField("content-disposition").find("SFML-master.zip") == std::string::npos);
+            CHECK_FALSE(response.getField("Server").empty());
+            CHECK_FALSE(response.getField("server").empty());
+            CHECK_FALSE(response.getField("Content-Type").find("text/html") == std::string::npos);
+            CHECK_FALSE(response.getField("content-type").find("text/html") == std::string::npos);
+            CHECK(response.getField("Accept-Ranges") == "bytes");
+            CHECK(response.getField("accept-ranges") == "bytes");
         }
     }
 }

--- a/test/Network/IpAddress.test.cpp
+++ b/test/Network/IpAddress.test.cpp
@@ -2,9 +2,17 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <NetworkUtil.hpp>
 #include <sstream>
 #include <string_view>
 #include <type_traits>
+
+// Allow testing deprecated functions
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)
+#else
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 using namespace std::string_literals;
 using namespace std::string_view_literals;
@@ -20,9 +28,9 @@ TEST_CASE("[Network] sf::IpAddress")
         STATIC_CHECK(std::is_trivially_copyable_v<sf::IpAddress>);
     }
 
-    SECTION("Construction")
+    SECTION("Backwards compatibility")
     {
-        SECTION("static 'create' function")
+        SECTION("static 'resolve' function")
         {
             const auto ipAddress = sf::IpAddress::resolve("203.0.113.2"sv);
             REQUIRE(ipAddress.has_value());
@@ -50,144 +58,514 @@ TEST_CASE("[Network] sf::IpAddress")
             CHECK(localHost->toInteger() == 0x7F'00'00'01);
             CHECK(*localHost == sf::IpAddress::LocalHost);
 
-            CHECK(!sf::IpAddress::resolve("255.255.255.256"s).has_value());
-            CHECK(!sf::IpAddress::resolve("").has_value());
+            CHECK_FALSE(sf::IpAddress::resolve("255.255.255.256"s).has_value());
+            CHECK_FALSE(sf::IpAddress::resolve("").has_value());
         }
 
-        SECTION("Byte constructor")
+        SECTION("Constants")
         {
-            const sf::IpAddress ipAddress(198, 51, 100, 234);
-            CHECK(ipAddress.toString() == "198.51.100.234"s);
-            CHECK(ipAddress.toInteger() == 0xC6'33'64'EA);
-        }
-
-        SECTION("std::uint32_t constructor")
-        {
-            const sf::IpAddress ipAddress(0xCB'00'71'9A);
-            CHECK(ipAddress.toString() == "203.0.113.154"s);
-            CHECK(ipAddress.toInteger() == 0xCB'00'71'9A);
+            CHECK(sf::IpAddress::Any == sf::IpAddress::AnyV4);
+            CHECK(sf::IpAddress::LocalHost == sf::IpAddress::LocalHostV4);
+            CHECK(sf::IpAddress::Broadcast == sf::IpAddress::BroadcastV4);
         }
     }
 
-    SECTION("Static functions")
+    SECTION("Construction")
     {
-        // These functions require external network access to work thus imposing an additional
-        // requirement on our test suite of internet access. This causes issues for developers
-        // trying to work offline and for package managers who may be building and running the
-        // tests offline as well.
-        (void)[]
+        SECTION("IPv4")
         {
-            const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getLocalAddress();
-            REQUIRE(ipAddress.has_value());
-            CHECK(ipAddress->toString() != "0.0.0.0");
-            CHECK(ipAddress->toInteger() != 0);
-        };
-
-        (void)[]
-        {
-            const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getPublicAddress(sf::seconds(1));
-            if (ipAddress.has_value())
+            SECTION("static 'fromString' function")
             {
-                CHECK(ipAddress->toString() != "0.0.0.0");
-                CHECK(ipAddress->toInteger() != 0);
+                const auto ipAddress = sf::IpAddress::fromString("203.0.113.2"sv);
+                REQUIRE(ipAddress.has_value());
+                CHECK(ipAddress->isV4());
+                CHECK_FALSE(ipAddress->isV6());
+                CHECK(ipAddress->toString() == "203.0.113.2"s);
+                CHECK(ipAddress->toInteger() == 0xCB'00'71'02);
+                CHECK(*ipAddress != sf::IpAddress::AnyV4);
+                CHECK(*ipAddress != sf::IpAddress::BroadcastV4);
+                CHECK(*ipAddress != sf::IpAddress::LocalHostV4);
+
+                const auto broadcast = sf::IpAddress::fromString("255.255.255.255"sv);
+                REQUIRE(broadcast.has_value());
+                CHECK(broadcast->isV4());
+                CHECK_FALSE(broadcast->isV6());
+                CHECK(broadcast->toString() == "255.255.255.255"s);
+                CHECK(broadcast->toInteger() == 0xFF'FF'FF'FF);
+                CHECK(*broadcast == sf::IpAddress::BroadcastV4);
+
+                const auto any = sf::IpAddress::fromString("0.0.0.0"sv);
+                REQUIRE(any.has_value());
+                CHECK(any->isV4());
+                CHECK_FALSE(any->isV6());
+                CHECK(any->toString() == "0.0.0.0"s);
+                CHECK(any->toInteger() == 0x00'00'00'00);
+                CHECK(*any == sf::IpAddress::Any);
+
+                CHECK_FALSE(sf::IpAddress::fromString("255.255.255.256"s).has_value());
+                CHECK_FALSE(sf::IpAddress::fromString("").has_value());
             }
-        };
+
+            SECTION("Byte constructor")
+            {
+                const sf::IpAddress ipAddress(198, 51, 100, 234);
+                CHECK(ipAddress.isV4());
+                CHECK_FALSE(ipAddress.isV6());
+                CHECK(ipAddress.toString() == "198.51.100.234"s);
+                CHECK(ipAddress.toInteger() == 0xC6'33'64'EA);
+            }
+
+            SECTION("std::uint32_t constructor")
+            {
+                const sf::IpAddress ipAddress(0xCB'00'71'9A);
+                CHECK(ipAddress.isV4());
+                CHECK_FALSE(ipAddress.isV6());
+                CHECK(ipAddress.toString() == "203.0.113.154"s);
+                CHECK(ipAddress.toInteger() == 0xCB'00'71'9A);
+            }
+        }
+
+        SECTION("IPv6")
+        {
+            SECTION("static 'fromString' function")
+            {
+                const auto ipAddress = sf::IpAddress::fromString("2600:1901:0:13e0::1"sv);
+                REQUIRE(ipAddress.has_value());
+                CHECK_FALSE(ipAddress->isV4());
+                CHECK(ipAddress->isV6());
+                CHECK(ipAddress->toString() == "2600:1901:0:13e0::1"s);
+                CHECK(ipAddress->toBytes() ==
+                      std::array<std::uint8_t,
+                                 16>{0x26, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
+                CHECK(*ipAddress != sf::IpAddress::AnyV6);
+                CHECK(*ipAddress != sf::IpAddress::LocalHostV6);
+
+                const auto any = sf::IpAddress::fromString("::"sv);
+                REQUIRE(any.has_value());
+                CHECK_FALSE(any->isV4());
+                CHECK(any->isV6());
+                CHECK(any->toString() == "::"s);
+                CHECK(any->toBytes() ==
+                      std::array<std::uint8_t,
+                                 16>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+                CHECK(*any == sf::IpAddress::AnyV6);
+
+                CHECK_FALSE(sf::IpAddress::fromString("1:::1"s).has_value());
+                CHECK_FALSE(sf::IpAddress::fromString("1:1"s).has_value());
+                CHECK_FALSE(sf::IpAddress::fromString("1::1::1"s).has_value());
+                CHECK_FALSE(sf::IpAddress::fromString("ghij:klmn:opqr:stuv::wxzy"s).has_value());
+                CHECK_FALSE(sf::IpAddress::fromString("").has_value());
+            }
+
+            SECTION("Byte constructor")
+            {
+                const sf::IpAddress ipAddress(
+                    {0x27, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02});
+                CHECK_FALSE(ipAddress.isV4());
+                CHECK(ipAddress.isV6());
+                CHECK(ipAddress.toString() == "2700:1901:0:13e0::2"s);
+                CHECK(ipAddress.toBytes() ==
+                      std::array<std::uint8_t,
+                                 16>{0x27, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02});
+            }
+        }
     }
 
     SECTION("Static constants")
     {
-        CHECK(sf::IpAddress::Any.toString() == "0.0.0.0"s);
-        CHECK(sf::IpAddress::Any.toInteger() == 0);
+        SECTION("IPv4")
+        {
+            CHECK(sf::IpAddress::AnyV4.toString() == "0.0.0.0"s);
+            CHECK(sf::IpAddress::AnyV4.toInteger() == 0);
 
-        CHECK(sf::IpAddress::LocalHost.toString() == "127.0.0.1"s);
-        CHECK(sf::IpAddress::LocalHost.toInteger() == 0x7F'00'00'01);
+            CHECK(sf::IpAddress::LocalHostV4.toString() == "127.0.0.1"s);
+            CHECK(sf::IpAddress::LocalHostV4.toInteger() == 0x7F'00'00'01);
 
-        CHECK(sf::IpAddress::Broadcast.toString() == "255.255.255.255"s);
-        CHECK(sf::IpAddress::Broadcast.toInteger() == 0xFF'FF'FF'FF);
+            CHECK(sf::IpAddress::BroadcastV4.toString() == "255.255.255.255"s);
+            CHECK(sf::IpAddress::BroadcastV4.toInteger() == 0xFF'FF'FF'FF);
+        }
+
+        SECTION("IPv6")
+        {
+            CHECK(sf::IpAddress::AnyV6.toString() == "::"s);
+            CHECK(sf::IpAddress::AnyV6.toBytes() ==
+                  std::array<std::uint8_t,
+                             16>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+
+            CHECK(sf::IpAddress::LocalHostV6.toString() == "::1"s);
+            CHECK(sf::IpAddress::LocalHostV6.toBytes() ==
+                  std::array<std::uint8_t,
+                             16>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
+        }
     }
 
     SECTION("Operators")
     {
-        SECTION("operator==")
+        SECTION("IPv4")
         {
-            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) == sf::IpAddress(0xC6'33'64'7B));
-            CHECK(sf::IpAddress(0xCB'00'71'D2) == sf::IpAddress(203, 0, 113, 210));
+            SECTION("operator==")
+            {
+                CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) == sf::IpAddress(0xC6'33'64'7B));
+                CHECK(sf::IpAddress(0xCB'00'71'D2) == sf::IpAddress(203, 0, 113, 210));
+            }
+
+            SECTION("operator!=")
+            {
+                CHECK(sf::IpAddress(0x12'34'43'21) != sf::IpAddress(1234));
+                CHECK(sf::IpAddress(198, 51, 100, 1) != sf::IpAddress(198, 51, 100, 11));
+            }
+
+            SECTION("operator<")
+            {
+                CHECK(sf::IpAddress(1) < sf::IpAddress(2));
+                CHECK(sf::IpAddress(0, 0, 0, 0) < sf::IpAddress(1, 0, 0, 0));
+                CHECK(sf::IpAddress(0, 1, 0, 0) < sf::IpAddress(1, 0, 0, 0));
+                CHECK(sf::IpAddress(0, 0, 1, 0) < sf::IpAddress(0, 1, 0, 0));
+                CHECK(sf::IpAddress(0, 0, 0, 1) < sf::IpAddress(0, 0, 1, 0));
+                CHECK(sf::IpAddress(0, 0, 0, 1) < sf::IpAddress(1, 0, 0, 1));
+            }
+
+            SECTION("operator>")
+            {
+                CHECK(sf::IpAddress(2) > sf::IpAddress(1));
+                CHECK(sf::IpAddress(1, 0, 0, 0) > sf::IpAddress(0, 0, 0, 0));
+                CHECK(sf::IpAddress(1, 0, 0, 0) > sf::IpAddress(0, 1, 0, 0));
+                CHECK(sf::IpAddress(0, 1, 0, 0) > sf::IpAddress(0, 0, 1, 0));
+                CHECK(sf::IpAddress(0, 0, 1, 0) > sf::IpAddress(0, 0, 0, 1));
+                CHECK(sf::IpAddress(1, 0, 0, 1) > sf::IpAddress(0, 0, 0, 1));
+            }
+
+            SECTION("operator<=")
+            {
+                CHECK(sf::IpAddress(1) <= sf::IpAddress(2));
+                CHECK(sf::IpAddress(0, 0, 0, 0) <= sf::IpAddress(1, 0, 0, 0));
+                CHECK(sf::IpAddress(0, 1, 0, 0) <= sf::IpAddress(1, 0, 0, 0));
+                CHECK(sf::IpAddress(0, 0, 1, 0) <= sf::IpAddress(0, 1, 0, 0));
+                CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(0, 0, 1, 0));
+                CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(1, 0, 0, 1));
+
+                CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) <= sf::IpAddress(0xC6'33'64'7B));
+                CHECK(sf::IpAddress(0xCB'00'71'D2) <= sf::IpAddress(203, 0, 113, 210));
+            }
+
+            SECTION("operator>=")
+            {
+                CHECK(sf::IpAddress(2) >= sf::IpAddress(1));
+                CHECK(sf::IpAddress(1, 0, 0, 0) >= sf::IpAddress(0, 0, 0, 0));
+                CHECK(sf::IpAddress(1, 0, 0, 0) >= sf::IpAddress(0, 1, 0, 0));
+                CHECK(sf::IpAddress(0, 1, 0, 0) >= sf::IpAddress(0, 0, 1, 0));
+                CHECK(sf::IpAddress(0, 0, 1, 0) >= sf::IpAddress(0, 0, 0, 1));
+                CHECK(sf::IpAddress(1, 0, 0, 1) >= sf::IpAddress(0, 0, 0, 1));
+
+                CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) >= sf::IpAddress(0xC6'33'64'7B));
+                CHECK(sf::IpAddress(0xCB'00'71'D2) >= sf::IpAddress(203, 0, 113, 210));
+            }
+
+            SECTION("operator>>")
+            {
+                std::optional<sf::IpAddress> ipAddress;
+                std::istringstream("198.51.100.4") >> ipAddress;
+                REQUIRE(ipAddress.has_value());
+                CHECK(ipAddress->isV4());
+                CHECK_FALSE(ipAddress->isV6());
+                CHECK(ipAddress->toString() == "198.51.100.4"s);
+                CHECK(ipAddress->toInteger() == 0xC6'33'64'04);
+
+                std::istringstream("203.0.113.72") >> ipAddress;
+                REQUIRE(ipAddress.has_value());
+                CHECK(ipAddress->isV4());
+                CHECK_FALSE(ipAddress->isV6());
+                CHECK(ipAddress->toString() == "203.0.113.72"s);
+                CHECK(ipAddress->toInteger() == 0xCB'00'71'48);
+
+                std::istringstream("") >> ipAddress;
+                CHECK_FALSE(ipAddress.has_value());
+            }
+
+            SECTION("operator<<")
+            {
+                std::ostringstream out;
+                out << sf::IpAddress(192, 0, 2, 10);
+                CHECK(out.str() == "192.0.2.10"s);
+            }
         }
 
-        SECTION("operator!=")
+        SECTION("IPv6")
         {
-            CHECK(sf::IpAddress(0x12'34'43'21) != sf::IpAddress(1234));
-            CHECK(sf::IpAddress(198, 51, 100, 1) != sf::IpAddress(198, 51, 100, 11));
+            SECTION("operator==")
+            {
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}) ==
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}));
+            }
+
+            SECTION("operator!=")
+            {
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}) !=
+                    sf::IpAddress(
+                        {0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00}));
+            }
+
+            SECTION("operator<")
+            {
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}) <
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}) <
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}));
+            }
+
+            SECTION("operator>")
+            {
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}) >
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}) >
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}) >
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}));
+            }
+
+            SECTION("operator<=")
+            {
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}) <=
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <=
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <=
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <=
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <=
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) <=
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+
+                CHECK(
+                    sf::IpAddress(
+                        {0x27, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}) <=
+                    sf::IpAddress(
+                        {0x27, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}));
+            }
+
+            SECTION("operator>=")
+            {
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}) >=
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >=
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >=
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >=
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >=
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+                CHECK(
+                    sf::IpAddress(
+                        {0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) >=
+                    sf::IpAddress(
+                        {0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+
+                CHECK(
+                    sf::IpAddress(
+                        {0x27, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}) >=
+                    sf::IpAddress(
+                        {0x27, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}));
+            }
+
+            SECTION("operator>>")
+            {
+                std::optional<sf::IpAddress> ipAddress;
+                std::istringstream("2600:1901:0:13e0::1") >> ipAddress;
+                REQUIRE(ipAddress.has_value());
+                CHECK_FALSE(ipAddress->isV4());
+                CHECK(ipAddress->isV6());
+                CHECK(ipAddress->toString() == "2600:1901:0:13e0::1"s);
+                CHECK(ipAddress->toBytes() ==
+                      std::array<std::uint8_t,
+                                 16>{0x26, 0x00, 0x19, 0x01, 0x00, 0x00, 0x13, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01});
+
+                std::istringstream("2a00:1450:4001:831::200e") >> ipAddress;
+                REQUIRE(ipAddress.has_value());
+                CHECK_FALSE(ipAddress->isV4());
+                CHECK(ipAddress->isV6());
+                CHECK(ipAddress->toString() == "2a00:1450:4001:831::200e"s);
+                CHECK(ipAddress->toBytes() ==
+                      std::array<std::uint8_t,
+                                 16>{0x2a, 0x00, 0x14, 0x50, 0x40, 0x01, 0x08, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x0e});
+
+                std::istringstream("") >> ipAddress;
+                CHECK_FALSE(ipAddress.has_value());
+            }
+
+            SECTION("operator<<")
+            {
+                std::ostringstream out;
+                out << sf::IpAddress(
+                    {0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc});
+                CHECK(out.str() == "fe80::1234:5678:9abc"s);
+            }
         }
+    }
+}
 
-        SECTION("operator<")
-        {
-            CHECK(sf::IpAddress(1) < sf::IpAddress(2));
-            CHECK(sf::IpAddress(0, 0, 0, 0) < sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) < sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) < sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 0, 1) < sf::IpAddress(0, 0, 1, 0));
-            CHECK(sf::IpAddress(0, 0, 0, 1) < sf::IpAddress(1, 0, 0, 1));
-        }
+TEST_CASE("[Network] sf::IpAddress Discovery (IPv4)", runIpV4InternetTests())
+{
+    SECTION("Local address")
+    {
+        const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getLocalAddress(sf::IpAddress::Type::IpV4);
+        REQUIRE(ipAddress.has_value());
+        CHECK(ipAddress->isV4());
+        CHECK_FALSE(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "0.0.0.0");
+        CHECK(ipAddress->toInteger() != 0);
+    }
 
-        SECTION("operator>")
-        {
-            CHECK(sf::IpAddress(2) > sf::IpAddress(1));
-            CHECK(sf::IpAddress(1, 0, 0, 0) > sf::IpAddress(0, 0, 0, 0));
-            CHECK(sf::IpAddress(1, 0, 0, 0) > sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) > sf::IpAddress(0, 0, 1, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) > sf::IpAddress(0, 0, 0, 1));
-            CHECK(sf::IpAddress(1, 0, 0, 1) > sf::IpAddress(0, 0, 0, 1));
-        }
+    SECTION("Public address")
+    {
+        const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getPublicAddress(sf::seconds(1),
+                                                                                       sf::IpAddress::Type::IpV4);
+        REQUIRE(ipAddress.has_value());
+        CHECK(ipAddress->isV4());
+        CHECK_FALSE(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "0.0.0.0");
+        CHECK(ipAddress->toInteger() != 0);
+    }
 
-        SECTION("operator<=")
-        {
-            CHECK(sf::IpAddress(1) <= sf::IpAddress(2));
-            CHECK(sf::IpAddress(0, 0, 0, 0) <= sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) <= sf::IpAddress(1, 0, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) <= sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(0, 0, 1, 0));
-            CHECK(sf::IpAddress(0, 0, 0, 1) <= sf::IpAddress(1, 0, 0, 1));
+    SECTION("Public address (secure)")
+    {
+        const std::optional<sf::IpAddress>
+            ipAddress = sf::IpAddress::getPublicAddress(sf::seconds(1), sf::IpAddress::Type::IpV4, true);
+        REQUIRE(ipAddress.has_value());
+        CHECK(ipAddress->isV4());
+        CHECK_FALSE(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "0.0.0.0");
+        CHECK(ipAddress->toInteger() != 0);
+    }
+}
 
-            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) <= sf::IpAddress(0xC6'33'64'7B));
-            CHECK(sf::IpAddress(0xCB'00'71'D2) <= sf::IpAddress(203, 0, 113, 210));
-        }
+TEST_CASE("[Network] sf::IpAddress Discovery (IPv6)", runIpV6InternetTests())
+{
+    SECTION("Local address")
+    {
+        const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getLocalAddress(sf::IpAddress::Type::IpV6);
+        REQUIRE(ipAddress.has_value());
+        CHECK_FALSE(ipAddress->isV4());
+        CHECK(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "::");
+        CHECK(ipAddress->toBytes() !=
+              std::array<std::uint8_t,
+                         16>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    }
 
-        SECTION("operator>=")
-        {
-            CHECK(sf::IpAddress(2) >= sf::IpAddress(1));
-            CHECK(sf::IpAddress(1, 0, 0, 0) >= sf::IpAddress(0, 0, 0, 0));
-            CHECK(sf::IpAddress(1, 0, 0, 0) >= sf::IpAddress(0, 1, 0, 0));
-            CHECK(sf::IpAddress(0, 1, 0, 0) >= sf::IpAddress(0, 0, 1, 0));
-            CHECK(sf::IpAddress(0, 0, 1, 0) >= sf::IpAddress(0, 0, 0, 1));
-            CHECK(sf::IpAddress(1, 0, 0, 1) >= sf::IpAddress(0, 0, 0, 1));
+    SECTION("Public address")
+    {
+        const std::optional<sf::IpAddress> ipAddress = sf::IpAddress::getPublicAddress(sf::seconds(1),
+                                                                                       sf::IpAddress::Type::IpV6);
+        REQUIRE(ipAddress.has_value());
+        CHECK_FALSE(ipAddress->isV4());
+        CHECK(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "::");
+        CHECK(ipAddress->toBytes() !=
+              std::array<std::uint8_t,
+                         16>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    }
 
-            CHECK(sf::IpAddress(0xC6, 0x33, 0x64, 0x7B) >= sf::IpAddress(0xC6'33'64'7B));
-            CHECK(sf::IpAddress(0xCB'00'71'D2) >= sf::IpAddress(203, 0, 113, 210));
-        }
-
-        SECTION("operator>>")
-        {
-            std::optional<sf::IpAddress> ipAddress;
-            std::istringstream("198.51.100.4") >> ipAddress;
-            REQUIRE(ipAddress.has_value());
-            CHECK(ipAddress->toString() == "198.51.100.4"s);
-            CHECK(ipAddress->toInteger() == 0xC6'33'64'04);
-
-            std::istringstream("203.0.113.72") >> ipAddress;
-            REQUIRE(ipAddress.has_value());
-            CHECK(ipAddress->toString() == "203.0.113.72"s);
-            CHECK(ipAddress->toInteger() == 0xCB'00'71'48);
-
-            std::istringstream("") >> ipAddress;
-            CHECK(!ipAddress.has_value());
-        }
-
-        SECTION("operator<<")
-        {
-            std::ostringstream out;
-            out << sf::IpAddress(192, 0, 2, 10);
-            CHECK(out.str() == "192.0.2.10"s);
-        }
+    SECTION("Public address (secure)")
+    {
+        const std::optional<sf::IpAddress>
+            ipAddress = sf::IpAddress::getPublicAddress(sf::seconds(1), sf::IpAddress::Type::IpV6, true);
+        REQUIRE(ipAddress.has_value());
+        CHECK_FALSE(ipAddress->isV4());
+        CHECK(ipAddress->isV6());
+        CHECK(ipAddress->toString() != "::");
+        CHECK(ipAddress->toBytes() !=
+              std::array<std::uint8_t,
+                         16>{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
     }
 }

--- a/test/Network/UdpSocket.test.cpp
+++ b/test/Network/UdpSocket.test.cpp
@@ -27,12 +27,25 @@ TEST_CASE("[Network] sf::UdpSocket")
 
     SECTION("bind()/unbind()")
     {
-        sf::UdpSocket udpSocket;
-        CHECK(udpSocket.bind(sf::Socket::AnyPort, sf::IpAddress::Broadcast) == sf::Socket::Status::Error);
-        CHECK(udpSocket.bind(sf::Socket::AnyPort) == sf::Socket::Status::Done);
-        CHECK(udpSocket.getLocalPort() != 0);
+        SECTION("IPv4")
+        {
+            sf::UdpSocket udpSocket;
+            CHECK(udpSocket.bind(sf::Socket::AnyPort, sf::IpAddress::Broadcast) == sf::Socket::Status::Error);
+            CHECK(udpSocket.bind(sf::Socket::AnyPort) == sf::Socket::Status::Done);
+            CHECK(udpSocket.getLocalPort() != 0);
 
-        udpSocket.unbind();
-        CHECK(udpSocket.getLocalPort() == 0);
+            udpSocket.unbind();
+            CHECK(udpSocket.getLocalPort() == 0);
+        }
+
+        SECTION("IPv6")
+        {
+            sf::UdpSocket udpSocket;
+            CHECK(udpSocket.bind(sf::Socket::AnyPort, sf::IpAddress::AnyV6) == sf::Socket::Status::Done);
+            CHECK(udpSocket.getLocalPort() != 0);
+
+            udpSocket.unbind();
+            CHECK(udpSocket.getLocalPort() == 0);
+        }
     }
 }

--- a/test/TestUtilities/NetworkUtil.cpp
+++ b/test/TestUtilities/NetworkUtil.cpp
@@ -1,24 +1,100 @@
+#include <SFML/Network/Dns.hpp>
+
 #include <NetworkUtil.hpp>
+#include <algorithm>
 #include <string>
 
-std::string runLoopbackTests()
+std::string runIpV4LoopbackTests()
 {
-#ifdef SFML_RUN_LOOPBACK_TESTS
+#if defined(SFML_RUN_LOOPBACK_TESTS) && defined(SFML_RUN_IPV4_LINK_TESTS)
     return "";
 #else
     // https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
     // This tag tells Catch2 to not run a given TEST_CASE
-    return "[.loopback]";
+    return "[.loopbackv4]";
 #endif
 }
 
-std::string runConnectionTests()
+std::string runIpV4LinkTests()
 {
-#ifdef SFML_RUN_CONNECTION_TESTS
+#if defined(SFML_RUN_IPV4_LINK_TESTS)
     return "";
 #else
     // https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
     // This tag tells Catch2 to not run a given TEST_CASE
-    return "[.connection]";
+    return "[.linkv4]";
 #endif
+}
+
+std::string runIpV4InternetTests()
+{
+#if defined(SFML_RUN_IPV4_INTERNET_TESTS)
+    return "";
+#else
+    // https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
+    // This tag tells Catch2 to not run a given TEST_CASE
+    return "[.internetv4]";
+#endif
+}
+
+std::string runIpV6LoopbackTests()
+{
+#if defined(SFML_RUN_LOOPBACK_TESTS) && defined(SFML_RUN_IPV6_LINK_TESTS)
+    return "";
+#else
+    // https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
+    // This tag tells Catch2 to not run a given TEST_CASE
+    return "[.loopbackv6]";
+#endif
+}
+
+std::string runIpV6LinkTests()
+{
+#if defined(SFML_RUN_IPV6_LINK_TESTS)
+    return "";
+#else
+    // https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
+    // This tag tells Catch2 to not run a given TEST_CASE
+    return "[.linkv6]";
+#endif
+}
+
+std::string runIpV6InternetTests()
+{
+#if defined(SFML_RUN_IPV6_INTERNET_TESTS)
+    return "";
+#else
+    // https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
+    // This tag tells Catch2 to not run a given TEST_CASE
+    return "[.internetv6]";
+#endif
+}
+
+std::string runDnsTestsAdvanced()
+{
+#if defined(SFML_RUN_IPV4_INTERNET_TESTS) || defined(SFML_RUN_IPV6_INTERNET_TESTS)
+    return "";
+#else
+    // https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#special-tags
+    // This tag tells Catch2 to not run a given TEST_CASE
+    return "[.dnsadvanced]";
+#endif
+}
+
+std::vector<sf::IpAddress> resolveV4(std::string_view hostname)
+{
+    auto addresses = sf::Dns::resolve(hostname).value_or(std::vector<sf::IpAddress>{});
+    addresses
+        .erase(std::remove_if(addresses.begin(), addresses.end(), [](const auto& address) { return !address.isV4(); }),
+               addresses.end());
+    return addresses;
+}
+
+std::vector<sf::IpAddress> resolveV6(std::string_view hostname)
+{
+    auto addresses = sf::Dns::resolve(hostname).value_or(std::vector<sf::IpAddress>{});
+    addresses
+        .erase(std::remove_if(addresses.begin(), addresses.end(), [](const auto& address) { return !address.isV6(); }),
+               addresses.end());
+    return addresses;
 }

--- a/test/TestUtilities/NetworkUtil.hpp
+++ b/test/TestUtilities/NetworkUtil.hpp
@@ -1,7 +1,25 @@
 #pragma once
 
+#include <SFML/Network/IpAddress.hpp>
+
 #include <string>
+#include <string_view>
+#include <vector>
 
-[[nodiscard]] std::string runLoopbackTests();
+[[nodiscard]] std::string runIpV4LoopbackTests();
 
-[[nodiscard]] std::string runConnectionTests();
+[[nodiscard]] std::string runIpV4LinkTests();
+
+[[nodiscard]] std::string runIpV4InternetTests();
+
+[[nodiscard]] std::string runIpV6LoopbackTests();
+
+[[nodiscard]] std::string runIpV6LinkTests();
+
+[[nodiscard]] std::string runIpV6InternetTests();
+
+[[nodiscard]] std::string runDnsTestsAdvanced();
+
+[[nodiscard]] std::vector<sf::IpAddress> resolveV4(std::string_view hostname);
+
+[[nodiscard]] std::vector<sf::IpAddress> resolveV6(std::string_view hostname);


### PR DESCRIPTION
Yet another necessary step to update SFML's implementation to modern standards.

IPv6 has been around for quite a while now and is the only real solution to IPv4 address exhaustion. Most serious ISPs that already had allocated IPv4 blocks now provide usable dual-stack implementations. Newer ISPs (or cost-optimized ISPs) that either never had IPv4 blocks reserved for their customers or relinquished them to save costs only provide their customers with globally routable IPv6 prefixes and commonly rely on [CGNAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT) to share a single routable IPv4 address among multiple customers. This means that long-term in order to establish true end-to-end connectivity between multiple end-points in the internet without having to resolve to NAT punch-through or other exotic workarounds, we have to support IPv6 not only within networking equipment and operating systems but also within the applications themselves. Any consumer-grade equipment and operating system that was purchased within at least the last 10 years should already support full dual-stack operation, so adding application support is really the last step of the entire process.

As a library, SFML has the responsibility of providing its users with the necessary tools required to be able to develop their application as they see fit. Since networking is still a part of SFML and will stay this way for the foreseeable future, providing IPv6 support in SFML becomes essential.

Adding IPv6 address support to the existing classes wasn't too complex. Most of the system APIs that we were already using also support IPv6 addresses via the corresponding data structures. Other than adding new overloads to `sf::IpAddress` and a way to tell if an IP address is either v4 or v6 not that much had to be done to `sf::IpAddress`. All other existing network classes also needed only slight modifications to the way they opened up their sockets or retrieve endpoint addresses.

In contrast to IPv4, where it was common to communicate addresses in dotted-decimal notation with other people, in IPv6 this is not as common. The length and format of the address string representation probably has a bit to do with this. Instead IPv6 relies heavily on name resolution to translate human-readable hostnames into their corresponding addresses. This was also how it was supposed to be with IPv4 but I guess people got too accustomed to just passing around addresses because it was easy. Because most internet hosts have to keep supporting IPv4 for backwards compatibility with older systems it means that name resolution can result in multiple addresses (even of the same address family i.e. multiple IPv4 or IPv6 addresses) being returned. This was already the case for pure-IPv4 systems and was used for e.g. load-balancing.

In order to maintain API compatibility within SFML 3, the functions returning an `std::optional<sf::IpAddress>` could not be converted to returning a list of them. For this reason calling `sf::IpAddress::resolve()` will still result in a single IPv4 address being returned even if name resolution would have provided the complete list. If the user wants to perform name resolution to retrieve the entire list of addresses in [RFC 6724 order](https://datatracker.ietf.org/doc/html/rfc6724) they can make use of the new family of DNS query functions provided in the `sf::Dns` namespace. `sf::Dns::resolve()` performs name lookup just as `sf::IpAddress::resolve()` does but returns all addresses to the user so they can select to which they want to e.g. connect to. In fact, internally `sf::IpAddress::resolve()` is implemented by calling `sf::Dns::resolve()` and returning the first available IPv4 address.

Because IPv6 shifts the focus to using names to connect to services, it is only fitting to provide a way for the user to query SRV and TXT records as well.

Typically, SRV records are used by applications to discover on what port a service identified by a hostname is running on a target system, they are a kind of "port resolution" analogous to address resolution. In the typical usage scenario this would allow multiple instances of a type of service (e.g. a game server) to run on different ports on a system with a single public IP address and not necessitate the server administrators to communicate the port numbers to their users because this can be automatically discovered by the application using a SRV query.

A SRV DNS record like almost all other record types mandates a fixed data format, if this is too rigid for the user application they can opt to store the necessary information within a TXT DNS record. There are virtually no constraints on what kind of data can be written into a TXT record other than that the data has to be in text form (as the record type implies). A common use case for TXT records is for implementing [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework).

To top it off, implementations for querying MX and NS records were also added.

Mail eXchange records as the name implies allow for discovering the servers in charge of handling mail for a given domain. While SFML itself does not currently provide facilities for sending/receiving mail, there are enough other libraries that the user can make use of that provide this functionality.

NameServer records are a very specialized record type that the domain name system uses to recursively delegate queries to the domain name servers in charge of the target zone. In most cases, this mechanism functions transparently and any recursive resolver will automatically make use of NS records to decide where to send a query to next if they can't answer it themselves. In some cases however, administrators of a system might not want their nameservers to be part of the global DNS and only answer queries for names that are e.g. hardcoded inside the client application. These names would not have to be officially registered (thus also saving costs) and can be used for application-specific purposes.

Since the facilities for performing advanced DNS queries were already available, I decided to implement public address discovery using DNS as an alternative to the previous mechanism that relied on HTTP. The most obvious advantage is that because DNS is a UDP query/response protocol, the entire process can be done within 1 RTT (round-trip time) as opposed to multiple RTTs required to open the TCP connection and send/receive the HTTP data. Because DNS servers are probably some of the most loaded servers on the internet most of them sit behind [Anycast](https://en.wikipedia.org/wiki/Anycast) addresses and are in addition to that highly load-balanced. This is in contrast to most IP discovery web servers (including SFML's) that aren't behind Anycast addresses and not load-balanced resulting in a single point of failure.

By default `sf::IpAddress::getPublicAddress()` now attempts to use DNS discovery first and falls back to HTTP discovery (using a list of multiple HTTP servers) in the very unlikely scenario that every major CDN in the internet disappears at the same time. I would probably have bigger things to worry about if this ever actually happens. From a user perspective this means public address discovery should now complete much faster and be more reliable than it was in the previous implementation. Currently, the minimal implementation of a DNS client required to perform queries ourselves only performs "traditional" non-DNSSEC queries. This means that these queries are vulnerable to attacks such as spoofing/tampering. If the user decides they need to use a secure mechanism to determine the public address they can opt to do so. In this case, SFML will discover the public address via a verified HTTPS connection.

And as a final note, although kind of self-explanatory, `sf::Http` now performs full DNS resolution and automatically iterates through the address list until it can connect to a server successfully (basically like any web browser). When using `sf::Http` with a given URL, the user does not have to know whether it is connecting to the server using IPv4 or IPv6 because it is all transparent. If name resolution results in the IPv6 addresses being given higher priority they will be the first to attempt to connect to. If, in certain situations (e.g. public address discovery) where only a specific address family should be used, this can be specified as well.

In summary, this change implements the following:
- Transparent IPv6 support for all existing `sfml-network` classes
- New `sf::Dns` namespace that allows looking up dual-stack address lists and perform NS, MX, SRV and TXT queries
- New method of discovering public IP address via DNS with HTTP remaining as a fallback
- More robust HTTP(S) public IP address discovery using a list of servers as opposed to only a single server
- Ability to perform DNS queries using a user-provided list of DNS servers if the system-provided servers should not be used for some reason
- `sf::Http` support for dual-stack operation and automatically retrying with alternative addresses

Examples are not provided for this change since most of it will be transparent and fully backward compatible with existing code. The new `sf::Dns` API is more or less self-explanatory for anyone familiar with the respective DNS record types.

Open point: I left `TODO` comments in the `sf::Dns` implementation marking the locations where [Punycode](https://en.wikipedia.org/wiki/Punycode) conversion would be necessary to fully support [internationalized domain names](https://en.wikipedia.org/wiki/Internationalized_domain_name) such as e.g. [bücher.de](https://bücher.de). When opening this link in Firefox, if you look fast enough at the address bar you might be able to see the encoded URL for a split second before the page loads and redirects to [buecher.de](https://buecher.de). Applications that want to support IDNs have to perform the conversion themselves before trying to resolve the encoded name. All modern browsers that I know of support IDNs. The question is whether this is something SFML wants to support at some point as well.

I know this is a big pull request, and thoroughly reviewing it will probably take a while™. All comments and feedback are as always welcome.

<p align="center"><img width="604" height="371" alt="image" src="https://github.com/user-attachments/assets/113b4b72-b7d8-4e46-8201-ea06428e637b" /></p>

Closes #1023.