### PR TITLE
Fixed audio issues

### DIFF
--- a/examples/sound_effects/SoundEffects.cpp
+++ b/examples/sound_effects/SoundEffects.cpp
@@ -811,7 +811,8 @@ struct HighPassFilter : BiquadFilter
     {
         static constexpr auto cutoffFrequency = 2000.f;
 
-        const auto c = std::tan(pi * cutoffFrequency / static_cast<float>(getMusic().getSampleRate()));
+        const auto c = std::tan(
+            pi * cutoffFrequency / static_cast<float>(sf::PlaybackDevice::getDeviceSampleRate().value_or(44100)));
 
         Coefficients coefficients;
 
@@ -835,7 +836,8 @@ struct LowPassFilter : BiquadFilter
     {
         static constexpr auto cutoffFrequency = 500.f;
 
-        const auto c = 1.f / std::tan(pi * cutoffFrequency / static_cast<float>(getMusic().getSampleRate()));
+        const auto c = 1.f / std::tan(pi * cutoffFrequency /
+                                      static_cast<float>(sf::PlaybackDevice::getDeviceSampleRate().value_or(44100)));
 
         Coefficients coefficients;
 
@@ -864,7 +866,7 @@ struct Echo : Processing
         static constexpr auto wet   = 0.8f;
         static constexpr auto dry   = 1.f;
 
-        const auto sampleRate    = music.getSampleRate();
+        const auto sampleRate    = sf::PlaybackDevice::getDeviceSampleRate().value_or(44100);
         const auto delayInFrames = static_cast<unsigned int>(static_cast<float>(sampleRate) * delay);
 
         // We use a mutable lambda to tie the lifetime of the state to the lambda itself
@@ -930,7 +932,7 @@ public:
         // this lambda hence we need to always have a usable state until the Music and the
         // associated lambda are destroyed
         music.setEffectProcessor(
-            [sampleRate = music.getSampleRate(),
+            [sampleRate = sf::PlaybackDevice::getDeviceSampleRate().value_or(44100),
              filters    = std::vector<ReverbFilter<float>>(),
              enabled    = getEnabled()](const float*  inputFrames,
                                      unsigned int& inputFrameCount,

--- a/include/SFML/Audio/SoundSource.hpp
+++ b/include/SFML/Audio/SoundSource.hpp
@@ -82,7 +82,13 @@ public:
     /// When the audio engine sources sound data from sound
     /// sources it will pass the data through an effects
     /// processor if one is set. The sound data will already be
-    /// converted to the internal floating point format.
+    /// converted to the internal floating point format and have
+    /// the same sample rate as the audio device and engine. The
+    /// device sample rate can differ from the sample rate of
+    /// the source data so keep this in mind when setting up
+    /// processing that is dependent on the sample rate. The
+    /// sample rate of the current playback device can be
+    /// retrieved using `sf::PlaybackDevice::getDeviceSampleRate()`.
     ///
     /// Sound data that is processed this way is provided in
     /// frames. Each frame contains 1 floating point sample per

--- a/src/SFML/Audio/AudioDevice.cpp
+++ b/src/SFML/Audio/AudioDevice.cpp
@@ -692,6 +692,34 @@ bool AudioDevice::initialize()
     playbackDeviceConfig.playback.format    = ma_format_f32;
     playbackDeviceConfig.playback.pDeviceID = deviceId ? &*deviceId : nullptr;
 
+    // Set the period size to 64 frames worth of data
+    // This value serves as a buffer size hint to the device driver but
+    // will be clamped to stay within valid minimum and maximum values
+    // The value also determines the rate at which data is pulled through
+    // the audio node graph
+    // Leaving this value at the default of 0 would instruct miniaudio to
+    // automatically determine how much data it should attempt to pull
+    // through the node graph every time new data is required
+    // When playing very short audio clips with a low frame count the total
+    // number of frames might not be enough to fill the allocated buffer
+    // This is more likely the higher the device sample rate is due to a
+    // bigger frame buffer being allocated to accomodate higher sample rate data
+    // Testing shows that if the buffer cannot be entirely filled with data,
+    // playing the short audio clip will lead to no audio being output until
+    // enough data has been pulled through the node graph to fill an entire
+    // buffer worth of data, subsequent playing of the audio clip after the
+    // buffer has already been filled the first time plays without issues
+    // In order to support playing short audio clips we therefore have to
+    // explicitly set periodSizeInFrames to a low value to ensure that initial
+    // data does not get stuck in the buffer which would lead to no output
+    // Decreasing periodSizeInFrames technically does increase CPU load since
+    // data is pulled through the node graph more frequently but empirical
+    // testing shows that this additional overhead is not significant
+    // If this does cause issues we would have to expose setting this value
+    // through the public API so the developer can set it to an appropriate
+    // value depending on the audio data they intend to play
+    playbackDeviceConfig.periodSizeInFrames = 64;
+
     if (const auto result = ma_device_init(&*m_context, &playbackDeviceConfig, &*m_playbackDevice); result != MA_SUCCESS)
     {
         m_playbackDevice.reset();


### PR DESCRIPTION
This changeset fixes 2 minor issues:
- The sample rate used by the sound effects example was incorrectly using the sample rate of the source audio data and not the sample rate of the playback device which is the sample rate of the data passed to the processing callback
- The size of the audio frame buffer that was automatically chosen by miniaudio for higher sample rate devices would be so big that playing very short audio clips would not output any audio until the buffer is filled entirely at least once

Miniaudio organizes sounds into a node graph. Data is recursively pulled from the sink (the audio device) back to the sources traversing the graph node by node. Because we are using the miniaudio engine for special effects (surround, doppler, etc.) the nodes are engine nodes as well. The engine is initialized to process data at the same sample rate as the device it is attached to. This means that as soon as data is read from the source e.g. an audio file it is converted into the engine/device format before it is sent through the graph.

SFML's support for audio effects processing via callback is implemented by a custom node we insert into the node graph right after the sound source. This means that audio data passing through our effects processing node will already be in the device format since conversion was performed in the source node. Before this change, the sound effects example was incorrectly using the sample rate of the source data instead of the device sample rate to perform filtering leading to incorrect processing taking place.

This becomes noticeable the more the audio playback device sample rate deviates from the audio file that is being played. To reproduce the problem, run the sound effects example using a playback device that is set to a higher than typical sample rate e.g. 384KHz and activate any of the processing filters e.g. echo or low/high-pass filters.

This fix changes the processing filters to use the device sample rate instead.

When running the tennis example with my audio device set to 384KHz sample rate I noticed that the first ball bounce sound was not playing. Subsequent ball bounce sounds played.

Through debugging I found out this was due to the allocated audio frame buffer for high sample rate devices being so large that the entirety of the ball bounce samples was not enough to fill it leading to the first play of the sound not outputting any audio. When creating a device, miniaudio allows specifying `periodSizeInFrames`. This value is used as a hint when allocating the device buffer, it is clamped between a minimum and maximum buffer size supported by the device. This value is also used as the size of the buffer used to pull audio data through the miniaudio node graph.

In order to prevent the entirety of a sound's samples not filling up the buffer used to pull audio, we simply reduce the size of the buffer used to pull audio data. The smaller the buffer the more frequent miniaudio has to pull audio data since each buffer will contain a smaller duration of data which means that CPU load increases, thus we don't want to set the value lower than it has to be. From testing it seems like setting `periodSizeInFrames` to 64 allows us to play very short audio clips even on high sample rate devices without the first plays of the audio going missing. If it turns out this value has to be adjusted in the future or a possibility has to be provided for the user to set it through the public API the discussion can continue in another issue.