### PR TITLE
doc: Improve documentation for mouse and focus event subtypes

### DIFF
--- a/include/SFML/Window/Event.hpp
+++ b/include/SFML/Window/Event.hpp
@@ -71,6 +71,13 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Lost focus event subtype
     ///
+    /// This event is triggered when the window loses keyboard
+    /// focus, typically when the user clicks on another window
+    /// or switches away via Alt+Tab.
+    ///
+    /// \note Behavior verified on Windows only. Other platforms
+    ///       may differ.
+    ///
     ////////////////////////////////////////////////////////////
     struct FocusLost
     {
@@ -79,6 +86,17 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Gained focus event subtype
     ///
+    /// This event is triggered when the window gains keyboard
+    /// focus, typically when the user clicks on it or switches
+    /// to it via Alt+Tab.
+    ///
+    /// \note This event is NOT triggered when the window is
+    ///       first created, only when focus is regained after
+    ///       having been lost.
+    ///
+    /// \note Behavior verified on Windows only. Other platforms
+    ///       may differ.
+    ///
     ////////////////////////////////////////////////////////////
     struct FocusGained
     {
@@ -86,6 +104,21 @@ public:
 
     ////////////////////////////////////////////////////////////
     /// \brief Text event subtype
+    ///
+    /// This event is triggered when a key that produces a
+    /// printable character is pressed, such as letters,
+    /// numbers, Enter, and Backspace.
+    ///
+    /// \note This event is NOT triggered for modifier keys
+    ///       such as Shift, Ctrl, Alt, or arrow keys as
+    ///       they do not produce printable characters.
+    ///
+    /// \note Unlike KeyPressed, this event returns the
+    ///       actual Unicode character produced, making it
+    ///       suitable for text input handling.
+    ///
+    /// \note Behavior verified on Windows only. Other
+    ///       platforms may differ.
     ///
     ////////////////////////////////////////////////////////////
     struct TextEntered
@@ -130,6 +163,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Mouse wheel scrolled event subtype
     ///
+    /// This event is triggered when the mouse wheel is
+    /// scrolled in any direction.
+    ///
+    /// \note Behavior verified on Windows only. Other
+    ///       platforms may differ.
+    ///
     ////////////////////////////////////////////////////////////
     struct MouseWheelScrolled
     {
@@ -141,6 +180,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Mouse button pressed event subtype
     ///
+    /// This event is triggered when any mouse button
+    /// is pressed.
+    ///
+    /// \note Behavior verified on Windows only. Other
+    ///       platforms may differ.
+    ///
     ////////////////////////////////////////////////////////////
     struct MouseButtonPressed
     {
@@ -151,6 +196,12 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Mouse button released event subtype
     ///
+    /// This event is triggered when any mouse button
+    /// is released.
+    ///
+    /// \note Behavior verified on Windows only. Other
+    ///       platforms may differ.
+    ///
     ////////////////////////////////////////////////////////////
     struct MouseButtonReleased
     {
@@ -160,6 +211,12 @@ public:
 
     ////////////////////////////////////////////////////////////
     /// \brief Mouse move event subtype
+    ///
+    /// This event is triggered when the mouse cursor moves
+    /// within the window's area.
+    ///
+    /// \note Behavior verified on Windows only. Other
+    ///       platforms may differ.
     ///
     ////////////////////////////////////////////////////////////
     struct MouseMoved
@@ -203,6 +260,15 @@ public:
     ////////////////////////////////////////////////////////////
     /// \brief Mouse entered event subtype
     ///
+    /// This event is triggered when the mouse cursor enters
+    /// the window's area. This includes:
+    /// - The cursor physically moving into the window
+    /// - The window being created or moved so that it overlaps
+    ///   a stationary cursor
+    ///
+    /// \note Behavior verified on Windows only. Other platforms
+    ///       may differ.
+    ///
     ////////////////////////////////////////////////////////////
     struct MouseEntered
     {
@@ -210,6 +276,14 @@ public:
 
     ////////////////////////////////////////////////////////////
     /// \brief Mouse left event subtype
+    ///
+    /// This event is triggered when the mouse cursor leaves
+    /// the window's area. This includes:
+    /// - The cursor physically moving out of the window
+    /// - The window being moved away from a stationary cursor
+    ///
+    /// \note Behavior verified on Windows only. Other platforms
+    ///       may differ.
     ///
     ////////////////////////////////////////////////////////////
     struct MouseLeft


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [x] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

Improves the documentation for the following event subtypes in Event.hpp
that previously only had a one-line description:

- FocusLost
- FocusGained
- MouseEntered
- MouseLeft
- MouseWheelScrolled
- MouseButtonPressed
- MouseButtonReleased
- MouseMoved

Closes #3663

This PR is related to the issue #3663

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run a small SFML program that prints event names to the console 
while interacting with the window (moving mouse, clicking, 
scrolling, Alt+Tab etc.) and verify the documented behavior 
matches what is observed.

Note: Joystick, touch, and sensor events were left undocumented 
as physical devices were not available for testing.

#include <SFML/Graphics.hpp>
#include <SFML/Window.hpp>
#include <iostream>

int main()
{
    sf::RenderWindow window(sf::VideoMode({800, 600}), "SFML Event Tester");

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
            else if (event->is<sf::Event::FocusGained>())
                std::cout << "FocusGained fired!\n";
            else if (event->is<sf::Event::FocusLost>())
                std::cout << "FocusLost fired!\n";
            else if (event->is<sf::Event::MouseEntered>())
                std::cout << "MouseEntered fired!\n";
            else if (event->is<sf::Event::MouseLeft>())
                std::cout << "MouseLeft fired!\n";
        }

        window.clear(sf::Color::Black);
        window.display();
    }
}

```cpp
#include <SFML/Graphics.hpp>

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "Minimal, complete and verifiable example");
    window.setFramerateLimit(60);

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
        }

        window.clear();
        window.display();
    }
}
```
