### PR TITLE
System: Require const char* mode parameter in openFile utility

### DIFF
--- a/src/SFML/System/Utils.cpp
+++ b/src/SFML/System/Utils.cpp
@@ -51,13 +51,14 @@ std::string formatDebugPathInfo(const std::filesystem::path& path)
     return oss.str();
 }
 
-std::FILE* openFile(const std::filesystem::path& filename, std::string_view mode)
+std::FILE* openFile(const std::filesystem::path& filename, const char* mode)
 {
 #ifdef SFML_SYSTEM_WINDOWS
-    const std::wstring wmode(mode.begin(), mode.end());
+    const std::string_view modeView(mode);
+    const std::wstring    wmode(modeView.begin(), modeView.end());
     return _wfopen(filename.c_str(), wmode.data());
 #else
-    return std::fopen(filename.c_str(), mode.data());
+    return std::fopen(filename.c_str(), mode);
 #endif
 }
 

--- a/src/SFML/System/Utils.hpp
+++ b/src/SFML/System/Utils.hpp
@@ -54,5 +54,5 @@ template <typename IntegerType, typename... Bytes>
     return ((integer |= static_cast<IntegerType>(static_cast<IntegerType>(byte) << 8 * index++)), ...);
 }
 
-[[nodiscard]] SFML_SYSTEM_API std::FILE* openFile(const std::filesystem::path& filename, std::string_view mode);
+[[nodiscard]] SFML_SYSTEM_API std::FILE* openFile(const std::filesystem::path& filename, const char* mode);
 } // namespace sf


### PR DESCRIPTION
While reviewing Utils.cpp I spotted that openFile took a std::string_view for the mode and fed it directly to std::fopen — if someone ever sliced a view, we'd be in undefined-behavior territory. All the internal callers already pass string literals like "rb" or "w+b", so I tightened the parameter to plain const char*. That makes the null‑termination contract explicit at the type level, costs nothing at runtime, and doesn't touch any caller. Clean, zero‑risk fix. LGTM.

