### PR TITLE
Fix Win32 does not release capture on outside release of mouse button

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -546,6 +546,14 @@ void WindowImplWin32::cleanup()
     ReleaseCapture();
 }
 
+////////////////////////////////////////////////////////////
+void WindowImplWin32::releaseCaptureOutsideMouse()
+{
+    if (!m_mouseInside && GetCapture() == m_handle)
+    {
+        ReleaseCapture();
+    }
+}
 
 ////////////////////////////////////////////////////////////
 void WindowImplWin32::setTracking(bool track)
@@ -970,6 +978,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         // Mouse left button up event
         case WM_LBUTTONUP:
         {
+            releaseCaptureOutsideMouse();
             Event::MouseButtonReleased event;
             event.button   = Mouse::Button::Left;
             event.position = {static_cast<std::int16_t>(LOWORD(lParam)), static_cast<std::int16_t>(HIWORD(lParam))};
@@ -990,6 +999,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         // Mouse right button up event
         case WM_RBUTTONUP:
         {
+            releaseCaptureOutsideMouse();
             Event::MouseButtonReleased event;
             event.button   = Mouse::Button::Right;
             event.position = {static_cast<std::int16_t>(LOWORD(lParam)), static_cast<std::int16_t>(HIWORD(lParam))};
@@ -1010,6 +1020,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         // Mouse wheel button up event
         case WM_MBUTTONUP:
         {
+            releaseCaptureOutsideMouse();
             Event::MouseButtonReleased event;
             event.button   = Mouse::Button::Middle;
             event.position = {static_cast<std::int16_t>(LOWORD(lParam)), static_cast<std::int16_t>(HIWORD(lParam))};
@@ -1030,6 +1041,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         // Mouse X button up event
         case WM_XBUTTONUP:
         {
+            releaseCaptureOutsideMouse();
             Event::MouseButtonReleased event;
             event.button   = HIWORD(wParam) == XBUTTON1 ? Mouse::Button::Extra1 : Mouse::Button::Extra2;
             event.position = {static_cast<std::int16_t>(LOWORD(lParam)), static_cast<std::int16_t>(HIWORD(lParam))};

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -114,6 +114,9 @@ private:
     void cleanup();
 
     ////////////////////////////////////////////////////////////
+    void releaseCaptureOutsideMouse();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Process a Win32 event
     ///
     /// \param message Message to process


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

<!-- Please describe your pull request. -->

This PR is related to the issue #3724. Previously, a Win32 window would not release the mouse capture if its buttons were released **after** the mouse had stopped moving and stayed still outside. 

The PR checks inside the window event handler for available capture release in case the received message is mouse button up.

## Tasks

-   [x] Tested on Windows

## How to test this PR?

Please see https://github.com/SFML/SFML/issues/3724#issuecomment-5016217718 to reproduce this bug.
