### PR TITLE
Unblock the main loop while resizing on Windows

### DIFF
--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -133,6 +133,88 @@ void initRawMouse()
     if (RegisterRawInputDevices(&rawMouse, 1, sizeof(rawMouse)) != TRUE)
         sf::err() << "Failed to initialize raw mouse input" << std::endl;
 }
+
+// While a window is being moved or resized, or while its system menu is open, Windows runs
+// its own modal message loop inside of DispatchMessage, which doesn't return until the user
+// is done with the interaction. In order to not block the application during that time,
+// messages are dispatched from a separate fiber, which can hand control back to the caller
+// of processEvents() from within such a modal loop and resume it on the next call.
+struct MessageFiber
+{
+    ~MessageFiber()
+    {
+        if (fiber)
+            DeleteFiber(fiber);
+
+        if (convertedThread)
+            ConvertFiberToThread();
+    }
+
+    void* fiber{};           // Fiber which dispatches the messages
+    void* mainFiber{};       // Fiber which runs the application's code
+    HWND  modalWindow{};     // Window whose modal loop is currently suspended
+    bool  onMessageFiber{};  // Is the message fiber the one currently running?
+    bool  convertedThread{}; // Was the thread converted to a fiber by us?
+    bool  failed{};          // Did the creation of the fiber fail?
+};
+
+thread_local MessageFiber messageFiber;
+
+// Unique identifier per window for the modal loop timer
+const UINT_PTR modalLoopTimerId = 0x53464D4C; // SFML in ASCII
+
+void dispatchMessages()
+{
+    MSG message;
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE))
+    {
+        TranslateMessage(&message);
+        DispatchMessageW(&message);
+    }
+}
+
+void CALLBACK messageFiberProc(void* /* parameter */)
+{
+    for (;;)
+    {
+        messageFiber.onMessageFiber = true;
+        dispatchMessages();
+        messageFiber.onMessageFiber = false;
+        SwitchToFiber(messageFiber.mainFiber);
+    }
+}
+
+// Get or create the message fiber of the current thread
+void* getOrCreateMessageFiber()
+{
+    if (!messageFiber.fiber && !messageFiber.failed)
+    {
+        // A thread has to be a fiber itself before it can switch to another one, so we convert it and
+        // remember the fiber we get. We don't use IsThreadAFiber or GetCurrentFiber, as they can't be
+        // used with every MinGW version. If the thread already is a fiber, i.e. the application manages
+        // fibers on its own, the conversion fails and we keep dispatching the messages inline.
+        messageFiber.mainFiber       = ConvertThreadToFiberEx(nullptr, FIBER_FLAG_FLOAT_SWITCH);
+        messageFiber.convertedThread = messageFiber.mainFiber != nullptr;
+        messageFiber.failed          = !messageFiber.convertedThread;
+
+        if (!messageFiber.failed)
+        {
+            messageFiber.fiber  = CreateFiberEx(0, 0, FIBER_FLAG_FLOAT_SWITCH, &messageFiberProc, nullptr);
+            messageFiber.failed = messageFiber.fiber == nullptr;
+        }
+
+        if (messageFiber.failed)
+            sf::err() << "Failed to create message fiber, the main loop will block while resizing or moving a window"
+                      << std::endl;
+    }
+
+    return messageFiber.fiber;
+}
+
+bool isOnMessageFiber()
+{
+    return messageFiber.onMessageFiber;
+}
 } // namespace
 
 namespace sf::priv
@@ -260,6 +342,17 @@ WindowImplWin32::~WindowImplWin32()
 {
     // TODO should we restore the cursor shape and visibility?
 
+    // If the window is in a suspended modal loop, end it before the window goes away
+    if (m_handle && messageFiber.modalWindow == m_handle && !isOnMessageFiber())
+    {
+        endModalLoop();
+        SendMessageW(m_handle, WM_CANCELMODE, 0, 0);
+        PostMessageW(m_handle, WM_NULL, 0, 0);
+
+        while (messageFiber.modalWindow == m_handle)
+            SwitchToFiber(messageFiber.fiber);
+    }
+
     // Destroy the custom icon, if any
     if (m_icon)
         DestroyIcon(m_icon);
@@ -305,14 +398,78 @@ WindowHandle WindowImplWin32::getNativeHandle() const
 void WindowImplWin32::processEvents()
 {
     // We process the window events only if we own it
-    if (!m_callback)
+    if (m_callback)
+        return;
+
+    // Dispatch the messages from the message fiber, unless we're already running on it
+    if (void* fiber = getOrCreateMessageFiber(); fiber && !isOnMessageFiber())
     {
-        MSG message;
-        while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE))
-        {
-            TranslateMessage(&message);
-            DispatchMessageW(&message);
-        }
+        SwitchToFiber(fiber);
+    }
+    else
+    {
+        dispatchMessages();
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+void WindowImplWin32::beginModalLoop()
+{
+    // We don't dispatch the messages of windows we don't own
+    if (m_callback)
+        return;
+
+    m_modalLoop = true;
+
+    // Get control back as soon as the modal loop is idle, i.e. once it has processed
+    // all pending input, and periodically in case the modal loop doesn't paint
+    m_paintYield = true;
+    InvalidateRect(m_handle, nullptr, FALSE);
+    SetTimer(m_handle, modalLoopTimerId, USER_TIMER_MINIMUM, nullptr);
+}
+
+
+////////////////////////////////////////////////////////////
+void WindowImplWin32::endModalLoop()
+{
+    m_modalLoop  = false;
+    m_paintYield = false;
+    KillTimer(m_handle, modalLoopTimerId);
+}
+
+
+////////////////////////////////////////////////////////////
+void WindowImplWin32::leaveModalLoop()
+{
+    if (!m_modalLoop || !isOnMessageFiber())
+        return;
+
+    // Let the application know about size changes while resizing
+    if (m_resizing && (m_lastSize != getSize()))
+    {
+        // Update the last handled size
+        m_lastSize = getSize();
+
+        // Push a resize event
+        pushEvent(Event::Resized{m_lastSize});
+    }
+
+    // Hand control back to the application
+    m_paintYield                = false;
+    messageFiber.modalWindow    = m_handle;
+    messageFiber.onMessageFiber = false;
+    SwitchToFiber(messageFiber.mainFiber);
+    messageFiber.onMessageFiber = true;
+    messageFiber.modalWindow    = nullptr;
+
+    // Get control back as soon as the modal loop runs out of messages, instead of letting it wait for
+    // the next one. WM_PAINT is only generated once no other messages are pending, so every call to
+    // processEvents() either processes one step of the modal loop or returns once there's nothing to do.
+    if (m_modalLoop)
+    {
+        m_paintYield = true;
+        InvalidateRect(m_handle, nullptr, FALSE);
     }
 }
 
@@ -780,6 +937,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         {
             m_resizing = true;
             grabCursor(false);
+            beginModalLoop();
             break;
         }
 
@@ -787,6 +945,7 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         case WM_EXITSIZEMOVE:
         {
             m_resizing = false;
+            endModalLoop();
 
             // Ignore cases where the window has only been moved
             if (m_lastSize != getSize())
@@ -800,6 +959,39 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
 
             // Restore/update cursor grabbing
             grabCursor(m_cursorGrabbed);
+            break;
+        }
+
+        // Start of a menu modal loop, e.g. the system menu
+        case WM_ENTERMENULOOP:
+        {
+            beginModalLoop();
+            break;
+        }
+
+        // End of a menu modal loop
+        case WM_EXITMENULOOP:
+        {
+            endModalLoop();
+            break;
+        }
+
+        // The modal loop is idle
+        case WM_PAINT:
+        {
+            if (m_paintYield && m_modalLoop)
+            {
+                ValidateRect(m_handle, nullptr);
+                leaveModalLoop();
+            }
+            break;
+        }
+
+        // Fallback, in case the modal loop doesn't paint
+        case WM_TIMER:
+        {
+            if (wParam == modalLoopTimerId)
+                leaveModalLoop();
             break;
         }
 
@@ -1147,6 +1339,10 @@ void WindowImplWin32::processEvent(UINT message, WPARAM wParam, LPARAM lParam)
         // When a maximum size is specified and the window is snapped to the edge of the display the window size is subtly too big
         case WM_WINDOWPOSCHANGED:
         {
+            // The window was moved or resized by the move/size modal loop, render a frame for every step
+            if (m_resizing)
+                leaveModalLoop();
+
             WINDOWPOS& pos = *reinterpret_cast<PWINDOWPOS>(lParam);
             if (pos.flags & SWP_NOSIZE)
                 break;

--- a/src/SFML/Window/Win32/WindowImplWin32.cpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.cpp
@@ -1518,6 +1518,58 @@ LRESULT CALLBACK WindowImplWin32::globalOnEvent(HWND handle, UINT message, WPARA
 
         if (window->m_callback)
             return CallWindowProcW(reinterpret_cast<WNDPROC>(window->m_callback), handle, message, wParam, lParam);
+
+        // Defer the handling of the title bar click until the mouse has actually moved
+        if ((message == WM_NCLBUTTONDOWN) && (wParam == HTCAPTION))
+        {
+            window->m_captionPressed       = true;
+            window->m_captionPressPosition = lParam;
+            return 0;
+        }
+
+        if (window->m_captionPressed &&
+            ((message == WM_MOUSEMOVE) || ((message == WM_NCMOUSEMOVE) && (lParam != window->m_captionPressPosition))))
+        {
+            window->m_captionPressed = false;
+
+            // Ignore the click if the button has been released somewhere else in the meantime
+            if (GetKeyState(VK_LBUTTON) < 0)
+            {
+                window->beginModalLoop();
+                DefWindowProcW(handle, WM_NCLBUTTONDOWN, HTCAPTION, window->m_captionPressPosition);
+                window->endModalLoop();
+            }
+        }
+
+        if ((message == WM_NCLBUTTONUP) || (message == WM_LBUTTONUP))
+            window->m_captionPressed = false;
+
+        // Clicking on the borders or the buttons of the window may also enter a modal loop
+        // before WM_ENTERSIZEMOVE is sent (e.g. while the mouse button is held without moving)
+        if (message == WM_NCLBUTTONDOWN)
+        {
+            window->beginModalLoop();
+            const LRESULT result = DefWindowProcW(handle, message, wParam, lParam);
+            window->endModalLoop();
+            return result;
+        }
+
+        // Defer opening the system menu when right-clicking on the title bar until after the
+        // button is released
+        if ((message == WM_NCRBUTTONDOWN) && ((wParam == HTCAPTION) || (wParam == HTSYSMENU)))
+        {
+            window->m_captionRightPressed = true;
+            return 0;
+        }
+
+        if ((message == WM_NCRBUTTONUP) || (message == WM_RBUTTONUP))
+        {
+            const bool pressed            = window->m_captionRightPressed;
+            window->m_captionRightPressed = false;
+
+            if (pressed && (message == WM_NCRBUTTONUP) && ((wParam == HTCAPTION) || (wParam == HTSYSMENU)))
+                return DefWindowProcW(handle, WM_CONTEXTMENU, reinterpret_cast<WPARAM>(handle), lParam);
+        }
     }
 
     // We don't forward the WM_CLOSE message to prevent the OS from automatically destroying the window

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -222,6 +222,9 @@ private:
     bool     m_resizing{};             //!< Is the window being resized?
     bool     m_modalLoop{};            //!< Is the window in a modal loop?
     bool     m_paintYield{};           //!< Should the next WM_PAINT hand control back to the application?
+    bool     m_captionPressed{};       //!< Is a click on the title bar pending?
+    LPARAM   m_captionPressPosition{}; //!< Position of the pending click on the title bar
+    bool     m_captionRightPressed{};  //!< Is a right click on the title bar pending?
     char16_t m_surrogate{}; //!< First half of the surrogate pair, in case we're receiving a Unicode character in two events
     bool m_mouseInside{};   //!< Mouse is inside the window?
     bool m_fullscreen{};    //!< Is the window fullscreen?

--- a/src/SFML/Window/Win32/WindowImplWin32.hpp
+++ b/src/SFML/Window/Win32/WindowImplWin32.hpp
@@ -145,6 +145,26 @@ private:
     void grabCursor(bool grabbed);
 
     ////////////////////////////////////////////////////////////
+    /// \brief Start handing control back to the application during a modal loop
+    ///
+    ////////////////////////////////////////////////////////////
+    void beginModalLoop();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Stop handing control back to the application after a modal loop
+    ///
+    ////////////////////////////////////////////////////////////
+    void endModalLoop();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Hand control back to the application from within a modal loop
+    ///
+    /// The modal loop resumes on the next call to processEvents().
+    ///
+    ////////////////////////////////////////////////////////////
+    void leaveModalLoop();
+
+    ////////////////////////////////////////////////////////////
     /// \brief Convert content size to window size including window chrome
     ///
     /// \param size Size to convert
@@ -200,6 +220,8 @@ private:
     bool     m_keyRepeatEnabled{true}; //!< Automatic key-repeat state for keydown events
     Vector2u m_lastSize;               //!< The last handled size of the window
     bool     m_resizing{};             //!< Is the window being resized?
+    bool     m_modalLoop{};            //!< Is the window in a modal loop?
+    bool     m_paintYield{};           //!< Should the next WM_PAINT hand control back to the application?
     char16_t m_surrogate{}; //!< First half of the surrogate pair, in case we're receiving a Unicode character in two events
     bool m_mouseInside{};   //!< Mouse is inside the window?
     bool m_fullscreen{};    //!< Is the window fullscreen?


### PR DESCRIPTION
## Description

This is another proposal in fixing the long standing "unable to render while resizing or dragging the window" issue on Windows. See also the solution design for it: https://github.com/SFML/SFML/wiki/SD:-Render-while-Resizing

Other proposals:
- #1601
- #3390
- https://github.com/SFML/SFML/commit/dcdbf23b9aa7264eec30ebc90a94c1db184374c1

Quick recap on the problem: While resizing, clicking the title bar / moving the window, the event dispatching goes into Windows own event loop (i.e. the modal loop) and doesn't return control to the caller, which means SFML applications pause on `pollEvents()`.

This PR essentially uses the "threading method", but instead of threads it uses [Fibers](https://learn.microsoft.com/en-us/windows/win32/procthread/fibers). Fibers are separate call stacks on the same thread, which allows SFML to pause the modal loop and return control to the main loop and its own fiber.

The second commit fixes the issue, where clicking on the title bar also blocks on the modal loop and right clicking blocks until the mouse button is released.

This PR fixes #3016

See also:

- The idea from this GLFW PR: https://github.com/glfw/glfw/pull/1426
- The title bar handling from Chromium: https://chromium.googlesource.com/chromium/src/+/main/ui/views/win/hwnd_message_handler.cc

## Tasks

-   [x] Tested on Windows

## How to test this PR?

Resize the window, drag it, right click on the title bar, click & hold on the title bar.

```cpp
#include <SFML/Graphics.hpp>

#include <algorithm>
#include <string>

int main()
{
    sf::RenderWindow window(sf::VideoMode({640, 480}), "Resize me");
    window.setVerticalSyncEnabled(true);

    sf::RectangleShape square({100.f, 100.f});
    square.setOrigin({50.f, 50.f});
    square.setFillColor(sf::Color(200, 120, 40));

    sf::RectangleShape outline;
    outline.setFillColor(sf::Color::Transparent);
    outline.setOutlineColor(sf::Color::Green);
    outline.setOutlineThickness(-4.f);

    const sf::Clock time;
    sf::Clock       frameClock;
    sf::Clock       titleClock;
    sf::Time        worstGap;
    int             frames = 0;

    while (window.isOpen())
    {
        while (const std::optional event = window.pollEvent())
        {
            if (event->is<sf::Event::Closed>())
                window.close();
            else if (const auto* resized = event->getIf<sf::Event::Resized>())
                window.setView(sf::View(sf::FloatRect({0.f, 0.f}, sf::Vector2f(resized->size))));
        }

        worstGap = std::max(worstGap, frameClock.restart());
        ++frames;
        if (titleClock.getElapsedTime() >= sf::seconds(1))
        {
            window.setTitle("Resize me - " + std::to_string(frames) + " FPS, worst frame gap " +
                            std::to_string(worstGap.asMilliseconds()) + " ms");
            frames   = 0;
            worstGap = sf::Time::Zero;
            titleClock.restart();
        }

        const sf::Vector2f size(window.getSize());
        square.setPosition(size / 2.f);
        square.setRotation(sf::degrees(time.getElapsedTime().asSeconds() * 90.f));
        outline.setSize(size);

        window.clear(sf::Color(30, 30, 60));
        window.draw(outline);
        window.draw(square);
        window.display();
    }
}
```

This PR

<img width="888" height="686" alt="librewolf_XgKa3dVJic" src="https://github.com/user-attachments/assets/bcfbf3eb-2433-427d-b1bc-2f2ffadd8268" />

1601 PR

<img width="1015" height="749" alt="librewolf_WYdQfkBAnc" src="https://github.com/user-attachments/assets/cccdf368-e478-4ea1-a344-1e35b5b322ac" />

3390 PR

<img width="871" height="686" alt="librewolf_bAOwFnNMBh" src="https://github.com/user-attachments/assets/9d31c502-965b-44f0-b1eb-703cf77b015a" />

JonnyPtn's commit

<img width="940" height="761" alt="librewolf_7YRuTERFey" src="https://github.com/user-attachments/assets/27c49aa8-f086-4f51-af51-7267c8db3cb7" />
