### PR TITLE
feat(audio): add early validation to OutputSoundFile::openFromFile

### DIFF
--- a/src/SFML/Audio/OutputSoundFile.cpp
+++ b/src/SFML/Audio/OutputSoundFile.cpp
@@ -58,6 +58,12 @@ bool OutputSoundFile::openFromFile(const std::filesystem::path&     filename,
 {
     // If the file is already open, first close it
     close();
+    
+    if (!sampleRate || !channelCount || (channelMap.size() != channelCount))
+    {
+        err() << "Failed to open output sound file from file (invalid sample rate/channel configuration)" << std::endl;
+        return false;
+    }
 
     // Find a suitable writer for the file type
     m_writer = SoundFileFactory::createWriterFromFilename(filename);

--- a/test/Audio/OutputSoundFile.test.cpp
+++ b/test/Audio/OutputSoundFile.test.cpp
@@ -40,4 +40,11 @@ TEST_CASE("[Audio] sf::OutputSoundFile")
         outputSoundFile.close();
         CHECK(std::filesystem::remove(filename));
     }
+    
+    SECTION("openFromFile() fails for invalid channel configuration")
+    {
+        sf::OutputSoundFile outputSoundFile;
+        CHECK(!outputSoundFile.openFromFile(filename, 44'100, static_cast<unsigned int>(channelMap.size()) + 1, channelMap));
+        CHECK(!std::filesystem::exists(filename));
+    }
 }


### PR DESCRIPTION
Add early parameter validation in OutputSoundFile::openFromFile

- Reject sampleRate == 0, channelCount == 0 or channelMap.size() != channelCount
- Improve error message clarity for invalid configurations
- Add test section verifying failure on mismatched channel count and map

No file is created on invalid input