### PR TITLE
Fix text bounds after line alignment

### DIFF
--- a/src/SFML/Graphics/Text.cpp
+++ b/src/SFML/Graphics/Text.cpp
@@ -822,6 +822,8 @@ void Text::ensureGeometryUpdate() const
     std::vector<std::uint32_t> currentLineTabIndices;
     hb_script_t                currentScript{};
     hb_direction_t             currentDirection{};
+    auto                       currentLineMinX = static_cast<float>(m_characterSize);
+    auto                       currentLineMaxX = 0.0f;
 
     const auto outputLine = [&]
     {
@@ -1028,6 +1030,10 @@ void Text::ensureGeometryUpdate() const
         minY = std::min(minY, lineMinY);
         maxY = std::max(maxY, lineMaxY);
 
+        // A physical line can contain several segments with different scripts or directions.
+        currentLineMinX = std::min(currentLineMinX, lineMinX);
+        currentLineMaxX = std::max(currentLineMaxX, lineMaxX);
+
         currentLine.clear();
         currentLineIndices.clear();
         currentLineTabIndices.clear();
@@ -1121,6 +1127,8 @@ void Text::ensureGeometryUpdate() const
         std::size_t    firstCodepointOffset = std::numeric_limits<std::size_t>::max();
         hb_direction_t direction{};
         float          lineWidth{};
+        float          minX{};
+        float          maxX{};
     };
 
     std::vector<LineRecord> lines;
@@ -1132,6 +1140,8 @@ void Text::ensureGeometryUpdate() const
         lineRecord.glyphsStart          = m_glyphs.size();
         lineRecord.verticesStart        = m_vertices.getVertexCount();
         lineRecord.outlineVerticesStart = m_outlineVertices.getVertexCount();
+        currentLineMinX                 = static_cast<float>(m_characterSize);
+        currentLineMaxX                 = 0.0f;
     };
 
     const auto endLineRecord = [&]
@@ -1142,6 +1152,8 @@ void Text::ensureGeometryUpdate() const
         lineRecord.verticesCount        = m_vertices.getVertexCount() - lineRecord.verticesStart;
         lineRecord.outlineVerticesCount = m_outlineVertices.getVertexCount() - lineRecord.outlineVerticesStart;
         lineRecord.lineWidth            = x;
+        lineRecord.minX                 = currentLineMinX;
+        lineRecord.maxX                 = currentLineMaxX;
     };
 
     if (!segments.empty())
@@ -1213,6 +1225,7 @@ void Text::ensureGeometryUpdate() const
                 // be returned instead of this glyph
                 glyph.cluster = index;
 
+                currentLineMinX = std::min(currentLineMinX, x);
                 endLineRecord();
                 beginLineRecord();
 
@@ -1262,20 +1275,6 @@ void Text::ensureGeometryUpdate() const
               m_glyphs.end(),
               [](const ShapedGlyph& left, const ShapedGlyph& right) { return left.cluster < right.cluster; });
 
-    // If we're using outline, update the current bounds
-    if (m_outlineThickness != 0)
-    {
-        const float outline = std::abs(std::ceil(m_outlineThickness));
-        minX -= outline;
-        maxX += outline;
-        minY -= outline;
-        maxY += outline;
-    }
-
-    // Update the bounding rectangle
-    m_bounds.position = Vector2f(minX, minY);
-    m_bounds.size     = Vector2f(maxX, maxY) - Vector2f(minX, minY);
-
     // Use line record data to post-process lines e.g. re-alignment etc.
     if (!lines.empty())
     {
@@ -1285,6 +1284,9 @@ void Text::ensureGeometryUpdate() const
                                                [](const LineRecord& left, const LineRecord& right)
                                                { return left.lineWidth < right.lineWidth; })
                                   ->lineWidth;
+
+        auto alignedMinX = std::numeric_limits<float>::max();
+        auto alignedMaxX = std::numeric_limits<float>::lowest();
 
         for (auto& line : lines)
         {
@@ -1302,7 +1304,15 @@ void Text::ensureGeometryUpdate() const
             {
                 shift = maxWidth - line.lineWidth;
             }
-            else
+            // Move each line's bounds by the same distance as its glyphs.
+            // The line advance can differ from its visible width, and each line has its own shift.
+            if (line.minX <= line.maxX)
+            {
+                alignedMinX = std::min(alignedMinX, line.minX + shift);
+                alignedMaxX = std::max(alignedMaxX, line.maxX + shift);
+            }
+
+            if (shift == 0.0f)
             {
                 // Skip modifying the data if there is nothing to shift
                 continue;
@@ -1321,16 +1331,26 @@ void Text::ensureGeometryUpdate() const
                 m_outlineVertices[i].position.x += shift;
         }
 
-        // Update bounds if necessary
-        if (m_lineAlignment == LineAlignment::Center)
+        if (alignedMinX <= alignedMaxX)
         {
-            m_bounds.position.x -= m_bounds.size.x / 2.0f;
-        }
-        else if (m_lineAlignment == LineAlignment::Right)
-        {
-            m_bounds.position.x -= m_bounds.size.x;
+            minX = alignedMinX;
+            maxX = alignedMaxX;
         }
     }
+
+    // If we're using outline, update the current bounds after aligning the lines.
+    if (m_outlineThickness != 0)
+    {
+        const float outline = std::abs(std::ceil(m_outlineThickness));
+        minX -= outline;
+        maxX += outline;
+        minY -= outline;
+        maxY += outline;
+    }
+
+    // Update the bounding rectangle
+    m_bounds.position = Vector2f(minX, minY);
+    m_bounds.size     = Vector2f(maxX, maxY) - Vector2f(minX, minY);
 }
 
 } // namespace sf

--- a/test/Graphics/Text.test.cpp
+++ b/test/Graphics/Text.test.cpp
@@ -7,7 +7,12 @@
 
 #include <GraphicsUtil.hpp>
 #include <WindowUtil.hpp>
+#include <algorithm>
+#include <array>
+#include <limits>
 #include <type_traits>
+
+#include <cmath>
 
 // Allow testing deprecated functions
 #ifdef _MSC_VER
@@ -218,15 +223,165 @@ TEST_CASE("[Graphics] sf::Text", runDisplayTests())
             CHECK_THAT(text.getLocalBounds(), equalsApprox(sf::FloatRect({1, 5}, {32, 13}), 1.f));
             CHECK_THAT(text.getGlobalBounds(), equalsApprox((sf::FloatRect({67, 182}, {32, 13})), 1.f));
         }
+    }
 
-        SECTION("Change alignment")
+    SECTION("Aligned bounds follow the rendered glyphs")
+    {
+        sf::Text text(font, "Test", 30);
+        text.setLineAlignment(sf::Text::LineAlignment::Left);
+        text.setPosition({100, 200});
+        text.setScale({1.5f, 0.75f});
+        text.setRotation(sf::degrees(25));
+
+        SECTION("Regular text")
         {
-            text.setLineAlignment(sf::Text::LineAlignment::Center);
-            CHECK_THAT(text.getLocalBounds(), equalsApprox(sf::FloatRect({-15, 5}, {32, 13}), 1.f));
-            CHECK_THAT(text.getGlobalBounds(), equalsApprox(sf::FloatRect({85, 205}, {32, 13}), 1.f));
-            text.setLineAlignment(sf::Text::LineAlignment::Right);
-            CHECK_THAT(text.getLocalBounds(), equalsApprox(sf::FloatRect({-31, 5}, {32, 13}), 1.f));
-            CHECK_THAT(text.getGlobalBounds(), equalsApprox(sf::FloatRect({69, 205}, {32, 13}), 1.f));
+        }
+
+        SECTION("Letter spacing")
+        {
+            text.setLetterSpacing(2);
+        }
+
+        SECTION("Outline")
+        {
+            text.setOutlineThickness(2.5f);
+        }
+
+        SECTION("Italic text")
+        {
+            text.setStyle(sf::Text::Italic);
+        }
+
+        SECTION("Trailing whitespace")
+        {
+            text.setString("Test \t");
+        }
+
+        const auto leftBounds = text.getLocalBounds();
+        const auto leftGlyphs = text.getShapedGlyphs();
+        REQUIRE_FALSE(leftGlyphs.empty());
+
+        for (const auto alignment : {sf::Text::LineAlignment::Center, sf::Text::LineAlignment::Right})
+        {
+            CAPTURE(static_cast<int>(alignment));
+            text.setLineAlignment(alignment);
+
+            const auto& glyphs = text.getShapedGlyphs();
+            REQUIRE(glyphs.size() == leftGlyphs.size());
+            const auto displacement = glyphs.front().position - leftGlyphs.front().position;
+
+            // A single line moves rigidly, so its bounds must follow the same displacement.
+            const sf::FloatRect expectedBounds(leftBounds.position + displacement, leftBounds.size);
+            CHECK_THAT(text.getLocalBounds(), equalsApprox(expectedBounds, 0.0001f));
+            CHECK_THAT(text.getGlobalBounds(), equalsApprox(text.getTransform().transformRect(expectedBounds), 0.0001f));
+
+            for (std::size_t i = 0; i < glyphs.size(); ++i)
+                CHECK_THAT(glyphs[i].position, equalsApprox(leftGlyphs[i].position + displacement, 0.0001f));
+        }
+    }
+
+    SECTION("Aligned multiline bounds enclose each line")
+    {
+        std::array<sf::String, 2> strings{"j", "Test"};
+        unsigned int              style = sf::Text::Regular;
+        float                     outlineThickness{};
+        float                     letterSpacing = 1;
+
+        SECTION("Different line widths and bearings")
+        {
+        }
+
+        SECTION("Reverse line order")
+        {
+            std::swap(strings[0], strings[1]);
+        }
+
+        SECTION("Italic text")
+        {
+            style = sf::Text::Italic;
+        }
+
+        SECTION("Outline and letter spacing")
+        {
+            outlineThickness = 2.5f;
+            letterSpacing    = 2;
+        }
+
+        SECTION("Whitespace")
+        {
+            strings = {"\tj ", "Test "};
+        }
+
+        sf::Text text(font, strings[0] + "\n" + strings[1], 30);
+        text.setStyle(style);
+        text.setOutlineThickness(outlineThickness);
+        text.setLetterSpacing(letterSpacing);
+        text.setLineAlignment(sf::Text::LineAlignment::Left);
+        const auto leftBounds = text.getLocalBounds();
+
+        for (const auto alignment :
+             {sf::Text::LineAlignment::Left, sf::Text::LineAlignment::Center, sf::Text::LineAlignment::Right})
+        {
+            CAPTURE(static_cast<int>(alignment));
+            text.setLineAlignment(alignment);
+            const auto& glyphs = text.getShapedGlyphs();
+            auto        minX   = std::numeric_limits<float>::max();
+            auto        maxX   = std::numeric_limits<float>::lowest();
+            std::size_t firstCluster{};
+
+            for (const auto& string : strings)
+            {
+                // Obtain each line's bounds independently, then locate that line in the shaped text.
+                sf::Text line(font, string, 30);
+                line.setStyle(style);
+                line.setOutlineThickness(outlineThickness);
+                line.setLetterSpacing(letterSpacing);
+                line.setLineAlignment(sf::Text::LineAlignment::Left);
+                const auto  lineBounds = line.getLocalBounds();
+                const auto& lineGlyphs = line.getShapedGlyphs();
+                REQUIRE_FALSE(lineGlyphs.empty());
+                const auto firstGlyph = std::find_if(glyphs.begin(),
+                                                     glyphs.end(),
+                                                     [&](const sf::Text::ShapedGlyph& glyph)
+                                                     { return glyph.cluster == firstCluster; });
+                REQUIRE(firstGlyph != glyphs.end());
+                const float displacement = firstGlyph->position.x - lineGlyphs.front().position.x;
+                minX                     = std::min(minX, lineBounds.position.x + displacement);
+                maxX                     = std::max(maxX, lineBounds.position.x + lineBounds.size.x + displacement);
+                firstCluster += string.getSize() + 1;
+            }
+
+            const sf::FloatRect expectedBounds({minX, leftBounds.position.y}, {maxX - minX, leftBounds.size.y});
+            CHECK_THAT(text.getLocalBounds(), equalsApprox(expectedBounds, 0.0001f));
+        }
+    }
+
+    SECTION("Aligned empty strings and empty lines")
+    {
+        for (const auto* string : {"", "\n", "\n\n", "\nTest", "Test\n", "\nTest\n"})
+        {
+            CAPTURE(string);
+            sf::Text text(font, string, 30);
+            text.setLineAlignment(sf::Text::LineAlignment::Left);
+            const auto leftBounds = text.getLocalBounds();
+
+            for (const auto alignment : {sf::Text::LineAlignment::Center, sf::Text::LineAlignment::Right})
+            {
+                CAPTURE(static_cast<int>(alignment));
+                text.setLineAlignment(alignment);
+                const auto bounds = text.getLocalBounds();
+                CHECK(std::isfinite(bounds.position.x));
+                CHECK(std::isfinite(bounds.position.y));
+                CHECK(std::isfinite(bounds.size.x));
+                CHECK(std::isfinite(bounds.size.y));
+                CHECK(bounds.size.x >= 0);
+                CHECK(bounds.size.y >= 0);
+                CHECK(bounds.position.y == leftBounds.position.y);
+                CHECK(bounds.size.y == leftBounds.size.y);
+
+                if (text.getString().isEmpty())
+                    CHECK(bounds == sf::FloatRect());
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #3745.

Centered and right-aligned text move glyphs using each line's advance, while the old bounds adjustment used the visible width of the entire text. These values can differ: with Tuffy at size 30, `Test` has a visible width of 52 and an advance of 55. Its centered bounds started at x = -25 instead of -26.5, and its right-aligned bounds started at -51 instead of -54.

Record each physical line's horizontal bounds, apply the same shift used for its glyphs, then take the union of the shifted bounds. Apply the existing outline expansion afterward. Accumulating all script/direction segments within a line also preserves automatic alignment of RTL text.

Add regression checks for single and multiple lines, transformed global bounds, letter spacing, outlines, italic text, whitespace, and empty lines. Expected bounds are derived from independently positioned glyphs. These replace four hard-coded alignment checks that encoded the old width-based shift; the other existing bounds checks remain.

## Tasks

- [x] Upstream CI: all 88 checks passed on the current PR head ([run 34439898291, attempt 2](https://github.com/SFML/SFML/actions/runs/34439898291), verified September 12, 2026).
- [x] Tested on Linux: Ubuntu under WSL, GCC 13.3, software OpenGL with Xvfb. Graphics: 29 test cases, 3,445 assertions passed.
- [x] Tested on Windows: native Windows 11, MSYS2 UCRT64 GCC 15.2, Intel OpenGL 4.6. Graphics including Win32 tests: 30 test cases, 4,269 assertions passed.
- [ ] Tested on macOS
- [ ] Tested on iOS
- [ ] Tested on Android
- [x] `clang-format-17 --dry-run --Werror` and diff whitespace checks passed.

## How to test this PR?

Build the Graphics tests with `SFML_BUILD_TEST_SUITE=ON` and `SFML_RUN_DISPLAY_TESTS=ON`, then run the `sf::Text` case. The same final test file produces 30 failures out of 336 assertions on the original implementation and passes all 336 assertions with this change. This was also reproduced from fresh source trees using the exported patch.

For a visual check, draw `Test` and its reported bounds using Left, Center, and Right alignment; repeat with two lines of different lengths. Both platforms produced the corrected centered and right-aligned coordinates above.

Local validation used harnesses compiling the repository's actual Graphics test sources and utilities. Audio and Network tests were outside the validation scope. MSVC and the native NVIDIA rendering path were not tested.

AI assistance: this patch and its regression tests were prepared with OpenAI Codex. Local validation and upstream CI have completed successfully; maintainer review is pending.
