### PR TITLE
Document how to run examples from a source build

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,0 +1,29 @@
+# SFML Examples
+
+## Running the examples
+
+When SFML is built from source with CMake, the example executables are generated in the `build/bin` directory.
+
+Most examples rely on external resources (textures, fonts, sounds) that are loaded using relative paths.
+Because of this, the programs must be run from their respective example directories; otherwise the resources cannot be located.
+
+For example (on Linux/macOS):
+
+```bash
+cd examples/tennis
+../../build/bin/tennis
+```
+
+For example (on Windows / Visual Studio):
+
+```cmd
+cd examples\tennis
+..\..\build\bin\Debug\tennis.exe
+```
+
+Running an example directly from `build/bin` may result in errors such as:
+
+```
+Failed to open sound file
+Failed to open sound buffer from file
+```


### PR DESCRIPTION
While building SFML from source on Linux, the examples compiled successfully but were not straightforward to run because they depend on relative resource paths.

Running the executables directly from `build/bin` produced missing resource errors (for example sound files failing to load). It was unclear that the programs should be launched from the corresponding example directory.

This PR adds a short section to `examples/README.md` explaining where the binaries are located and how to run them correctly, helping new users avoid these errors.
