### PR TITLE
System: Safely check all optional-unwrapping and filesystem calls in …

### DIFF
--- a/src/SFML/System/FileInputStream.cpp
+++ b/src/SFML/System/FileInputStream.cpp
@@ -154,11 +154,19 @@ std::optional<std::size_t> FileInputStream::getSize()
 #endif
     if (!m_file)
         return std::nullopt;
-    const auto position = tell().value();
-    std::fseek(m_file.get(), 0, SEEK_END);
-    const std::optional size = tell();
 
-    if (!seek(position).has_value())
+    const auto position = tell();
+    if (!position)
+        return std::nullopt;
+
+    if (std::fseek(m_file.get(), 0, SEEK_END) != 0)
+        return std::nullopt;
+
+    const auto size = tell();
+    if (!size)
+        return std::nullopt;
+
+    if (!seek(*position).has_value())
         return std::nullopt;
 
     return size;


### PR DESCRIPTION
While going through FileInputStream.cpp, I noticed getSize() was calling .value() directly on the std::optional returned by tell(). That looked like a potential crash if the stream position couldn’t be queried. 

On closer inspection, the function had two such tell() calls and only partially checked seek operations. I tightened the whole function so every filesystem interaction is validated — if anything fails, getSize() now returns std::nullopt instead of crashing, consistent with the library’s error model.

