### PR TITLE
Redirect Packet's operators to use unsigned overloads

### DIFF
--- a/src/SFML/Network/Packet.cpp
+++ b/src/SFML/Network/Packet.cpp
@@ -110,13 +110,7 @@ Packet& Packet::operator>>(bool& data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator>>(std::int8_t& data)
 {
-    if (checkSize(sizeof(data)))
-    {
-        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
-        m_readPos += sizeof(data);
-    }
-
-    return *this;
+    return *this >> reinterpret_cast<std::uint8_t&>(data);
 }
 
 
@@ -136,14 +130,7 @@ Packet& Packet::operator>>(std::uint8_t& data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator>>(std::int16_t& data)
 {
-    if (checkSize(sizeof(data)))
-    {
-        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
-        data = static_cast<std::int16_t>(ntohs(static_cast<std::uint16_t>(data)));
-        m_readPos += sizeof(data);
-    }
-
-    return *this;
+    return *this >> reinterpret_cast<std::uint16_t&>(data);
 }
 
 
@@ -164,14 +151,7 @@ Packet& Packet::operator>>(std::uint16_t& data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator>>(std::int32_t& data)
 {
-    if (checkSize(sizeof(data)))
-    {
-        std::memcpy(&data, &m_data[m_readPos], sizeof(data));
-        data = static_cast<std::int32_t>(ntohl(static_cast<std::uint32_t>(data)));
-        m_readPos += sizeof(data);
-    }
-
-    return *this;
+    return *this >> reinterpret_cast<std::uint32_t&>(data);
 }
 
 
@@ -192,19 +172,7 @@ Packet& Packet::operator>>(std::uint32_t& data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator>>(std::int64_t& data)
 {
-    if (checkSize(sizeof(data)))
-    {
-        // Since ntohll is not available everywhere, we have to convert
-        // to network byte order (big endian) manually
-        std::array<std::byte, sizeof(data)> bytes{};
-        std::memcpy(bytes.data(), &m_data[m_readPos], bytes.size());
-
-        data = toInteger<std::int64_t>(bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2], bytes[1], bytes[0]);
-
-        m_readPos += sizeof(data);
-    }
-
-    return *this;
+    return *this >> reinterpret_cast<std::uint64_t&>(data);
 }
 
 
@@ -395,9 +363,7 @@ Packet& Packet::operator<<(std::uint8_t data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator<<(std::int16_t data)
 {
-    const auto toWrite = static_cast<std::int16_t>(htons(static_cast<std::uint16_t>(data)));
-    append(&toWrite, sizeof(toWrite));
-    return *this;
+    return *this << static_cast<std::uint16_t>(data);
 }
 
 
@@ -413,9 +379,7 @@ Packet& Packet::operator<<(std::uint16_t data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator<<(std::int32_t data)
 {
-    const auto toWrite = static_cast<std::int32_t>(htonl(static_cast<std::uint32_t>(data)));
-    append(&toWrite, sizeof(toWrite));
-    return *this;
+    return *this << static_cast<std::uint32_t>(data);
 }
 
 
@@ -431,20 +395,7 @@ Packet& Packet::operator<<(std::uint32_t data)
 ////////////////////////////////////////////////////////////
 Packet& Packet::operator<<(std::int64_t data)
 {
-    // Since htonll is not available everywhere, we have to convert
-    // to network byte order (big endian) manually
-
-    const std::array toWrite = {static_cast<std::uint8_t>((data >> 56) & 0xFF),
-                                static_cast<std::uint8_t>((data >> 48) & 0xFF),
-                                static_cast<std::uint8_t>((data >> 40) & 0xFF),
-                                static_cast<std::uint8_t>((data >> 32) & 0xFF),
-                                static_cast<std::uint8_t>((data >> 24) & 0xFF),
-                                static_cast<std::uint8_t>((data >> 16) & 0xFF),
-                                static_cast<std::uint8_t>((data >> 8) & 0xFF),
-                                static_cast<std::uint8_t>((data) & 0xFF)};
-
-    append(toWrite.data(), toWrite.size());
-    return *this;
+    return *this << static_cast<std::uint64_t>(data);
 }
 
 


### PR DESCRIPTION
`std::intN_t` types are required to be 2's compliment so the unsigned/signed representations are the same, we can just cast them instead of duplicating the code.

`signed T` can safely be `reinterpret_cast`ed to `unsigned T` and vice versa per https://eel.is/c++draft/basic.lval#11 