### PR TITLE
Add support for iOS joystick

### DIFF
--- a/src/SFML/Window/CMakeLists.txt
+++ b/src/SFML/Window/CMakeLists.txt
@@ -227,6 +227,7 @@ elseif(SFML_OS_IOS)
         ${SRCROOT}/iOS/InputImpl.mm
         ${SRCROOT}/iOS/JoystickImpl.mm
         ${SRCROOT}/iOS/JoystickImpl.hpp
+        ${SRCROOT}/iOS/JoystickRegistryImpl.hpp
         ${SRCROOT}/iOS/SensorImpl.mm
         ${SRCROOT}/iOS/SensorImpl.hpp
         ${SRCROOT}/iOS/VideoModeImpl.mm
@@ -242,6 +243,7 @@ elseif(SFML_OS_IOS)
         ${SRCROOT}/iOS/SFMain.hpp
         ${SRCROOT}/iOS/SFMain.mm
     )
+    set_property(SOURCE ${SRCROOT}/iOS/JoystickImpl.mm APPEND PROPERTY COMPILE_OPTIONS -fobjc-arc)
     source_group("ios" FILES ${PLATFORM_SRC})
 elseif(SFML_OS_ANDROID)
     set(PLATFORM_SRC
@@ -336,7 +338,7 @@ elseif(SFML_OS_FREEBSD)
 elseif(SFML_OS_MACOS)
     target_link_libraries(sfml-window PRIVATE "-framework Foundation" "-framework AppKit" "-framework IOKit" "-framework Carbon")
 elseif(SFML_OS_IOS)
-    target_link_libraries(sfml-window PUBLIC "-framework Foundation" "-framework UIKit" "-framework CoreGraphics" "-framework QuartzCore" "-framework CoreMotion")
+    target_link_libraries(sfml-window PUBLIC "-framework Foundation" "-framework UIKit" "-framework CoreGraphics" "-framework QuartzCore" "-framework CoreMotion" "-framework GameController")
 elseif(SFML_OS_ANDROID)
     target_link_libraries(sfml-window PRIVATE android)
 endif()

--- a/src/SFML/Window/iOS/JoystickImpl.mm
+++ b/src/SFML/Window/iOS/JoystickImpl.mm
@@ -26,68 +26,391 @@
 // Headers
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/JoystickImpl.hpp>
+#include <SFML/Window/iOS/JoystickRegistryImpl.hpp>
+
+#import <UIKit/UIKit.h>
+
+#include <cstring>
+
+
+namespace
+{
+////////////////////////////////////////////////////////////
+sf::priv::JoystickRegistryImpl& getRegistry()
+{
+    static sf::priv::JoystickRegistryImpl registry;
+    return registry;
+}
+
+
+////////////////////////////////////////////////////////////
+GCControllerButtonInput* getShareButton(GCExtendedGamepad* gamepad)
+{
+    if (@available(iOS 15.0, *))
+    {
+        if ([gamepad isKindOfClass:[GCXboxGamepad class]])
+        {
+            auto* const xboxGamepad = static_cast<GCXboxGamepad*>(gamepad);
+            return xboxGamepad.buttonShare;
+        }
+    }
+
+    return nil;
+}
+} // namespace
 
 
 namespace sf::priv
 {
 ////////////////////////////////////////////////////////////
+void JoystickRegistryImpl::initialize()
+{
+    {
+        const std::lock_guard lock(m_mutex);
+        m_initialized = true;
+    }
+
+    NSNotificationCenter* const center = [NSNotificationCenter defaultCenter];
+    m_connectObserver                  = [center
+        addObserverForName:GCControllerDidConnectNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(NSNotification* notification) {
+                    connect(notification.object);
+                }];
+    m_disconnectObserver               = [center
+        addObserverForName:GCControllerDidDisconnectNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(NSNotification* notification) {
+                    disconnect(notification.object);
+                }];
+
+    refresh();
+}
+
+
+////////////////////////////////////////////////////////////
+void JoystickRegistryImpl::cleanup()
+{
+    id connectObserver;
+    id disconnectObserver;
+
+    {
+        const std::lock_guard lock(m_mutex);
+        m_initialized        = false;
+        connectObserver      = m_connectObserver;
+        disconnectObserver   = m_disconnectObserver;
+        m_connectObserver    = nil;
+        m_disconnectObserver = nil;
+        ++m_revision;
+
+        for (Slot& slot : m_slots)
+        {
+            slot.controller = nil;
+            ++slot.generation;
+        }
+    }
+
+    NSNotificationCenter* const center = [NSNotificationCenter defaultCenter];
+    if (connectObserver)
+        [center removeObserver:connectObserver];
+    if (disconnectObserver)
+        [center removeObserver:disconnectObserver];
+}
+
+
+////////////////////////////////////////////////////////////
+void JoystickRegistryImpl::refresh()
+{
+    std::uint64_t revision{};
+    {
+        const std::lock_guard lock(m_mutex);
+        if (!m_initialized)
+            return;
+
+        revision = m_revision;
+    }
+
+    NSArray<GCController*>* const controllers = [GCController controllers];
+    NSMutableArray<GCController*>* const supportedControllers = [[NSMutableArray alloc] initWithCapacity:controllers.count];
+    for (GCController* controller in controllers) // NOLINT(cppcoreguidelines-init-variables)
+    {
+        if (controller.extendedGamepad)
+            [supportedControllers addObject:controller];
+    }
+
+    const std::lock_guard lock(m_mutex);
+
+    // A notification may have changed the connections while the list was being obtained.
+    if (!m_initialized || revision != m_revision)
+        return;
+
+    bool changed = false;
+    for (Slot& slot : m_slots)
+    {
+        if (slot.controller && [supportedControllers indexOfObjectIdenticalTo:slot.controller] == NSNotFound)
+        {
+            slot.controller = nil;
+            ++slot.generation;
+            changed = true;
+        }
+    }
+
+    for (GCController* controller in supportedControllers) // NOLINT(cppcoreguidelines-init-variables)
+        changed |= assignController(controller);
+
+    if (changed)
+        ++m_revision;
+}
+
+
+////////////////////////////////////////////////////////////
+bool JoystickRegistryImpl::isConnected(unsigned int index)
+{
+    const std::lock_guard lock(m_mutex);
+    return index < m_slots.size() && m_slots[index].controller != nil;
+}
+
+
+////////////////////////////////////////////////////////////
+bool JoystickRegistryImpl::open(unsigned int index, std::uint64_t& generation)
+{
+    const std::lock_guard lock(m_mutex);
+    if (index >= m_slots.size() || !m_slots[index].controller)
+        return false;
+
+    generation = m_slots[index].generation;
+    return true;
+}
+
+
+////////////////////////////////////////////////////////////
+GCController* JoystickRegistryImpl::getController(unsigned int index, std::uint64_t generation)
+{
+    const std::lock_guard lock(m_mutex);
+    if (index >= m_slots.size() || m_slots[index].generation != generation)
+        return nil;
+
+    return m_slots[index].controller;
+}
+
+
+////////////////////////////////////////////////////////////
+void JoystickRegistryImpl::connect(GCController* controller)
+{
+    const bool            supported = controller.extendedGamepad != nil;
+    const std::lock_guard lock(m_mutex);
+    if (!m_initialized)
+        return;
+
+    ++m_revision;
+    if (supported)
+        (void)assignController(controller);
+}
+
+
+////////////////////////////////////////////////////////////
+void JoystickRegistryImpl::disconnect(GCController* controller)
+{
+    const std::lock_guard lock(m_mutex);
+    if (!m_initialized)
+        return;
+
+    ++m_revision;
+    for (Slot& slot : m_slots)
+    {
+        if (slot.controller == controller)
+        {
+            slot.controller = nil;
+            ++slot.generation;
+            return;
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+bool JoystickRegistryImpl::assignController(GCController* controller)
+{
+    for (const Slot& slot : m_slots)
+    {
+        if (slot.controller == controller)
+            return false;
+    }
+
+    for (Slot& slot : m_slots)
+    {
+        if (!slot.controller)
+        {
+            slot.controller = controller;
+            ++slot.generation;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////
 void JoystickImpl::initialize()
 {
-    // Not implemented
+    @autoreleasepool
+    {
+        getRegistry().initialize();
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
 void JoystickImpl::cleanup()
 {
-    // Not implemented
+    @autoreleasepool
+    {
+        getRegistry().cleanup();
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::isConnected(unsigned int /* index */)
+bool JoystickImpl::isConnected(unsigned int index)
 {
-    // Not implemented
-    return false;
+    @autoreleasepool
+    {
+        JoystickRegistryImpl& registry = getRegistry();
+        registry.refresh();
+        return registry.isConnected(index);
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
-bool JoystickImpl::open(unsigned int /* index */)
+bool JoystickImpl::open(unsigned int index)
 {
-    // Not implemented
-    return false;
+    @autoreleasepool
+    {
+        close();
+
+        if (!getRegistry().open(index, m_generation))
+            return false;
+
+        m_index = index;
+        return true;
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
 void JoystickImpl::close()
 {
-    // Not implemented
+    m_index      = Joystick::Count;
+    m_generation = 0;
 }
 
 
 ////////////////////////////////////////////////////////////
 JoystickCaps JoystickImpl::getCapabilities() const
 {
-    // Not implemented
-    return {};
+    @autoreleasepool
+    {
+        GCController* const      controller = getRegistry().getController(m_index, m_generation);
+        GCExtendedGamepad* const gamepad    = controller.extendedGamepad;
+        if (!gamepad)
+            return {};
+
+        JoystickCaps capabilities;
+        capabilities.axes.fill(true);
+        capabilities.buttonCount = 13;
+        if (gamepad.buttonOptions)
+            capabilities.buttonCount = 14;
+
+        if (@available(iOS 14.0, *))
+        {
+            if (gamepad.buttonHome)
+                capabilities.buttonCount = 15;
+        }
+
+        if (getShareButton(gamepad))
+            capabilities.buttonCount = 16;
+
+        return capabilities;
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
 Joystick::Identification JoystickImpl::getIdentification() const
 {
-    // Not implemented
-    return {};
+    @autoreleasepool
+    {
+        GCController* const controller = getRegistry().getController(m_index, m_generation);
+        if (!controller)
+            return {};
+
+        NSString* name = controller.vendorName;
+        if (name.length == 0)
+            name = controller.productCategory;
+
+        Joystick::Identification identification;
+        identification.name = "Game Controller";
+        if (const char* utf8Name = name.UTF8String; utf8Name && *utf8Name)
+            identification.name = String::fromUtf8(utf8Name, utf8Name + std::strlen(utf8Name));
+
+        return identification;
+    }
 }
 
 
 ////////////////////////////////////////////////////////////
-JoystickState JoystickImpl::update()
+JoystickState JoystickImpl::update() const
 {
-    // Not implemented
-    return {};
+    @autoreleasepool
+    {
+        JoystickRegistryImpl& registry = getRegistry();
+        registry.refresh();
+
+        GCController* const      controller = registry.getController(m_index, m_generation);
+        GCExtendedGamepad* const gamepad    = controller.extendedGamepad;
+        if (!gamepad)
+            return {};
+
+        JoystickState state;
+        state.connected = true;
+
+        if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive)
+        {
+            state.axes[Joystick::Axis::X]    = gamepad.leftThumbstick.xAxis.value * 100.f;
+            state.axes[Joystick::Axis::Y]    = gamepad.leftThumbstick.yAxis.value * -100.f;
+            state.axes[Joystick::Axis::Z]    = gamepad.rightThumbstick.xAxis.value * 100.f;
+            state.axes[Joystick::Axis::R]    = gamepad.rightThumbstick.yAxis.value * -100.f;
+            state.axes[Joystick::Axis::U]    = gamepad.leftTrigger.value * 100.f;
+            state.axes[Joystick::Axis::V]    = gamepad.rightTrigger.value * 100.f;
+            state.axes[Joystick::Axis::PovX] = gamepad.dpad.xAxis.value * 100.f;
+            state.axes[Joystick::Axis::PovY] = gamepad.dpad.yAxis.value * 100.f;
+
+            state.buttons[0]  = gamepad.buttonA.pressed;
+            state.buttons[1]  = gamepad.buttonB.pressed;
+            state.buttons[3]  = gamepad.buttonX.pressed;
+            state.buttons[4]  = gamepad.buttonY.pressed;
+            state.buttons[6]  = gamepad.leftShoulder.pressed;
+            state.buttons[7]  = gamepad.rightShoulder.pressed;
+            state.buttons[8]  = gamepad.leftTrigger.pressed;
+            state.buttons[9]  = gamepad.rightTrigger.pressed;
+            state.buttons[10] = gamepad.leftThumbstickButton.pressed;
+            state.buttons[11] = gamepad.rightThumbstickButton.pressed;
+            state.buttons[12] = gamepad.buttonMenu.pressed;
+            state.buttons[13] = gamepad.buttonOptions.pressed;
+
+            if (@available(iOS 14.0, *))
+                state.buttons[14] = gamepad.buttonHome.pressed;
+
+            state.buttons[15] = getShareButton(gamepad).pressed;
+        }
+
+        // Do not return input from a connection invalidated while its state was being read.
+        return registry.getController(m_index, m_generation) == controller ? state : JoystickState{};
+    }
 }
 
 } // namespace sf::priv

--- a/src/SFML/Window/iOS/JoystickRegistryImpl.hpp
+++ b/src/SFML/Window/iOS/JoystickRegistryImpl.hpp
@@ -29,48 +29,63 @@
 ////////////////////////////////////////////////////////////
 #include <SFML/Window/Joystick.hpp>
 
+#import <GameController/GameController.h>
+#include <array>
+#include <mutex>
+
 #include <cstdint>
 
 
 namespace sf::priv
 {
-struct JoystickCaps;
-struct JoystickState;
-
 ////////////////////////////////////////////////////////////
-class JoystickImpl
+class JoystickRegistryImpl
 {
 public:
     ////////////////////////////////////////////////////////////
-    static void initialize();
+    void initialize();
 
     ////////////////////////////////////////////////////////////
-    static void cleanup();
+    void cleanup();
 
     ////////////////////////////////////////////////////////////
-    static bool isConnected(unsigned int index);
+    void refresh();
 
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] bool open(unsigned int index);
+    [[nodiscard]] bool isConnected(unsigned int index);
 
     ////////////////////////////////////////////////////////////
-    void close();
+    [[nodiscard]] bool open(unsigned int index, std::uint64_t& generation);
 
     ////////////////////////////////////////////////////////////
-    [[nodiscard]] JoystickCaps getCapabilities() const;
-
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] Joystick::Identification getIdentification() const;
-
-    ////////////////////////////////////////////////////////////
-    [[nodiscard]] JoystickState update() const;
+    [[nodiscard]] GCController* getController(unsigned int index, std::uint64_t generation);
 
 private:
     ////////////////////////////////////////////////////////////
+    struct Slot
+    {
+        GCController* controller{};
+        std::uint64_t generation{};
+    };
+
+    ////////////////////////////////////////////////////////////
+    void connect(GCController* controller);
+
+    ////////////////////////////////////////////////////////////
+    void disconnect(GCController* controller);
+
+    ////////////////////////////////////////////////////////////
+    [[nodiscard]] bool assignController(GCController* controller);
+
+    ////////////////////////////////////////////////////////////
     // Member data
     ////////////////////////////////////////////////////////////
-    unsigned int  m_index{Joystick::Count}; ///< Controller slot
-    std::uint64_t m_generation{};           ///< Connection associated with this instance
+    std::mutex                        m_mutex;
+    std::array<Slot, Joystick::Count> m_slots{};
+    id                                m_connectObserver{};
+    id                                m_disconnectObserver{};
+    std::uint64_t                     m_revision{};
+    bool                              m_initialized{};
 };
 
 } // namespace sf::priv


### PR DESCRIPTION
## Description

This PR implements the previously unimplemented iOS joystick backend using Apple's GameController framework. Controllers exposing an extended gamepad profile can now be queried through `sf::Joystick` and generate the existing joystick events.

The implementation:

This PR implements the previously unimplemented iOS joystick backend using Apple's GameController framework for controllers exposing `GCExtendedGamepad`.

It tracks controllers through connection notifications and enumeration, rejects input from stale connections, and clears input while the application is inactive. Optional Options, Home, and Xbox Share buttons are read when available, subject to system gesture handling.

The iOS build now links GameController and compiles `JoystickImpl.mm` with ARC.

## Tasks

-   [ ] Tested on Linux
-   [ ] Tested on Windows
-   [x] Tested on macOS
-   [x] Tested on iOS
-   [ ] Tested on Android

## How to test this PR?

Build SFML for iOS and run the following example in an iOS application linked against `SFML::Graphics` and `SFML::Main`. Observe the event output in the Xcode debug console. The window turns green while button A on joystick 0 is held, exercising the real-time polling API as well as the event API.

The existing `joystick` example is currently excluded from iOS builds, so enabling `SFML_BUILD_EXAMPLES` alone does not provide an iOS joystick test application.

1. Launch with an extended-gamepad controller already connected, then repeat by connecting it after launch. Verify detection, a readable controller name, and the reported button count in both cases, plus a connection event when connecting after launch.
2. Move both sticks, fully press and release both triggers, and use the D-pad. Verify the corresponding axis events and return to neutral when released.
3. Press and release each available button. Verify the reported indices, including optional buttons on controllers and OS versions that expose them.
4. Connect two controllers and disconnect one. The remaining controller should retain its joystick index. Reconnect or replace the disconnected controller and verify connection events and fresh input without stale pressed buttons or axis values.
5. Hold a button or move a stick, make the app inactive, release the input, and return to the app. Verify there is no stuck input. When inspecting joystick state during an inactive update, all axes should be zero and all buttons released.

```cpp
#include <SFML/Graphics.hpp>
#include <SFML/Main.hpp>

#include <iostream>
#include <optional>

void printController(unsigned int id)
{
    std::cout << "Connected " << id << ": "
              << sf::Joystick::getIdentification(id).name.toAnsiString()
              << ", buttons: " << sf::Joystick::getButtonCount(id) << '\n';
}

int main()
{
    sf::RenderWindow window(sf::VideoMode({1280, 720}), "iOS joystick test");
    window.setFramerateLimit(60);

    for (unsigned int id = 0; id < sf::Joystick::Count; ++id)
    {
        if (sf::Joystick::isConnected(id))
            printController(id);
    }

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
            else if (const auto* connected = event->getIf<sf::Event::JoystickConnected>())
                printController(connected->joystickId);
            else if (const auto* disconnected = event->getIf<sf::Event::JoystickDisconnected>())
                std::cout << "Disconnected " << disconnected->joystickId << '\n';
            else if (const auto* pressed = event->getIf<sf::Event::JoystickButtonPressed>())
                std::cout << "Joystick " << pressed->joystickId << ", button "
                          << pressed->button << " pressed\n";
            else if (const auto* released = event->getIf<sf::Event::JoystickButtonReleased>())
                std::cout << "Joystick " << released->joystickId << ", button "
                          << released->button << " released\n";
            else if (const auto* moved = event->getIf<sf::Event::JoystickMoved>())
                std::cout << "Joystick " << moved->joystickId << ", axis "
                          << static_cast<int>(moved->axis) << ": " << moved->position << '\n';
        }

        const bool pressed = sf::Joystick::isConnected(0) && sf::Joystick::isButtonPressed(0, 0);
        window.clear(pressed ? sf::Color::Green : sf::Color::Black);
        window.display();
    }
}
```
