### PR TITLE
Fix integer overflow and pointer wrapping in sf::Image::resize

### DIFF
--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -51,6 +51,7 @@
 #include <array>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -121,6 +122,12 @@ bool isQoiMagicNumber(std::string_view buffer)
 
     return buffer[0] == 'q' && buffer[1] == 'o' && buffer[2] == 'i' && buffer[3] == 'f';
 }
+
+// Helper to check if the product of width, height, and channels overflows std::size_t
+bool isProductOverflow(sf::Vector2u size, std::size_t channels)
+{
+    return size.x > 0 && size.y > 0 && (size.x > std::numeric_limits<std::size_t>::max() / channels / size.y);
+}
 } // namespace
 
 
@@ -169,6 +176,9 @@ void Image::resize(Vector2u size, Color color)
 {
     if (size.x && size.y)
     {
+        if (isProductOverflow(size, 4))
+            throw Exception("Failed to resize image: size is too large (integer overflow)");
+
         // Create a new pixel buffer first for exception safety's sake
         std::vector<std::uint8_t> newPixels(std::size_t{size.x} * std::size_t{size.y} * 4);
 
@@ -205,8 +215,11 @@ void Image::resize(Vector2u size, const std::uint8_t* pixels)
 {
     if (pixels && size.x && size.y)
     {
+        if (isProductOverflow(size, 4))
+            throw Exception("Failed to resize image: size is too large (integer overflow)");
+
         // Create a new pixel buffer first for exception safety's sake
-        std::vector<std::uint8_t> newPixels(pixels, pixels + size.x * size.y * 4);
+        std::vector<std::uint8_t> newPixels(pixels, pixels + std::size_t{size.x} * std::size_t{size.y} * 4);
 
         // Commit the new pixel buffer
         m_pixels = std::move(newPixels);

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -263,6 +263,25 @@ TEST_CASE("[Graphics] sf::Image")
                 }
             }
         }
+
+        SECTION("resize overflow")
+        {
+            sf::Image image;
+            CHECK_THROWS_AS(image.resize({3'000'000'000, 3'000'000'000}), sf::Exception);
+            std::uint8_t pixel = 0;
+            CHECK_THROWS_AS(image.resize({3'000'000'000, 3'000'000'000}, &pixel), sf::Exception);
+
+            // Test zero dimensions and valid paths
+            CHECK_NOTHROW(image.resize({0, 0}));
+            CHECK_NOTHROW(image.resize({0, 1000}));
+            CHECK_NOTHROW(image.resize({1000, 0}));
+            CHECK_NOTHROW(image.resize({1, 1}));
+
+            // Test boundary overflow cases
+            const std::size_t maxBytes = std::numeric_limits<std::size_t>::max() / 4;
+            if (maxBytes <= std::numeric_limits<unsigned int>::max())
+                CHECK_THROWS_AS(image.resize({static_cast<unsigned int>(maxBytes) + 1, 1}), sf::Exception);
+        }
     }
 
     SECTION("loadFromFile()")


### PR DESCRIPTION
While reading Image.cpp I noticed that resize multiplies two unsigned int dimensions by 4 to get a buffer size. On 64‑bit systems that multiplication can overflow a 32‑bit int, leading to tiny allocations or undefined pointer wrapping.

 I added a quick overflow check that safely handles zero‑size images, throws sf::Exception if it would overflow, and fixed the pointer maths to use std::size_t casts. Covered it with a few tests for the overflow, zero dimensions, and a normal resize.

