### PR TITLE
Fixed sf::SocketSelector epoll implementation not correctly interpreting sf::Time::Zero as a request to wait indefinitely

### DIFF
--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -194,7 +194,10 @@ struct SocketSelector::SocketSelectorImpl
     bool wait(Time timeout)
     {
         events.resize(sockets.size());
-        const auto result = epoll_wait(epollHandle, events.data(), static_cast<int>(events.size()), timeout.asMilliseconds());
+        const auto result = epoll_wait(epollHandle,
+                                       events.data(),
+                                       static_cast<int>(events.size()),
+                                       timeout != Time::Zero ? timeout.asMilliseconds() : -1);
         if (result > 0)
         {
             eventsCount = result;


### PR DESCRIPTION
Title.

This bug was introduced with the recent rewrite of the `sf::SocketSelector` implementation to make use of epoll and kqueue.

The other implementations handle `sf::Time::Zero` correctly.