### PR TITLE
Replace old attribute syntax with new attribute syntax

### DIFF
--- a/include/SFML/Config.hpp
+++ b/include/SFML/Config.hpp
@@ -150,8 +150,8 @@
 
 #else // Linux, FreeBSD, macOS
 
-#define SFML_API_EXPORT __attribute__((__visibility__("default")))
-#define SFML_API_IMPORT __attribute__((__visibility__("default")))
+#define SFML_API_EXPORT [[gnu::visibility("default")]]
+#define SFML_API_IMPORT [[gnu::visibility("default")]]
 
 #endif
 

--- a/include/SFML/Graphics/Glsl.inl
+++ b/include/SFML/Graphics/Glsl.inl
@@ -46,8 +46,8 @@ namespace sf::priv
 /// \brief Helper functions to copy `sf::Transform` to `sf::Glsl::Mat3/4`
 ///
 ////////////////////////////////////////////////////////////
-void SFML_GRAPHICS_API copyMatrix(const Transform& source, Matrix<3, 3>& dest);
-void SFML_GRAPHICS_API copyMatrix(const Transform& source, Matrix<4, 4>& dest);
+SFML_GRAPHICS_API void copyMatrix(const Transform& source, Matrix<3, 3>& dest);
+SFML_GRAPHICS_API void copyMatrix(const Transform& source, Matrix<4, 4>& dest);
 
 ////////////////////////////////////////////////////////////
 /// \brief Copy array-based matrix with given number of elements
@@ -56,7 +56,7 @@ void SFML_GRAPHICS_API copyMatrix(const Transform& source, Matrix<4, 4>& dest);
 /// <algorithm> and MSVC's annoying 4996 warning in header
 ///
 ////////////////////////////////////////////////////////////
-void SFML_GRAPHICS_API copyMatrix(const float* source, std::size_t elements, float* dest);
+SFML_GRAPHICS_API void copyMatrix(const float* source, std::size_t elements, float* dest);
 
 
 ////////////////////////////////////////////////////////////

--- a/include/SFML/Network/IpAddress.hpp
+++ b/include/SFML/Network/IpAddress.hpp
@@ -171,7 +171,11 @@ public:
     // NOLINTEND(readability-identifier-naming)
 
 private:
+#if defined(SFML_SYSTEM_WINDOWS)
     friend SFML_NETWORK_API bool operator<(IpAddress left, IpAddress right);
+#else
+    friend bool operator<(IpAddress left, IpAddress right);
+#endif
 
     ////////////////////////////////////////////////////////////
     // Member data

--- a/include/SFML/System/Sleep.hpp
+++ b/include/SFML/System/Sleep.hpp
@@ -52,6 +52,6 @@ class Time;
 /// \param duration Time to sleep
 ///
 ////////////////////////////////////////////////////////////
-void SFML_SYSTEM_API sleep(Time duration);
+SFML_SYSTEM_API void sleep(Time duration);
 
 } // namespace sf

--- a/include/SFML/System/String.hpp
+++ b/include/SFML/System/String.hpp
@@ -641,8 +641,13 @@ public:
     [[nodiscard]] bool isSentenceBoundary(std::size_t position) const;
 
 private:
+#if defined(SFML_SYSTEM_WINDOWS)
     friend SFML_SYSTEM_API bool operator==(const String& left, const String& right);
     friend SFML_SYSTEM_API bool operator<(const String& left, const String& right);
+#else
+    friend bool operator==(const String& left, const String& right);
+    friend bool operator<(const String& left, const String& right);
+#endif
 
     ////////////////////////////////////////////////////////////
     // Member data


### PR DESCRIPTION
Title.

C++11 provided us with a standardized way to specify attributes. We already use this where we mark symbols as deprecated and everywhere where `[[nodiscard]]` is present. This change migrates `SFML_API_EXPORT` and `SFML_API_IMPORT` for non-Windows platforms to the new syntax.

This change also reveals a few places where we were using the macros incorrectly, so those were fixed as well. The tricky part is that we use the same macros for `__declspec` on Windows and attributes on non-Windows. They are not syntactically equivalent, thus differentiating between Windows and non-Windows when declaring friends was necessary.

Continuing to use the old attribute syntax would cause issues if we additionally wanted to mark entire classes as deprecated as in #3675. Chaining multiple attributes with different styles is not supported by every compiler so migrating to using the new syntax would avoid that problem as well.