### PR TITLE
Disable HarfBuzz GPU library, was SFML doesn't use it yet

### DIFF
--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -152,6 +152,7 @@ else()
         set(HB_BUILD_SUBSET OFF)
         set(HB_BUILD_RASTER OFF)
         set(HB_BUILD_VECTOR OFF)
+        set(HB_BUILD_GPU OFF)
         set(HB_HAVE_FREETYPE ON)
         set(HB_HAVE_CORETEXT OFF)
 


### PR DESCRIPTION
## Description

[Version 14.0.0](https://github.com/harfbuzz/harfbuzz/releases/tag/14.0.0) introduced libharfbuzz-gpu with the Slug algorithm, but as we're not using it (yet?!), there's no need in building said library.

## How to test this PR?

CI should pass