### PR TITLE
Fix documentation to show that scroll lock is not supported on macOS

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -106,8 +106,8 @@ public:
         bool               shift{};      //!< Is the Shift key pressed?
         bool               system{};     //!< Is the System key pressed?
         bool               capsLock{};   //!< Is the CapsLock key toggled?
-        bool               numLock{};    //!< Is the NumLock key toggled? (Not supported on macOS)
-        bool               scrollLock{}; //!< Is the ScrollLock key toggled?
+        bool               numLock{};    //!< Is the NumLock key toggled?
+        bool               scrollLock{}; //!< Is the ScrollLock key toggled? (Not supported on macOS)
     };
 
     ////////////////////////////////////////////////////////////
@@ -123,8 +123,8 @@ public:
         bool               shift{};      //!< Is the Shift key pressed?
         bool               system{};     //!< Is the System key pressed?
         bool               capsLock{};   //!< Is the CapsLock key toggled?
-        bool               numLock{};    //!< Is the NumLock key toggled? (Not supported on macOS)
-        bool               scrollLock{}; //!< Is the ScrollLock key toggled?
+        bool               numLock{};    //!< Is the NumLock key toggled?
+        bool               scrollLock{}; //!< Is the ScrollLock key toggled? (Not supported on macOS)
     };
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

Fixes the documentation as pointed out by @kimci86 in https://github.com/SFML/SFML/pull/3238#pullrequestreview-4222972776

## How to test this PR?

CI should pass