### PR TITLE
Use `generic_string()` instead on libssh2 calls

### DIFF
--- a/src/SFML/Network/Sftp.cpp
+++ b/src/SFML/Network/Sftp.cpp
@@ -83,29 +83,18 @@ struct SftpSessionDeleter
 
 // Portable UTF-8 string conversions for C++17/C++20 compatibility
 // See: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r3.html
-[[maybe_unused]] std::string fromUtf8String(const std::string& s)
+std::string pathToUtf8(const std::filesystem::path& path)
 {
-    return s;
+    const auto s = path.generic_u8string();
+    return {s.begin(), s.end()};
 }
 
-[[maybe_unused]] std::string fromUtf8String(std::string&& s)
-{
-    return std::move(s);
-}
-
-#if defined(__cpp_lib_char8_t)
-std::string fromUtf8String(const std::u8string& s)
-{
-    return std::string(s.begin(), s.end());
-}
-#endif
-
-std::filesystem::path pathFromUtf8(const std::string& utf8Str)
+std::filesystem::path pathFromUtf8(std::string_view utf8Str)
 {
 #if defined(__cpp_lib_char8_t)
-    return std::filesystem::path(std::u8string(utf8Str.begin(), utf8Str.end()));
+    return {std::u8string(utf8Str.begin(), utf8Str.end())};
 #else
-    return std::filesystem::path(utf8Str);
+    return std::filesystem::u8path(utf8Str);
 #endif
 }
 
@@ -873,7 +862,7 @@ Sftp::PathResult Sftp::resolvePath(const std::filesystem::path& path, const Time
     if ((path == ".") && !m_impl->cachedHomePath.empty())
         return {Result(Result::Value::Success), m_impl->cachedHomePath};
 
-    const auto             pathString = fromUtf8String(path.generic_u8string());
+    const auto             pathString = pathToUtf8(path);
     std::array<char, 4096> buffer{};
     const auto             result = m_impl->waitForOperationComplete(
         [&]
@@ -894,7 +883,7 @@ Sftp::PathResult Sftp::resolvePath(const std::filesystem::path& path, const Time
         return {makeError(m_impl->ssh2Session.get(), m_impl->sftpSession.get()), {}};
 
     // The path from libssh2 is UTF-8 encoded, convert before constructing filesystem::path
-    const auto resolvedPath = pathFromUtf8(std::string(buffer.data(), static_cast<std::size_t>(result)));
+    const auto resolvedPath = pathFromUtf8({buffer.data(), static_cast<std::size_t>(result)});
 
     // Cache the result for the home path
     if (path == ".")
@@ -916,7 +905,7 @@ Sftp::AttributesResult Sftp::getAttributes(const std::filesystem::path& path, bo
 {
     LIBSSH2_SFTP_ATTRIBUTES attributes{};
 
-    const auto pathString = fromUtf8String(path.generic_u8string());
+    const auto pathString = pathToUtf8(path);
     const auto result     = m_impl->waitForOperationComplete(
         [&]
         {
@@ -944,7 +933,7 @@ Sftp::ListingResult Sftp::getDirectoryListing(const std::filesystem::path& path,
     LIBSSH2_SFTP_HANDLE* handle{};
 
     {
-        const auto pathString = fromUtf8String(path.generic_u8string());
+        const auto pathString = pathToUtf8(path);
         const auto result     = m_impl->waitForOperationComplete(
             [&]
             {
@@ -985,8 +974,7 @@ Sftp::ListingResult Sftp::getDirectoryListing(const std::filesystem::path& path,
             {
                 // The filename from libssh2 is UTF-8 encoded, convert before constructing filesystem::path
                 listing.emplace_back(
-                    makeAttributes(path / pathFromUtf8(std::string(buffer.data(), static_cast<std::size_t>(result))),
-                                   attributes));
+                    makeAttributes(path / pathFromUtf8({buffer.data(), static_cast<std::size_t>(result)}), attributes));
 
                 continue;
             }
@@ -1018,7 +1006,7 @@ Sftp::Result Sftp::createDirectory(const std::filesystem::path& path,
                                    std::filesystem::perms       permissions,
                                    const TimeoutWithPredicate&  timeout)
 {
-    const auto pathString = fromUtf8String(path.generic_u8string());
+    const auto pathString = pathToUtf8(path);
     const auto result     = m_impl->waitForOperationComplete(
         [&]
         {
@@ -1042,7 +1030,7 @@ Sftp::Result Sftp::createDirectory(const std::filesystem::path& path,
 ////////////////////////////////////////////////////////////
 Sftp::Result Sftp::deleteDirectory(const std::filesystem::path& path, const TimeoutWithPredicate& timeout)
 {
-    const auto pathString = fromUtf8String(path.generic_u8string());
+    const auto pathString = pathToUtf8(path);
     const auto result     = m_impl->waitForOperationComplete(
         [&]
         {
@@ -1068,8 +1056,8 @@ Sftp::Result Sftp::rename(const std::filesystem::path& oldPath,
                           bool                         overwrite,
                           const TimeoutWithPredicate&  timeout)
 {
-    const auto oldPathString = fromUtf8String(oldPath.generic_u8string());
-    const auto newPathString = fromUtf8String(newPath.generic_u8string());
+    const auto oldPathString = pathToUtf8(oldPath);
+    const auto newPathString = pathToUtf8(newPath);
 
     // POSIX rename is only supported starting from libssh2 1.11.1
 #if (LIBSSH2_VERSION_NUM >= 0x010b01)
@@ -1126,7 +1114,7 @@ Sftp::Result Sftp::rename(const std::filesystem::path& oldPath,
 ////////////////////////////////////////////////////////////
 Sftp::Result Sftp::deleteFile(const std::filesystem::path& path, const TimeoutWithPredicate& timeout)
 {
-    const auto pathString = fromUtf8String(path.generic_u8string());
+    const auto pathString = pathToUtf8(path);
     const auto result     = m_impl->waitForOperationComplete(
         [&]
         {
@@ -1159,7 +1147,7 @@ Sftp::Result Sftp::download(const std::filesystem::path&                        
 
     // Open the file for reading
     {
-        const auto pathString = fromUtf8String(remotePath.generic_u8string());
+        const auto pathString = pathToUtf8(remotePath);
         const auto result     = m_impl->waitForOperationComplete(
             [&]
             {
@@ -1276,7 +1264,7 @@ Sftp::Result Sftp::upload(const std::filesystem::path&                          
 
     // Open the file for writing
     {
-        const auto pathString = fromUtf8String(remotePath.generic_u8string());
+        const auto pathString = pathToUtf8(remotePath);
         const auto result     = m_impl->waitForOperationComplete(
             [&]
             {


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->
Trying to build the library fails on C++20 and C++23, because `std::filesystem::path::generic_u8string()` returns `std::u8string` (with `char8_t` elements), which in C++20 and 23, cannot implicitly convert to `const char*` as required by libssh2 APIs.

Instead, we fix the problem by using `std::filesystem::path::generic_string()` in calls that pass through libssh2.

No current relevant issue exists.

## Tasks

-   [x] Tested on Linux
-   [x] Tested on Windows
-   [x] Tested on macOS
-   [x] Tested on iOS
-   [x] Tested on Android

## How to test this PR?
The current version breaks on C++20 and C++23, applying these changes allows the library to build on C++20 and C++23.
