### PR TITLE
Fix `target_link_options` for Android.

### DIFF
--- a/src/SFML/Main/CMakeLists.txt
+++ b/src/SFML/Main/CMakeLists.txt
@@ -30,7 +30,7 @@ if(SFML_OS_ANDROID)
     target_link_libraries(sfml-main PRIVATE android)
 
     # Ensure this method is not stripped
-    target_link_options(sfml-main PUBLIC "LINKER:-u ANativeActivity_onCreate")
+    target_link_options(sfml-main PUBLIC "LINKER:-u,ANativeActivity_onCreate")
 
     target_link_libraries(sfml-main PUBLIC SFML::System)
 elseif(SFML_OS_IOS)


### PR DESCRIPTION
The [earlier PR](https://github.com/SFML/SFML/pull/3697) introduced syntax that did not work for others.
Later, [it was revealed](https://discord.com/channels/175298431294636032/477173543281491968/1490583954829479936) that I misinterpretted the `target_link_options`'s `LINK:<expr>` syntax and it required a comma.

This fix worked for user Lapinozz and I was able to verify this fix also worked in my environment as well. Hopefully fixing this linker issue for everyone when building for android.

-   [x] Tested on Android
