### PR TITLE
Ensure that input element is still valid

### DIFF
--- a/src/SFML/Window/macOS/HIDInputManager.mm
+++ b/src/SFML/Window/macOS/HIDInputManager.mm
@@ -979,6 +979,15 @@ bool HIDInputManager::isPressed(IOHIDElements& elements) const
         IOHIDValueRef value = nil;
 
         IOHIDDeviceRef device = IOHIDElementGetDevice(*it);
+
+        if (!device)
+        {
+            // This means some kind of error / disconnection so we remove this element from our database.
+            CFRelease(*it);
+            it = elements.erase(it);
+            continue;
+        }
+
         IOHIDDeviceGetValue(device, *it, &value);
 
         if (!value)

--- a/src/SFML/Window/macOS/JoystickImpl.cpp
+++ b/src/SFML/Window/macOS/JoystickImpl.cpp
@@ -434,14 +434,18 @@ JoystickState JoystickImpl::update()
     unsigned int i = 0;
     for (auto it = m_buttons.begin(); it != m_buttons.end(); ++it, ++i)
     {
-        IOHIDValueRef value = nil;
-        IOHIDDeviceGetValue(IOHIDElementGetDevice(*it), *it, &value);
+        IOHIDValueRef  value  = nil;
+        IOHIDDeviceRef device = IOHIDElementGetDevice(*it);
 
-        // Check for plug out.
-        if (!value)
-        {
+        // Check for unplugging
+        if (!device)
             return disconnectedState;
-        }
+
+        IOHIDDeviceGetValue(device, *it, &value);
+
+        // Check for unplugging
+        if (!value)
+            return disconnectedState;
 
         // 1 means pressed, others mean released
         state.buttons[i] = IOHIDValueGetIntegerValue(value) == 1;
@@ -450,14 +454,18 @@ JoystickState JoystickImpl::update()
     // Update axes' state
     for (const auto& [axis, iohidElementRef] : m_axis)
     {
-        IOHIDValueRef value = nil;
-        IOHIDDeviceGetValue(IOHIDElementGetDevice(iohidElementRef), iohidElementRef, &value);
+        IOHIDValueRef  value  = nil;
+        IOHIDDeviceRef device = IOHIDElementGetDevice(iohidElementRef);
 
-        // Check for plug out.
-        if (!value)
-        {
+        // Check for unplugging
+        if (!device)
             return disconnectedState;
-        }
+
+        IOHIDDeviceGetValue(device, iohidElementRef, &value);
+
+        // Check for unplugging
+        if (!value)
+            return disconnectedState;
 
         // We want to bind [physicalMin,physicalMax] to [-100=min,100=max].
         //
@@ -487,14 +495,18 @@ JoystickState JoystickImpl::update()
     //
     if (m_hat != nullptr)
     {
-        IOHIDValueRef value = nil;
-        IOHIDDeviceGetValue(IOHIDElementGetDevice(m_hat), m_hat, &value);
+        IOHIDValueRef  value  = nil;
+        IOHIDDeviceRef device = IOHIDElementGetDevice(m_hat);
 
-        // Check for plug out.
-        if (!value)
-        {
+        // Check for unplugging
+        if (!device)
             return disconnectedState;
-        }
+
+        IOHIDDeviceGetValue(device, m_hat, &value);
+
+        // Check for unplugging
+        if (!value)
+            return disconnectedState;
 
         const CFIndex raw = IOHIDValueGetIntegerValue(value);
 


### PR DESCRIPTION
## Description

The following report highlighted a potential issue where the input element could be invalid and we're not performing any checks for it: https://github.com/Lorenzooone/cc3dsfs/issues/38

There's no guarantee that `IOHIDDeviceGetValue` can handle `nullptr` references.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [x] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run the Joystick example on macOS and try to unplug the gamepad at random times.