### PR TITLE
Fix RelWithDebInfo / MinSizeRel when using find_package(SFML)

### DIFF
--- a/cmake/SFMLConfig.cmake.in
+++ b/cmake/SFMLConfig.cmake.in
@@ -52,7 +52,8 @@
 # - For each specified module XXX (System, Window, Graphics, Network, Audio, Main):
 #   - SFML::XXX
 # The SFML targets are the same for both Debug and Release build configurations and will automatically provide
-# correct settings based on your currently active build configuration. The SFML targets name also do not change
+# correct settings based on your currently active build configuration. RelWithDebInfo and MinSizeRel (multi-config
+# generators such as Visual Studio) map to the Release import libraries. The SFML targets name also do not change
 # when using dynamic or static SFML libraries.
 #
 # When linking against a SFML target, you do not need to specify indirect dependencies. For example, linking
@@ -178,6 +179,17 @@ foreach(component ${FIND_SFML_COMPONENTS_SORTED})
 endforeach()
 
 if(SFML_FOUND)
+    # Multi-config generators (e.g. Visual Studio) also build RelWithDebInfo and MinSizeRel. SFML's exported
+    # targets only provide Debug and Release locations; without an explicit map, CMake can pick the wrong one and
+    # consumers see CRT / ABI mismatches at runtime. See https://github.com/SFML/SFML/issues/3424
+    foreach(component ${FIND_SFML_COMPONENTS_SORTED})
+        if(TARGET SFML::${component})
+            set_target_properties(SFML::${component} PROPERTIES
+                MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
+                MAP_IMPORTED_CONFIG_MINSIZEREL Release)
+        endif()
+    endforeach()
+
     set(SFML_VERSION_IS_RELEASE @VERSION_IS_RELEASE@)
 else()
     if(SFML_FIND_REQUIRED)


### PR DESCRIPTION
Multi-config generators (e.g. Visual Studio) define RelWithDebInfo and MinSizeRel, but installed SFML package files only declare Debug and Release import locations. Set MAP_IMPORTED_CONFIG_* so those configurations use the Release libraries and avoid incorrect .lib selection and CRT mismatches at runtime.

Fixes #3424

Made-with: Cursor

<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ No] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ Yes] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ No] Have you provided some example/test code for your changes?
-   [need  to test with other test cases ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

This PR is related to the issue #

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

<!-- Describe how to best test these changes. -->

<!-- Please provide a [minimal, complete and verifiable example](https://stackoverflow.com/help/mcve) if possible, you can use the following template as a start: -->

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        window.clear();
        window.display();
    }
}
```
