### PR TITLE
Fixed network tests inadvertently causing network access

### DIFF
--- a/test/Network/Dns.test.cpp
+++ b/test/Network/Dns.test.cpp
@@ -7,6 +7,89 @@
 using namespace std::string_literals;
 using namespace std::string_view_literals;
 
+TEST_CASE("[Network] sf::Dns (Invalid hosts)")
+{
+    // Strings that fail parsing as an IP address will be treated as hostnames
+    // and cause a name lookup to be performed if the string satisfies the
+    // hostname grammar specified in RFC 952 and RFC 1123
+    // According to RFC 1123:
+    // Whenever a user inputs the identity of an Internet host, it SHOULD
+    // be possible to enter either (1) a host domain name or (2) an IP
+    // address in dotted-decimal ("#.#.#.#") form.  The host SHOULD check
+    // the string syntactically for a dotted-decimal number before
+    // looking it up in the Domain Name System.
+
+    // If we deliberately want the resolution to fail we have to pass strings
+    // that are neither valid IP addresses nor valid hostnames
+
+    // In the following a label refers to a sequence of valid non-dot characters between dot characters
+    // If no trailing dot character is specified at the end of a hostname one is implied
+
+    SECTION("IPv4")
+    {
+        // Hostnames are not allowed to be empty
+        CHECK(resolveV4(""s).empty());
+
+        // Hostnames are not allowed to contain spaces
+        CHECK(resolveV4(" "s).empty());
+
+        // Hostnames must start with a digit or letter
+        CHECK(resolveV4("!"s).empty());
+        CHECK(resolveV4("@+"s).empty());
+        CHECK(resolveV4("-0.0.0.0"s).empty());
+
+        // Labels not directly under the root zone must not be empty
+        // A string consisting of a single dot is a valid hostname and refers to the root zone
+        CHECK(resolveV4(".."s).empty());
+        CHECK(resolveV4(".com"s).empty());
+        CHECK(resolveV4(".com."s).empty());
+        CHECK(resolveV4(".org"s).empty());
+        CHECK(resolveV4(".org."s).empty());
+
+        // The maximum label length must not exceed 63 characters
+        CHECK(resolveV4("0123456789012345678901234567890123456789012345678901234567890123"s).empty());
+
+        // The total length of the hostname must not exceed 255 characters
+        CHECK(resolveV4("0123456789012345678901234567890123456789012345678901234567890123"
+                        "0123456789012345678901234567890123456789012345678901234567890123"
+                        "0123456789012345678901234567890123456789012345678901234567890123"
+                        "0123456789012345678901234567890123456789012345678901234567890123"s)
+                  .empty());
+    }
+
+    SECTION("IPv6")
+    {
+        // Hostnames are not allowed to be empty
+        CHECK(resolveV6(""s).empty());
+
+        // Hostnames are not allowed to contain spaces
+        CHECK(resolveV6(" "s).empty());
+
+        // Hostnames must start with a digit or letter
+        CHECK(resolveV6("!"s).empty());
+        CHECK(resolveV6("@+"s).empty());
+        CHECK(resolveV6("-0::0"s).empty());
+
+        // Labels not directly under the root zone must not be empty
+        // A string consisting of a single dot is a valid hostname and refers to the root zone
+        CHECK(resolveV6(".."s).empty());
+        CHECK(resolveV6(".com"s).empty());
+        CHECK(resolveV6(".com."s).empty());
+        CHECK(resolveV6(".org"s).empty());
+        CHECK(resolveV6(".org."s).empty());
+
+        // The maximum label length must not exceed 63 characters
+        CHECK(resolveV6("0123456789012345678901234567890123456789012345678901234567890123"s).empty());
+
+        // The total length of the hostname must not exceed 255 characters
+        CHECK(resolveV6("0123456789012345678901234567890123456789012345678901234567890123"
+                        "0123456789012345678901234567890123456789012345678901234567890123"
+                        "0123456789012345678901234567890123456789012345678901234567890123"
+                        "0123456789012345678901234567890123456789012345678901234567890123"s)
+                  .empty());
+    }
+}
+
 TEST_CASE("[Network] sf::Dns (IPv4)", runIpV4InternetTests())
 {
     SECTION("Well known hosts")

--- a/test/Network/Http.test.cpp
+++ b/test/Network/Http.test.cpp
@@ -15,31 +15,6 @@ TEST_CASE("[Network] sf::Http")
         STATIC_CHECK(!std::is_nothrow_move_assignable_v<sf::Http>);
     }
 
-    SECTION("setHost")
-    {
-        sf::Http http;
-
-        SECTION("Valid host w/ prefix")
-        {
-            CHECK(http.setHost("http://google.com"));
-        }
-
-        SECTION("Valid host w/o prefix")
-        {
-            CHECK(http.setHost("google.com"));
-        }
-
-        SECTION("Invalid host w/ prefix")
-        {
-            CHECK(!http.setHost("http://dummy"));
-        }
-
-        SECTION("Invalid host w/o prefix")
-        {
-            CHECK(!http.setHost("dummy"));
-        }
-    }
-
     SECTION("Request")
     {
         SECTION("Type traits")
@@ -75,6 +50,32 @@ TEST_CASE("[Network] sf::Http")
 
 TEST_CASE("[Network] sf::Http Connection", runIpV4InternetTests())
 {
+    // Setting the host causes a name lookup to be performed and thus requires internet connectivity
+    SECTION("setHost")
+    {
+        sf::Http http;
+
+        SECTION("Valid host w/ prefix")
+        {
+            CHECK(http.setHost("http://google.com"));
+        }
+
+        SECTION("Valid host w/o prefix")
+        {
+            CHECK(http.setHost("google.com"));
+        }
+
+        SECTION("Invalid host w/ prefix")
+        {
+            CHECK_FALSE(http.setHost("http://dummy"));
+        }
+
+        SECTION("Invalid host w/o prefix")
+        {
+            CHECK_FALSE(http.setHost("dummy"));
+        }
+    }
+
     SECTION("HTTP Connection")
     {
         const sf::Http http("http://github.com");

--- a/test/Network/IpAddress.test.cpp
+++ b/test/Network/IpAddress.test.cpp
@@ -58,8 +58,51 @@ TEST_CASE("[Network] sf::IpAddress")
             CHECK(localHost->toInteger() == 0x7F'00'00'01);
             CHECK(*localHost == sf::IpAddress::LocalHost);
 
-            CHECK_FALSE(sf::IpAddress::resolve("255.255.255.256"s).has_value());
-            CHECK_FALSE(sf::IpAddress::resolve("").has_value());
+            // Strings that fail parsing as an IP address will be treated as hostnames
+            // and cause a name lookup to be performed if the string satisfies the
+            // hostname grammar specified in RFC 952 and RFC 1123
+            // According to RFC 1123:
+            // Whenever a user inputs the identity of an Internet host, it SHOULD
+            // be possible to enter either (1) a host domain name or (2) an IP
+            // address in dotted-decimal ("#.#.#.#") form.  The host SHOULD check
+            // the string syntactically for a dotted-decimal number before
+            // looking it up in the Domain Name System.
+
+            // If we deliberately want the resolution to fail we have to pass strings
+            // that are neither valid IP addresses nor valid hostnames
+
+            // Hostnames are not allowed to be empty
+            CHECK_FALSE(sf::IpAddress::resolve(""s).has_value());
+
+            // Hostnames are not allowed to contain spaces
+            CHECK_FALSE(sf::IpAddress::resolve(" "s).has_value());
+
+            // Hostnames must start with a digit or letter
+            CHECK_FALSE(sf::IpAddress::resolve("!"s).has_value());
+            CHECK_FALSE(sf::IpAddress::resolve("@+"s).has_value());
+            CHECK_FALSE(sf::IpAddress::resolve("-0.0.0.0"s).has_value());
+
+            // In the following a label refers to a sequence of valid non-dot characters between dot characters
+            // If no trailing dot character is specified at the end of a hostname one is implied
+
+            // Labels not directly under the root zone must not be empty
+            // A string consisting of a single dot is a valid hostname and refers to the root zone
+            CHECK_FALSE(sf::IpAddress::resolve(".."s).has_value());
+            CHECK_FALSE(sf::IpAddress::resolve(".com"s).has_value());
+            CHECK_FALSE(sf::IpAddress::resolve(".com."s).has_value());
+            CHECK_FALSE(sf::IpAddress::resolve(".org"s).has_value());
+            CHECK_FALSE(sf::IpAddress::resolve(".org."s).has_value());
+
+            // The maximum label length must not exceed 63 characters
+            CHECK_FALSE(
+                sf::IpAddress::resolve("0123456789012345678901234567890123456789012345678901234567890123"s).has_value());
+
+            // The total length of the hostname must not exceed 255 characters
+            CHECK_FALSE(sf::IpAddress::resolve("0123456789012345678901234567890123456789012345678901234567890123"
+                                               "0123456789012345678901234567890123456789012345678901234567890123"
+                                               "0123456789012345678901234567890123456789012345678901234567890123"
+                                               "0123456789012345678901234567890123456789012345678901234567890123"s)
+                            .has_value());
         }
 
         SECTION("Constants")

--- a/test/Network/Sftp.test.cpp
+++ b/test/Network/Sftp.test.cpp
@@ -169,9 +169,8 @@ TEST_CASE("[Network] sf::Sftp")
 
     SECTION("Connect to non-existant server and timeout")
     {
-        sf::Sftp sftp;
-        // 213.0.113.0/24 is reserved for TEST-NET-3 and shouldn't contain hosts under normal circumstances
-        const auto result = sftp.connect(sf::IpAddress(213, 0, 113, 1), 22, sf::milliseconds(1));
+        sf::Sftp   sftp;
+        const auto result = sftp.connect(sf::IpAddress::Any, 22, sf::milliseconds(1));
         CHECK(result.getValue() != sf::Sftp::Result::Value::Success);
         CHECK(result.getMessage().empty());
         CHECK_FALSE(sftp.getSessionInfo().has_value());


### PR DESCRIPTION
Fixed network tests inadvertently causing network access even when network access is disabled via configuration.

See #3709 for the problem description.

This change fixes the issues reported in #3709 by moving test blocks that do require access to the network into guarded test cases and fixing blocks that shouldn't require access to the network so they don't access the network.

Verified by building and running tests in a docker container after disconnecting it from its network bridge. Also verified that with a connected network Wireshark reported no outgoing or incoming traffic to the host.

Fixes #3709

@jcowgill 