### PR TITLE
Fall back to the X11 screen size when XRandR provides no desktop mode

### DIFF
--- a/src/SFML/Window/Unix/VideoModeImpl.cpp
+++ b/src/SFML/Window/Unix/VideoModeImpl.cpp
@@ -179,6 +179,15 @@ VideoMode VideoModeImpl::getDesktopMode()
             // XRandr extension is not supported: we cannot get the video modes
             err() << "Failed to use the XRandR extension while trying to get the desktop video modes" << std::endl;
         }
+
+        // XRandR may provide an empty size list on some multi-monitor setups
+        // (e.g. when only an external display is enabled): fall back to the X11 screen size
+        if (desktopMode.size.x == 0 || desktopMode.size.y == 0)
+        {
+            desktopMode = VideoMode({static_cast<unsigned int>(DisplayWidth(display.get(), screen)),
+                                     static_cast<unsigned int>(DisplayHeight(display.get(), screen))},
+                                    static_cast<unsigned int>(DefaultDepth(display.get(), screen)));
+        }
     }
     else
     {


### PR DESCRIPTION
<!--
Thanks a lot for making a contribution to SFML! 🙂

Please make sure you are targetting the correct branch. No more features are planned for the 2.x branches! (See [the readme](https://github.com/SFML/SFML#state-of-development))

Before creating the pull request, we ask you to check the following boxes: (For small changes not everything needs to ticked, but the more the better!)

-   [ ] Has this change been discussed on [the forum](https://en.sfml-dev.org/forums/index.php#c3) or in an issue before?
-   [ ] Does the code follow the SFML [Code Style Guide](https://www.sfml-dev.org/style.php)?
-   [ ] Have you provided some example/test code for your changes?
-   [ ] If you have additional steps which need to be performed, please list them as tasks!
-->

## Description

On some multi-monitor configurations (e.g. a laptop with its built-in panel disabled and only an external display enabled, such as with an eGPU), the legacy XRandR screen configuration API returns an empty size list: XRRGetScreenInfo() succeeds but XRRConfigSizes() yields zero sizes. getDesktopMode() then silently returned a default-constructed VideoMode of 0x0, and creating a window from it failed.

Fall back to the core X11 screen dimensions (DisplayWidth/DisplayHeight) whenever the XRandR query did not produce a usable mode.

No issue related to this PR was found.

## Tasks

-   [x] Tested on Linux
-   [ ] Tested on Windows
-   [ ] Tested on macOS
-   [ ] Tested on iOS
-   [ ] Tested on Android
