### PR TITLE
Fix potential crash in FileInputStream::getSize() when stream is in e…

### DIFF
--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -154,12 +154,31 @@ std::optional<std::size_t> FileInputStream::getSize()
 #endif
     if (!m_file)
         return std::nullopt;
-    const auto position = tell().value();
-    std::fseek(m_file.get(), 0, SEEK_END);
-    const std::optional size = tell();
 
-    if (!seek(position).has_value())
+    // 1. Save current position
+    const auto originalPos = tell();
+    if (!originalPos.has_value())
         return std::nullopt;
+
+    // 2. Seek to end
+    if (std::fseek(m_file.get(), 0, SEEK_END) != 0)
+    {
+        // Attempt to restore even if seek fails; the state is indeterminate,
+        // but this is the best we can do.
+        (void)seek(*originalPos);
+        return std::nullopt;
+    }
+
+    // 3. Obtain size
+    const auto size = tell();
+    if (!size.has_value())
+    {
+        (void)seek(*originalPos);
+        return std::nullopt;
+    }
+
+    // 4. Restore original position (failure here is not critical for the result)
+    (void)seek(*originalPos);
 
     return size;
 }

--- a/test/System/FileInputStream.test.cpp
+++ b/test/System/FileInputStream.test.cpp
@@ -108,4 +108,11 @@ TEST_CASE("[System] sf::FileInputStream")
         CHECK(fileInputStream.seek(6) == 6);
         CHECK(fileInputStream.tell() == 6);
     }
+
+    SECTION("getSize() on an unopened stream returns nullopt")
+    {
+        sf::FileInputStream fileInputStream;
+        CHECK(!fileInputStream.open("this_file_does_not_exist.xyz"));
+        CHECK(fileInputStream.getSize() == std::nullopt);
+    }
 }


### PR DESCRIPTION
While going through FileInputStream.cpp, I noticed that getSize() called tell().value() without checking for failure, and ignored the return value of fseek. If the file stream was in an error state, the .value() would throw and crash the application. I added explicit checks for every operation that can fail, and made sure the original file position is always restored – even on error paths. A unit test confirms that getSize() safely returns nullopt when the stream hasn’t been successfully opened.

