### PR TITLE
fix(Graphics): Add bounds validation and optional safety for QOI load…

### DIFF
--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -287,20 +287,13 @@ bool Image::loadFromFile(const std::filesystem::path& filename)
         file.seekg(0, std::ios::beg);
 
         // Check size bounds before reading (direct file loading path)
-        if (streamSize == -1 || streamSize == 0 || streamSize > std::numeric_limits<int>::max())
-        {
-            err() << "Failed to load QOI image: invalid or too large size" << std::endl;
+        if (streamSize <= 0 || streamSize > std::numeric_limits<int>::max())
             return false;
-        }
 
         // Read in the file contents since QOI doesn't support streams
         std::vector<uint8_t> buffer(static_cast<size_t>(streamSize));
-        file.read(reinterpret_cast<char*>(buffer.data()), streamSize);
-        if (!file)
-        {
-            err() << "Failed to load QOI image: cannot read file data" << std::endl;
+        if (!file.read(reinterpret_cast<char*>(buffer.data()), streamSize))
             return false;
-        }
 
         qoi_desc formatDesc = {};
         if (const auto ptr = MallocPtr(qoi_decode(buffer.data(), static_cast<int>(streamSize), &formatDesc, 4)))
@@ -340,10 +333,7 @@ bool Image::loadFromMemory(const void* data, std::size_t size)
         if (isQoiMagicNumber(std::string_view(qoiMagicNumBuffer, size)))
         {
             if (size == 0 || size > static_cast<std::size_t>(std::numeric_limits<int>::max()))
-            {
-                err() << "Failed to load QOI image: invalid or too large size" << std::endl;
                 return false;
-            }
 
             qoi_desc formatDesc = {};
             if (const auto ptr = MallocPtr(qoi_decode(data, static_cast<int>(size), &formatDesc, 4)))
@@ -402,35 +392,21 @@ bool Image::loadFromStream(InputStream& stream)
     if (qoiMagicCount.has_value() && isQoiMagicNumber(std::string_view(qoiMagicNumber.data(), *qoiMagicCount)))
     {
         const auto streamSize = stream.getSize();
-        if (streamSize && *streamSize > 0 && *streamSize <= static_cast<std::size_t>(std::numeric_limits<int>::max()))
-        {
-            if (!stream.seek(0).has_value())
-            {
-                err() << "Failed to load QOI image: stream does not support seeking" << std::endl;
-                return false;
-            }
-
-            // Read in the file contents since QOI doesn't support streams
-            std::vector<char> buffer(*streamSize);
-            const auto        readDataSize = stream.read(buffer.data(), *streamSize);
-            if (!readDataSize || *readDataSize != *streamSize)
-            {
-                err() << "Failed to load QOI image: cannot read stream data" << std::endl;
-                return false;
-            }
-
-            qoi_desc formatDesc = {};
-            if (const auto ptr = MallocPtr(qoi_decode(buffer.data(), static_cast<int>(*streamSize), &formatDesc, 4)))
-            {
-                const Vector2u imageSize = {formatDesc.width, formatDesc.height};
-                resize(imageSize, static_cast<const uint8_t*>(ptr.get()));
-                return true;
-            }
-        }
-        else
-        {
-            err() << "Failed to load QOI image: invalid or too large size" << std::endl;
+        if (!streamSize || *streamSize == 0 || *streamSize > static_cast<std::size_t>(std::numeric_limits<int>::max()) || !stream.seek(0).has_value())
             return false;
+
+        // Read in the file contents since QOI doesn't support streams
+        std::vector<char> buffer(*streamSize);
+        const auto        readDataSize = stream.read(buffer.data(), *streamSize);
+        if (!readDataSize || *readDataSize != *streamSize)
+            return false;
+
+        qoi_desc formatDesc = {};
+        if (const auto ptr = MallocPtr(qoi_decode(buffer.data(), static_cast<int>(*streamSize), &formatDesc, 4)))
+        {
+            const Vector2u imageSize = {formatDesc.width, formatDesc.height};
+            resize(imageSize, static_cast<const uint8_t*>(ptr.get()));
+            return true;
         }
     }
 

--- a/src/SFML/Graphics/Image.cpp
+++ b/src/SFML/Graphics/Image.cpp
@@ -50,6 +50,7 @@
 #include <algorithm>
 #include <array>
 #include <fstream>
+#include <limits>
 #include <iomanip>
 #include <memory>
 #include <ostream>
@@ -285,9 +286,21 @@ bool Image::loadFromFile(const std::filesystem::path& filename)
         const auto streamSize = static_cast<std::streamsize>(file.tellg());
         file.seekg(0, std::ios::beg);
 
+        // Check size bounds before reading (direct file loading path)
+        if (streamSize == -1 || streamSize == 0 || streamSize > std::numeric_limits<int>::max())
+        {
+            err() << "Failed to load QOI image: invalid or too large size" << std::endl;
+            return false;
+        }
+
         // Read in the file contents since QOI doesn't support streams
         std::vector<uint8_t> buffer(static_cast<size_t>(streamSize));
         file.read(reinterpret_cast<char*>(buffer.data()), streamSize);
+        if (!file)
+        {
+            err() << "Failed to load QOI image: cannot read file data" << std::endl;
+            return false;
+        }
 
         qoi_desc formatDesc = {};
         if (const auto ptr = MallocPtr(qoi_decode(buffer.data(), static_cast<int>(streamSize), &formatDesc, 4)))
@@ -326,6 +339,12 @@ bool Image::loadFromMemory(const void* data, std::size_t size)
         const auto* qoiMagicNumBuffer = static_cast<const char*>(data);
         if (isQoiMagicNumber(std::string_view(qoiMagicNumBuffer, size)))
         {
+            if (size == 0 || size > static_cast<std::size_t>(std::numeric_limits<int>::max()))
+            {
+                err() << "Failed to load QOI image: invalid or too large size" << std::endl;
+                return false;
+            }
+
             qoi_desc formatDesc = {};
             if (const auto ptr = MallocPtr(qoi_decode(data, static_cast<int>(size), &formatDesc, 4)))
             {
@@ -382,19 +401,36 @@ bool Image::loadFromStream(InputStream& stream)
     // Read the QOI file if it's valid
     if (qoiMagicCount.has_value() && isQoiMagicNumber(std::string_view(qoiMagicNumber.data(), *qoiMagicCount)))
     {
-        if (const auto streamSize = stream.getSize(); streamSize.has_value())
+        const auto streamSize = stream.getSize();
+        if (streamSize && *streamSize > 0 && *streamSize <= static_cast<std::size_t>(std::numeric_limits<int>::max()))
         {
+            if (!stream.seek(0).has_value())
+            {
+                err() << "Failed to load QOI image: stream does not support seeking" << std::endl;
+                return false;
+            }
+
             // Read in the file contents since QOI doesn't support streams
             std::vector<char> buffer(*streamSize);
             const auto        readDataSize = stream.read(buffer.data(), *streamSize);
+            if (!readDataSize || *readDataSize != *streamSize)
+            {
+                err() << "Failed to load QOI image: cannot read stream data" << std::endl;
+                return false;
+            }
 
             qoi_desc formatDesc = {};
-            if (const auto ptr = MallocPtr(qoi_decode(buffer.data(), static_cast<int>(*readDataSize), &formatDesc, 4)))
+            if (const auto ptr = MallocPtr(qoi_decode(buffer.data(), static_cast<int>(*streamSize), &formatDesc, 4)))
             {
                 const Vector2u imageSize = {formatDesc.width, formatDesc.height};
                 resize(imageSize, static_cast<const uint8_t*>(ptr.get()));
                 return true;
             }
+        }
+        else
+        {
+            err() << "Failed to load QOI image: invalid or too large size" << std::endl;
+            return false;
         }
     }
 

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -134,6 +134,13 @@ TEST_CASE("[Graphics] sf::Image")
                 CHECK(image.getPixel({0, 0}) == sf::Color::Green);
                 CHECK(image.getPixel({23, 23}) == sf::Color::Green);
             }
+
+            SECTION("Memory loading QOI with too large size")
+            {
+                const std::array<char, 4> qoif = {'q', 'o', 'i', 'f'};
+                sf::Image image;
+                CHECK(!image.loadFromMemory(qoif.data(), static_cast<std::size_t>(std::numeric_limits<int>::max()) + 1));
+            }
         }
 
         SECTION("Stream constructor")
@@ -144,6 +151,75 @@ TEST_CASE("[Graphics] sf::Image")
             CHECK(image.getPixelsPtr() != nullptr);
             CHECK(image.getPixel({0, 0}) == sf::Color(255, 255, 255, 0));
             CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
+        }
+
+        SECTION("Stream loading QOI with invalid stream")
+        {
+            struct FailingQoiStream : sf::InputStream
+            {
+                std::optional<std::size_t> read(void* data, std::size_t size) override
+                {
+                    if (size == 4)
+                    {
+                        std::memcpy(data, "qoif", 4);
+                        return 4;
+                    }
+                    return std::nullopt;
+                }
+                std::optional<std::size_t> seek(std::size_t) override { return 0; }
+                std::optional<std::size_t> tell() override { return 0; }
+                std::optional<std::size_t> getSize() override { return 100; }
+            };
+            FailingQoiStream stream;
+            sf::Image image;
+            CHECK(!image.loadFromStream(stream));
+        }
+
+        SECTION("Stream loading QOI with too large size")
+        {
+            struct TooLargeQoiStream : sf::InputStream
+            {
+                std::optional<std::size_t> read(void* data, std::size_t size) override
+                {
+                    if (size == 4)
+                    {
+                        std::memcpy(data, "qoif", 4);
+                        return 4;
+                    }
+                    return 0;
+                }
+                std::optional<std::size_t> seek(std::size_t) override { return 0; }
+                std::optional<std::size_t> tell() override { return 0; }
+                std::optional<std::size_t> getSize() override
+                {
+                    return static_cast<std::size_t>(std::numeric_limits<int>::max()) + 1;
+                }
+            };
+            TooLargeQoiStream stream;
+            sf::Image image;
+            CHECK(!image.loadFromStream(stream));
+        }
+
+        SECTION("Stream loading QOI with zero size")
+        {
+            struct ZeroSizeQoiStream : sf::InputStream
+            {
+                std::optional<std::size_t> read(void* data, std::size_t size) override
+                {
+                    if (size == 4)
+                    {
+                        std::memcpy(data, "qoif", 4);
+                        return 4;
+                    }
+                    return 0;
+                }
+                std::optional<std::size_t> seek(std::size_t) override { return 0; }
+                std::optional<std::size_t> tell() override { return 0; }
+                std::optional<std::size_t> getSize() override { return 0; }
+            };
+            ZeroSizeQoiStream stream;
+            sf::Image         image;
+            CHECK(!image.loadFromStream(stream));
         }
 
         SECTION("Vector2 constructor")

--- a/test/Graphics/Image.test.cpp
+++ b/test/Graphics/Image.test.cpp
@@ -153,32 +153,13 @@ TEST_CASE("[Graphics] sf::Image")
             CHECK(image.getPixel({200, 150}) == sf::Color(144, 208, 62));
         }
 
-        SECTION("Stream loading QOI with invalid stream")
+        SECTION("Stream loading QOI error cases")
         {
-            struct FailingQoiStream : sf::InputStream
+            struct MockQoiStream : sf::InputStream
             {
-                std::optional<std::size_t> read(void* data, std::size_t size) override
-                {
-                    if (size == 4)
-                    {
-                        std::memcpy(data, "qoif", 4);
-                        return 4;
-                    }
-                    return std::nullopt;
-                }
-                std::optional<std::size_t> seek(std::size_t) override { return 0; }
-                std::optional<std::size_t> tell() override { return 0; }
-                std::optional<std::size_t> getSize() override { return 100; }
-            };
-            FailingQoiStream stream;
-            sf::Image image;
-            CHECK(!image.loadFromStream(stream));
-        }
+                std::size_t sizeToReturn = 100;
+                bool shouldFailRead = false;
 
-        SECTION("Stream loading QOI with too large size")
-        {
-            struct TooLargeQoiStream : sf::InputStream
-            {
                 std::optional<std::size_t> read(void* data, std::size_t size) override
                 {
                     if (size == 4)
@@ -186,40 +167,29 @@ TEST_CASE("[Graphics] sf::Image")
                         std::memcpy(data, "qoif", 4);
                         return 4;
                     }
-                    return 0;
+                    return shouldFailRead ? std::nullopt : std::optional<std::size_t>(0);
                 }
                 std::optional<std::size_t> seek(std::size_t) override { return 0; }
                 std::optional<std::size_t> tell() override { return 0; }
-                std::optional<std::size_t> getSize() override
-                {
-                    return static_cast<std::size_t>(std::numeric_limits<int>::max()) + 1;
-                }
+                std::optional<std::size_t> getSize() override { return sizeToReturn; }
             };
-            TooLargeQoiStream stream;
-            sf::Image image;
-            CHECK(!image.loadFromStream(stream));
-        }
 
-        SECTION("Stream loading QOI with zero size")
-        {
-            struct ZeroSizeQoiStream : sf::InputStream
-            {
-                std::optional<std::size_t> read(void* data, std::size_t size) override
-                {
-                    if (size == 4)
-                    {
-                        std::memcpy(data, "qoif", 4);
-                        return 4;
-                    }
-                    return 0;
-                }
-                std::optional<std::size_t> seek(std::size_t) override { return 0; }
-                std::optional<std::size_t> tell() override { return 0; }
-                std::optional<std::size_t> getSize() override { return 0; }
-            };
-            ZeroSizeQoiStream stream;
-            sf::Image         image;
-            CHECK(!image.loadFromStream(stream));
+            sf::Image image;
+
+            // Test 1: Invalid read
+            MockQoiStream stream1;
+            stream1.shouldFailRead = true;
+            CHECK(!image.loadFromStream(stream1));
+
+            // Test 2: Too large size
+            MockQoiStream stream2;
+            stream2.sizeToReturn = static_cast<std::size_t>(std::numeric_limits<int>::max()) + 1;
+            CHECK(!image.loadFromStream(stream2));
+
+            // Test 3: Zero size
+            MockQoiStream stream3;
+            stream3.sizeToReturn = 0;
+            CHECK(!image.loadFromStream(stream3));
         }
 
         SECTION("Vector2 constructor")


### PR DESCRIPTION
While going through the QOI loading code in sf::Image, I spotted that std::optional return values from stream reads were being dereferenced without checking for failure—undefined behavior waiting to happen. 

I also noticed the size parameters were cast straight to int without validation, risking integer overflow on large inputs. This patch adds the missing guards, seeks the stream back to the start after the magic read, logs errors cleanly, and returns false on any failure, with tests to cover the edge cases.

