### PR TITLE
Add OES_texture_npot extension for OpenGL ES

### DIFF
--- a/src/SFML/Graphics/GLExtensions.hpp
+++ b/src/SFML/Graphics/GLExtensions.hpp
@@ -111,7 +111,7 @@ inline int SF_GL_OES_vertex_buffer_object = 1;
 #define GLEXT_blend_equation_separate_dependencies SF_GLAD_GL_OES_blend_equation_separate, glBlendEquationSeparateOES
 
 // Core since 2.0 - OES_texture_npot
-#define GLEXT_texture_non_power_of_two false
+#define GLEXT_texture_non_power_of_two SF_GLAD_GL_OES_texture_npot
 
 // Core since 2.0 - OES_framebuffer_object
 #define GLEXT_framebuffer_object               SF_GLAD_GL_OES_framebuffer_object


### PR DESCRIPTION
For some reason since the first ever mobile SFML version 12 years ago, the GLEXT_texture_non_power_of_two support has been hardcoded to false on mobile devices. It clearly says in the comment above the name of the extension but it is set to false anyway.
Since I had some texture scaling issues with imgui-sfml, I decided to investigate what was going on and simply enabling this extension seems to have fixed my issue, textures with imgui-sfml now look fine.

The issue was likely here: https://github.com/SFML/SFML/blob/master/src/SFML/Graphics/Texture.cpp#L1073
SFML thinking the system does not support non power of two textures when it does.