### PR TITLE
[Android] Implement Android clipboard setString

### DIFF
--- a/src/SFML/Window/Android/ClipboardImpl.cpp
+++ b/src/SFML/Window/Android/ClipboardImpl.cpp
@@ -27,9 +27,13 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Android/ClipboardImpl.hpp>
 
+#include <SFML/System/Android/Activity.hpp>
 #include <SFML/System/Err.hpp>
 #include <SFML/System/String.hpp>
 
+#include <jni.h>
+
+#include <mutex>
 #include <ostream>
 
 
@@ -44,9 +48,71 @@ String ClipboardImpl::getString()
 
 
 ////////////////////////////////////////////////////////////
-void ClipboardImpl::setString(const String& /* text */)
+void ClipboardImpl::setString(const String& text)
 {
-    err() << "Clipboard API not implemented for Android.\n";
+    ActivityStates&       states = getActivity();
+    const std::lock_guard lock(states.mutex);
+
+    JavaVM* javaVM = states.activity->vm;
+    JNIEnv* env    = states.activity->env;
+
+    JavaVMAttachArgs attachArgs;
+    attachArgs.version = JNI_VERSION_1_6;
+    attachArgs.name    = "NativeThread";
+    attachArgs.group   = nullptr;
+
+    const jint envStatus = javaVM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (envStatus == JNI_EVERSION)
+    {
+        err() << "Failed to access JNI, couldn't set the clipboard contents" << std::endl;
+        return;
+    }
+
+    const bool detach = (envStatus == JNI_EDETACHED);
+    if (detach && javaVM->AttachCurrentThread(&env, &attachArgs) == JNI_ERR)
+    {
+        err() << "Failed to initialize JNI, couldn't set the clipboard contents" << std::endl;
+        return;
+    }
+
+    const auto utf16 = text.toUtf16();
+    jstring    label = env->NewStringUTF("SFML Clipboard");
+    jstring    data  = env->NewString(reinterpret_cast<const jchar*>(utf16.data()), static_cast<jsize>(utf16.size()));
+
+    jclass    contextClass           = env->FindClass("android/content/Context");
+    jfieldID  clipboardServiceField  = env->GetStaticFieldID(contextClass, "CLIPBOARD_SERVICE", "Ljava/lang/String;");
+    jobject   clipboardService       = env->GetStaticObjectField(contextClass, clipboardServiceField);
+    jobject   nativeActivity         = states.activity->clazz;
+    jclass    nativeActivityClass    = env->GetObjectClass(nativeActivity);
+    jmethodID getSystemServiceMethod = env->GetMethodID(nativeActivityClass,
+                                                        "getSystemService",
+                                                        "(Ljava/lang/String;)Ljava/lang/Object;");
+    jobject   clipboardManager       = env->CallObjectMethod(nativeActivity, getSystemServiceMethod, clipboardService);
+
+    jclass    clipDataClass         = env->FindClass("android/content/ClipData");
+    jmethodID newPlainTextMethod    = env->GetStaticMethodID(clipDataClass,
+                                                          "newPlainText",
+                                                          "(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Landroid/"
+                                                             "content/ClipData;");
+    jobject   clipData              = env->CallStaticObjectMethod(clipDataClass, newPlainTextMethod, label, data);
+    jclass    clipboardManagerClass = env->FindClass("android/content/ClipboardManager");
+    jmethodID setPrimaryClipMethod  = env->GetMethodID(clipboardManagerClass,
+                                                      "setPrimaryClip",
+                                                      "(Landroid/content/ClipData;)V");
+    env->CallVoidMethod(clipboardManager, setPrimaryClipMethod, clipData);
+
+    env->DeleteLocalRef(clipboardManagerClass);
+    env->DeleteLocalRef(clipData);
+    env->DeleteLocalRef(clipDataClass);
+    env->DeleteLocalRef(clipboardManager);
+    env->DeleteLocalRef(nativeActivityClass);
+    env->DeleteLocalRef(clipboardService);
+    env->DeleteLocalRef(contextClass);
+    env->DeleteLocalRef(data);
+    env->DeleteLocalRef(label);
+
+    if (detach)
+        javaVM->DetachCurrentThread();
 }
 
 } // namespace sf::priv


### PR DESCRIPTION
### Motivation
- Replace the previous stub that logged "Clipboard API not implemented for Android" with a working implementation to allow setting the system clipboard from Android.
- Ensure thread-safety and proper JNI attachment/detachment when invoked from native threads.

### Description
- Added includes for `Activity.hpp`, `jni.h`, and `<mutex>` and implemented `ClipboardImpl::setString(const String& text)` to interact with the Android Clipboard via JNI.
- Acquire `ActivityStates` and lock `states.mutex`, obtain `JavaVM`/`JNIEnv`, and attach the current thread to the JVM when necessary using `AttachCurrentThread` and `DetachCurrentThread`.
- Convert the `sf::String` to UTF-16, create `jstring` label and data, obtain `CLIPBOARD_SERVICE` from `android/content/Context`, call `getSystemService`, create a `ClipData` via `ClipData.newPlainText`, and call `ClipboardManager.setPrimaryClip`.
- Clean up all local JNI references after the call and only detach the thread if it was attached in this function.

### Testing
- Performed an Android build of the project using the standard CI-style build (`cmake`/NDK/`ninja`) which completed successfully.
- Tested in my project locally

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19430233b08320bf85d18f3939ea0d)