### PR TITLE
Add functions to get useful standard paths

### DIFF
--- a/include/SFML/System/StandardPaths.hpp
+++ b/include/SFML/System/StandardPaths.hpp
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2026 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#pragma once
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+
+#include <filesystem>
+#include <optional>
+#include <string_view>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \ingroup system
+/// \brief Well-known user folders that may be queried via `getUserFolder`
+///
+////////////////////////////////////////////////////////////
+enum class UserFolder
+{
+    Home,      //!< User's home directory
+    Desktop,   //!< User's desktop directory
+    Documents, //!< User's documents directory
+    Downloads, //!< User's downloads directory
+    Pictures,  //!< User's pictures directory
+    Music,     //!< User's music directory
+    Videos     //!< User's videos directory
+};
+
+////////////////////////////////////////////////////////////
+/// \ingroup system
+/// \brief Get the directory containing the application's bundled, read-only resources
+///
+/// The returned path is platform-specific:
+/// \li Windows / Linux / BSD: directory containing the running executable
+/// \li macOS: `Contents/Resources` of the application bundle, or the executable
+///     directory when not running from a bundle
+/// \li iOS: the application bundle's resource directory
+/// \li Android: empty path (resources live inside the APK and must be read via
+///     `sf::FileInputStream`, which transparently uses the asset manager)
+///
+/// Use this when locating game assets that ship alongside the executable, instead
+/// of relying on the current working directory, which is unreliable for bundled
+/// applications.
+///
+/// \return Path to the resource directory, or an empty path if it could not be determined
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_SYSTEM_API std::filesystem::path getResourceDirectory();
+
+////////////////////////////////////////////////////////////
+/// \ingroup system
+/// \brief Get a per-application directory suitable for read/write user data
+///
+/// Use this for save games, settings, and other persistent application data. The
+/// returned directory is namespaced by `organization` and `application` to avoid
+/// collisions with other applications. The directory is not guaranteed to exist
+/// on disk; create it before writing.
+///
+/// The base location depends on the platform:
+/// \li Windows: `%APPDATA%\<organization>\<application>`
+/// \li Linux / BSD: `$XDG_DATA_HOME/<organization>/<application>` or
+///     `~/.local/share/<organization>/<application>`
+/// \li macOS: `~/Library/Application Support/<organization>/<application>`
+/// \li iOS: `<sandbox>/Library/Application Support/<organization>/<application>`
+/// \li Android: the activity's internal data path, with org/app subdirectories
+///
+/// \param organization Name of the organization (used as a parent directory)
+/// \param application  Name of the application (used as a leaf directory)
+///
+/// \return Path to the user data directory, or an empty path on failure
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_SYSTEM_API std::filesystem::path getUserDataDirectory(std::string_view organization,
+                                                                        std::string_view application);
+
+////////////////////////////////////////////////////////////
+/// \ingroup system
+/// \brief Get the path to a well-known user folder
+///
+/// Returns `std::nullopt` if the folder does not exist or has no meaningful path
+/// on the current platform. For example, on iOS only `Home` and `Documents`
+/// resolve to a real path; on Android most folders return `std::nullopt` because
+/// access is mediated by `MediaStore` rather than a direct filesystem path.
+///
+/// \param folder The well-known folder to look up
+///
+/// \return Path to the folder, or `std::nullopt` if unavailable
+///
+////////////////////////////////////////////////////////////
+[[nodiscard]] SFML_SYSTEM_API std::optional<std::filesystem::path> getUserFolder(UserFolder folder);
+
+} // namespace sf

--- a/src/SFML/System/Android/StandardPathsImpl.cpp
+++ b/src/SFML/System/Android/StandardPathsImpl.cpp
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2026 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Android/Activity.hpp>
+#include <SFML/System/StandardPathsImpl.hpp>
+
+
+namespace sf::priv::StandardPaths
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path getResourceDirectory()
+{
+    // Android resources live inside the APK and are not addressable as a
+    // filesystem path; they must be read via the asset manager (which
+    // sf::FileInputStream does automatically). Return an empty path to
+    // signal this.
+    return {};
+}
+
+
+////////////////////////////////////////////////////////////
+std::filesystem::path getUserDataBaseDirectory()
+{
+    if (ActivityStates* states = getActivityStatesPtr(); states != nullptr && states->activity != nullptr)
+    {
+        if (const char* path = states->activity->internalDataPath; path != nullptr)
+            return path;
+    }
+    return {};
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<std::filesystem::path> getUserFolder(UserFolder folder)
+{
+    // Scoped storage on modern Android forbids direct filesystem access to
+    // public folders; apps must use MediaStore / SAF instead. The only
+    // path-addressable directory is the app's private home (internalDataPath).
+    if (folder == UserFolder::Home)
+    {
+        if (ActivityStates* states = getActivityStatesPtr(); states != nullptr && states->activity != nullptr)
+        {
+            if (const char* path = states->activity->internalDataPath; path != nullptr)
+                return std::filesystem::path(path);
+        }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace sf::priv::StandardPaths

--- a/src/SFML/System/CMakeLists.txt
+++ b/src/SFML/System/CMakeLists.txt
@@ -16,6 +16,9 @@ set(SRC
     ${INCROOT}/NativeActivity.hpp
     ${SRCROOT}/Sleep.cpp
     ${INCROOT}/Sleep.hpp
+    ${SRCROOT}/StandardPaths.cpp
+    ${INCROOT}/StandardPaths.hpp
+    ${SRCROOT}/StandardPathsImpl.hpp
     ${SRCROOT}/String.cpp
     ${INCROOT}/String.hpp
     ${INCROOT}/String.inl
@@ -46,12 +49,30 @@ if(SFML_OS_WINDOWS)
     set(PLATFORM_SRC
         ${SRCROOT}/Win32/SleepImpl.cpp
         ${SRCROOT}/Win32/SleepImpl.hpp
+        ${SRCROOT}/Win32/StandardPathsImpl.cpp
     )
     source_group("windows" FILES ${PLATFORM_SRC})
+elseif(SFML_OS_MACOS)
+    enable_language(OBJCXX)
+    set(PLATFORM_SRC
+        ${SRCROOT}/Unix/SleepImpl.cpp
+        ${SRCROOT}/Unix/SleepImpl.hpp
+        ${SRCROOT}/macOS/StandardPathsImpl.mm
+    )
+    source_group("mac" FILES ${PLATFORM_SRC})
+elseif(SFML_OS_IOS)
+    enable_language(OBJCXX)
+    set(PLATFORM_SRC
+        ${SRCROOT}/Unix/SleepImpl.cpp
+        ${SRCROOT}/Unix/SleepImpl.hpp
+        ${SRCROOT}/iOS/StandardPathsImpl.mm
+    )
+    source_group("ios" FILES ${PLATFORM_SRC})
 else()
     set(PLATFORM_SRC
         ${SRCROOT}/Unix/SleepImpl.cpp
         ${SRCROOT}/Unix/SleepImpl.hpp
+        ${SRCROOT}/Unix/StandardPathsImpl.cpp
     )
 
     if(SFML_OS_ANDROID)
@@ -61,7 +82,12 @@ else()
             ${SRCROOT}/Android/NativeActivity.cpp
             ${SRCROOT}/Android/ResourceStream.cpp
             ${SRCROOT}/Android/ResourceStream.cpp
+            ${SRCROOT}/Android/StandardPathsImpl.cpp
             ${SRCROOT}/Android/SuspendAwareClock.cpp
+        )
+        # Drop the Unix StandardPaths impl on Android in favour of the Android one
+        list(REMOVE_ITEM PLATFORM_SRC
+            ${SRCROOT}/Unix/StandardPathsImpl.cpp
         )
     endif()
 
@@ -94,7 +120,17 @@ target_link_libraries(sfml-system PRIVATE Threads::Threads)
 if(SFML_OS_LINUX)
     target_link_libraries(sfml-system PRIVATE rt)
 elseif(SFML_OS_WINDOWS)
-    target_link_libraries(sfml-system PRIVATE winmm)
+    target_link_libraries(sfml-system PRIVATE winmm shell32 ole32)
+elseif(SFML_OS_MACOS)
+    target_link_libraries(sfml-system PRIVATE "-framework Foundation")
+elseif(SFML_OS_IOS)
+    target_link_libraries(sfml-system PUBLIC "-framework Foundation")
 elseif(SFML_OS_ANDROID)
     target_link_libraries(sfml-system PRIVATE android log)
+endif()
+
+# When static linking on macOS, we need this flag for Objective-C to work
+# https://developer.apple.com/library/archive/qa/qa1490/_index.html
+if((NOT BUILD_SHARED_LIBS) AND SFML_OS_MACOS)
+    target_link_libraries(sfml-system PRIVATE -ObjC)
 endif()

--- a/src/SFML/System/StandardPaths.cpp
+++ b/src/SFML/System/StandardPaths.cpp
@@ -22,37 +22,41 @@
 //
 ////////////////////////////////////////////////////////////
 
-#pragma once
-
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-
-#include <SFML/Config.hpp>
-
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
-#include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
 #include <SFML/System/StandardPaths.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/TimeoutWithPredicate.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
-#include <SFML/System/Version.hpp>
+#include <SFML/System/StandardPathsImpl.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path getResourceDirectory()
+{
+    return priv::StandardPaths::getResourceDirectory();
+}
 
 
 ////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
-///
+std::filesystem::path getUserDataDirectory(std::string_view organization, std::string_view application)
+{
+    auto base = priv::StandardPaths::getUserDataBaseDirectory();
+    if (base.empty())
+        return {};
+
+    if (!organization.empty())
+        base /= std::filesystem::path(organization);
+    if (!application.empty())
+        base /= std::filesystem::path(application);
+    return base;
+}
+
+
 ////////////////////////////////////////////////////////////
+std::optional<std::filesystem::path> getUserFolder(UserFolder folder)
+{
+    return priv::StandardPaths::getUserFolder(folder);
+}
+
+} // namespace sf

--- a/src/SFML/System/StandardPathsImpl.hpp
+++ b/src/SFML/System/StandardPathsImpl.hpp
@@ -27,32 +27,34 @@
 ////////////////////////////////////////////////////////////
 // Headers
 ////////////////////////////////////////////////////////////
-
-#include <SFML/Config.hpp>
-
-#include <SFML/System/Angle.hpp>
-#include <SFML/System/Clock.hpp>
-#include <SFML/System/Err.hpp>
-#include <SFML/System/Exception.hpp>
-#include <SFML/System/FileInputStream.hpp>
-#include <SFML/System/InputStream.hpp>
-#include <SFML/System/MemoryInputStream.hpp>
-#include <SFML/System/Sleep.hpp>
 #include <SFML/System/StandardPaths.hpp>
-#include <SFML/System/String.hpp>
-#include <SFML/System/Time.hpp>
-#include <SFML/System/TimeoutWithPredicate.hpp>
-#include <SFML/System/Utf.hpp>
-#include <SFML/System/Vector2.hpp>
-#include <SFML/System/Vector3.hpp>
-#include <SFML/System/Version.hpp>
+
+#include <filesystem>
+#include <optional>
 
 
+namespace sf::priv::StandardPaths
+{
+
 ////////////////////////////////////////////////////////////
-/// \defgroup system System module
-///
-/// Base module of SFML, defining various utilities. It provides
-/// vector classes, Unicode strings and conversion functions,
-/// threads and mutexes, timing classes.
+/// \copydoc sf::getResourceDirectory
 ///
 ////////////////////////////////////////////////////////////
+std::filesystem::path getResourceDirectory();
+
+////////////////////////////////////////////////////////////
+/// \brief Get the base directory used to derive `sf::getUserDataDirectory`
+///
+/// The public `sf::getUserDataDirectory` appends the organization and
+/// application names to the value returned here.
+///
+////////////////////////////////////////////////////////////
+std::filesystem::path getUserDataBaseDirectory();
+
+////////////////////////////////////////////////////////////
+/// \copydoc sf::getUserFolder
+///
+////////////////////////////////////////////////////////////
+std::optional<std::filesystem::path> getUserFolder(UserFolder folder);
+
+} // namespace sf::priv::StandardPaths

--- a/src/SFML/System/Unix/StandardPathsImpl.cpp
+++ b/src/SFML/System/Unix/StandardPathsImpl.cpp
@@ -1,0 +1,229 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2026 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/StandardPathsImpl.hpp>
+
+#include <fstream>
+#include <string>
+#include <system_error>
+
+#include <cstdlib>
+#include <pwd.h>
+#include <unistd.h>
+
+#if defined(SFML_SYSTEM_FREEBSD) || defined(SFML_SYSTEM_NETBSD) || defined(SFML_SYSTEM_OPENBSD)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#endif
+
+
+namespace
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path getHomeDirectory()
+{
+    if (const char* env = std::getenv("HOME"); env != nullptr && *env != '\0')
+        return env;
+
+    if (const passwd* pw = getpwuid(geteuid()); pw != nullptr && pw->pw_dir != nullptr)
+        return pw->pw_dir;
+
+    return {};
+}
+
+
+////////////////////////////////////////////////////////////
+// Parse the XDG user-dirs.dirs file to look up an entry like
+// `XDG_DOCUMENTS_DIR="$HOME/Documents"`. Returns an empty path if
+// the file or key is not present.
+////////////////////////////////////////////////////////////
+std::filesystem::path lookupXdgUserDir(const std::string& key)
+{
+    const std::filesystem::path home = getHomeDirectory();
+
+    std::filesystem::path configDir;
+    if (const char* env = std::getenv("XDG_CONFIG_HOME"); env != nullptr && *env != '\0')
+        configDir = env;
+    else if (!home.empty())
+        configDir = home / ".config";
+    else
+        return {};
+
+    std::ifstream file(configDir / "user-dirs.dirs");
+    if (!file)
+        return {};
+
+    std::string line;
+    while (std::getline(file, line))
+    {
+        // Skip comments and blanks
+        const auto first = line.find_first_not_of(" \t");
+        if (first == std::string::npos || line[first] == '#')
+            continue;
+
+        if (line.compare(first, key.size(), key) != 0)
+            continue;
+        const auto eq = line.find('=', first + key.size());
+        if (eq == std::string::npos)
+            continue;
+
+        // Value is quoted: XDG_DOCUMENTS_DIR="$HOME/Documents"
+        const auto quoteStart = line.find('"', eq);
+        const auto quoteEnd   = (quoteStart == std::string::npos) ? std::string::npos : line.find('"', quoteStart + 1);
+        if (quoteStart == std::string::npos || quoteEnd == std::string::npos)
+            continue;
+
+        std::string value = line.substr(quoteStart + 1, quoteEnd - quoteStart - 1);
+        const std::string prefix = "$HOME";
+        if (value.compare(0, prefix.size(), prefix) == 0)
+        {
+            if (home.empty())
+                return {};
+            return home / std::filesystem::path(value.substr(prefix.size() + 1)); // skip the trailing '/'
+        }
+        return value;
+    }
+
+    return {};
+}
+
+
+////////////////////////////////////////////////////////////
+std::filesystem::path executablePath()
+{
+#if defined(SFML_SYSTEM_LINUX) || defined(SFML_SYSTEM_ANDROID)
+    std::error_code ec;
+    auto            path = std::filesystem::read_symlink("/proc/self/exe", ec);
+    if (!ec)
+        return path;
+#elif defined(SFML_SYSTEM_FREEBSD) || defined(SFML_SYSTEM_NETBSD)
+    // Try the procfs route first (often disabled by default on these)
+    std::error_code ec;
+#if defined(SFML_SYSTEM_FREEBSD)
+    auto path = std::filesystem::read_symlink("/proc/curproc/file", ec);
+#else
+    auto path = std::filesystem::read_symlink("/proc/curproc/exe", ec);
+#endif
+    if (!ec)
+        return path;
+
+    // Fall back to KERN_PROC_PATHNAME via sysctl
+    int    mib[4]   = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+    char   buffer[4096] = {};
+    size_t length   = sizeof(buffer);
+    if (sysctl(mib, 4, buffer, &length, nullptr, 0) == 0 && length > 0)
+        return std::filesystem::path(std::string(buffer, length - 1));
+#elif defined(SFML_SYSTEM_OPENBSD)
+    // OpenBSD does not expose the executable path; nothing we can do reliably.
+#endif
+
+    return {};
+}
+} // namespace
+
+
+namespace sf::priv::StandardPaths
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path getResourceDirectory()
+{
+    auto path = executablePath();
+    if (path.empty())
+        return {};
+    return path.parent_path();
+}
+
+
+////////////////////////////////////////////////////////////
+std::filesystem::path getUserDataBaseDirectory()
+{
+    if (const char* env = std::getenv("XDG_DATA_HOME"); env != nullptr && *env != '\0')
+        return env;
+
+    const auto home = getHomeDirectory();
+    if (home.empty())
+        return {};
+    return home / ".local" / "share";
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<std::filesystem::path> getUserFolder(UserFolder folder)
+{
+    const auto home = getHomeDirectory();
+
+    if (folder == UserFolder::Home)
+    {
+        if (home.empty())
+            return std::nullopt;
+        return home;
+    }
+
+    if (home.empty())
+        return std::nullopt;
+
+    // Map enum -> XDG key + default folder name
+    const char* xdgKey      = nullptr;
+    const char* defaultName = nullptr;
+    switch (folder)
+    {
+        case UserFolder::Desktop:
+            xdgKey      = "XDG_DESKTOP_DIR";
+            defaultName = "Desktop";
+            break;
+        case UserFolder::Documents:
+            xdgKey      = "XDG_DOCUMENTS_DIR";
+            defaultName = "Documents";
+            break;
+        case UserFolder::Downloads:
+            xdgKey      = "XDG_DOWNLOAD_DIR";
+            defaultName = "Downloads";
+            break;
+        case UserFolder::Pictures:
+            xdgKey      = "XDG_PICTURES_DIR";
+            defaultName = "Pictures";
+            break;
+        case UserFolder::Music:
+            xdgKey      = "XDG_MUSIC_DIR";
+            defaultName = "Music";
+            break;
+        case UserFolder::Videos:
+            xdgKey      = "XDG_VIDEOS_DIR";
+            defaultName = "Videos";
+            break;
+        case UserFolder::Home:
+            // Already handled above
+            return home;
+    }
+
+    if (auto fromXdg = lookupXdgUserDir(xdgKey); !fromXdg.empty())
+        return fromXdg;
+
+    return home / defaultName;
+}
+
+} // namespace sf::priv::StandardPaths

--- a/src/SFML/System/Win32/StandardPathsImpl.cpp
+++ b/src/SFML/System/Win32/StandardPathsImpl.cpp
@@ -1,0 +1,110 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2026 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/StandardPathsImpl.hpp>
+#include <SFML/System/Win32/WindowsHeader.hpp>
+
+#include <ShlObj.h>
+#include <KnownFolders.h>
+
+
+namespace
+{
+std::filesystem::path knownFolderPath(REFKNOWNFOLDERID id)
+{
+    PWSTR rawPath = nullptr;
+    if (FAILED(SHGetKnownFolderPath(id, 0, nullptr, &rawPath)) || rawPath == nullptr)
+    {
+        if (rawPath != nullptr)
+            CoTaskMemFree(rawPath);
+        return {};
+    }
+
+    std::filesystem::path result(rawPath);
+    CoTaskMemFree(rawPath);
+    return result;
+}
+} // namespace
+
+
+namespace sf::priv::StandardPaths
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path getResourceDirectory()
+{
+    wchar_t buffer[MAX_PATH] = {};
+    const DWORD length = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+    if (length == 0 || length == MAX_PATH)
+        return {};
+
+    return std::filesystem::path(buffer).parent_path();
+}
+
+
+////////////////////////////////////////////////////////////
+std::filesystem::path getUserDataBaseDirectory()
+{
+    return knownFolderPath(FOLDERID_RoamingAppData);
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<std::filesystem::path> getUserFolder(UserFolder folder)
+{
+    KNOWNFOLDERID id{};
+    switch (folder)
+    {
+        case UserFolder::Home:
+            id = FOLDERID_Profile;
+            break;
+        case UserFolder::Desktop:
+            id = FOLDERID_Desktop;
+            break;
+        case UserFolder::Documents:
+            id = FOLDERID_Documents;
+            break;
+        case UserFolder::Downloads:
+            id = FOLDERID_Downloads;
+            break;
+        case UserFolder::Pictures:
+            id = FOLDERID_Pictures;
+            break;
+        case UserFolder::Music:
+            id = FOLDERID_Music;
+            break;
+        case UserFolder::Videos:
+            id = FOLDERID_Videos;
+            break;
+    }
+
+    auto path = knownFolderPath(id);
+    if (path.empty())
+        return std::nullopt;
+    return path;
+}
+
+} // namespace sf::priv::StandardPaths

--- a/src/SFML/System/iOS/StandardPathsImpl.mm
+++ b/src/SFML/System/iOS/StandardPathsImpl.mm
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2026 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/StandardPathsImpl.hpp>
+
+#import <Foundation/Foundation.h>
+
+
+namespace
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path firstSearchPath(NSSearchPathDirectory directory)
+{
+    NSArray<NSString*>* paths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, YES);
+    if (paths.count == 0)
+        return {};
+    return std::filesystem::path([paths.firstObject UTF8String]);
+}
+} // namespace
+
+
+namespace sf::priv::StandardPaths
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path getResourceDirectory()
+{
+    NSString* resourcePath = [[NSBundle mainBundle] resourcePath];
+    if (resourcePath == nil)
+        return {};
+    return std::filesystem::path([resourcePath UTF8String]);
+}
+
+
+////////////////////////////////////////////////////////////
+std::filesystem::path getUserDataBaseDirectory()
+{
+    return firstSearchPath(NSApplicationSupportDirectory);
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<std::filesystem::path> getUserFolder(UserFolder folder)
+{
+    // iOS apps are sandboxed: only Home and Documents map to real filesystem paths.
+    // The rest (Desktop, Downloads, Pictures, Music, Videos) require dedicated
+    // frameworks (PhotoKit, MediaPlayer, ...) and have no path-based access.
+    switch (folder)
+    {
+        case UserFolder::Home:
+            return std::filesystem::path([NSHomeDirectory() UTF8String]);
+        case UserFolder::Documents:
+        {
+            auto path = firstSearchPath(NSDocumentDirectory);
+            if (path.empty())
+                return std::nullopt;
+            return path;
+        }
+        case UserFolder::Desktop:
+        case UserFolder::Downloads:
+        case UserFolder::Pictures:
+        case UserFolder::Music:
+        case UserFolder::Videos:
+            return std::nullopt;
+    }
+
+    return std::nullopt;
+}
+
+} // namespace sf::priv::StandardPaths

--- a/src/SFML/System/macOS/StandardPathsImpl.mm
+++ b/src/SFML/System/macOS/StandardPathsImpl.mm
@@ -1,0 +1,99 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2026 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/StandardPathsImpl.hpp>
+
+#import <Foundation/Foundation.h>
+
+
+namespace
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path firstSearchPath(NSSearchPathDirectory directory)
+{
+    NSArray<NSString*>* paths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, YES);
+    if (paths.count == 0)
+        return {};
+    return std::filesystem::path([paths.firstObject UTF8String]);
+}
+} // namespace
+
+
+namespace sf::priv::StandardPaths
+{
+////////////////////////////////////////////////////////////
+std::filesystem::path getResourceDirectory()
+{
+    NSString* resourcePath = [[NSBundle mainBundle] resourcePath];
+    if (resourcePath == nil)
+        return {};
+    return std::filesystem::path([resourcePath UTF8String]);
+}
+
+
+////////////////////////////////////////////////////////////
+std::filesystem::path getUserDataBaseDirectory()
+{
+    return firstSearchPath(NSApplicationSupportDirectory);
+}
+
+
+////////////////////////////////////////////////////////////
+std::optional<std::filesystem::path> getUserFolder(UserFolder folder)
+{
+    std::filesystem::path path;
+    switch (folder)
+    {
+        case UserFolder::Home:
+            path = std::filesystem::path([NSHomeDirectory() UTF8String]);
+            break;
+        case UserFolder::Desktop:
+            path = firstSearchPath(NSDesktopDirectory);
+            break;
+        case UserFolder::Documents:
+            path = firstSearchPath(NSDocumentDirectory);
+            break;
+        case UserFolder::Downloads:
+            path = firstSearchPath(NSDownloadsDirectory);
+            break;
+        case UserFolder::Pictures:
+            path = firstSearchPath(NSPicturesDirectory);
+            break;
+        case UserFolder::Music:
+            path = firstSearchPath(NSMusicDirectory);
+            break;
+        case UserFolder::Videos:
+            path = firstSearchPath(NSMoviesDirectory);
+            break;
+    }
+
+    if (path.empty())
+        return std::nullopt;
+    return path;
+}
+
+} // namespace sf::priv::StandardPaths


### PR DESCRIPTION
Primarily motivated by issues on Mac when using app bundles - they default the working directory to `/` which means it's tricky for users to write cross-platform code with SFML, they either have to manually adjust the working directory or get the path to the app resources themselves.

Otherwise, these functions have a wide range of uses for the types of applications SFML users create - saving screenshots, user settings, loading user pictures, etc.

Influenced by how some other libraries offer the same, such as [SDL](https://wiki.libsdl.org/SDL3/SDL_GetUserFolder)

Purely additive API so could be a candidate for the next minor release