### PR TITLE
Add CMake preset for iOS

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -62,7 +62,7 @@ jobs:
       run: cmake --preset dev ${{ matrix.platform.name != 'Android' && '-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++' || ''}} -DCMAKE_UNITY_BUILD=ON -DSFML_RUN_IPV4_LINK_TESTS=ON -DSFML_RUN_IPV4_INTERNET_TESTS=ON -DSFML_RUN_IPV6_LINK_TESTS=ON -DSFML_NETWORK_TESTS_MAX_FDS=1028 ${{matrix.platform.flags}}
 
     - name: Analyze Code
-      run: cmake --build build --target tidy
+      run: cmake --build build/dev --target tidy
 
   sanitize:
     name: Sanitizing on ${{ matrix.platform.name }}
@@ -95,7 +95,7 @@ jobs:
       run: cmake --preset dev -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSFML_BUILD_EXAMPLES=OFF -DSFML_ENABLE_SANITIZERS=ON -DSFML_RUN_IPV4_LINK_TESTS=ON -DSFML_RUN_IPV4_INTERNET_TESTS=ON -DSFML_RUN_IPV6_LINK_TESTS=ON -DSFML_NETWORK_TESTS_MAX_FDS=1028 ${{matrix.platform.flags}}
 
     - name: Build
-      run: cmake --build build
+      run: cmake --build build/dev
 
     - name: Prepare Test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
       run: cmake --preset dev -DCMAKE_VERBOSE_MAKEFILE=ON -DSFML_RUN_IPV4_LINK_TESTS=ON -DSFML_RUN_IPV4_INTERNET_TESTS=ON -DSFML_RUN_IPV6_LINK_TESTS=ON -DSFML_NETWORK_TESTS_MAX_FDS=1028 ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}}
 
     - name: Build
-      run: cmake --build build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
+      run: cmake --build build/dev --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} --target install
 
     - name: Build Android example
       if: matrix.platform.name == 'Android'
@@ -220,7 +220,7 @@ jobs:
     - name: Test (Windows)
       if: runner.os == 'Windows' && !contains(matrix.platform.name, 'MinGW') && !contains(matrix.platform.name, 'arm64')
       run: |
-        cmake --build build --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
+        cmake --build build/dev --target runtests --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
     - name: Test (Linux/macOS/MinGW)
       if: (runner.os != 'Windows' || contains(matrix.platform.name, 'MinGW')) && !contains(matrix.platform.name, 'iOS') && !contains(matrix.platform.name, 'Android')
@@ -245,13 +245,13 @@ jobs:
     - name: Test Install Interface (Package path)
       if: matrix.platform.name != 'Android'
       run: |
-        cmake -S test/install -B test/install/build -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/build/install -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}} -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
+        cmake -S test/install -B test/install/build -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/build/dev/install -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}} -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH
         cmake --build test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
     - name: Test Install Interface (Config path)
       if: matrix.platform.name != 'Android' && !contains(matrix.config.name, 'Frameworks')
       run: |
-        cmake -S test/install -B test/install/build -DSFML_DIR=$GITHUB_WORKSPACE/build/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}} --fresh
+        cmake -S test/install -B test/install/build -DSFML_DIR=$GITHUB_WORKSPACE/build/dev/install/lib/cmake/SFML -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }} ${{matrix.platform.flags}} ${{matrix.config.flags}} ${{matrix.type.flags}} --fresh
         cmake --build test/install/build --config ${{ matrix.type.name == 'Debug' && 'Debug' || 'Release' }}
 
   coverage:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,8 +3,8 @@
   "configurePresets":[
     {
       "name": "dev",
-      "binaryDir": "build",
-      "installDir": "${sourceDir}/build/install",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "installDir": "${sourceDir}/build/${presetName}/install",
       "cacheVariables": {
         "CMAKE_CXX_EXTENSIONS": "OFF",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
@@ -12,6 +12,14 @@
         "SFML_BUILD_TEST_SUITE": "ON",
         "SFML_ENABLE_STDLIB_ASSERTIONS": "ON",
         "SFML_WARNINGS_AS_ERRORS": "ON"
+      }
+    },
+    {
+      "name": "ios",
+      "inherits": "dev",
+      "generator": "Xcode",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME" : "iOS"
       }
     }
   ]


### PR DESCRIPTION
Makes building for iOS much simpler, having a separate build directory that doesn't conflict with the standard dev one and will be ignored by git