### PR TITLE
Switch to the latest Windows runner image

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows,         os: windows-2025, flags: -GNinja }
+        - { name: Windows,         os: windows-2025-vs2026, flags: -GNinja }
         - { name: Linux,           os: ubuntu-24.04 }
         - { name: Linux DRM,       os: ubuntu-24.04, flags: -DSFML_USE_DRM=ON }
         - { name: Linux OpenGL ES, os: ubuntu-24.04, flags: -DSFML_OPENGL_ES=ON }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2022 x86,             os: windows-2025, flags: -DSFML_USE_MESA3D=ON -GNinja }
-        - { name: Windows VS2022 x64,             os: windows-2025, flags: -DSFML_USE_MESA3D=ON -GNinja }
-        - { name: Windows VS2022 arm64,           os: windows-2025, flags: -DSFML_USE_MESA3D=OFF -GNinja -DSFML_BUILD_TEST_SUITE=OFF }
-        - { name: Windows VS2022 ClangCL MSBuild, os: windows-2025, flags: -DSFML_USE_MESA3D=ON -T ClangCL } # ninja doesn't support specifying the toolset, so use the ClangCL toolset to test building with MSBuild as well
-        - { name: Windows VS2022 OpenGL ES,       os: windows-2025, flags: -DSFML_USE_MESA3D=ON -DSFML_OPENGL_ES=ON -GNinja }
-        - { name: Windows VS2022 Unity,           os: windows-2025, flags: -DSFML_USE_MESA3D=ON -DCMAKE_UNITY_BUILD=ON -GNinja }
-        - { name: Windows LLVM/Clang,             os: windows-2025, flags: -DSFML_USE_MESA3D=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
-        - { name: Windows MinGW,                  os: windows-2025, flags: -DSFML_USE_MESA3D=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
+        - { name: Windows VS2026 x86,             os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=ON -GNinja }
+        - { name: Windows VS2026 x64,             os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=ON -GNinja }
+        - { name: Windows VS2026 arm64,           os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=OFF -GNinja -DSFML_BUILD_TEST_SUITE=OFF }
+        - { name: Windows VS2026 ClangCL MSBuild, os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=ON -T ClangCL } # ninja doesn't support specifying the toolset, so use the ClangCL toolset to test building with MSBuild as well
+        - { name: Windows VS2026 OpenGL ES,       os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=ON -DSFML_OPENGL_ES=ON -GNinja }
+        - { name: Windows VS2026 Unity,           os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=ON -DCMAKE_UNITY_BUILD=ON -GNinja }
+        - { name: Windows LLVM/Clang,             os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja }
+        - { name: Windows MinGW,                  os: windows-2025-vs2026, flags: -DSFML_USE_MESA3D=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja }
         - { name: Linux GCC,                      os: ubuntu-24.04, flags: -GNinja }
         - { name: Linux Clang,                    os: ubuntu-24.04, flags: -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -GNinja , gcovr_options: '--gcov-executable="llvm-cov-$CLANG_VERSION gcov"' }
         - { name: Linux GCC DRM,                  os: ubuntu-24.04, flags: -DSFML_USE_DRM=ON -DSFML_RUN_DISPLAY_TESTS=OFF -GNinja }
@@ -51,7 +51,7 @@ jobs:
         - { name: Debug, flags: -DCMAKE_BUILD_TYPE=Debug -DSFML_ENABLE_COVERAGE=ON -DSFML_FATAL_OPENGL_ERRORS=ON }
 
         include:
-        - platform: { name: Windows VS2022 x64, os: windows-2025 }
+        - platform: { name: Windows VS2026 x64, os: windows-2025-vs2026 }
           config: { name: Static with PCH (MSVC), flags: -DSFML_USE_MESA3D=ON -GNinja -DBUILD_SHARED_LIBS=OFF -DSFML_ENABLE_PCH=ON }
         - platform: { name: Linux GCC, os: ubuntu-24.04 }
           config: { name: Static with PCH (GCC), flags: -GNinja -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=OFF -DSFML_ENABLE_PCH=ON }
@@ -61,9 +61,9 @@ jobs:
           config: { name: Bundled Deps Static, flags: -GNinja -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=OFF -DSFML_USE_SYSTEM_DEPS=OFF }
         - platform: { name: Linux GCC, os: ubuntu-24.04 }
           config: { name: Bundled Deps Shared, flags: -GNinja -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=ON -DSFML_USE_SYSTEM_DEPS=OFF }
-        - platform: { name: Windows MinGW, os: windows-2025 }
+        - platform: { name: Windows MinGW, os: windows-2025-vs2026 }
           config: { name: Static Standard Libraries, flags: -GNinja -DSFML_USE_MESA3D=ON -DCMAKE_CXX_COMPILER=g++ -DSFML_USE_STATIC_STD_LIBS=ON }
-        - platform: { name: Windows MinGW, os: windows-2025 }
+        - platform: { name: Windows MinGW, os: windows-2025-vs2026 }
           config: { name: Static with PCH (GCC), flags: -GNinja -DSFML_USE_MESA3D=ON -DCMAKE_CXX_COMPILER=g++ -DBUILD_SHARED_LIBS=OFF -DSFML_ENABLE_PCH=ON -DSFML_ENABLE_STDLIB_ASSERTIONS=OFF } # disabling stdlib assertions due to false positive
         - platform: { name: macOS, os: macos-14 }
           config: { name: Frameworks, flags: -GNinja -DSFML_BUILD_FRAMEWORKS=ON -DBUILD_SHARED_LIBS=ON }
@@ -147,7 +147,7 @@ jobs:
     # In addition to installing a known working version of CCache, this action also takes care of saving and restoring the cache for us
     # Additionally it outputs information at the end of each job that helps us to verify if the cache is working properly
     - name: Setup CCache
-      uses: hendrikmuhs/ccache-action@v1.2.21
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         verbose: 2
         key: ${{ matrix.platform.name }}-${{ matrix.config.name }}-${{ matrix.type.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2022 x86, os: windows-2025 }
-        - { name: Windows VS2022 x64, os: windows-2025 }
-        - { name: Windows MinGW x86,  os: windows-2025, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
-        - { name: Windows MinGW x64,  os: windows-2025, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
+        - { name: Windows VS2026 x86, os: windows-2025-vs2026 }
+        - { name: Windows VS2026 x64, os: windows-2025-vs2026 }
+        - { name: Windows MinGW x86,  os: windows-2025-vs2026, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
+        - { name: Windows MinGW x64,  os: windows-2025-vs2026, flags: -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ }
         - { name: Linux GCC,          os: ubuntu-24.04 }
         - { name: macOS x64,          os: macos-15,     flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 }
         - { name: macOS arm64,        os: macos-15 }
@@ -282,10 +282,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows VS2022 x86, os: windows-2025 }
-        - { name: Windows VS2022 x64, os: windows-2025 }
-        - { name: Windows MinGW x86,  os: windows-2025 }
-        - { name: Windows MinGW x64,  os: windows-2025 }
+        - { name: Windows VS2026 x86, os: windows-2025-vs2026 }
+        - { name: Windows VS2026 x64, os: windows-2025-vs2026 }
+        - { name: Windows MinGW x86,  os: windows-2025-vs2026 }
+        - { name: Windows MinGW x64,  os: windows-2025-vs2026 }
         - { name: Linux GCC,          os: ubuntu-24.04 }
         - { name: macOS x64,          os: macos-15 }
         - { name: macOS arm64,        os: macos-15 }


### PR DESCRIPTION
## Description

Runner image with VS 2026 is generally available and will replace `windows-latest` images will soon default to `windows-2025-vs2026`, as such it makes sense to switch earlier, rather than wait for the eventual sunset of the VS 2022 images.

https://github.com/actions/runner-images/issues/14016

## How to test this PR?

CI should pass