### PR TITLE
Allow more granular selection of system dependencies (inc. SheenBidi)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ else()
 endif()
 
 sfml_set_option(SFML_USE_SYSTEM_DEPS ${SFML_USE_SYSTEM_DEPS_DEFAULT} BOOL "ON to use system dependencies, OFF to use the bundled ones.")
+sfml_set_option(SFML_USE_SYSTEM_FLAC_VORBIS ${SFML_USE_SYSTEM_DEPS} BOOL "ON to use system FLAC and Vorbis, OFF to use the bundled ones.")
+sfml_set_option(SFML_USE_SYSTEM_FREETYPE_HARFBUZZ ${SFML_USE_SYSTEM_DEPS} BOOL "ON to use system Freetype and HarfBuzz, OFF to use the bundled ones.")
+sfml_set_option(SFML_USE_SYSTEM_LIBSSH2_MBEDTLS ${SFML_USE_SYSTEM_DEPS} BOOL "ON to use system libssh2 and MbedTLS, OFF to use the bundled ones.")
+sfml_set_option(SFML_USE_SYSTEM_SHEENBIDI OFF BOOL "ON to use system SheenBidi, OFF to use the bundled one.")
 
 if(SFML_COMPILER_MSVC)
     # add an option to choose whether PDB debug symbols should be generated (defaults to true when possible)

--- a/cmake/Modules/FindSheenBidi.cmake
+++ b/cmake/Modules/FindSheenBidi.cmake
@@ -1,0 +1,24 @@
+#
+# Try to find SheenBidi libraries and include paths.
+# Once done this will define
+#
+# SHEENBIDI_FOUND
+# SHEENBIDI_INCLUDE_DIR
+# SHEENBIDI_LIBRARY
+#
+
+find_path(SHEENBIDI_INCLUDE_DIR SheenBidi/SheenBidi.h)
+find_library(SHEENBIDI_LIBRARY NAMES SheenBidi)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SheenBidi DEFAULT_MSG SHEENBIDI_LIBRARY SHEENBIDI_INCLUDE_DIR)
+
+mark_as_advanced(SHEENBIDI_INCLUDE_DIR SHEENBIDI_LIBRARY)
+
+add_library(SheenBidi::SheenBidi IMPORTED UNKNOWN)
+set_target_properties(SheenBidi::SheenBidi PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${SHEENBIDI_INCLUDE_DIR})
+if(SHEENBIDI_LIBRARY MATCHES "/([^/]+)\\.framework$")
+    set_target_properties(SheenBidi::SheenBidi PROPERTIES IMPORTED_LOCATION ${SHEENBIDI_LIBRARY}/${CMAKE_MATCH_1})
+else()
+    set_target_properties(SheenBidi::SheenBidi PROPERTIES IMPORTED_LOCATION ${SHEENBIDI_LIBRARY})
+endif()

--- a/src/SFML/Audio/CMakeLists.txt
+++ b/src/SFML/Audio/CMakeLists.txt
@@ -68,7 +68,7 @@ if(SFML_OS_IOS)
 endif()
 
 # find external libraries
-if(SFML_USE_SYSTEM_DEPS)
+if(SFML_USE_SYSTEM_FLAC_VORBIS)
     find_package(Vorbis REQUIRED)
     find_package(FLAC REQUIRED)
 else()

--- a/src/SFML/Audio/Dependencies.cmake.in
+++ b/src/SFML/Audio/Dependencies.cmake.in
@@ -24,12 +24,12 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 # When installing, save whether SFML was built using system dependencies.
-set(SFML_BUILT_USING_SYSTEM_DEPS @SFML_USE_SYSTEM_DEPS@)
+set(SFML_BUILT_USING_SYSTEM_FLAC_VORBIS @SFML_USE_SYSTEM_FLAC_VORBIS@)
 
 # start with an empty list
 set(FIND_SFML_DEPENDENCIES_NOTFOUND)
 
-if(SFML_BUILT_USING_SYSTEM_DEPS)
+if(SFML_BUILT_USING_SYSTEM_FLAC_VORBIS)
     find_dependency(Vorbis)
     find_dependency(FLAC)
 else()

--- a/src/SFML/Graphics/CMakeLists.txt
+++ b/src/SFML/Graphics/CMakeLists.txt
@@ -108,7 +108,7 @@ elseif(SFML_OS_IOS)
     target_link_libraries(sfml-graphics PRIVATE z bz2)
 endif()
 
-if(SFML_USE_SYSTEM_DEPS)
+if(SFML_USE_SYSTEM_FREETYPE_HARFBUZZ)
     find_package(Freetype REQUIRED)
     find_package(HarfBuzz REQUIRED)
 else()
@@ -236,43 +236,47 @@ endif()
 
 target_link_libraries(sfml-graphics PRIVATE Freetype::Freetype HarfBuzz::HarfBuzz)
 
-# we have to build SheenBidi ourselves in both cases since there is no system package for it
-# use a block to scope option variables we have to set
-block()
-    include(FetchContent)
+if(SFML_USE_SYSTEM_SHEENBIDI)
+    find_package(SheenBidi REQUIRED)
+    target_link_libraries(sfml-graphics PRIVATE SheenBidi::SheenBidi)
+else()
+    # use a block to scope option variables we have to set
+    block()
+        include(FetchContent)
 
-    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-    set(BUILD_SHARED_LIBS OFF)
+        set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+        set(BUILD_SHARED_LIBS OFF)
 
-    FetchContent_Declare(SheenBidi
-        GIT_REPOSITORY https://github.com/Tehreer/SheenBidi.git
-        GIT_TAG v3.0.0
-        GIT_SHALLOW ON
-        # patch out parts we don't want of the SheenBidi CMake configuration
-        # - disable installation
-        # - turn the library into an object library so we can merge it into sfml-graphics
-        PATCH_COMMAND ${CMAKE_COMMAND} -DSHEENBIDI_DIR=${FETCHCONTENT_BASE_DIR}/sheenbidi-src -P ${PROJECT_SOURCE_DIR}/tools/sheenbidi/PatchSheenBidi.cmake)
-    FetchContent_MakeAvailable(SheenBidi)
-endblock()
+        FetchContent_Declare(SheenBidi
+            GIT_REPOSITORY https://github.com/Tehreer/SheenBidi.git
+            GIT_TAG v3.0.0
+            GIT_SHALLOW ON
+            # patch out parts we don't want of the SheenBidi CMake configuration
+            # - disable installation
+            # - turn the library into an object library so we can merge it into sfml-graphics
+            PATCH_COMMAND ${CMAKE_COMMAND} -DSHEENBIDI_DIR=${FETCHCONTENT_BASE_DIR}/sheenbidi-src -P ${PROJECT_SOURCE_DIR}/tools/sheenbidi/PatchSheenBidi.cmake)
+        FetchContent_MakeAvailable(SheenBidi)
+    endblock()
 
-set_target_properties(SheenBidi PROPERTIES FOLDER "Dependencies")
+    set_target_properties(SheenBidi PROPERTIES FOLDER "Dependencies")
 
-# disable building SheenBidi as part of our unity build, it has its own internal unity build system
-set_target_properties(SheenBidi PROPERTIES UNITY_BUILD OFF)
+    # disable building SheenBidi as part of our unity build, it has its own internal unity build system
+    set_target_properties(SheenBidi PROPERTIES UNITY_BUILD OFF)
 
-sfml_set_stdlib(SheenBidi)
+    sfml_set_stdlib(SheenBidi)
 
-# add SheenBidi object library and headers to our own target
-target_sources(sfml-graphics PRIVATE $<TARGET_OBJECTS:SheenBidi>)
-target_include_directories(sfml-graphics SYSTEM PRIVATE "${SheenBidi_SOURCE_DIR}/Headers")
+    # add SheenBidi object library and headers to our own target
+    target_sources(sfml-graphics PRIVATE $<TARGET_OBJECTS:SheenBidi>)
+    target_include_directories(sfml-graphics SYSTEM PRIVATE "${SheenBidi_SOURCE_DIR}/Headers")
 
-# Disable all warnings
-target_compile_options(SheenBidi PRIVATE -w)
+    # Disable all warnings
+    target_compile_options(SheenBidi PRIVATE -w)
 
-# if building SFML as a shared library or on android (where exes are shared libs) and linking our dependencies in
-# as static libraries we need to build them with -fPIC
-if(BUILD_SHARED_LIBS OR SFML_OS_ANDROID)
-    set_target_properties(SheenBidi PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    # if building SFML as a shared library or on android (where exes are shared libs) and linking our dependencies in
+    # as static libraries we need to build them with -fPIC
+    if(BUILD_SHARED_LIBS OR SFML_OS_ANDROID)
+        set_target_properties(SheenBidi PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endif()
 endif()
 
 # add preprocessor symbols

--- a/src/SFML/Graphics/Dependencies.cmake.in
+++ b/src/SFML/Graphics/Dependencies.cmake.in
@@ -3,12 +3,13 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 include(CMakeFindDependencyMacro)
 
 # When installing, save whether SFML was built using system dependencies.
-set(SFML_BUILT_USING_SYSTEM_DEPS @SFML_USE_SYSTEM_DEPS@)
+set(SFML_BUILT_USING_SYSTEM_FREETYPE_HARFBUZZ @SFML_USE_SYSTEM_FREETYPE_HARFBUZZ@)
+set(SFML_BUILT_USING_SYSTEM_SHEENBIDI @SFML_USE_SYSTEM_SHEENBIDI@)
 
 # start with an empty list
 set(FIND_SFML_DEPENDENCIES_NOTFOUND)
 
-if(SFML_BUILT_USING_SYSTEM_DEPS)
+if(SFML_BUILT_USING_SYSTEM_FREETYPE_HARFBUZZ)
     find_dependency(Freetype)
     find_dependency(HarfBuzz)
 else()
@@ -20,6 +21,10 @@ else()
     # because we broke the link in CMakeLists.txt we have to link FreeType back up to HarfBuzz here
     # so CMake can solve the circular dependency by adjusting the linker command line
     set_target_properties(freetype PROPERTIES INTERFACE_LINK_LIBRARIES "harfbuzz::harfbuzz")
+endif()
+
+if(SFML_BUILT_USING_SYSTEM_SHEENBIDI)
+    find_dependency(SheenBidi)
 endif()
 
 if(FIND_SFML_DEPENDENCIES_NOTFOUND)

--- a/src/SFML/Network/CMakeLists.txt
+++ b/src/SFML/Network/CMakeLists.txt
@@ -56,7 +56,7 @@ elseif(SFML_OS_LINUX OR SFML_OS_IOS OR SFML_OS_MACOS)
     target_link_libraries(sfml-network PRIVATE resolv)
 endif()
 
-if(SFML_USE_SYSTEM_DEPS)
+if(SFML_USE_SYSTEM_LIBSSH2_MBEDTLS)
     find_package(MbedTLS REQUIRED)
     find_package(Libssh2 REQUIRED)
 else()

--- a/src/SFML/Network/Dependencies.cmake.in
+++ b/src/SFML/Network/Dependencies.cmake.in
@@ -3,12 +3,12 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 include(CMakeFindDependencyMacro)
 
 # When installing, save whether SFML was built using system dependencies.
-set(SFML_BUILT_USING_SYSTEM_DEPS @SFML_USE_SYSTEM_DEPS@)
+set(SFML_BUILT_USING_SYSTEM_LIBSSH2_MBEDTLS @SFML_USE_SYSTEM_LIBSSH2_MBEDTLS@)
 
 # start with an empty list
 set(FIND_SFML_DEPENDENCIES_NOTFOUND)
 
-if(SFML_BUILT_USING_SYSTEM_DEPS)
+if(SFML_BUILT_USING_SYSTEM_LIBSSH2_MBEDTLS)
     find_dependency(MbedTLS)
     find_dependency(Libssh2)
 else()


### PR DESCRIPTION
-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [x] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?

## Description

"System deps" might be used not only when the corresponding packages are installed by the OS package manager, but also when compiling them separately. In either case, it would be useful to allow selecting which system/external dependencies shoud be used and which should be built within SFML more granularly.

Add the corresponding options. Freetype and Harfbuzz are combined into one option due to their circular dependencies, same with FLAC and Vorbis, and MbedTLS and libssh. Allow using external SheenBidi. The default behaves just like before the change, and the global `SFML_USE_SYSTEM_DEPS` switch is still here.

## Tasks

-   [ ] Tested on Linux
-   [x] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Compile test on different OSes and different combinations of the system dependencies options.