### PR TITLE
Add angle wrapping boundary checks to close mutation test gaps

### DIFF
--- a/test/System/Angle.test.cpp
+++ b/test/System/Angle.test.cpp
@@ -37,6 +37,12 @@ TEST_CASE("[System] sf::Angle")
         CHECK(sf::degrees(-360).wrapSigned() == Approx(sf::degrees(0)));
         CHECK(sf::degrees(720).wrapSigned() == Approx(sf::degrees(0)));
         CHECK(sf::degrees(-720).wrapSigned() == Approx(sf::degrees(0)));
+
+        // Test offsets near full rotations to break mathematical symmetry
+        CHECK(sf::degrees(361).wrapSigned() == Approx(sf::degrees(1)));
+        CHECK(sf::degrees(-361).wrapSigned() == Approx(sf::degrees(-1)));
+        CHECK(sf::degrees(721).wrapSigned() == Approx(sf::degrees(1)));
+        CHECK(sf::degrees(-721).wrapSigned() == Approx(sf::degrees(-1)));
     }
 
     SECTION("wrapUnsigned()")


### PR DESCRIPTION
## Description

This PR fixes the surviving math operator mutations inside Angle.inl highlighted in issue #3334.

Changes:
- Added boundary offset tests (361, -361, 721, -721) inside the wrapSigned() testing section of Angle.test.cpp.
- Verified that asymmetric excessive values correctly fail if the internal wrapping math properties are broken.

This PR is related to the issue #3334.

## Tasks

-   [ ] Tested on Linux
-   [X] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Run the unit test runner binary targeting the isolated module:
in the powershell run the following
.\build\bin\test-sfml-system.exe "*Angle*" 