### PR TITLE
Fixed allocated buffer being too small when converting CFStringRef to std::string in the macOS joystick implementation.

### DIFF
--- a/src/SFML/Window/macOS/JoystickImpl.cpp
+++ b/src/SFML/Window/macOS/JoystickImpl.cpp
@@ -43,9 +43,8 @@ namespace
 // Convert a CFStringRef to std::string
 std::string stringFromCFString(CFStringRef cfString)
 {
-    const CFIndex     length = CFStringGetLength(cfString);
-    std::vector<char> str(static_cast<std::size_t>(length));
-    const CFIndex     maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
+    const CFIndex     maxSize = CFStringGetMaximumSizeForEncoding(CFStringGetLength(cfString), kCFStringEncodingUTF8);
+    std::vector<char> str(static_cast<std::size_t>(maxSize) + 1, '\0');
     CFStringGetCString(cfString, str.data(), maxSize, kCFStringEncodingUTF8);
     return str.data();
 }


### PR DESCRIPTION
Title.

`CFStringGetLength()` retrieves the string length in UTF-16 codepoints.
`CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8)` retrieves the maximum UTF-8 byte count of the UTF-16 string.

If we use the UTF-16 length to allocate a buffer into which we write up to UTF-8 length bytes we will overflow it in cases where UTF-16 codepoints are represented by multi-byte UTF-8 sequences.

This change allocates the buffer based on the computed UTF-8 byte length.

Fixes #3679.