### PR TITLE
Fix bundle resource handling on apple platforms

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -44,7 +44,6 @@ function(sfml_set_common_ios_properties target)
     get_target_property(target_type ${target} TYPE)
     if(target_type STREQUAL "EXECUTABLE")
         set_target_properties(${target} PROPERTIES
-            MACOSX_BUNDLE ON # Bare executables are not usable on iOS, only bundle applications
             MACOSX_BUNDLE_GUI_IDENTIFIER "org.sfml-dev.${target}" # If missing, trying to launch an example in simulator will make Xcode < 9.3 crash
             MACOSX_BUNDLE_BUNDLE_NAME "${target}"
             MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
@@ -318,20 +317,30 @@ macro(sfml_add_example target)
     if(THIS_GUI_APP AND SFML_OS_WINDOWS AND NOT DEFINED CMAKE_CONFIGURATION_TYPES AND ${CMAKE_BUILD_TYPE} STREQUAL "Release")
         add_executable(${target} WIN32 ${target_input})
         target_link_libraries(${target} PRIVATE SFML::Main)
-    elseif(THIS_GUI_APP AND SFML_OS_IOS)
-
-        # For iOS apps we need the launch screen storyboard,
-        # and a custom info.plist to use it
-        set(LAUNCH_SCREEN "${PROJECT_SOURCE_DIR}/examples/assets/LaunchScreen.storyboard")
-        set(LOGO "${PROJECT_SOURCE_DIR}/examples/assets/logo.png")
+    elseif(THIS_GUI_APP AND (SFML_OS_IOS OR SFML_OS_MACOS))
         set(INFO_PLIST "${PROJECT_SOURCE_DIR}/examples/assets/info.plist")
         set(ICONS "${PROJECT_SOURCE_DIR}/examples/assets/icon.icns")
-        add_executable(${target} MACOSX_BUNDLE ${target_input} ${LAUNCH_SCREEN} ${LOGO} ${ICONS})
-        set(RESOURCES ${LAUNCH_SCREEN} ${LOGO} ${ICONS})
+        set(RESOURCES ${ICONS})
+
+        if(SFML_OS_IOS)
+            # For iOS apps we also need the launch screen storyboard and logo
+            set(LAUNCH_SCREEN "${PROJECT_SOURCE_DIR}/examples/assets/LaunchScreen.storyboard")
+            set(LOGO "${PROJECT_SOURCE_DIR}/examples/assets/logo.png")
+            list(APPEND RESOURCES ${LAUNCH_SCREEN} ${LOGO})
+        endif()
+
+        if(THIS_BUNDLE_RESOURCES)
+            # Put the required resources in the app bundle, respecting their relative paths
+            foreach(resource ${THIS_BUNDLE_RESOURCES})
+                cmake_path(GET resource PARENT_PATH resource_parent)
+                set_source_files_properties(${resource} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/${resource_parent})
+            endforeach()
+        endif()
+
+        add_executable(${target} MACOSX_BUNDLE ${target_input} ${RESOURCES})
         set_target_properties(${target} PROPERTIES RESOURCE "${RESOURCES}"
                                                    MACOSX_BUNDLE_INFO_PLIST ${INFO_PLIST}
                                                    MACOSX_BUNDLE_ICON_FILE icon.icns)
-        target_link_libraries(${target} PRIVATE SFML::Main)
     elseif(THIS_GUI_APP AND SFML_OS_ANDROID)
         # Executables on android are shared libraries loaded by the native activity
         add_library(${target} SHARED ${target_input})
@@ -377,6 +386,7 @@ macro(sfml_add_example target)
 
     if(SFML_OS_IOS)
         sfml_set_common_ios_properties(${target})
+        target_link_libraries(${target} PRIVATE SFML::Main)
     endif()
 
     if(SFML_OS_WINDOWS AND SFML_USE_MESA3D)

--- a/examples/event_handling/CMakeLists.txt
+++ b/examples/event_handling/CMakeLists.txt
@@ -1,11 +1,7 @@
 # all source files
 set(SRC EventHandling.cpp)
-
-if(SFML_OS_IOS)
-    set(RESOURCES
-        resources/tuffy.ttf)
-    set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-endif()
+set(RESOURCES
+    resources/tuffy.ttf)
 
 # define the event_handling target
 sfml_add_example(event_handling GUI_APP

--- a/examples/event_handling/EventHandling.cpp
+++ b/examples/event_handling/EventHandling.cpp
@@ -8,14 +8,6 @@
 
 namespace
 {
-std::filesystem::path resourcesDir()
-{
-#ifdef SFML_SYSTEM_IOS
-    return "";
-#else
-    return "resources";
-#endif
-}
 std::string vec2ToString(const sf::Vector2i vec2)
 {
     return '(' + std::to_string(vec2.x) + ", " + std::to_string(vec2.y) + ')';
@@ -392,7 +384,7 @@ private:
     // Member data
     ////////////////////////////////////////////////////////////
     sf::RenderWindow m_window{sf::VideoMode({800u, 600u}), "SFML Event Handling", sf::Style::Titlebar | sf::Style::Close};
-    const sf::Font           m_font{resourcesDir() / "tuffy.ttf"};
+    const sf::Font           m_font{"resources/tuffy.ttf"};
     sf::Text                 m_logText{m_font, "", 20};
     sf::Text                 m_handlerText{m_font, "Current Handler: Classic", 24};
     sf::Text                 m_instructions{m_font, "Press Enter to change handler type", 24};

--- a/examples/keyboard/CMakeLists.txt
+++ b/examples/keyboard/CMakeLists.txt
@@ -1,13 +1,10 @@
 # all source files
 set(SRC Keyboard.cpp)
-if(SFML_OS_IOS)
-    set(RESOURCES
-        resources/error_005.ogg
-        resources/mouseclick1.ogg
-        resources/mouserelease1.ogg
-        resources/Tuffy.ttf)
-    set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-endif()
+set(RESOURCES
+    resources/error_005.ogg
+    resources/mouseclick1.ogg
+    resources/mouserelease1.ogg
+    resources/Tuffy.ttf)
 
 # define the keyboard target
 sfml_add_example(keyboard GUI_APP

--- a/examples/keyboard/Keyboard.cpp
+++ b/examples/keyboard/Keyboard.cpp
@@ -17,15 +17,6 @@
 
 namespace
 {
-std::filesystem::path resourcesDir()
-{
-#ifdef SFML_SYSTEM_IOS
-    return "";
-#else
-    return "resources";
-#endif
-}
-
 // Get the C++ enumerator name of the given `sf::Keyboard::Key` value including `Key::` prefix
 std::string keyIdentifier(sf::Keyboard::Key code)
 {
@@ -756,9 +747,9 @@ int main()
     window.setFramerateLimit(25);
 
     // Load sound buffers
-    const sf::SoundBuffer errorSoundBuffer(resourcesDir() / "error_005.ogg");
-    const sf::SoundBuffer pressedSoundBuffer(resourcesDir() / "mouseclick1.ogg");
-    const sf::SoundBuffer releasedSoundBuffer(resourcesDir() / "mouserelease1.ogg");
+    const sf::SoundBuffer errorSoundBuffer("resources/error_005.ogg");
+    const sf::SoundBuffer pressedSoundBuffer("resources/mouseclick1.ogg");
+    const sf::SoundBuffer releasedSoundBuffer("resources/mouserelease1.ogg");
 
     // Create sound objects to play them upon keyboard events
     sf::Sound errorSound(errorSoundBuffer);
@@ -766,7 +757,7 @@ int main()
     sf::Sound releasedSound(releasedSoundBuffer);
 
     // Open the font used for all texts
-    const sf::Font font(resourcesDir() / "Tuffy.ttf");
+    const sf::Font font("resources/Tuffy.ttf");
 
     // Create object to display all scancodes descriptions, related events and real-time state
     KeyboardView keyboardView(font);

--- a/examples/opengl/CMakeLists.txt
+++ b/examples/opengl/CMakeLists.txt
@@ -1,12 +1,8 @@
 # all source files
 set(SRC OpenGL.cpp)
-
-if(SFML_OS_IOS)
-    set(RESOURCES
-        resources/background.jpg
-        resources/tuffy.ttf)
-    set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-endif()
+set(RESOURCES
+    resources/background.jpg
+    resources/tuffy.ttf)
 
 # define the opengl target
 sfml_add_example(opengl GUI_APP

--- a/examples/opengl/OpenGL.cpp
+++ b/examples/opengl/OpenGL.cpp
@@ -20,17 +20,6 @@
 #define GL_SRGB8_ALPHA8 0x8C43
 #endif
 
-namespace
-{
-std::filesystem::path resourcesDir()
-{
-#ifdef SFML_SYSTEM_IOS
-    return "";
-#else
-    return "resources";
-#endif
-}
-} // namespace
 
 ////////////////////////////////////////////////////////////
 /// Entry point of application
@@ -61,11 +50,11 @@ int main()
         window.setMaximumSize(sf::Vector2u(1200, 900));
 
         // Create a sprite for the background
-        const sf::Texture backgroundTexture(resourcesDir() / "background.jpg", sRgb);
+        const sf::Texture backgroundTexture(std::filesystem::path("resources/background.jpg"), sRgb);
         const sf::Sprite  background(backgroundTexture);
 
         // Create some text to draw on top of our OpenGL object
-        const sf::Font font(resourcesDir() / "tuffy.ttf");
+        const sf::Font font("resources/tuffy.ttf");
 
         sf::Text text(font, "SFML / OpenGL demo");
         sf::Text sRgbInstructions(font, "Press space to toggle sRGB conversion");
@@ -78,7 +67,7 @@ int main()
         mipmapInstructions.setPosition({200.f, 550.f});
 
         // Load a texture to apply to our 3D cube
-        sf::Texture texture(resourcesDir() / "logo.png");
+        sf::Texture texture("resources/logo.png");
 
         // Attempt to generate a mipmap for our cube texture
         // We don't check the return value here since
@@ -222,7 +211,7 @@ int main()
                     if (mipmapEnabled)
                     {
                         // We simply reload the texture to disable mipmapping
-                        texture = sf::Texture(resourcesDir() / "logo.png");
+                        texture = sf::Texture("resources/logo.png");
 
                         // Rebind the texture
                         sf::Texture::bind(&texture);

--- a/examples/sound_effects/CMakeLists.txt
+++ b/examples/sound_effects/CMakeLists.txt
@@ -1,12 +1,9 @@
 # all source files
 set(SRC SoundEffects.cpp)
-if(SFML_OS_IOS)
-    set(RESOURCES
-        resources/doodle_pop.ogg
-        resources/text-background.png
-        resources/tuffy.ttf)
-    set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-endif()
+set(RESOURCES
+    resources/doodle_pop.ogg
+    resources/text-background.png
+    resources/tuffy.ttf)
 
 # define the sound-effects target
 sfml_add_example(sound-effects GUI_APP

--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -23,14 +23,6 @@ constexpr auto windowHeight = 600u;
 constexpr auto pi           = 3.14159265359f;
 constexpr auto sqrt2        = 2.0f * 0.707106781186547524401f;
 
-std::filesystem::path resourcesDir()
-{
-#ifdef SFML_SYSTEM_IOS
-    return "";
-#else
-    return "resources";
-#endif
-}
 } // namespace
 
 
@@ -116,9 +108,10 @@ public:
         m_listener.setFillColor(sf::Color::Red);
 
         // Load the music file
-        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
+        const std::filesystem::path musicPath("resources/doodle_pop.ogg");
+        if (!m_music.openFromFile(musicPath))
         {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
+            std::cerr << "Failed to load " << musicPath << std::endl;
             std::abort();
         }
 
@@ -178,9 +171,10 @@ public:
         m_volumeText(getFont(), "Volume: " + std::to_string(m_volume))
     {
         // Load the music file
-        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
+        const std::filesystem::path musicPath("resources/doodle_pop.ogg");
+        if (!m_music.openFromFile(musicPath))
         {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
+            std::cerr << "Failed to load " << musicPath << std::endl;
             std::abort();
         }
 
@@ -284,9 +278,10 @@ public:
         makeCone(m_soundConeInner, innerConeAngle);
 
         // Load the music file
-        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
+        const std::filesystem::path musicPath("resources/doodle_pop.ogg");
+        if (!m_music.openFromFile(musicPath))
         {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
+            std::cerr << "Failed to load " << musicPath << std::endl;
             std::abort();
         }
 
@@ -678,9 +673,10 @@ protected:
         m_instructions.setPosition({windowWidth / 2.f - 250.f, windowHeight * 3.f / 4.f});
 
         // Load the music file
-        if (!m_music.openFromFile(resourcesDir() / "doodle_pop.ogg"))
+        const std::filesystem::path musicPath("resources/doodle_pop.ogg");
+        if (!m_music.openFromFile(musicPath))
         {
-            std::cerr << "Failed to load " << (resourcesDir() / "doodle_pop.ogg").string() << std::endl;
+            std::cerr << "Failed to load " << musicPath << std::endl;
             std::abort();
         }
 
@@ -1081,7 +1077,7 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Open the application font and pass it to the Effect class
-    const sf::Font font(resourcesDir() / "tuffy.ttf");
+    const sf::Font font("resources/tuffy.ttf");
     Effect::setFont(font);
 
     // Create the effects
@@ -1110,7 +1106,7 @@ int main()
     effects[current]->start();
 
     // Create the messages background
-    const sf::Texture textBackgroundTexture(resourcesDir() / "text-background.png");
+    const sf::Texture textBackgroundTexture("resources/text-background.png");
     sf::Sprite        textBackground(textBackgroundTexture);
     textBackground.setPosition({0.f, 520.f});
     textBackground.setColor(sf::Color(255, 255, 255, 200));

--- a/examples/tennis/CMakeLists.txt
+++ b/examples/tennis/CMakeLists.txt
@@ -1,12 +1,9 @@
 # all source files
 set(SRC Tennis.cpp)
-if(SFML_OS_IOS)
-    set(RESOURCES
-        resources/ball.wav
-        resources/sfml_logo.png
-        resources/tuffy.ttf)
-    set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-endif()
+set(RESOURCES
+    resources/ball.wav
+    resources/sfml_logo.png
+    resources/tuffy.ttf)
 
 # define the tennis target
 sfml_add_example(tennis GUI_APP

--- a/examples/tennis/Tennis.cpp
+++ b/examples/tennis/Tennis.cpp
@@ -16,17 +16,6 @@
 #include <SFML/Main.hpp>
 #endif
 
-namespace
-{
-std::filesystem::path resourcesDir()
-{
-#ifdef SFML_SYSTEM_IOS
-    return "";
-#else
-    return "resources";
-#endif
-}
-} // namespace
 
 ////////////////////////////////////////////////////////////
 /// Entry point of application
@@ -52,11 +41,11 @@ int main()
     window.setVerticalSyncEnabled(true);
 
     // Load the sounds used in the game
-    const sf::SoundBuffer ballSoundBuffer(resourcesDir() / "ball.wav");
+    const sf::SoundBuffer ballSoundBuffer("resources/ball.wav");
     sf::Sound             ballSound(ballSoundBuffer);
 
     // Create the SFML logo texture:
-    const sf::Texture sfmlLogoTexture(resourcesDir() / "sfml_logo.png");
+    const sf::Texture sfmlLogoTexture("resources/sfml_logo.png");
     sf::Sprite        sfmlLogo(sfmlLogoTexture);
     sfmlLogo.setPosition({170.f, 50.f});
 
@@ -85,7 +74,7 @@ int main()
     ball.setOrigin({ballRadius / 2.f, ballRadius / 2.f});
 
     // Open the text font
-    const sf::Font font(resourcesDir() / "tuffy.ttf");
+    const sf::Font font("resources/tuffy.ttf");
 
     // Initialize the pause message
     sf::Text pauseMessage(font);

--- a/examples/text/CMakeLists.txt
+++ b/examples/text/CMakeLists.txt
@@ -1,25 +1,22 @@
 # all source files
 set(SRC Text.cpp)
-if(SFML_OS_IOS)
-    set(RESOURCES
-        resources/NotoNaskhArabic-Regular.ttf
-        resources/NotoSerif-Regular.ttf
-        resources/NotoSerifArmenian-Regular.ttf
-        resources/NotoSerifDevanagari-Regular.ttf
-        resources/NotoSerifEthiopic-Regular.ttf
-        resources/NotoSerifGeorgian-Regular.ttf
-        resources/NotoSerifHebrew-Regular.ttf
-        resources/NotoSerifJP-Regular.subset.ttf
-        resources/NotoSerifKhmer-Regular.ttf
-        resources/NotoSerifKR-Regular.subset.ttf
-        resources/NotoSerifMyanmar-Regular.ttf
-        resources/NotoSerifTamil-Regular.ttf
-        resources/NotoSerifTC-Regular.subset.ttf
-        resources/NotoSerifThai-Regular.ttf
-        resources/NotoSerifTibetan-Regular.ttf
-        resources/tuffy.ttf)
-    set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-endif()
+set(RESOURCES
+    resources/NotoNaskhArabic-Regular.ttf
+    resources/NotoSerif-Regular.ttf
+    resources/NotoSerifArmenian-Regular.ttf
+    resources/NotoSerifDevanagari-Regular.ttf
+    resources/NotoSerifEthiopic-Regular.ttf
+    resources/NotoSerifGeorgian-Regular.ttf
+    resources/NotoSerifHebrew-Regular.ttf
+    resources/NotoSerifJP-Regular.subset.ttf
+    resources/NotoSerifKhmer-Regular.ttf
+    resources/NotoSerifKR-Regular.subset.ttf
+    resources/NotoSerifMyanmar-Regular.ttf
+    resources/NotoSerifTamil-Regular.ttf
+    resources/NotoSerifTC-Regular.subset.ttf
+    resources/NotoSerifThai-Regular.ttf
+    resources/NotoSerifTibetan-Regular.ttf
+    resources/tuffy.ttf)
 
 # define the text target
 sfml_add_example(text GUI_APP

--- a/examples/text/Text.cpp
+++ b/examples/text/Text.cpp
@@ -17,14 +17,6 @@
 
 namespace
 {
-std::filesystem::path resourcesDir()
-{
-#ifdef SFML_SYSTEM_IOS
-    return "";
-#else
-    return "resources";
-#endif
-}
 constexpr auto windowWidth           = 1200u;
 constexpr auto textSize              = 23u;
 constexpr auto textSpacing           = 5.0f;
@@ -41,7 +33,7 @@ const auto sfmlVersionString = "\u202A" + std::string(sf::version().string) + "\
 struct DemoText
 {
     DemoText(const std::filesystem::path& fontFilename, std::string_view message) :
-        font(std::make_unique<sf::Font>(resourcesDir() / fontFilename)),
+        font(std::make_unique<sf::Font>("resources" / fontFilename)),
         text(*font, sf::String::fromUtf8(message.begin(), message.end()), textSize)
     {
         // Generate per-character effect data
@@ -638,7 +630,7 @@ int main()
     sf::RenderWindow window(sf::VideoMode({windowWidth, 800u}), "SFML Text", sf::Style::Titlebar | sf::Style::Close);
     window.setVerticalSyncEnabled(true);
 
-    const sf::Font font(resourcesDir() / "tuffy.ttf");
+    const sf::Font font("resources/tuffy.ttf");
     sf::Text       instructions(font,
                           "F1: Toggle text bounding box\nF2: Toggle glyph bounding box\nF3: Toggle cursor\nF4: Cycle "
                                 "pre-processing (None, Color, Outline, Italicize, Embolden)\nLeft/Right "


### PR DESCRIPTION
On iOS:
- Put the resources in a resources subfolder so we no longer need the `resourcesDir` workaround in the examples

On Mac:
- Share the resource behaviour with iOS So the resources are included in the bundle
- When an example is a "GUI" app (denoted by the existing `GUI_APP` parameter of `sfml_add_example`) build an app bundle instead of a raw executable

No intended effects on other platforms - I chose not to keep the `RESOURCE` element of the example CMake as apple only because they have no negative effects on other platforms, and have potential to be useful if/when we want to package or install the examples

Should note - bundles on Mac still don't work as SFML doesn't provide any way to get the path to the bundle resources, but I hope to propose an API for that in the not too distant future